### PR TITLE
fix(auth-server): correct Apple IAP credentials refs in initSubplat

### DIFF
--- a/packages/fxa-auth-server/lib/payments/initSubplat.ts
+++ b/packages/fxa-auth-server/lib/payments/initSubplat.ts
@@ -66,7 +66,14 @@ export async function initSubplat({
     collectionName: `${config.authFirestore.prefix}iap-play-purchases`,
   };
   const appleClientConfig: AppleIapClientConfig = {
-    credentials: [config.subscriptions.appStore.credentials as any],
+    credentials: Object.entries(config.subscriptions.appStore.credentials).map(
+      ([bundleKey, v]: [string, any]) => ({
+        bundleId: bundleKey.replace(/_/g, '.'),
+        key: v.serverApiKey,
+        keyId: v.serverApiKeyId,
+        issuerId: v.issuerId,
+      })
+    ),
     environment: config.subscriptions.appStore.sandbox
       ? Environment.Sandbox
       : Environment.Production,


### PR DESCRIPTION
Because:

* initSubplat was inserting the wrong struct into the credentials array (e.g. { "org_mozilla_ios_FirefoxVPN": { "issuerId": "foo", "serverApiKey": "bar", "serverApiKeyId": "baz" } })
* This caused subsequent calls that expected this array to be of the form `bundleKey: { bundleId, key, keyId, issuerId }` to break. Notably, calls to {credential}.bundleId were retuning undefined.

This commit:

* Updates the map of the credentials object to the correct syntax and structure within the initSubplat method

Closes #N/A

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
