### PR TITLE
fix(profile): disable byte-range support on the JSON API server

### DIFF
--- a/packages/fxa-profile-server/lib/batch.js
+++ b/packages/fxa-profile-server/lib/batch.js
@@ -40,6 +40,13 @@ function batch(request, routeFieldsMap) {
   let numForbidden = 0;
   const routeFieldsKeys = Object.keys(routeFieldsMap);
 
+  // Drop range/conditional headers before fanning out — internal JSON routes
+  // shouldn't honour client byte-range requests, and forwarding `range` triggers
+  // Hapi's 206 partial-content path with an empty body (FXA-13625).
+  const injectHeaders = Object.assign({}, request.headers);
+  delete injectHeaders.range;
+  delete injectHeaders['if-range'];
+
   return P.all(
     routeFieldsKeys.map((url) => {
       return request.server
@@ -47,7 +54,7 @@ function batch(request, routeFieldsMap) {
           allowInternals: true,
           method: 'get',
           url: url,
-          headers: request.headers,
+          headers: injectHeaders,
           auth: {
             credentials: request.auth.credentials,
             // As of Hapi 18: "To use the new format simply wrap the credentials and optional

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -64,6 +64,12 @@ exports.create = async function createServer() {
         // which is more forgiving of missing Origin header.
         origin: ['*'],
       },
+      // Byte-range slicing is meaningless for a JSON API and triggers Hapi's
+      // 206 partial-content path on otherwise-fine responses (FXA-13625).
+      // Static image serving lives on a separate server (server/_static.js).
+      response: {
+        ranges: false,
+      },
       security: {
         hsts: {
           maxAge: 31536000,


### PR DESCRIPTION
## Because

Split out of #20555 (FXA-13625) so the byte-range fix can be reviewed and rolled back independently of the diagnostic / error-shape improvements.

BigQuery investigation of [FXA-PROFILE-1F](https://mozilla.sentry.io/issues/FXA-PROFILE-1F) revealed that the dominant failure mode is `batch./v1/_core_profile:206` (and identical counts on `/v1/avatar`, `/v1/uid`). HTTP 206 from an internal Hapi `inject()` only originates from `transmit.js:198`, the byte-range slicer, on a *successful* response.

Byte-range slicing is meaningless for a JSON API — clients asking for "bytes 0-1023 of my profile" get back unparseable partial JSON. The cleanest fix is to disable Range support on the JSON API server entirely. The static avatar / image server in `lib/server/_static.js` (port + 1) is unaffected, so binary image clients can still use Range there if they need to.

## This pull request

- **`lib/server/web.js`** — sets `routes.response.ranges = false` on the JSON API server. Any incoming `Range` header is ignored and clients get a normal 200 with the full response body.
- **`lib/batch.js`** — defense-in-depth: shallow-copies `request.headers` and deletes `range` / `if-range` before passing them into the internal `inject()`. So even if the server-wide setting is ever re-enabled, the fan-out remains safe.

## Issue that this pull request solves

Refs: [FXA-13625](https://mozilla-hub.atlassian.net/browse/FXA-13625)

## Checklist

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review

- **Files changed:** `lib/server/web.js` (+6/-0), `lib/batch.js` (+8/-1).
- **Suggested review order:**
  1. `lib/server/web.js` — the primary fix; one config flag on the JSON-only server.
  2. `lib/batch.js` — defense-in-depth header sanitization at the inject() call site.
- **Risky bits:**
  - Disabling Range on the JSON server changes the response code from 206 → 200 for any client that was sending Range headers. Clients that explicitly handle 206 will simply stop seeing it; no client should break.
  - Static image serving (`_static.js`, port + 1) is unaffected and retains Range support for legitimate image fetchers.

## Other information

Companion PR: **#20555** — covers wrapper hardening (`AppError.from` defensive parsing, auth-server errno preservation, Sentry context-passing) and the integration-test update. The two PRs are independently revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FXA-13625]: https://mozilla-hub.atlassian.net/browse/FXA-13625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ