### PR TITLE
FXA-13463: The “Bad request” page is displayed for account with 2Fa that tried to use backup codes at sign in

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
@@ -10,7 +10,11 @@ import { LocationProvider } from '@reach/router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import SigninRecoveryCodeContainer from './container';
 import { createMockWebIntegration } from '../../../lib/integrations/mocks';
-import { Integration, useAuthClient, useSensitiveDataClient } from '../../../models';
+import {
+  Integration,
+  useAuthClient,
+  useSensitiveDataClient,
+} from '../../../models';
 import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../../models/mocks';
 import {
   MOCK_STORED_ACCOUNT,
@@ -24,6 +28,16 @@ import { mockSigninLocationState } from '../mocks';
 import { waitFor } from '@testing-library/react';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
+import {
+  useFinishOAuthFlowHandler,
+  useOAuthKeysCheck,
+} from '../../../lib/oauth/hooks';
+
+jest.mock('../../../lib/oauth/hooks', () => ({
+  __esModule: true,
+  useFinishOAuthFlowHandler: jest.fn(),
+  useOAuthKeysCheck: jest.fn(),
+}));
 
 let integration: Integration;
 function mockWebIntegration() {
@@ -122,6 +136,13 @@ function applyDefaultMocks() {
   mockWebIntegration();
   resetMockSensitiveDataClient();
   resetMockAuthClient();
+  (useFinishOAuthFlowHandler as jest.Mock).mockImplementation(() => ({
+    finishOAuthFlowHandler: jest.fn(),
+    oAuthDataError: null,
+  }));
+  (useOAuthKeysCheck as jest.Mock).mockImplementation(() => ({
+    oAuthKeysCheckError: null,
+  }));
 }
 
 function render() {
@@ -167,6 +188,36 @@ describe('SigninRecoveryCode container', () => {
       expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
         SensitiveData.Key.Auth
       );
+    });
+  });
+
+  describe('useOAuthKeysCheck', () => {
+    it('passes isPasswordlessFlow to skip the keys check', () => {
+      mockReachRouter('signin_recovery_code', {
+        signinState: { ...mockSigninLocationState, isPasswordlessFlow: true },
+      });
+      render();
+      expect(useOAuthKeysCheck).toHaveBeenCalledWith(
+        integration,
+        MOCK_KEY_FETCH_TOKEN,
+        MOCK_UNWRAP_BKEY,
+        true
+      );
+    });
+
+    it('renders the recovery code component when keys check is skipped for passwordless flow', () => {
+      (useOAuthKeysCheck as jest.Mock).mockImplementationOnce(
+        (_integration: any, _kft: any, _ubk: any, skipKeysCheck: boolean) => ({
+          oAuthKeysCheckError: skipKeysCheck
+            ? null
+            : { errno: 1, message: 'TRY_AGAIN' },
+        })
+      );
+      mockReachRouter('signin_recovery_code', {
+        signinState: { ...mockSigninLocationState, isPasswordlessFlow: true },
+      });
+      render();
+      expect(currentSigninRecoveryCodeProps).toBeDefined();
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -58,7 +58,7 @@ export const SigninRecoveryCodeContainer = ({
     integration,
     keyFetchToken,
     unwrapBKey,
-    signinState?.isSignInWithThirdPartyAuth
+    signinState?.isSignInWithThirdPartyAuth || signinState?.isPasswordlessFlow
   );
 
   const submitRecoveryCode: SubmitRecoveryCode = useCallback(

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
@@ -105,6 +105,7 @@ function applyDefaultMocks() {
   jest.resetAllMocks();
   jest.restoreAllMocks();
 
+  currentPageProps = undefined;
   mockSigninRecoveryPhoneModule();
   (useFinishOAuthFlowHandler as jest.Mock).mockImplementation(() => ({
     finishOAuthFlowHandler: jest
@@ -246,6 +247,34 @@ describe('SigninRecoveryPhoneContainer', () => {
           performNavigation: false,
         })
       );
+    });
+  });
+
+  describe('useOAuthKeysCheck', () => {
+    it('passes isPasswordlessFlow to skip the keys check', () => {
+      mockReachRouter('/signin_recovery_phone', {
+        signinState: { ...mockSigninLocationState, isPasswordlessFlow: true },
+        lastFourPhoneDigits: '1234',
+      });
+      renderSigninRecoveryPhoneContainer();
+      const lastArg = (useOAuthKeysCheck as jest.Mock).mock.calls[0]?.[3];
+      expect(lastArg).toBe(true);
+    });
+
+    it('renders the recovery phone component when keys check is skipped for passwordless flow', () => {
+      (useOAuthKeysCheck as jest.Mock).mockImplementationOnce(
+        (_integration: any, _kft: any, _ubk: any, skipKeysCheck: boolean) => ({
+          oAuthKeysCheckError: skipKeysCheck
+            ? null
+            : { errno: 1, message: 'TRY_AGAIN' },
+        })
+      );
+      mockReachRouter('/signin_recovery_phone', {
+        signinState: { ...mockSigninLocationState, isPasswordlessFlow: true },
+        lastFourPhoneDigits: '1234',
+      });
+      renderSigninRecoveryPhoneContainer();
+      expect(currentPageProps).toBeDefined();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
@@ -70,7 +70,7 @@ const SigninRecoveryPhoneContainer = ({
     integration,
     keyFetchToken,
     unwrapBKey,
-    signinState?.isSignInWithThirdPartyAuth
+    signinState?.isSignInWithThirdPartyAuth || signinState?.isPasswordlessFlow
   );
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);


### PR DESCRIPTION
  ## Because

  - Passwordless (OTP-email) sign-in users with 2FA hit a "Bad Request" page when navigating to backup-code or recovery-phone entry because `useOAuthKeysCheck` raised `TRY_AGAIN` for a session that never owns OAuth keys.
  - The same skip-keys-check escape hatch already existed for third-party auth, but did not cover passwordless sign-in, blocking these users from completing 2FA.

  ## This pull request

  - Updates `SigninRecoveryCode/container.tsx` and `SigninRecoveryPhone/container.tsx` to pass `signinState?.isPasswordlessFlow` into `useOAuthKeysCheck`, OR'd with the existing third-party-auth flag.
  - Adds unit tests in both `container.test.tsx` files asserting the skip flag is forwarded and that the recovery component still renders when the keys check is bypassed.
  - Resets `currentPageProps` in `applyDefaultMocks` in the recovery-phone test so the rendered-component assertion can't be a false positive from a prior test (PR feedback).

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13463

  ## Checklist

  _Put an `x` in the boxes that apply_

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**
  1. Create an account with passwordless (OTP-email) sign-in and 2FA enabled.
  2. Initiate an OAuth sign-in flow that lands on the 2FA challenge.
  3. From the TOTP page, click "Trouble entering code?" → backup code (then repeat with recovery phone).
  4. Expected: the backup-code / recovery-phone entry page renders. Previously it showed "Bad Request".