### PR TITLE
fix(fxa): Update smoketest headers

### DIFF
--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -398,7 +398,9 @@ export class TestAccountTracker {
 
     const { sessionToken } = await this.target.authClient.signIn(
       account.email,
-      account.password
+      account.password,
+      {},
+      this.target.ciHeader
     );
 
     const [status, has2FA] = await Promise.all([

--- a/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
@@ -18,10 +18,15 @@ test.describe('severity-2 #smoke', () => {
     password: string
   ) {
     const client = target.createAuthClient(version);
-    const response = await client.signIn(email, password, {
-      keys: true,
-      skipPasswordUpgrade: true,
-    });
+    const response = await client.signIn(
+      email,
+      password,
+      {
+        keys: true,
+        skipPasswordUpgrade: true,
+      },
+      target.ciHeader
+    );
     expect(response.keyFetchToken).toBeDefined();
     expect(response.unwrapBKey).toBeDefined();
 

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -20,10 +20,15 @@ test.describe('severity-2 #smoke', () => {
     password: string
   ) {
     const client = target.createAuthClient(version);
-    const response = await client.signIn(email, password, {
-      keys: true,
-      skipPasswordUpgrade: true,
-    });
+    const response = await client.signIn(
+      email,
+      password,
+      {
+        keys: true,
+        skipPasswordUpgrade: true,
+      },
+      target.ciHeader
+    );
     expect(response.keyFetchToken).toBeDefined();
     expect(response.unwrapBKey).toBeDefined();
 

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -18,10 +18,15 @@ test.describe('severity-2 #smoke', () => {
     password: string
   ) {
     const client = target.createAuthClient(version);
-    const response = await client.signIn(email, password, {
-      keys: true,
-      skipPasswordUpgrade: true,
-    });
+    const response = await client.signIn(
+      email,
+      password,
+      {
+        keys: true,
+        skipPasswordUpgrade: true,
+      },
+      target.ciHeader
+    );
     expect(response.keyFetchToken).toBeDefined();
     expect(response.unwrapBKey).toBeDefined();
 

--- a/packages/functional-tests/tests/misc/authClientV2.spec.ts
+++ b/packages/functional-tests/tests/misc/authClientV2.spec.ts
@@ -63,7 +63,12 @@ test.describe('auth-client-tests', () => {
     expect(status.clientSalt).toBeUndefined();
 
     // Login IN
-    const signInResult = await client.signIn(email, password, { keys: true });
+    const signInResult = await client.signIn(
+      email,
+      password,
+      { keys: true },
+      target.ciHeader
+    );
     expect(signInResult.keyFetchToken).toBeDefined();
     expect(signInResult.unwrapBKey).toBeDefined();
 
@@ -96,7 +101,12 @@ test.describe('auth-client-tests', () => {
     expect(status.upgradeNeeded).toBeFalsy();
 
     // Login IN
-    const signInResult = await client.signIn(email, password, { keys: true });
+    const signInResult = await client.signIn(
+      email,
+      password,
+      { keys: true },
+      target.ciHeader
+    );
     expect(signInResult).toBeDefined();
     expect(signInResult.keyFetchToken).toBeDefined();
     expect(signInResult.unwrapBKey).toBeDefined();
@@ -117,7 +127,8 @@ test.describe('auth-client-tests', () => {
     const v1SignInResult = (await client.signInWithAuthPW(
       email,
       v1Credentials.authPW,
-      { keys: true }
+      { keys: true },
+      target.ciHeader
     )) as any;
     expect(v1SignInResult).toBeDefined();
     expect(v1SignInResult.keyFetchToken).toBeDefined();
@@ -132,7 +143,12 @@ test.describe('auth-client-tests', () => {
 
     await signUp(client, email, password, target);
 
-    const signInResult = await client.signIn(email, password, { keys: true });
+    const signInResult = await client.signIn(
+      email,
+      password,
+      { keys: true },
+      target.ciHeader
+    );
     expect(signInResult.keyFetchToken).toBeDefined();
     expect(signInResult.unwrapBKey).toBeDefined();
 
@@ -157,9 +173,14 @@ test.describe('auth-client-tests', () => {
     expect(statusBefore.currentVersion).toBe('v1');
 
     // The sign in should automatically upgrade the password, but return V1 creds
-    const signInResult2 = await client2.signIn(email, password, {
-      keys: true,
-    });
+    const signInResult2 = await client2.signIn(
+      email,
+      password,
+      {
+        keys: true,
+      },
+      target.ciHeader
+    );
     expect(signInResult2).toBeDefined();
     expect(signInResult2.keyFetchToken).toBeDefined();
     expect(signInResult2.unwrapBKey).toBeDefined();
@@ -186,9 +207,14 @@ test.describe('auth-client-tests', () => {
     expect(statusAfter.currentVersion).toBe('v2');
 
     // Do another signin to get V2 credentials
-    const signInResult3 = await client2.signIn(email, password, {
-      keys: true,
-    });
+    const signInResult3 = await client2.signIn(
+      email,
+      password,
+      {
+        keys: true,
+      },
+      target.ciHeader
+    );
 
     // Check unwrapKB. It should match our V1 credential unwrapBKey.
     const status = await client.getCredentialStatusV2(email);

--- a/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
@@ -89,7 +89,9 @@ test.describe('severity-1 #smoke', () => {
       // Attempt to sign in with new password
       const { sessionToken } = await target.authClient.signIn(
         credentials.email,
-        newPassword
+        newPassword,
+        {},
+        target.ciHeader
       );
 
       const newAccountData = await target.authClient.sessionReauth(


### PR DESCRIPTION
Because:

* The April 28 change `feat(auth): enable CORS credentials on /account/login` routed `/account/login` through Fastly's WAF on stage and prod.
* Smoke-test `signIn` / `signInWithAuthPW` calls that omit the `fxa-ci` bypass header now receive an empty response body, surfacing as`SyntaxError: Unexpected end of JSON input` at fxa-auth-client/lib/client.ts:411
* Companion commits already fixed the passwordless paths (1e1581783d, c3fc7ce5ab, 488071ab55); the `signIn` callers were missed.

This commit:

* Passes `target.ciHeader` (or `this.target.ciHeader`) as the 4th argument to every `client.signIn` / `signInWithAuthPW` call in functional-tests that previously omitted it.
* Covers the shared cleanup path in `lib/testAccountTracker.ts` (destroyAccount), the three `_getKeys` helpers in `tests/key-stretching-v2/`, the six call sites in `tests/misc/authClientV2.spec.ts`, and the severity-1 smoke in `tests/resetPassword/resetPasswordRecoveryKey.spec.ts`.
* No production code paths are affected; `target.ciHeader` resolves to `undefined` when `CI_WAF_TOKEN` is unset, so local runs are unchanged.

Closes #N/A

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
