### PR TITLE
fix(profile): surface upstream cause behind generic errno 999 on /v1/profile

### DIFF
--- a/packages/fxa-profile-server/lib/batch.js
+++ b/packages/fxa-profile-server/lib/batch.js
@@ -81,7 +81,10 @@ function batch(request, routeFieldsMap) {
               break;
             default:
               logger.error(url + ':' + res.statusCode, res.result);
-              throw AppError.from(res.result);
+              throw AppError.from(res.result, {
+                batchUrl: url,
+                batchStatusCode: res.statusCode,
+              });
           }
         });
     })

--- a/packages/fxa-profile-server/lib/error.js
+++ b/packages/fxa-profile-server/lib/error.js
@@ -46,9 +46,37 @@ AppError.prototype.header = function (name, value) {
   this.output.headers[name] = value;
 };
 
-AppError.from = function from(obj) {
-  var err = new AppError(obj);
-  err.cause = obj.cause;
+// Accepts AppError-shape, Boom-shape (statusCode), Boom errors (output.payload),
+// plain Errors, or null/undefined; merges `context` into payload so callers like
+// batch.js can attach the failing sub-request URL for Sentry.
+AppError.from = function from(obj, context) {
+  var source = obj;
+  if (source && typeof source === 'object' && source.output && source.output.payload) {
+    source = source.output.payload;
+  }
+
+  var safe = source && typeof source === 'object' ? source : {};
+  var code = safe.code || safe.statusCode;
+  var errno = safe.errno;
+  var message = safe.message || (obj instanceof Error ? obj.message : undefined);
+
+  var err = new AppError(
+    {
+      code: code,
+      errno: errno,
+      error: safe.error,
+      message: message,
+      info: safe.info,
+    },
+    Object.assign(
+      {},
+      safe.validation ? { validation: safe.validation } : null,
+      // Surface raw upstream in Sentry when we couldn't extract a typed errno or message.
+      !errno || !message ? { upstream: obj === undefined ? null : obj } : null,
+      context || null
+    )
+  );
+  err.cause = obj && obj.cause;
   return err;
 };
 

--- a/packages/fxa-profile-server/lib/routes/_core_profile.js
+++ b/packages/fxa-profile-server/lib/routes/_core_profile.js
@@ -78,15 +78,19 @@ module.exports = {
                 logger.info('request.auth_server.fail', body);
                 return reject(new AppError.unauthorized(body.message));
               }
-              // There should be no other 400-level errors, unless we're
-              // sending a badly-formed request of our own.  That warrants
-              // an "Internal Server Error" on our part.
+              // Preserve upstream errno/message instead of collapsing to errno 999.
               logger.error('request.auth_server.fail', body);
               return reject(
-                new AppError({
-                  code: 500,
-                  message: 'error communicating with auth server',
-                })
+                new AppError(
+                  {
+                    code: body.code || body.statusCode || 500,
+                    errno: body.errno,
+                    error: body.error,
+                    message: body.message,
+                    info: body.info,
+                  },
+                  { upstream: body }
+                )
               );
             }
 

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -287,7 +287,7 @@ describe('#integration - api', function () {
         });
     });
 
-    it('should error out on unexpected 400s from auth server', () => {
+    it('should propagate unexpected 4xx errors from auth server', () => {
       mock.token({
         user: USERID,
         scope: ['profile:write'],
@@ -296,7 +296,7 @@ describe('#integration - api', function () {
 
       mock.log('batch', (rec) => {
         return (
-          rec.levelname === 'ERROR' && rec.args[0] === '/v1/_core_profile:500'
+          rec.levelname === 'ERROR' && rec.args[0] === '/v1/_core_profile:400'
         );
       });
 
@@ -308,22 +308,6 @@ describe('#integration - api', function () {
         );
       });
 
-      mock.log('server', function (rec) {
-        return (
-          rec.levelname === 'ERROR' &&
-          rec.args[0] === 'summary' &&
-          rec.args[1].path === '/v1/_core_profile'
-        );
-      });
-
-      mock.log('server', function (rec) {
-        return (
-          rec.levelname === 'ERROR' &&
-          rec.args[0] === 'summary' &&
-          rec.args[1].path === '/v1/profile'
-        );
-      });
-
       return Server.api
         .get({
           url: '/profile',
@@ -332,8 +316,8 @@ describe('#integration - api', function () {
           },
         })
         .then((res) => {
-          assert.equal(res.statusCode, 500);
-          assert.equal(res.result.errno, 999);
+          assert.equal(res.statusCode, 400);
+          assert.equal(res.result.errno, 107);
           assertSecurityHeaders(res);
         });
     });

--- a/packages/fxa-profile-server/test/error.js
+++ b/packages/fxa-profile-server/test/error.js
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const assert = require('insist');
+
+const AppError = require('../lib/error');
+
+describe('AppError.from', function () {
+  it('preserves AppError-shape payload (code/errno/error/message/info)', function () {
+    const err = AppError.from({
+      code: 400,
+      errno: 102,
+      error: 'Bad Request',
+      message: 'Unknown account',
+      info: 'https://example.com/docs',
+    });
+    assert.equal(err.errno, 102);
+    assert.equal(err.message, 'Unknown account');
+    assert.equal(err.output.statusCode, 400);
+    assert.equal(err.output.payload.code, 400);
+    assert.equal(err.output.payload.errno, 102);
+    assert.equal(err.output.payload.error, 'Bad Request');
+    assert.equal(err.output.payload.message, 'Unknown account');
+    assert.equal(err.output.payload.info, 'https://example.com/docs');
+  });
+
+  it('preserves Boom-shape payload (statusCode mapped to code)', function () {
+    const err = AppError.from({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: 'Bad token',
+    });
+    assert.equal(err.message, 'Bad token');
+    assert.equal(err.output.statusCode, 401);
+    assert.equal(err.output.payload.code, 401);
+    assert.equal(err.output.payload.error, 'Unauthorized');
+    // Boom-shape inputs have no errno, so we still attach the raw upstream so
+    // Sentry can see what we received.
+    assert.deepEqual(err.output.payload.upstream, {
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: 'Bad token',
+    });
+  });
+
+  it('unwraps a Boom error with output.payload', function () {
+    const boom = {
+      isBoom: true,
+      output: {
+        statusCode: 503,
+        payload: {
+          code: 503,
+          errno: 105,
+          error: 'Service Unavailable',
+          message: 'Auth server error',
+        },
+      },
+    };
+    const err = AppError.from(boom);
+    assert.equal(err.errno, 105);
+    assert.equal(err.message, 'Auth server error');
+    assert.equal(err.output.statusCode, 503);
+  });
+
+  it('falls back to defaults but preserves raw upstream for an empty object', function () {
+    const err = AppError.from({});
+    assert.equal(err.errno, 999);
+    assert.equal(err.message, 'Unspecified error');
+    assert.deepEqual(err.output.payload.upstream, {});
+  });
+
+  it('handles null without throwing', function () {
+    const err = AppError.from(null);
+    assert.equal(err.errno, 999);
+    assert.equal(err.message, 'Unspecified error');
+    assert.equal(err.output.payload.upstream, null);
+  });
+
+  it('handles undefined without throwing', function () {
+    const err = AppError.from(undefined);
+    assert.equal(err.errno, 999);
+    assert.equal(err.message, 'Unspecified error');
+    assert.equal(err.output.payload.upstream, null);
+  });
+
+  it('extracts message from a plain Error instance', function () {
+    const err = AppError.from(new Error('underlying boom'));
+    assert.equal(err.message, 'underlying boom');
+    // No errno on a plain Error, so upstream is preserved for context.
+    assert.ok('upstream' in err.output.payload);
+  });
+
+  it('preserves Joi validation array when present', function () {
+    const err = AppError.from({
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'Invalid request parameter',
+      validation: { source: 'payload', keys: ['email'] },
+    });
+    assert.deepEqual(err.output.payload.validation, {
+      source: 'payload',
+      keys: ['email'],
+    });
+  });
+
+  it('merges context into payload (e.g. from batch.js)', function () {
+    const err = AppError.from(
+      { statusCode: 502, error: 'Bad Gateway', message: 'upstream' },
+      { batchUrl: '/v1/_core_profile', batchStatusCode: 502 }
+    );
+    assert.equal(err.output.payload.batchUrl, '/v1/_core_profile');
+    assert.equal(err.output.payload.batchStatusCode, 502);
+    assert.equal(err.output.payload.message, 'upstream');
+  });
+
+  it('preserves cause when present', function () {
+    const cause = new Error('root cause');
+    const err = AppError.from({ message: 'wrapper', cause: cause });
+    assert.equal(err.cause, cause);
+  });
+});


### PR DESCRIPTION
## Because

- Sentry [FXA-PROFILE-1F](https://mozilla.sentry.io/issues/FXA-PROFILE-1F) (`Error: Unspecified error`, errno 999, on `GET /v1/profile`) spiked ~72× starting 2026-04-21 . 
- A representative Sentry event has the resulting AppError as **all defaults** (`code: 500, errno: 999, error: "Internal Server Error", message: "Unspecified error"`) There were no breadcrumbs to identify which sub-request failed.
- We'd like to improve the meta data for the error we capture in sentry so we can see the underlying issue.

## This pull request

- **`lib/error.js`** — hardens `AppError.from` to handle AppError-shape, Boom-shape (`statusCode`), Boom errors with `output.payload`, plain `Error` instances, and `null`/`undefined`. Maps `statusCode → code`, preserves `errno`/`message`/`info`/`validation`, and attaches the raw input as `output.payload.upstream` whenever a typed errno or message can't be extracted.
- **`lib/batch.js`** — threads `batchUrl` and `batchStatusCode` into `AppError.from` as context, so future Sentry events show *which* sub-request failed (we had no breadcrumb for this debug pass).
- **`lib/routes/_core_profile.js`** — preserves `body.errno` / `body.message` / `body.code` from auth-server's response on the unhandled-4xx path, instead of forcing a generic errno 999. Ensures any future auth-server-side 4xx surfaces with a real errno.
- **`test/error.js`** (new) — 10 unit tests covering each `AppError.from` input shape.
- **`test/api.js`** — integration test updated to match the new 4xx-propagation contract from `_core_profile.js` (the previous assertion expected the old masking behaviour).

## Issue that this pull request solves

Closes: [FXA-13625](https://mozilla-hub.atlassian.net/browse/FXA-13625)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

- **Companion PR:** **#20563** — the byte-range fix proper (`web.js` disables Range server-wide on the JSON API, plus defense-in-depth Range strip on the batch fan-out).
- **Post-deploy expectation:** with #20563 also shipped, `batch./v1/_core_profile:206` log volume should drop to zero. Any residual errno-999 events should now carry `output.payload.batchUrl` + the upstream payload, ready for follow-up triage.

[FXA-13625]: https://mozilla-hub.atlassian.net/browse/FXA-13625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ