### PR TITLE
feat(auth-client): add passkey authentication methods

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -245,6 +245,24 @@ export interface PublicKeyCredentialCreationOptionsJSON {
   extensions?: AuthenticationExtensionsJSON;
 }
 
+export interface PublicKeyCredentialRequestOptionsJSON {
+  challenge: Base64URLString;
+  timeout?: number;
+  rpId?: string;
+  allowCredentials?: PublicKeyCredentialDescriptorJSON[];
+  userVerification?: UserVerificationRequirement;
+  hints?: ('hybrid' | 'security-key' | 'client-device')[];
+  extensions?: AuthenticationExtensionsJSON;
+}
+
+export type PasskeyAuthenticationResult = {
+  uid: hexstring;
+  sessionToken: hexstring;
+  verified: boolean;
+  requiresPasswordForSync: boolean;
+  hasPassword: boolean;
+};
+
 export interface PublicKeyCredentialJSON {
   id: Base64URLString;
   rawId: Base64URLString;
@@ -3539,6 +3557,85 @@ export default class AuthClient {
       { name },
       headers
     );
+  }
+
+  /**
+   * Starts a passkey authentication (assertion) flow.
+   *
+   * No email is sent — the server returns options with an empty
+   * `allowCredentials` so the browser uses discoverable credentials, which
+   * prevents account enumeration.
+   *
+   * @param headers Optional additional headers
+   */
+  async beginPasskeyAuthentication(
+    headers?: Headers
+  ): Promise<PublicKeyCredentialRequestOptionsJSON> {
+    return this.request('POST', '/passkey/authentication/start', {}, headers);
+  }
+
+  /**
+   * Completes a passkey authentication flow by submitting the browser's
+   * assertion response together with the original challenge.
+   *
+   * @param response `PublicKeyCredentialJSON` returned by the browser
+   * @param challenge The challenge string returned by `beginPasskeyAuthentication`
+   * @param options.service Optional service identifier (e.g. `sync`). Drives
+   *   `requiresPasswordForSync` in the response.
+   * @param headers Optional additional headers
+   */
+  async completePasskeyAuthentication(
+    response: PublicKeyCredentialJSON,
+    challenge: string,
+    options: { service?: string } = {},
+    headers?: Headers
+  ): Promise<PasskeyAuthenticationResult> {
+    const payload: {
+      response: PublicKeyCredentialJSON;
+      challenge: string;
+      service?: string;
+    } = {
+      response,
+      challenge,
+      ...(options.service ? { service: options.service } : {}),
+    };
+
+    return this.request(
+      'POST',
+      '/passkey/authentication/finish',
+      payload,
+      headers
+    );
+  }
+
+  /**
+   * Verifies the user's password after a passkey authentication, in order to
+   * unlock Sync keys. Reauthenticates the passkey-verified session with
+   * `keys: true` to obtain a `keyFetchToken` and `unwrapBKey`; the caller can
+   * then fetch wrapped keys via `accountKeys`.
+   *
+   * @param sessionToken The passkey-verified session token
+   * @param email The account's primary email (needed to derive credentials)
+   * @param password The user's password
+   * @param headers Optional additional headers
+   */
+  async verifyPasswordAfterPasskey(
+    sessionToken: hexstring,
+    email: string,
+    password: string,
+    headers?: Headers
+  ): Promise<{ keyFetchToken: hexstring; unwrapBKey: hexstring }> {
+    const { keyFetchToken, unwrapBKey } = await this.sessionReauth(
+      sessionToken,
+      email,
+      password,
+      { keys: true },
+      headers
+    );
+    return {
+      keyFetchToken: keyFetchToken as hexstring,
+      unwrapBKey: unwrapBKey as hexstring,
+    };
   }
 
   protected async getPayloadV2({


### PR DESCRIPTION
Because:

* We need these endpoints to drive the passkey sign-in flow in settings

This commit:

* Adds beginPasskeyAuthentication for POST /passkey/authentication/start
* Adds completePasskeyAuthentication for POST /passkey/authentication/finish
* Adds verifyPasswordAfterPasskey for the password-fallback sync key flow

Closes FXA-13098

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

> [!NOTE] 
> This makes an assumption of how FXA-13096 implementation will go (option A). So, this can be reviewed likely, but may change and is blocked from merging until that issue is done.

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
