### PR TITLE
fix(pair): retry fxa_status before bailing to a new OAuth flow

### DIFF
--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -290,9 +290,9 @@ describe('Pair', () => {
         },
       ],
     ])(
-      'starts an OAuth flow when fxa_status returns %s',
+      'starts an OAuth flow when fxa_status returns %s on every attempt',
       async (_, response) => {
-        requestSignedInUserMock.mockResolvedValueOnce(response);
+        requestSignedInUserMock.mockResolvedValue(response);
         renderWithRouter(<Pair />);
         await waitFor(() =>
           expect(fxaOAuthFlowBeginMock).toHaveBeenCalledWith([
@@ -303,12 +303,33 @@ describe('Pair', () => {
       }
     );
 
+    it('retries fxa_status once when the first reply is empty, then reveals on success', async () => {
+      requestSignedInUserMock
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({
+          uid: 'sync-uid',
+          email: 'sync@example.com',
+          sessionToken: 'token',
+          verified: true,
+        });
+      await renderPair();
+      expect(requestSignedInUserMock).toHaveBeenCalledTimes(2);
+      expect(fxaOAuthFlowBeginMock).not.toHaveBeenCalled();
+    });
+
+    it('caps fxa_status at two asks before falling through to OAuth', async () => {
+      requestSignedInUserMock.mockResolvedValue(undefined);
+      renderWithRouter(<Pair />);
+      await waitFor(() => expect(fxaOAuthFlowBeginMock).toHaveBeenCalled());
+      expect(requestSignedInUserMock).toHaveBeenCalledTimes(2);
+    });
+
     it('hard-navigates to / with the OAuth params Firefox returned', async () => {
       const hardNavigateSpy = jest
         .spyOn(ReactUtils, 'hardNavigate')
         .mockImplementation(() => {});
       try {
-        requestSignedInUserMock.mockResolvedValueOnce(undefined);
+        requestSignedInUserMock.mockResolvedValue(undefined);
         fxaOAuthFlowBeginMock.mockResolvedValueOnce({
           action: 'signin',
           response_type: 'code',

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -112,14 +112,29 @@ const Pair = ({
 
     let cancelled = false;
     (async () => {
-      const signedInUser = await firefox
-        .requestSignedInUser(
-          Constants.OAUTH_CONTEXT,
-          true,
-          Constants.SYNC_SERVICE
-        )
-        .catch(() => undefined);
+      const askFirefox = () =>
+        firefox
+          .requestSignedInUser(
+            Constants.OAUTH_CONTEXT,
+            true,
+            Constants.SYNC_SERVICE
+          )
+          .catch(() => undefined);
+
+      // Retry on empty replies so a slow fxaLogin handoff doesn't bail to /signin.
+      const MAX_RETRIES = 1;
+      let signedInUser = await askFirefox();
+      for (
+        let attempt = 0;
+        !cancelled &&
+        attempt < MAX_RETRIES &&
+        (!signedInUser?.sessionToken || !signedInUser?.verified);
+        attempt++
+      ) {
+        signedInUser = await askFirefox();
+      }
       if (cancelled) return;
+
       if (signedInUser?.sessionToken && signedInUser.verified) {
         setBootstrapping(false);
         return;


### PR DESCRIPTION
  ## Because

  - After signing into Sync, users were sometimes redirected to `/signin` instead of `/pair`, even though Firefox had received the new login.
  - `/pair`'s bootstrap calls `firefox.requestSignedInUser` immediately after the page's `fxaLogin` / `fxaOAuthLogin` message. If Firefox has not yet processed that login, it returns no user; `/pair` then starts a fresh OAuth flow and `hardNavigate`s to `/`, where the Index page routes the cached account to `/signin`.

  ## This pull request

  - Retries `requestSignedInUser` once in `Pair/Index/index.tsx` before falling through to `fxaOAuthFlowBegin`. Each call carries its own 500ms WebChannel timeout, so the worst case on a cold visit with no Sync user is around one second.
  - Adds two unit tests in `Pair/Index/index.test.tsx`: one for the retry success path, one for the retry cap.

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13724

  ## Checklist

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**
  1. From a Firefox Desktop profile not signed into Sync, start Sync signin
  2. Sign in and enter the verify-login code.
  3. Land on `/pair` with the choice screen, not `/signin`.

  **Worst-case latency:** ~1s on cold visits with no signed-in Sync user (two sequential 500ms WebChannel timeouts) before the OAuth flow starts.