### PR TITLE
chore(claude): add fxa-pr-open skill

### DIFF
--- a/.claude/skills/fxa-jira-bug-description/SKILL.md
+++ b/.claude/skills/fxa-jira-bug-description/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: fxa-jira-bug-description
-description: Drafts a Jira bug report for an FXA issue. Gathers repro steps, expected vs actual behaviour, and affected surface, then outputs a structured report ready to file or hand to Claude for investigation.
+description: Drafts a Jira bug report for an FXA issue. Gathers repro steps, expected vs actual behaviour, and affected surface, outputs a structured report, and optionally files the ticket via the Atlassian MCP. Returns the new FXA-N key when filed.
 user-invocable: true
 ---
 
 # FXA Jira Bug Report
 
-Draft a Jira bug report for an FXA issue. Output the description only — do not create, edit, or suggest changes to any source files.
+Draft a Jira bug report for an FXA issue, and optionally file the ticket via the Atlassian MCP. Do not create, edit, or suggest changes to any source files.
 
 ## Step 1: Gather Context
 
@@ -76,9 +76,29 @@ Specific files relevant to investigation or fix. One line each.
 
 **Open Questions:** *(omit if none)*
 
+## Step 4: Optionally file the ticket via Atlassian MCP
+
+After producing the draft (Step 3), check whether the Atlassian MCP is available in the current session (look for `mcp__atlassian__createJiraIssue` in the available tools). If not available, stop — the user files the ticket manually using the drafted description.
+
+If available, ask the user via `AskUserQuestion` whether to file now:
+
+- "File now via Atlassian MCP (Recommended)"
+- "Skip — I'll file manually"
+
+If the user picks "Skip", stop and output the draft. If "File now", call `mcp__atlassian__createJiraIssue` with:
+
+- `cloudId`: `mozilla-hub.atlassian.net` (the Atlassian MCP accepts the site hostname directly; fall back to `getAccessibleAtlassianResources` if the call ever rejects this form).
+- `projectKey`: `FXA`
+- `issueTypeName`: `Bug`
+- `summary`: the `[area] <concise bug description>` line from Step 3
+- `description`: the rest of the drafted body from Step 3 (Background, Steps to Reproduce, Expected/Actual, Severity, etc.)
+- `contentFormat`: `markdown`
+
+Surface the returned `FXA-N` key and the issue URL. That key is this skill's return value when invoked inline by another skill (e.g. `/fxa-pr-open` uses it to populate the `Closes:` line).
+
 ## Guidelines
 
-- Output the description only — no source file changes
+- Do not create, edit, or suggest changes to any source files. Filing a Jira ticket via the MCP (Step 4) is not a source file change.
 - Steps to Reproduce must be precise enough for another engineer to reproduce independently
 - Do not speculate on root cause unless there is clear evidence — use Open Questions instead
 - Severity should reflect user impact, not code complexity

--- a/.claude/skills/fxa-jira-feature-description/SKILL.md
+++ b/.claude/skills/fxa-jira-feature-description/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: fxa-jira-feature-description
-description: Drafts a concise Jira description for an FXA task. Gathers context via targeted interview, researches relevant patterns in the repo, then outputs a clean description ready for an engineer to hand to Claude for implementation.
+description: Drafts a concise Jira description for an FXA task. Gathers context via targeted interview, researches relevant patterns in the repo, outputs a clean description, and optionally files the ticket via the Atlassian MCP. Returns the new FXA-N key when filed.
 user-invocable: true
 ---
 
 # FXA Jira Description
 
-Draft a Jira description for an FXA task. Output the description only — do not create, edit, or suggest changes to any source files.
+Draft a Jira description for an FXA task, and optionally file the ticket via the Atlassian MCP. Do not create, edit, or suggest changes to any source files.
 
 ## Step 1: Gather Context
 
@@ -57,9 +57,29 @@ Specific files the implementer should read before starting. One line each.
 
 **Open Questions:** *(omit if none)*
 
+## Step 4: Optionally file the ticket via Atlassian MCP
+
+After producing the draft (Step 3), check whether the Atlassian MCP is available in the current session (look for `mcp__atlassian__createJiraIssue` in the available tools). If not available, stop — the user files the ticket manually using the drafted description.
+
+If available, ask the user via `AskUserQuestion` whether to file now:
+
+- "File now via Atlassian MCP (Recommended)"
+- "Skip — I'll file manually"
+
+If the user picks "Skip", stop and output the draft. If "File now", call `mcp__atlassian__createJiraIssue` with:
+
+- `cloudId`: `mozilla-hub.atlassian.net` (the Atlassian MCP accepts the site hostname directly; fall back to `getAccessibleAtlassianResources` if the call ever rejects this form).
+- `projectKey`: `FXA`
+- `issueTypeName`: `Task`
+- `summary`: the one-line "what" sentence from Step 1 / the leading description sentence
+- `description`: the full drafted body from Step 3 (Background, AC, Implementation Steps, etc.)
+- `contentFormat`: `markdown`
+
+Surface the returned `FXA-N` key and the issue URL. That key is this skill's return value when invoked inline by another skill (e.g. `/fxa-pr-open` uses it to populate the `Closes:` line).
+
 ## Guidelines
 
-- Output the description only — no source file changes
+- Do not create, edit, or suggest changes to any source files. Filing a Jira ticket via the MCP (Step 4) is not a source file change.
 - Implementation Steps should give enough detail to start work without follow-up questions — file paths and patterns, not prose
 - Do not include design details (copy, colours, layout, component specifics) — note that the implementer should refer to the latest Figma file
 - Omit redundant or obvious acceptance criteria

--- a/.claude/skills/fxa-pr-open/SKILL.md
+++ b/.claude/skills/fxa-pr-open/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: fxa-pr-open
+description: Drafts an FXA pull request title and body following the repo PR template and team conventions, then opens the PR as a draft after explicit confirmation. Use when a feature branch is ready and the user wants to open a PR. Do not invoke for edits to an existing PR.
+argument-hint: Optional Jira key (e.g. FXA-13099)
+---
+
+# Open an FXA PR
+
+Order of operations: gather state → ask the user up front → align ticket/commits → draft title and body → confirm and open as draft. The intake step exists so the user can fix scope, amend commits, run a pre-merge review, or capture screenshots *before* a draft is produced — drafting late means the draft reflects validated, approved scope.
+
+## Hard rules
+
+- **PRs always open as draft.** `gh pr create --draft`. Marking ready is a separate action (`gh pr ready`) that needs its own approval — never bundle it with create.
+- **Confirm before every state-changing command.** `git push`, `gh pr create`, and any later `gh pr edit/comment/ready/merge/review` each need their own approval — prior approval does not roll forward.
+- **No co-author trailer.** Do not add `Co-Authored-By: Claude ...` anywhere. Team policy.
+- **PR description uses `Closes: FXA-N` (colon, no hash).** This differs from commit footers, which use `Closes #FXA-N` (hash, no colon).
+- **Preserve template section order, headings, and placeholder text verbatim.**
+- **Never pre-check the Checklist boxes.** Leave every `- [ ]` unchecked in the draft. Those are manual attestations (GPG signing, tests run locally, docs, RTL verification, AI code review) that only the user can truthfully make. Do not tick them on the user's behalf even if you believe the condition holds.
+- **Never force-push** to a shared branch. If the branch was already pushed, default to a normal push.
+- **Do not touch existing PRs.** This skill is for opening a new PR only. If `gh pr view` shows a PR already exists for the branch, stop and ask the user how to proceed.
+- **Don't invoke review skills from within this one** (`/fxa-review-quick`, `/fxa-review`, `/fxa-security-review`) — they can produce findings requiring new commits, invalidating the discovery this skill just did (commits, diff scope, alignment). The user runs them separately and re-enters this skill after. **Exceptions:** `/fxa-pr-screenshots` and the Jira authoring skills (`/fxa-jira-feature-description`, `/fxa-jira-bug-description`) produce external artifacts (image attachments, Jira tickets) with no code changes, so they may be invoked inline when the user selects them in Step 2 (Jira) or Step 3c (screenshots).
+
+## Step 1 — Pre-flight
+
+Run these in parallel:
+- `git fetch origin main --quiet` — refresh the base ref so the diff is against current `main` (tolerate failure if offline)
+- `git rev-parse --abbrev-ref HEAD` — current branch name
+- `git log --format=%B main..HEAD` — full commit messages on this branch
+- `git diff main...HEAD --name-only` — changed files
+- `git diff main...HEAD --stat` — files/lines summary
+- `git status -sb` — confirm clean tree and check ahead/behind vs upstream
+- `gh pr view --json url,state 2>/dev/null` — confirm no PR exists yet
+
+If `gh pr view` returns a PR, stop (see hard rules) and ask whether the user wants to edit that PR (different workflow — confirm each `gh pr edit` separately) or target a different base.
+
+If the branch is `main`, the working tree is dirty, or the branch has no commits ahead of `main` (empty `git log` output), stop and flag it.
+
+## Step 2 — Gather Jira context
+
+Extract the Jira key from the branch name when it matches `FXA-\d+`. If `$ARGUMENTS` contains an explicit key, prefer that. If the user is logged into the Atlassian MCP, fetch the ticket summary, description, and acceptance criteria — they are needed for the alignment check in Step 3 and the "Because" bullets in Step 4. If the Atlassian MCP is not available, ask the user to share the ticket summary and AC so 3b can still run a real alignment pass; if they decline, proceed and flag in 3b that alignment was partial.
+
+### No ticket for this work?
+
+If no Jira key can be derived from the branch, arguments, or the user, call `AskUserQuestion` with these options:
+
+- **"Create a feature/task ticket now via `/fxa-jira-feature-description`" (Recommended for product/code changes)** — invoke the skill inline (see hard rules carve-out). When it returns, parse the new `FXA-N` key from its output and use it for the `Closes:` line.
+- **"Create a bug ticket now via `/fxa-jira-bug-description`"** — same flow for bug fixes.
+- **"Provide an existing ticket key"** — user types `FXA-N`; continue with that.
+- **"Waive — chore-only, no ticket needed"** — set the `Closes:` line to `N/A` and capture the user's reason for `## Other information (Optional)` in Step 4.
+
+The authoring skills file via Atlassian MCP when it's available and return the new key. If the MCP isn't available, they output the draft only and stop — in that case, exit this skill so the user can file the ticket manually, then re-enter with the key.
+
+## Step 3 — Intake & alignment (before drafting)
+
+This step is the structured conversation with the user before any drafting happens. It exists to catch scope, framing, and process issues while they are still cheap to fix.
+
+The intake is split into a short briefing (3a + 3b) followed by a structured interview (3c). **Do not collapse the interview into one open-ended prose prompt** — use `AskUserQuestion` so each decision is answered discretely.
+
+### 3a. Summarize what you see
+
+Output a short paragraph: branch name, commit count, packages touched, against ticket `FXA-N: <ticket summary>`.
+
+### 3b. Run an alignment pass
+
+Compare three sources of truth:
+
+1. **Jira ticket** — summary, description, acceptance criteria (from Step 2).
+2. **Commits** — full commit messages including `Because:` / `This commit:` bodies (from Step 1).
+3. **Diff scope** — changed files grouped by package (from Step 1).
+
+Check for:
+- **Scope match.** Do the commits and diff cover what the ticket asks for? Is anything in the diff outside the ticket's scope?
+- **Motivation match.** Does the ticket's framing (bug vs feature, user impact) match what the commits do?
+- **Acceptance criteria coverage.** For each AC on the ticket, is at least one commit clearly addressing it? Call out any uncovered AC.
+- **Commit-type consistency.** Do `type(scope):` prefixes agree across commits and roughly match the likely PR title?
+- **Out-of-scope creep.** Any commits touching unrelated files (formatting churn, drive-by refactors)?
+
+Surface each concern as a bullet with a concrete recommended action — e.g. "Ticket AC #3 mentions L10n strings but no `.ftl` files changed — confirm out of scope?" or "Two commits are `chore(deps):` unrelated bumps — split into a separate PR?".
+
+### 3c. Present the briefing, then interview with `AskUserQuestion`
+
+First, send a brief message (just the 3a summary + 3b alignment bullets) so the user has the context. Keep it tight — no checkbox lists, no trailing open question.
+
+Then call `AskUserQuestion` with 2–4 structured questions. The questions verify *prerequisites the user has met* (mirroring the PR template's Checklist), not actions the skill will run. Skip any question whose answer is already determined by the diff. The first option of each question should be the recommendation, marked `(Recommended)` in the label.
+
+Suggested question set:
+
+1. **Pre-merge review attestation** — has one been run already?
+   - "Yes — completed `/<recommended>` (Recommended)" — name the right skill in the label based on the diff:
+     - `/fxa-security-review` when OAuth, session, password, OTP/TOTP, recovery, or `/account/*` routes are touched
+     - `/fxa-review` when auth, payments, crypto, sessions, migrations, or multi-package changes are involved
+     - `/fxa-review-quick` otherwise
+   - "Not yet — pause; exit so I can run it" — exit the skill; the user re-enters after.
+   - "N/A — trivial change, no review needed" — capture the user's reason via the question's notes field and append it to `## Other information (Optional)` in Step 4.
+
+2. **Screenshots attestation** — only ask when the diff touches `packages/fxa-settings/**/*.tsx`, `packages/fxa-react/**/*.tsx`, or any `.ftl` with user-visible copy.
+   - "Yes — already captured (Recommended)"
+   - "Capture now via `/fxa-pr-screenshots`" — invoke inline (see hard rules carve-out). Use the returned image references in `## Screenshots` of Step 4.
+   - "N/A — no user-visible change"
+
+3. **Framing for the body** — `multiSelect: true`. Pull concrete option labels from the discovery (related PR links surfaced in commits, feature-flag rollout notes when the diff touches config, follow-up tickets mentioned in commit bodies, deploy-ordering caveats for migrations). Don't use generic placeholders — every option should be a real candidate for *this* branch. Always include "Nothing extra" as one option. The user's selections feed into `## Other information` or `## Because` framing in Step 4.
+
+**If the user picks "Not yet — pause" on any attestation, stop here.** They will exit, complete the prerequisite, and re-enter the skill. Do not draft a body that will be invalidated.
+
+Otherwise, move on to Step 4 with the attestation answers and framing selections in hand.
+
+## Step 4 — Draft the title and body
+
+Read `.github/PULL_REQUEST_TEMPLATE.md` — that is the canonical body skeleton. Preserve its section order, headings, and placeholder text verbatim, and fill it in per the drafting guidance below. Substitute `FXA-NNNNN` on the `Closes:` line with the actual ticket key.
+
+Title guidance:
+- Follow the commit-message convention: `type(scope): subject`, imperative present tense, ≤72 chars.
+- If the branch has a single commit, reuse its subject as the PR title.
+- Otherwise, summarize the cumulative change — do not just use the latest commit subject.
+
+Body drafting guidance:
+- **"Because"** bullets describe motivation/user impact in complete sentences — derive from the Jira ticket and the intake answers, not from the file list. Reference the user need, bug, or requirement, not the code change.
+- **"This pull request"** bullets describe what the code now does in complete sentences — be specific (e.g. "Adds `signinFlow.ts` to handle passkey discovery before falling back to password sign-in"), not vague ("Refactors the sign-in page"). Refer to files with backticks (e.g. `` `packages/fxa-settings/src/pages/Index/index.tsx` ``).
+- **"How to review"** — fill in only when the diff is non-trivial (>~5 files or any risky path). Otherwise leave the three sub-bullets empty.
+- **"Screenshots"** — if the user captured some in Step 3, reference them here (markdown image syntax once attached) or leave the placeholder line for the user to drop attachments into. Leave untouched if no UI changed.
+- **"Other information"** — feature-flag rollout notes, follow-up tickets, deploy ordering caveats, related PRs from intake. Leave placeholder if none.
+
+## Step 5 — Confirm and open as draft
+
+Present **both the proposed title and the full draft body** to the user. Ask:
+1. Any edits to the title or body before opening?
+2. Ready to open the PR? (From Step 1's `git status -sb`: if the branch isn't pushed or is ahead of upstream, the push will run first.)
+
+Only after the user explicitly approves:
+1. Push the branch if not yet pushed, or if local is ahead of upstream (use upstream tracking on first push).
+2. Open the PR as a draft against `main` with the approved title and body.
+3. Print the PR URL.
+
+After the PR is opened as draft, **stop**. Do not amend the body, add comments, mark ready, or push more commits without a new explicit ask. Each subsequent `gh pr edit/comment/ready/merge/review` is a separate action that needs its own approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,4 @@ Suggest these proactively when the task matches — do not wait to be asked.
 | `/fxa-explain-code`             | Understanding what changed and why                                                          |
 | `/fxa-simplify`                 | Cleaning up recently written code                                                           |
 | `/fxa-check-githistory`         | Checking for regressions or conflicts with past fixes                                       |
+| `/fxa-pr-open`                  | Opening a new pull request from a feature branch                                            |


### PR DESCRIPTION
## Because

- Opening FXA PRs manually leads to inconsistent bodies and forgotten conventions (template section order, `Closes:` vs `Closes #`, no co-author trailer, draft-by-default).
- A structured intake catches scope, alignment, and prerequisite gaps before the draft is produced, when they're cheap to fix.

## This pull request

- Adds `.claude/skills/fxa-pr-open/SKILL.md` — a Claude Code skill that runs pre-flight git checks, gathers Jira context (with a structured "No ticket?" prompt offering inline ticket creation), surfaces alignment concerns between commits and the ticket, interviews the user via `AskUserQuestion` for pre-merge-review/screenshots/framing attestations, drafts the title and body against `.github/PULL_REQUEST_TEMPLATE.md`, and opens the PR as a draft after explicit confirmation.
- Extends `/fxa-jira-feature-description` and `/fxa-jira-bug-description` to optionally file the ticket via the Atlassian MCP (`createJiraIssue`) when available; otherwise unchanged (draft-only).
- Registers `/fxa-pr-open` in CLAUDE.md's Available Skills table.

## Issue that this pull request solves

Closes: FXA-13717

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Risky or complex part: the inline-invocation carve-out in SKILL.md's hard rules — verify the scope (`/fxa-pr-screenshots` + Jira authoring) is what we want.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Paired with `/fxa-pr-screenshots` (separate PR on this ticket). Both skills land under `.claude/skills/` and are shared with the team.
