### PR TITLE
fix(release): Add 034-033 db migration to support accountAuthorizations revert

### DIFF
--- a/packages/db-migrations/databases/fxa_oauth/patches/patch-034-033.sql
+++ b/packages/db-migrations/databases/fxa_oauth/patches/patch-034-033.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS `accountAuthorizations`;
+
+UPDATE dbMetadata SET value = '33' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
We reverted #20500 in #20565 and the release was borked. 😿 

the target-patch is already pointed at 033.