### PR TITLE
feat(admin): point WAF token guidance at env-specific waf.tf

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -17,7 +17,7 @@ import { AdminPanelFeature } from '@fxa/shared/guards';
 import { Guard } from '../Guard';
 import { useGuardContext } from '../../hooks/GuardContext';
 import { useUserContext } from '../../hooks/UserContext';
-import { getFormattedDate } from '../../lib/utils';
+import { getFormattedDate, getWafTfPath } from '../../lib/utils';
 import { TableRowYHeader, TableYHeaders } from '../TableYHeaders';
 import { adminApi } from '../../lib/api';
 
@@ -598,9 +598,9 @@ const DeleteRelyingParty = ({
       {wafToken && (
         <p className="p-4 m-2 rounded bg-yellow-50">
           <b>⚠️ This RP has a linked WAF bypass token.</b> It will be removed
-          from the database automatically, but you must also remove it from the
-          Fastly <code>fxa_ci_bypass_tokens</code> list in both{' '}
-          <code>accounts</code> and <code>accounts-api</code>.
+          from the database automatically, but you must also remove it from the{' '}
+          <code>fxa_ci_bypass_tokens</code> list in{' '}
+          <code>{getWafTfPath()}</code> (webservices-infra).
         </p>
       )}
       <form onSubmit={handleSubmit}>

--- a/packages/fxa-admin-panel/src/components/PageWafTokens/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageWafTokens/index.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { adminApi } from '../../lib/api';
 import { AdminPanelFeature } from '@fxa/shared/guards';
 import { Guard } from '../Guard';
-import { getFormattedDate } from '../../lib/utils';
+import { getFormattedDate, getWafTfPath } from '../../lib/utils';
 import type {
   WafBypassTokenDto,
   RelyingPartyDto,
@@ -47,7 +47,7 @@ const WafTokenRow = ({
   const handleRotate = async () => {
     if (
       !window.confirm(
-        `Rotate token "${token.name}"?\n\nThe old token will continue to work until fxa_ci_bypass_tokens is updated in webservices-infra.`
+        `Rotate token "${token.name}"?\n\nThe old token will continue to work until fxa_ci_bypass_tokens is updated in ${getWafTfPath()} (webservices-infra).`
       )
     )
       return;
@@ -63,7 +63,7 @@ const WafTokenRow = ({
   const handleDelete = async () => {
     if (
       !window.confirm(
-        `Delete token "${token.name}"? The token will continue to be used until it's also removed from fxa_ci_bypass_tokens in webservices-infra.`
+        `Delete token "${token.name}"? The token will continue to be used until it's also removed from fxa_ci_bypass_tokens in ${getWafTfPath()} (webservices-infra).`
       )
     )
       return;
@@ -144,9 +144,9 @@ const CreateTokenForm = ({
       <div className="p-4 border border-grey-100 rounded mt-4">
         <p className="font-bold mb-2">Token created.</p>
         <p className="mb-1">
-          Add this value to <code>fxa_ci_bypass_tokens</code> in both the{' '}
-          <code>accounts</code> and <code>accounts-api</code> Fastly sites, then
-          run <code>terraform apply</code>:
+          Add this value to <code>fxa_ci_bypass_tokens</code> in{' '}
+          <code>{getWafTfPath()}</code> (webservices-infra), then run{' '}
+          <code>terraform apply</code>:
         </p>
         <pre className="p-3 bg-grey-50 rounded mb-3">{createdToken}</pre>
         <button className={btnClass} onClick={onCancel}>
@@ -259,9 +259,9 @@ export const PageWafTokens = () => {
     const lines = tokens.map((t) => {
       const rawLabel = t.clientId ? rpById[t.clientId] || t.clientId : t.name;
       const label = rawLabel.replace(/[\r\n]+/g, ' ');
-      return `  "${t.token}",  # ${label}`;
+      return `    "${t.token}", # ${label}`;
     });
-    const hcl = `entries = [\n${lines.join('\n')}\n]`;
+    const hcl = `locals {\n  fxa_ci_bypass_tokens = [\n${lines.join('\n')}\n  ]\n}`;
     try {
       await navigator.clipboard.writeText(hcl);
       setExportCopied(true);
@@ -288,10 +288,11 @@ export const PageWafTokens = () => {
       </ul>
       <p className="mb-4 p-3 rounded bg-yellow-50 text-sm">
         <b>Reminder:</b> Changes here do <b>not</b> automatically update the
-        WAF. After generating or rotating a token, add it to{' '}
-        <code>fxa_ci_bypass_tokens</code> in both the <code>accounts</code> and{' '}
-        <code>accounts-api</code> Fastly sites in <code>webservices-infra</code>{' '}
-        and run <code>terraform apply</code>.
+        WAF. After generating or rotating a token, update{' '}
+        <code>fxa_ci_bypass_tokens</code> in <code>{getWafTfPath()}</code>{' '}
+        (webservices-infra) and run <code>terraform apply</code>. Use{' '}
+        <b>Export for Terraform</b> below to copy the full <code>locals</code>{' '}
+        block.
       </p>
 
       <hr />

--- a/packages/fxa-admin-panel/src/lib/utils.ts
+++ b/packages/fxa-admin-panel/src/lib/utils.ts
@@ -17,3 +17,8 @@ export const getFormattedDuration = (seconds: number) => {
   const secs = seconds % 60;
   return `${hours}h ${minutes}m ${secs}s`;
 };
+
+export const getWafTfPath = () =>
+  window.location.host.startsWith('fxa-admin-panel.prod.')
+    ? 'fxa/tf/prod/waf.tf'
+    : 'fxa/tf/stage/waf.tf';


### PR DESCRIPTION
## Because

- Stage and prod now have separate `fxa_ci_bypass_tokens` lists in webservices-infra (https://github.com/mozilla/webservices-infra/pull/10908), but the admin panel directs devs to the env-agnostic files
- Infra now uses a `locals` var to keep the multiple lists in sync

## This pull request

- Updates WAF-token copy in `PageWafTokens` and the `DeleteRelyingParty` warning to point at the env-specific `waf.tf`.
- Rewrites "Export for Terraform" output to emit a full `locals { ... }` block.

## Issue that this pull request solves

Closes: FXA-13700

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- On stage admin panel, open WAF Bypass Tokens — reminder banner should reference `fxa/tf/stage/waf.tf`.
- Click **Export for Terraform** → clipboard contains a full `locals { fxa_ci_bypass_tokens = [...] }` block, ready to paste into `fxa/tf/stage/waf.tf`.
- Generate / rotate / delete a token — confirms and after-create message all show the stage path.
- Delete an RP that has a linked token — warning shows the stage path.