### PR TITLE
fix(content): enable passwordless otp in local

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -78,7 +78,8 @@
     "paymentsNextSubscriptionManagement": true,
     "passkeysEnabled": true,
     "passkeyRegistrationEnabled": true,
-    "passkeyAuthenticationEnabled": false
+    "passkeyAuthenticationEnabled": false,
+    "passwordlessEnabled": true
   },
   "darkMode": {
     "enabled": true


### PR DESCRIPTION
## Because

- Passwordless OTP is not enabled by default in local

## This pull request

- Enables passwordless OTP by default for local.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
