### PR TITLE
fix(backbone): Add 'passkeys' to DEPRECATED_KEYS in backbone's account model

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -95,6 +95,7 @@ const DEPRECATED_KEYS = [
   'emails',
   'totp',
   'backupCodes',
+  'passkeys',
   // Note: 'recoveryKey' is NOT deprecated - it contains estimatedSyncDeviceCount needed by fxa-settings
   'recoveryPhone',
   'attachedClients',
@@ -1703,7 +1704,6 @@ const Account = Backbone.Model.extend(
     createCadReminder() {
       return this._fxaClient.createCadReminder(this.get('sessionToken'));
     },
-
   },
   {
     ALLOWED_KEYS: ALLOWED_KEYS,


### PR DESCRIPTION
Because:
* The Account model in backbone throws on any unknown key during mergeBrowserAccount, and keys that should not throw are listed in DEPRECATED_KEYS

This commit:
* Adds the 'passkeys' value which was added for passkey support in React, to the account backbone model