### PR TITLE
task(auth): add per-uid rate limiting to passkey auth failures

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -158,20 +158,22 @@ mfaOtpCodeVerifyForPassword            : uid              : 5           : 5 minu
 mfaOtpCodeVerifyForRecoveryKey         : uid              : 5           : 5 minutes       : 15 minutes   : block
 
 #
+# Passkey Authentication
+# More lenient than passwords - passkeys cannot be credential-stuffed or brute-forced.
+# Rate limits are primarily for DoS prevention and to ban clearly malicious IPs when high failure rate is encountered.
+#
+# The passkeyAuthFinishFailed rule is a clear signal of bogus requests. In this case, ban the IP, and block the UID,
+# which will prevent further passkey auth attempts from that account.
+#
+passkeyAuthStart                       : ip                : 100         : 15 minutes      : 15 minutes  : block
+passkeyAuthFinish                      : ip                : 100         : 15 minutes      : 15 minutes  : block
+passkeyAuthFinishFailed                : ip                : 1000        : 24 hours        : 15 minutes  : ban
+#
 # Passkey Registration
 # MFA-protected endpoints for registering new passkeys. Moderate limits since these require existing auth.
 #
 passkeyRegisterStart                   : ip_uid            : 10           : 10 minutes      : 10 minutes  : block
 passkeyRegisterFinish                  : ip_uid            : 10           : 10 minutes      : 10 minutes  : block
-
-#
-# Passkey Authentication
-# More lenient than passwords - passkeys cannot be credential-stuffed or brute-forced.
-# Rate limits are primarily for DoS prevention.
-#
-passkeyAuthenticationStart             : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
-passkeyAuthenticationVerify            : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
-passkeyLogin                           : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
 
 #
 # Passkey Management

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -1176,6 +1176,76 @@ describe('passkeys routes', () => {
         expect.anything()
       );
     });
+
+    it('calls checkIpOnly with passkeyAuthFinishFailed when verification fails', async () => {
+      mockPasskeyService.verifyAuthenticationResponse = jest
+        .fn()
+        .mockRejectedValue(AppError.passkeyAuthenticationFailed());
+
+      await expect(() =>
+        runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        })
+      ).rejects.toThrow();
+
+      expect(customs.checkIpOnly).toHaveBeenCalledWith(
+        expect.anything(),
+        'passkeyAuthFinishFailed'
+      );
+    });
+
+    it('rethrows the original verification error after recording the failure signal', async () => {
+      const verificationError = AppError.passkeyAuthenticationFailed();
+      mockPasskeyService.verifyAuthenticationResponse = jest
+        .fn()
+        .mockRejectedValue(verificationError);
+
+      await expect(
+        runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        })
+      ).rejects.toBe(verificationError);
+    });
+
+    it('does not call checkIpOnly with passkeyAuthFinishFailed on successful authentication', async () => {
+      await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload,
+      });
+
+      const allCalls = (customs.checkIpOnly as jest.Mock).mock.calls.map(
+        (args: string[]) => args[1]
+      );
+      expect(allCalls).not.toContain('passkeyAuthFinishFailed');
+    });
+
+    // Documents current behavior: if customs throws during the passkeyAuthFinishFailed
+    // signal, the original verification error is masked by the customs error.
+    // Consider wrapping in a try/catch (like the email-send pattern) to preserve
+    // the original error for the caller.
+    it('propagates a customs failure from passkeyAuthFinishFailed instead of the original verification error', async () => {
+      mockPasskeyService.verifyAuthenticationResponse = jest
+        .fn()
+        .mockRejectedValue(AppError.passkeyAuthenticationFailed());
+      const customsError = new Error('customs service unavailable');
+      customs.checkIpOnly = jest
+        .fn()
+        .mockResolvedValueOnce(undefined) // passkeyAuthFinish — succeeds
+        .mockRejectedValueOnce(customsError); // passkeyAuthFinishFailed — fails
+
+      await expect(
+        runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        })
+      ).rejects.toBe(customsError);
+    });
   });
 
   describe('PasskeyHandler.createPasskeySessionToken', () => {

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -405,6 +405,8 @@ export class PasskeyHandler {
         db: this.db,
         request,
       });
+      // Add a failure signal. This can be useful to ban clearly bad actors.
+      await this.customs.checkIpOnly(request, 'passkeyAuthFinishFailed');
       throw err;
     }
 


### PR DESCRIPTION
## Because

- We want to rate limit failures since this is a more clear signal of repeated attempts.

## This pull request

- Updates passkey AppErrors to take a UID, so we can rate limit on failure.
- In the event of failure, we now look up the account and run a rate limit check.
- Adds configuration that limits repeated passkey failures on an account.
- Fixes naming conventions for existing pass key rate limit rules.

## Issue that this pull request solves

Closes: FXA-13675

## Checklist

_Put an \`x\` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to Test

- Edit `rate-limit-rules.txt` to set a tight \`passkeyAuthFinishFailed\` rule (e.g. 1 attempt per 10 minutes by uid) for fast verification
- Sign in to a test account that has a registered passkey.
- Sign out and trigger \`POST /passkey/authentication/finish\` repeatedly with a tampered/invalid assertion against the same account. 
- Observer the rate limiting failure.