### PR TITLE
chore(functional-tests): default test accounts to v2 key stretching

### DIFF
--- a/packages/functional-tests/lib/targets/base.ts
+++ b/packages/functional-tests/lib/targets/base.ts
@@ -52,14 +52,19 @@ export abstract class BaseTarget {
     readonly authServerUrl: string,
     emailUrl?: string
   ) {
+    // Default to v2 key stretching — that's the state new accounts are
+    // created in nowadays. Creating accounts as v1 here means the first
+    // sign-in triggers a v1→v2 upgrade (password/change/start + finish)
+    // that bumps account.verifierSetAt; subsequent OAuth /authorization
+    // calls reusing the cached session then 401 on assertion validation.
     const keyStretchVersion = parseInt(
-      process.env.AUTH_CLIENT_KEY_STRETCH_VERSION || '1'
+      process.env.AUTH_CLIENT_KEY_STRETCH_VERSION || '2'
     );
     this.authClient = this.createAuthClient(keyStretchVersion);
     this.emailClient = new EmailClient(emailUrl);
   }
 
-  createAuthClient(keyStretchVersion = 1): AuthClient {
+  createAuthClient(keyStretchVersion = 2): AuthClient {
     if (![1, 2].includes(keyStretchVersion)) {
       throw new Error(
         `Invalid keyStretchVersion =${keyStretchVersion}. The` +

--- a/packages/functional-tests/tests/misc/authClientV2.spec.ts
+++ b/packages/functional-tests/tests/misc/authClientV2.spec.ts
@@ -51,7 +51,8 @@ test.describe('auth-client-tests', () => {
     target,
     testAccountTracker,
   }) => {
-    const client = target.authClient;
+    // target.authClient defaults to v2 now; force v1 for this test.
+    const client = target.createAuthClient(1);
     const { email, password } = testAccountTracker.generateAccountDetails();
 
     await signUp(client, email, password, target);
@@ -127,7 +128,8 @@ test.describe('auth-client-tests', () => {
     target,
     testAccountTracker,
   }) => {
-    const client = target.authClient;
+    // target.authClient defaults to v2 now; force v1 for this test.
+    const client = target.createAuthClient(1);
     const { email, password } = testAccountTracker.generateAccountDetails();
 
     await signUp(client, email, password, target);


### PR DESCRIPTION
## Summary

- Default \`BaseTarget\`'s auth-client to \`keyStretchVersion=2\` (still overridable via \`AUTH_CLIENT_KEY_STRETCH_VERSION\`). Real new accounts have been created with v2 key stretching for a while; matching that in tests removes an unnecessary v1→v2 upgrade flow on every sign-in and makes the test setup line up with production.
- Switch the two v1-specific tests in \`authClientV2.spec.ts\` (\`it creates with v1 and signs in\`, \`it creates with v1 and upgrades to v2 on signin\`) to use \`target.createAuthClient(1)\` explicitly, so they keep exercising the v1 path even though the shared client is now v2. The peer v2 test in the same file already uses \`target.createAuthClient(2)\`, so this matches the existing pattern.

Pre-work that's independent of, but related to, https://github.com/mozilla/fxa/pull/20543 (the actual VPN-integration race fix).

## Test plan
- [ ] CI: \`auth-client-tests\` should still pass (both v1 and v2 cases)
- [ ] CI: existing functional tests that use \`testAccountTracker.signUp\` continue passing — the auth-server accepts both v1 and v2 password hashes on \`/account/create\`, so any test that signs in with either still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)