### PR TITLE
fix(payments-next): CurrencyForCustomerNotFoundError: Could not determine currency code for customer

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
@@ -30,7 +30,10 @@ export default async function StripePaymentManagementPage({
   try {
     stripeClientSession = await getStripeClientSession();
   } catch (error) {
-    if (error.name === 'AccountCustomerNotFoundError') {
+    if (
+      error.name === 'AccountCustomerNotFoundError' ||
+      error.name === 'CurrencyForCustomerNotFoundError'
+    ) {
       // TODO: replace with redirect to collect tax location data and create customer / accountCustomer
       redirect(
         `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -1048,7 +1048,9 @@ export class SubscriptionManagementService {
     return currency;
   }
 
-  @SanitizeExceptions({ allowlist: [AccountCustomerNotFoundError] })
+  @SanitizeExceptions({
+    allowlist: [AccountCustomerNotFoundError, CurrencyForCustomerNotFoundError],
+  })
   async getStripePaymentManagementDetails(uid: string) {
     const accountCustomer =
       await this.accountCustomerManager.getAccountCustomerByUid(uid);

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -26,6 +26,7 @@ import {
   ManagePaymentMethodIntentTryAgainError,
   ManagePaymentMethodIntentInsufficientFundsError,
   ManagePaymentMethodTaxAddressRequiredError,
+  CurrencyForCustomerNotFoundError,
 } from '@fxa/payments/management';
 import {
   CheckoutTokenManager,
@@ -1126,7 +1127,9 @@ export class NextJSActionsService {
     );
   }
 
-  @SanitizeExceptions({ allowlist: [AccountCustomerNotFoundError] })
+  @SanitizeExceptions({
+    allowlist: [AccountCustomerNotFoundError, CurrencyForCustomerNotFoundError],
+  })
   @NextIOValidator(
     GetStripePaymentManagementDetailsArgs,
     GetStripePaymentManagementDetailsResult


### PR DESCRIPTION
## Because

* If a customer has an iap subscription, but also has a Stripe customer id without a Stripe subscription (no currency saved), then if they navigate to the /payments/stripe page, an error is thrown and the customer sees "Something went wrong."

## This pull request

* In the payments/stripe page, extends the error name check to both AccountCustomerNotFoundError and CurrencyForCustomerNotFoundError, following the pattern in payments/paypal to redirect to subscriptions/landing page if no currency is present.
* Alternative solution considered: Move the check for currency to the payments/stripe page, following pattern of payments/paypal, and if no currency then redirect to SubManage page. Would require updates to getStripePaymentManagementDetails and no more error throwing.

## Issue that this pull request solves

Closes #[PAY-3380](https://mozilla-hub.atlassian.net/browse/PAY-3380)
Note: when trying to access the Sentry issue linked in the ticket, I see "The issue you were looking for was not found." I used another occurrence of the same error, [here](https://mozilla.sentry.io/issues/7436164354/?environment=prod&environment=production&environment=stage&query=CurrencyForCustomerNotFoundError&referrer=issue-stream)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

To replicate locally:
1. Make an FxA account, find its uid.
2. Make a firestore google play iap purchase (sample screenshot below):

<img width="2800" height="1796" alt="image" src="https://github.com/user-attachments/assets/edfd695b-c077-45de-a519-10a5bec092fb" />


3. Make a Stripe customer with the uid from step 1, but without any currency:
CLI command I used:
`stripe customers create --email='2@moz.com' --description='70aa3717af5d42d08709129389dccc35' -d 'metadata[userid]=70aa3717af5d42d08709129389dccc35'` (replace `70aa3717af5d42d08709129389dccc35` with uid).

4. Update db, replace with corresponding customer id and uid:
INSERT INTO fxa.accountCustomers (uid, stripeCustomerId, createdAt, updatedAt)
  VALUES (
    UNHEX('70aa3717af5d42d08709129389dccc35'),
    'cus_UV0PNqPXwDDAj9',
    UNIX_TIMESTAMP() * 1000,
    UNIX_TIMESTAMP() * 1000
  );

Video of bug, before fix:

https://github.com/user-attachments/assets/7a4ddd0b-5b19-436a-bd35-ebbc22a94a90

Video after fix (just redirect to SubMange):

https://github.com/user-attachments/assets/61d3599e-0563-4806-9158-78a1d0c33f8d


- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3380]: https://mozilla-hub.atlassian.net/browse/PAY-3380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ