### PR TITLE
FXA-13474: “Device connected” page displays unknown browser and device after refresh

### DIFF
--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import AuthComplete, { viewName } from '.';
+import AuthComplete, { PAIR_DEVICE_INFO_PREFIX, viewName } from '.';
 import { MOCK_METADATA_UNKNOWN_LOCATION } from '../../../components/DeviceInfoBlock/mocks';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
@@ -16,8 +16,12 @@ jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
 }));
 
+const MOCK_CHANNEL_ID = 'test-channel-id';
+const MOCK_DEVICE_INFO_KEY = `${PAIR_DEVICE_INFO_PREFIX}${MOCK_CHANNEL_ID}`;
+
 jest.mock('../../../models/integrations/pairing-authority-integration', () => ({
   PairingAuthorityIntegration: class {
+    channelId = 'test-channel-id';
     getSupplicantMetadata = jest.fn().mockResolvedValue(null);
     complete = jest.fn();
     destroy = jest.fn();
@@ -85,6 +89,7 @@ describe('AuthComplete page', () => {
       );
       mockIntegration = new PAI();
       mockIntegration.data = { entrypoint: undefined };
+      sessionStorage.clear();
     });
 
     it('calls complete() on mount and destroy() on unmount', () => {
@@ -94,6 +99,64 @@ describe('AuthComplete page', () => {
       expect(mockIntegration.complete).toHaveBeenCalled();
       unmount();
       expect(mockIntegration.destroy).toHaveBeenCalled();
+    });
+
+    it('clears cached device info from sessionStorage on unmount', () => {
+      sessionStorage.setItem(
+        MOCK_DEVICE_INFO_KEY,
+        JSON.stringify({
+          deviceFamily: 'Firefox',
+          deviceOS: 'Windows',
+          ipAddress: '1.2.3.4',
+        })
+      );
+
+      const { unmount } = renderWithLocalizationProvider(
+        <AuthComplete integration={mockIntegration as unknown as Integration} />
+      );
+      expect(sessionStorage.getItem(MOCK_DEVICE_INFO_KEY)).not.toBeNull();
+      unmount();
+      expect(sessionStorage.getItem(MOCK_DEVICE_INFO_KEY)).toBeNull();
+    });
+
+    it('restores device info from sessionStorage after refresh', () => {
+      const cachedInfo = {
+        deviceFamily: 'Firefox',
+        deviceOS: 'Windows',
+        ipAddress: '1.2.3.4',
+      };
+      sessionStorage.setItem(MOCK_DEVICE_INFO_KEY, JSON.stringify(cachedInfo));
+
+      renderWithLocalizationProvider(
+        <AuthComplete integration={mockIntegration as unknown as Integration} />
+      );
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+        'You are now syncing with: Firefox on Windows'
+      );
+      expect(mockIntegration.getSupplicantMetadata).not.toHaveBeenCalled();
+    });
+
+    it('persists fetched device info to sessionStorage', async () => {
+      const fetchedInfo = {
+        deviceFamily: 'Firefox',
+        deviceOS: 'Android',
+        ipAddress: '1.2.3.4',
+      };
+      mockIntegration.getSupplicantMetadata.mockResolvedValue(fetchedInfo);
+
+      renderWithLocalizationProvider(
+        <AuthComplete integration={mockIntegration as unknown as Integration} />
+      );
+
+      await waitFor(() =>
+        expect(sessionStorage.getItem(MOCK_DEVICE_INFO_KEY)).toBe(
+          JSON.stringify(fetchedInfo)
+        )
+      );
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+        'You are now syncing with: Firefox on Android'
+      );
     });
   });
 

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.tsx
@@ -19,6 +19,8 @@ import { isSendTabEntrypoint } from '../../../lib/utilities';
 
 export const viewName = 'pair.auth.complete';
 
+export const PAIR_DEVICE_INFO_PREFIX = 'pair.supp.device-info.';
+
 type AuthCompleteProps = {
   suppDeviceInfo?: RemoteMetadata;
   supportsFirefoxView?: boolean;
@@ -36,37 +38,66 @@ const AuthComplete = ({
 }: AuthCompleteProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const ftlMsgResolver = useFtlMsgResolver();
-  const [deviceInfo, setDeviceInfo] = useState<RemoteMetadata | undefined>(
-    suppDeviceInfoProp
-  );
-
   const authorityIntegration =
     integration instanceof PairingAuthorityIntegration
       ? integration
       : undefined;
 
+  // Namespace the cache by pairing channel so a different pairing session in
+  // the same tab cannot restore the previous supplicant's metadata.
+  const deviceInfoKey = authorityIntegration
+    ? `${PAIR_DEVICE_INFO_PREFIX}${authorityIntegration.channelId}`
+    : undefined;
+
+  const [deviceInfo, setDeviceInfo] = useState<RemoteMetadata | undefined>(
+    () => {
+      if (suppDeviceInfoProp) return suppDeviceInfoProp;
+      if (!deviceInfoKey) return undefined;
+      try {
+        const cached = sessionStorage.getItem(deviceInfoKey);
+        return cached ? (JSON.parse(cached) as RemoteMetadata) : undefined;
+      } catch {
+        return undefined;
+      }
+    }
+  );
+
   const deviceFamily = deviceInfo?.deviceFamily || 'Unknown';
   const deviceOS = deviceInfo?.deviceOS || 'Unknown';
   const isSendTab = isSendTabEntrypoint(integration?.data.entrypoint);
 
-  // Fetch supplicant metadata if not provided via props
+  // Fetch supplicant metadata if not already available from props or sessionStorage
   useEffect(() => {
-    if (suppDeviceInfoProp) {
+    if (suppDeviceInfoProp || deviceInfo) {
       return;
     }
     authorityIntegration
       ?.getSupplicantMetadata()
-      .then(setDeviceInfo)
+      .then((info) => {
+        try {
+          if (deviceInfoKey) {
+            sessionStorage.setItem(deviceInfoKey, JSON.stringify(info));
+          }
+        } catch {}
+        setDeviceInfo(info);
+      })
       .catch(() => {});
-  }, [authorityIntegration, suppDeviceInfoProp]);
+  }, [authorityIntegration, suppDeviceInfoProp, deviceInfo, deviceInfoKey]);
 
-  // Signal pairing complete to Firefox on mount
+  // Signal pairing complete to Firefox on mount. On teardown, drop the
+  // cached metadata so a fresh pairing in the same tab doesn't reuse the
+  // previous supplicant's browser/OS.
   useEffect(() => {
     authorityIntegration?.complete();
     return () => {
       authorityIntegration?.destroy();
+      try {
+        if (deviceInfoKey) {
+          sessionStorage.removeItem(deviceInfoKey);
+        }
+      } catch {}
     };
-  }, [authorityIntegration]);
+  }, [authorityIntegration, deviceInfoKey]);
 
   const handleSeeTabsButtonClick = useCallback((e: React.MouseEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Because

- Refreshing the `/pair/auth/complete` ("Device connected") page rendered the supplicant browser and OS as "Unknown"
- The WebChannel request for supplicant metadata fails once the pairing session is complete, and the error was silently swallowed, leaving no recovery path on reload

## This pull request

- Caches the fetched `RemoteMetadata` in `sessionStorage` under a new `PAIR_DEVICE_INFO_KEY` so a refresh restores the correct browser/OS without the now-closed WebChannel session (`AuthComplete/index.tsx`)
- Lazily initializes `deviceInfo` state from `sessionStorage` and skips the metadata fetch when a value is already available from props or cache
- Removes the cached metadata on component teardown so a fresh pairing in the same tab does not reuse the previous supplicant's info

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13474

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:**
1. Start a pairing flow and reach the `/pair/auth/complete` "Device connected" page
2. Confirm the heading reads e.g. "You are now syncing with: Firefox on Windows"
3. Refresh the page (F5)
4. The browser/OS should persist instead of showing "Unknown"