### PR TITLE
feat(auth): automate inactive account notification enqueue

### DIFF
--- a/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.spec.ts
+++ b/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.spec.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { maybeEnqueueFirstEmail } from './enqueue-inactive-account-deletions';
+
+const uid = '0123456789abcdef0123456789abcdef';
+
+const buildDeps = (overrides: any = {}) => {
+  const glean = {
+    inactiveAccountDeletion: {
+      firstEmailTaskRequest: jest.fn().mockResolvedValue(undefined),
+      firstEmailTaskEnqueued: jest.fn().mockResolvedValue(undefined),
+      firstEmailTaskRejected: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+
+  return {
+    accountEventsManager: {
+      findEmailEvents: jest.fn().mockResolvedValue([]),
+    },
+    emailCloudTasks: {
+      scheduleFirstEmail: jest.fn().mockResolvedValue('task-name'),
+    },
+    glean,
+    statsd: { increment: jest.fn() },
+    log: { error: jest.fn() },
+    debugLog: jest.fn(),
+    msTilFirstEmail: 0,
+    now: () => 1_700_000_000_000,
+    ...overrides,
+  };
+};
+
+describe('maybeEnqueueFirstEmail', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('skips accounts that already received an inactiveAccountFirstWarning email', async () => {
+    const deps = buildDeps({
+      accountEventsManager: {
+        findEmailEvents: jest
+          .fn()
+          .mockResolvedValue([{ name: 'emailSent' }]),
+      },
+    });
+
+    const enqueued = await maybeEnqueueFirstEmail(uid, deps as any);
+
+    expect(enqueued).toBe(false);
+    // the skip is the idempotency guard: no task should be scheduled
+    expect(deps.emailCloudTasks.scheduleFirstEmail).not.toHaveBeenCalled();
+    expect(
+      deps.glean.inactiveAccountDeletion.firstEmailTaskRequest
+    ).not.toHaveBeenCalled();
+    expect(deps.statsd.increment).toHaveBeenCalledWith(
+      'accounts.inactive.cron.skipped-already-notified'
+    );
+    // queried using the first-warning template within [0, now()]
+    expect(deps.accountEventsManager.findEmailEvents).toHaveBeenCalledWith(
+      uid,
+      'emailSent',
+      'inactiveAccountFirstWarning',
+      0,
+      1_700_000_000_000
+    );
+  });
+
+  it('fails safe (skips, no enqueue) when the dedup lookup rejects', async () => {
+    const deps = buildDeps({
+      accountEventsManager: {
+        findEmailEvents: jest.fn().mockRejectedValue(new Error('firestore down')),
+      },
+    });
+
+    const enqueued = await maybeEnqueueFirstEmail(uid, deps as any);
+
+    // must not throw (would be an unhandled rejection in the queued task) and
+    // must not enqueue when the duplicate check is inconclusive
+    expect(enqueued).toBe(false);
+    expect(deps.emailCloudTasks.scheduleFirstEmail).not.toHaveBeenCalled();
+    expect(deps.statsd.increment).toHaveBeenCalledWith(
+      'accounts.inactive.cron.dedupe-check.error'
+    );
+    expect(deps.log.error).toHaveBeenCalledWith(
+      'accounts.inactive.dedupeCheckError',
+      expect.objectContaining({ uid })
+    );
+  });
+
+  it('enqueues a first-email task when no prior first-warning event exists', async () => {
+    const deps = buildDeps({ msTilFirstEmail: 86_400_000 });
+
+    const enqueued = await maybeEnqueueFirstEmail(uid, deps as any);
+
+    expect(enqueued).toBe(true);
+    expect(deps.emailCloudTasks.scheduleFirstEmail).toHaveBeenCalledWith({
+      payload: { uid },
+      emailOptions: { deliveryTime: 1_700_000_000_000 + 86_400_000 },
+      taskOptions: { taskId: `${uid}-inactive-delete-first-email` },
+    });
+    expect(
+      deps.glean.inactiveAccountDeletion.firstEmailTaskEnqueued
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      deps.glean.inactiveAccountDeletion.firstEmailTaskRejected
+    ).not.toHaveBeenCalled();
+  });
+
+  it('returns false and records a rejection when scheduling throws', async () => {
+    const deps = buildDeps({
+      emailCloudTasks: {
+        scheduleFirstEmail: jest
+          .fn()
+          .mockRejectedValue(Object.assign(new Error('boom'), { code: 13 })),
+      },
+    });
+
+    const enqueued = await maybeEnqueueFirstEmail(uid, deps as any);
+
+    expect(enqueued).toBe(false);
+    expect(deps.statsd.increment).toHaveBeenCalledWith(
+      'cloud-tasks.inactive-account-email.enqueue.error-code',
+      { errorCode: 13 }
+    );
+    expect(
+      deps.glean.inactiveAccountDeletion.firstEmailTaskRejected
+    ).toHaveBeenCalledTimes(1);
+    expect(deps.log.error).toHaveBeenCalledWith(
+      'accounts.inactive.emailEnqueueError',
+      expect.objectContaining({ uid })
+    );
+  });
+});

--- a/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
+++ b/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
@@ -48,12 +48,14 @@ import {
 
 import { collect, parseBooleanArg } from '../lib/args';
 import { emitStatsdMetrics } from '../lib/metrics';
-import { AppConfig, AuthLogger } from '../../lib/types';
+import { AccountEventsManager } from '../../lib/account-events';
+import { AppConfig, AuthFirestore, AuthLogger } from '../../lib/types';
 import appConfig from '../../config';
+import { setupFirestore } from '../../lib/firestore-db';
 import { requestForGlean } from '../../lib/inactive-accounts';
 import initLog from '../../lib/log';
 import initRedis from '../../lib/redis';
-import { gleanMetrics } from '../../lib/metrics/glean';
+import { gleanMetrics, GleanMetricsType } from '../../lib/metrics/glean';
 import Token from '../../lib/tokens';
 import * as random from '../../lib/crypto/random';
 import { createDB } from '../../lib/db';
@@ -65,7 +67,6 @@ import {
   hasActiveRefreshToken,
   hasActiveSessionToken,
   IsActiveFnBuilder,
-  setDateToUTC,
   buildExclusionsTempTableQuery,
 } from './lib';
 
@@ -75,7 +76,7 @@ const statsd = new StatsD({ ...config.statsd });
 // {{{ constants and defaults
 
 const defaultDaysTilFirstEmail = 0;
-const defaultResultsLImit = 500000;
+const defaultBatchSize = 1000;
 const defaultConcurrency = 100;
 const twoYearsAgo = () => {
   const x = new Date();
@@ -87,6 +88,120 @@ const exclusionsTempTableName = 'exclusions';
 
 // /constants and defaults }}}
 
+type MaybeEnqueueFirstEmailDeps = {
+  accountEventsManager: Pick<AccountEventsManager, 'findEmailEvents'>;
+  emailCloudTasks: {
+    scheduleFirstEmail: (task: {
+      payload: InactiveAccountEmailTaskPayloadParam;
+      emailOptions?: { deliveryTime: number };
+      taskOptions?: CloudTaskOptions;
+    }) => Promise<unknown>;
+  };
+  glean: GleanMetricsType;
+  statsd: Pick<StatsD, 'increment'>;
+  log: Pick<AuthLogger, 'error'>;
+  debugLog: (message: string) => void;
+  msTilFirstEmail: number;
+  // injectable for testing
+  now?: () => number;
+};
+
+/**
+ * Enqueue the first inactive-account notification email for a single uid.
+ *
+ * Accounts that have already received an `inactiveAccountFirstWarning`
+ * `emailSent` event are skipped.  This skip is the primary idempotency guard
+ * that makes repeated scheduled runs of this script safe: no state is persisted
+ * between runs, so without it an account could be notified more than once.
+ *
+ * @returns `true` if a Cloud Task was enqueued, `false` if the account was
+ *   skipped (already notified) or enqueuing failed.
+ */
+export const maybeEnqueueFirstEmail = async (
+  uid: string,
+  {
+    accountEventsManager,
+    emailCloudTasks,
+    glean,
+    statsd,
+    log,
+    debugLog,
+    msTilFirstEmail,
+    now = Date.now,
+  }: MaybeEnqueueFirstEmailDeps
+): Promise<boolean> => {
+  let priorEvents;
+  try {
+    priorEvents = await accountEventsManager.findEmailEvents(
+      uid,
+      'emailSent',
+      'inactiveAccountFirstWarning',
+      0,
+      now()
+    );
+  } catch (dedupeCheckError) {
+    // Fail safe: if we can't confirm whether a first-warning email was already
+    // sent, skip this uid rather than risk notifying it twice.  It will be
+    // reconsidered on the next scheduled run.
+    statsd.increment('accounts.inactive.cron.dedupe-check.error');
+    log.error('accounts.inactive.dedupeCheckError', {
+      dedupeCheckError,
+      uid,
+    });
+    return false;
+  }
+  if (priorEvents && priorEvents.length > 0) {
+    statsd.increment('accounts.inactive.cron.skipped-already-notified');
+    debugLog(`Skipping ${uid}: first-warning email already sent.`);
+    return false;
+  }
+
+  // @TODO this function could be abstracted and moved to InactiveAccountsManager
+  const taskPayload: InactiveAccountEmailTaskPayloadParam = {
+    uid,
+  };
+  const taskId = `${uid}-inactive-delete-first-email`;
+  const taskOptions: CloudTaskOptions = {
+    taskId,
+  };
+
+  try {
+    await glean.inactiveAccountDeletion.firstEmailTaskRequest(requestForGlean, {
+      uid,
+    });
+
+    await emailCloudTasks.scheduleFirstEmail({
+      payload: taskPayload,
+      emailOptions: { deliveryTime: now() + msTilFirstEmail },
+      taskOptions: taskOptions,
+    });
+
+    await glean.inactiveAccountDeletion.firstEmailTaskEnqueued(
+      requestForGlean,
+      {
+        uid,
+      }
+    );
+    return true;
+  } catch (cloudTaskQueueError) {
+    // Note that the fxa cloud tasks lib already emitted some statsd metrics
+    statsd.increment('cloud-tasks.inactive-account-email.enqueue.error-code', {
+      errorCode: cloudTaskQueueError.code as unknown as string,
+    });
+    await glean.inactiveAccountDeletion.firstEmailTaskRejected(
+      requestForGlean,
+      {
+        uid,
+      }
+    );
+    log.error('accounts.inactive.emailEnqueueError', {
+      cloudTaskQueueError,
+      uid,
+    });
+    return false;
+  }
+};
+
 const exclusionList = collect();
 
 const init = async () => {
@@ -94,16 +209,13 @@ const init = async () => {
   program
     .description(
       'Starts the inactive account deletion process by enqueuing the first email\n' +
-        'notification for inactive accounts.  This script allows segmenting the\n' +
-        'accounts to search by account creation date. It also optionally accepts a\n' +
-        'date at or after when an account is active in order to be excluded.\n\n' +
-        'For example, to start the inactive deletion process on accounts created\n' +
-        'between 2015-01-01 and 2015-01-31 where the account is not active after\n' +
-        '2024-10-31:\n' +
-        '  enqueue-inactive-account-deletions.ts \\\n' +
-        '    --start-date 2015-01-01 \\\n' +
-        '    --end-date 2015-12-31 \\\n' +
-        '    --active-by-date 2024-10-31'
+        'notification for the oldest N inactive accounts that have not yet been\n' +
+        'notified.  Designed to be invoked on a schedule (e.g. a Kubernetes CronJob).\n\n' +
+        'Each run picks up to --batch-size candidates with createdAt < two-years-ago,\n' +
+        'ordered by createdAt ASC, then filters out any that have already received an\n' +
+        'inactiveAccountFirstWarning email.  No state is persisted between runs; the\n' +
+        'cursor advances implicitly as old accounts are deleted ~60 days after\n' +
+        'notification.'
     )
     .option(
       '--dry-run [true|false]',
@@ -130,35 +242,19 @@ const init = async () => {
       false
     )
     .option(
-      '--active-by-date [date]',
-      'An account is considered active if it has any activity at or after this date.  Optional.  Defaults to two years ago from script execution time.',
-      Date.parse
-    )
-    .option(
-      '--start-date [date]',
-      'Start of date range of account creation date, inclusive.  Optional.  Defaults to 2012-03-12.',
-      Date.parse,
-      '2012-03-12'
-    )
-    .option(
-      '--end-date [date]',
-      'End of date range of account creation date, inclusive.  Defaults to a day before active by date.',
-      Date.parse
-    )
-    .option(
       '--days-til-first-email [float]',
       'The amount of time from now until the first email is sent, in days.  Defaults to 0.  Max allowed (GCP limit) is 30.',
       parseFloat
     )
     .option(
-      '--results-limit [number]',
-      'The number of results per accounts DB query.  Defaults to 500000.',
+      '--batch-size [number]',
+      `The max number of candidate accounts to consider per run.  Defaults to ${defaultBatchSize}.`,
       (x) => parseInt(x),
-      defaultResultsLImit
+      defaultBatchSize
     )
     .option(
       '--output-path [path]',
-      'File path to write the list of UIDs from MySQL.  Optional.  Defaults to CWD and filename based on the end date.'
+      'File path to write the list of UIDs from MySQL.  Optional.  Defaults to CWD and filename based on the run timestamp.'
     )
     .option(
       '--bq-dataset <string>',
@@ -185,22 +281,19 @@ const init = async () => {
     throw new Error('BigQuery dataset ID is required.');
   }
 
-  const startDate = setDateToUTC(program.startDate);
-  const endDate = program.endDate
-    ? setDateToUTC(program.endDate)
-    : twoYearsAgo();
-  const activeByDate = program.activeByDate
-    ? setDateToUTC(program.activeByDate)
-    : twoYearsAgo();
-  const startDateTimestamp = startDate.valueOf();
-  const endDateTimestamp = endDate.valueOf() + 86400000; // next day for < comparisons
-  const activeByDateTimestamp = activeByDate.valueOf();
-
-  if (endDateTimestamp <= startDateTimestamp) {
-    throw new Error(
-      'The end date must be on the same day or later than the start date.'
-    );
+  const batchSize = program.batchSize;
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error('--batch-size must be a positive integer.');
   }
+
+  const endDate = twoYearsAgo();
+  const activeByDate = twoYearsAgo();
+  // No lower bound on createdAt — ORDER BY createdAt ASC + LIMIT batchSize
+  // naturally starts at the oldest still-existing candidate. As accounts age
+  // out via deletion, the cursor advances implicitly.
+  const startDateTimestamp = 0;
+  const endDateTimestamp = endDate.valueOf();
+  const activeByDateTimestamp = activeByDate.valueOf();
 
   const daysTilFirstEmail =
     program.daysTilFirstEmail !== undefined
@@ -214,24 +307,19 @@ const init = async () => {
   }
 
   const msTilFirstEmail = daysTilFirstEmail * 86400000;
+  const runTag = `${Date.now()}`;
   const mysqlResCsvPath =
     program.outputPath ||
-    path.join(
-      process.cwd(),
-      `mysql-inactive-account-uids-${endDate
-        .toISOString()
-        .substring(0, 10)}.csv`
-    );
+    path.join(process.cwd(), `mysql-inactive-account-uids-${runTag}.csv`);
 
   // /arguments }}}
 
   console.log(`Save inactive account UIDs: ${program.saveUids}`);
   console.log(`Enqueue emails: ${program.enqueueEmails}`);
-  console.log(`Start date: ${startDate.toISOString()}`);
-  console.log(`End date: ${endDate.toISOString()}`);
+  console.log(`Batch size: ${batchSize}`);
+  console.log(`End date (createdAt <): ${endDate.toISOString()}`);
   console.log(`Active by date: ${activeByDate.toISOString()}`);
   console.log(`Days 'til first email: ${daysTilFirstEmail}`);
-  console.log(`Per MySQL query results limit: ${program.resultsLimit}`);
 
   if (program.dryRun) {
     console.log(
@@ -295,20 +383,16 @@ const init = async () => {
 
   Container.set(AppConfig, config);
   Container.set(AuthLogger, log);
+  Container.set(StatsD, statsd);
+  if (!Container.has(AuthFirestore)) {
+    Container.set(AuthFirestore, setupFirestore(config));
+  }
+  const accountEventsManager = new AccountEventsManager();
+  Container.set(AccountEventsManager, accountEventsManager);
 
   // /dependencies }}}
 
-  const postfixTableName = (prefix: string) =>
-    `${prefix}_${startDate
-      .toISOString()
-      .substring(0, 10)
-      .replaceAll('-', '')}_${endDate
-      .toISOString()
-      .substring(0, 10)
-      .replaceAll('-', '')}_${activeByDate
-      .toISOString()
-      .substring(0, 10)
-      .replaceAll('-', '')}`;
+  const postfixTableName = (prefix: string) => `${prefix}_${runTag}`;
 
   // {{{ build exclusions temp table in BQ and start a session
 
@@ -368,45 +452,23 @@ const init = async () => {
 
   // {{{ write MySQL results to CSV and load into BQ temp table
 
-  const accountQueryBuilder = () =>
-    accountWhereAndOrderByQueryBuilder(
-      startDateTimestamp,
-      endDateTimestamp,
-      activeByDateTimestamp
-    )
-      .select('accounts.uid')
-      .limit(program.resultsLimit);
+  const accountsQuery = accountWhereAndOrderByQueryBuilder(
+    startDateTimestamp,
+    endDateTimestamp,
+    activeByDateTimestamp
+  )
+    .select('accounts.uid')
+    .limit(batchSize);
 
-  let hasMaxResultsCount = true;
-  let totalRowsReturned = 0;
-  let inactiveCandidateUids: string[] = [];
+  const accounts = await emitStatsdMetrics(
+    async () => await accountsQuery,
+    'accounts.inactive.sql-query',
+    statsd
+  )();
 
-  while (hasMaxResultsCount) {
-    const accountsQuery = accountQueryBuilder();
-    accountsQuery.offset(totalRowsReturned);
+  const inactiveCandidateUids: string[] = accounts.map((x) => x.uid);
 
-    const accounts = await emitStatsdMetrics(
-      async () => await accountsQuery,
-      'accounts.inactive.sql-query',
-      statsd
-    )();
-
-    debugLog(`MySQL results count: ${accounts.length}`);
-
-    if (!accounts.length) {
-      hasMaxResultsCount = false;
-      break;
-    }
-
-    inactiveCandidateUids = inactiveCandidateUids.concat(
-      accounts.map((x) => x.uid)
-    );
-
-    hasMaxResultsCount = accounts.length === program.resultsLimit;
-    totalRowsReturned += accounts.length;
-  }
-
-  debugLog(`MySQL total rows returned: ${totalRowsReturned}`);
+  debugLog(`MySQL results count: ${inactiveCandidateUids.length}`);
 
   const inactivesMySqlResultsTableName = await saveUidsToBqTable(
     inactiveCandidateUids,
@@ -580,52 +642,17 @@ const init = async () => {
       await queue.onSizeLessThan(concurrency * 5);
 
       queue.add(async () => {
-        // @TODO this function could be abstracted and moved to InactiveAccountsManager
-        const taskPayload: InactiveAccountEmailTaskPayloadParam = {
-          uid,
-        };
-        const taskId = `${uid}-inactive-delete-first-email`;
-        const taskOptions: CloudTaskOptions = {
-          taskId,
-        };
-
-        try {
-          await glean.inactiveAccountDeletion.firstEmailTaskRequest(
-            requestForGlean,
-            {
-              uid,
-            }
-          );
-
-          await emailCloudTasks.scheduleFirstEmail({
-            payload: taskPayload,
-            emailOptions: { deliveryTime: Date.now() + msTilFirstEmail },
-            taskOptions: taskOptions,
-          });
-
+        const enqueued = await maybeEnqueueFirstEmail(uid, {
+          accountEventsManager,
+          emailCloudTasks,
+          glean,
+          statsd,
+          log,
+          debugLog,
+          msTilFirstEmail,
+        });
+        if (enqueued) {
           emailsQueued++;
-          await glean.inactiveAccountDeletion.firstEmailTaskEnqueued(
-            requestForGlean,
-            {
-              uid,
-            }
-          );
-        } catch (cloudTaskQueueError) {
-          // Note that the fxa cloud tasks lib already emitted some statsd metrics
-          statsd.increment(
-            'cloud-tasks.inactive-account-email.enqueue.error-code',
-            { errorCode: cloudTaskQueueError.code as unknown as string }
-          );
-          await glean.inactiveAccountDeletion.firstEmailTaskRejected(
-            requestForGlean,
-            {
-              uid,
-            }
-          );
-          log.error('accounts.inactive.emailEnqueueError', {
-            cloudTaskQueueError,
-            uid,
-          });
         }
       });
     }

--- a/packages/fxa-auth-server/test/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.in.spec.ts
@@ -43,14 +43,11 @@ describe('enqueue inactive account deletions script', () => {
     const diff = Math.abs(now.valueOf() - nowish.valueOf());
     expect(diff).toBeLessThanOrEqual(1000);
 
-    const startDateString = getOutputValue(outputLines, 'Start date');
-    expect(startDateString?.startsWith('2012-03-12')).toBe(true);
+    const batchSizeString = getOutputValue(outputLines, 'Batch size');
+    expect(batchSizeString).toBe('1000');
 
     const daysTilFirstEmailString = getOutputValue(outputLines, "Days 'til");
     expect(daysTilFirstEmailString).toBe('0');
-
-    const dbResultsLimitString = getOutputValue(outputLines, 'Per MySQL query');
-    expect(dbResultsLimitString).toBe('500000');
   });
 
   it('requires an BQ dataset id', async () => {
@@ -66,22 +63,19 @@ describe('enqueue inactive account deletions script', () => {
     await exec(cmd.join(' '), execOptions);
   });
 
-  it('requires the end date to be the same or later than the start date', async () => {
+  it('rejects a non-positive --batch-size', async () => {
     try {
       const cmd = [
         ...command,
-        '--end-date 2020-12-22',
-        '--start-date 2021-12-22',
+        '--batch-size 0',
         '--bq-dataset fxa-dev.inactives-testo',
       ];
       await exec(cmd.join(' '), execOptions);
-      throw new Error(
-        'Expected script to fail with end date before start date'
-      );
+      throw new Error('Expected script to fail with non-positive batch size');
     } catch (err: any) {
       expect(err.code).toBe(1);
       expect(err.stderr).toContain(
-        'The end date must be on the same day or later than the start date.'
+        '--batch-size must be a positive integer.'
       );
     }
   });


### PR DESCRIPTION
## Because

- Manually opening a `webservices-infra` PR per [FXA-13709](https://mozilla-hub.atlassian.net/browse/FXA-13709) for each new batch of inactive accounts is repetitive chore work.

## This pull request

- Removes `--start-date`, `--end-date`, `--active-by-date`, `--results-limit` from `enqueue-inactive-account-deletions.ts`; adds `--batch-size` (default 1000).
- Each run picks the oldest *batchSize* candidates (createdAt < two-years-ago, ORDER BY createdAt ASC); the floor advances implicitly as deleted accounts drop out — no DB-tracked cursor.
- Filters out UIDs that already have an `inactiveAccountFirstWarning` `emailSent` event in Firestore before enqueueing, so overlapping runs are safe. Emits `accounts.inactive.cron.skipped-already-notified`.
- Wires `StatsD`, `AuthFirestore`, and `AccountEventsManager` into the typedi Container for the script.

## Issue that this pull request solves

Closes: FXA-13709

## Checklist

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts`
- Risky or complex parts: dropping the lower-bound `createdAt` filter relies on `ORDER BY ASC + LIMIT` plus the Firestore dedup to converge correctly across runs.

## Other information (Optional)

Follow-up in `webservices-infra`: add a Kubernetes CronJob manifest that invokes this script with `--batch-size=<N> --dry-run=false --enqueue-emails=true` on a schedule.

[FXA-13709]: https://mozilla-hub.atlassian.net/browse/FXA-13709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ