### PR TITLE
fix(settings,auth): Fix sumo login issue

### DIFF
--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -131,11 +131,13 @@ const buildArgs = (
     emails: [{ email: EMAIL, isPrimary: true, verified: true }],
     totp: { exists: false, verified: false },
   });
+  const sessionResendVerifyCode = jest.fn();
 
   const authClient = {
     beginPasskeyAuthentication,
     completePasskeyAuthentication,
     account,
+    sessionResendVerifyCode,
   } as jest.Mocked<PasskeySignInAuthClient>;
   const integration = {
     isSync: () => false,
@@ -236,6 +238,7 @@ describe('usePasskeySignIn', () => {
       performNavigation: true,
       isPasskeySession: true,
       accountHasTotp: false,
+      authClient: args.authClient,
     });
     expect(storeAccountData).toHaveBeenCalledWith({
       email: EMAIL,
@@ -319,6 +322,7 @@ describe('usePasskeySignIn', () => {
       performNavigation: true,
       isPasskeySession: true,
       accountHasTotp: false,
+      authClient: args.authClient,
     });
   });
 

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -190,7 +190,10 @@ export function resolvePasskeyService(
 /** Pick<> so tests can pass minimal mocks without `as any`. */
 export type PasskeySignInAuthClient = Pick<
   AuthClient,
-  'beginPasskeyAuthentication' | 'completePasskeyAuthentication' | 'account'
+  | 'beginPasskeyAuthentication'
+  | 'completePasskeyAuthentication'
+  | 'account'
+  | 'sessionResendVerifyCode'
 >;
 
 /**
@@ -427,6 +430,7 @@ export function usePasskeySignIn({
         performNavigation: !integration.isFirefoxMobileClient(),
         isPasskeySession: true,
         accountHasTotp,
+        authClient,
       });
 
       if (navError) {

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -147,10 +147,12 @@ export function mockAuthClient() {
   if (typeof jest !== 'undefined') {
     return {
       sessionStatus: jest.fn().mockResolvedValue(mockSessionStatus),
+      sessionResendVerifyCode: jest.fn().mockResolvedValue(undefined),
     } as unknown as AuthClient;
   } else {
     return {
       sessionStatus: () => Promise.resolve(mockSessionStatus),
+      sessionResendVerifyCode: () => Promise.resolve(undefined),
     } as unknown as AuthClient;
   }
 }

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -11,7 +11,6 @@ import {
   RelierAccount,
   useAuthClient,
   useConfig,
-  useSession,
 } from '../../models';
 
 import { useCallback, useEffect, useState, useRef } from 'react';
@@ -58,7 +57,6 @@ const AuthorizationContainer = ({
   const config = useConfig();
   const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
-  const session = useSession();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,
     integration
@@ -76,12 +74,9 @@ const AuthorizationContainer = ({
         relierAccount
       );
 
-      const isOauthPromptNone = true;
       const { data, error } = await cachedSignIn(
         account?.sessionToken!,
-        authClient,
-        session,
-        isOauthPromptNone
+        authClient
       );
 
       if (error === AuthUiErrors.SESSION_EXPIRED) {
@@ -122,6 +117,7 @@ const AuthorizationContainer = ({
           redirectTo: integration.data.redirectTo,
           finishOAuthFlowHandler,
           queryParams: location.search,
+          authClient,
         };
 
         const { error: navError } = await handleNavigation(navigationOptions);
@@ -156,7 +152,6 @@ const AuthorizationContainer = ({
     integration,
     location.search,
     navigateWithQuery,
-    session,
   ]);
 
   useEffect(() => {

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -139,7 +139,7 @@ const SetPasswordContainer = ({
             //       the email provided was the original email. Therefore we could
             //       have been setting passwords that were NOT hashed with the original
             //       account email.
-            {original: emails.original },
+            { original: emails.original },
             newPassword
           );
 
@@ -195,6 +195,7 @@ const SetPasswordContainer = ({
             // users will see a "flash" of whatever page we navigate them to
             // before the client closes the view. See FXA-11944
             performNavigation: !integration.isFirefoxMobileClient(),
+            authClient,
           };
 
           const { error } = await handleNavigation(navigationOptions);

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -12,7 +12,7 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 import ThirdPartyAuthCallback from '.';
 import { AppContext } from '../../../models';
 import { createAppContext, mockAppContext } from '../../../models/mocks';
-import { useAccount } from '../../../models';
+import { useAccount, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import {
   handleNavigation,
@@ -24,17 +24,19 @@ import { MOCK_EMAIL, MOCK_SESSION_TOKEN } from '../../mocks';
 import { LocationProvider } from '@reach/router';
 import { GenericData } from '../../../lib/model-data';
 
-jest.mock('../../../models', () => ({
-  ...jest.requireActual('../../../models'),
-  useClientInfoState: jest.fn(),
-  useProductInfoState: jest.fn(),
-  useAccount: jest.fn(),
-  useAuthClient: () => {
-    return {
-      checkTotpTokenExists: jest.fn().mockResolvedValue({ verified: true }),
-    };
-  },
-}));
+jest.mock('../../../models', () => {
+  const mockAuthClient = {
+    checkTotpTokenExists: jest.fn().mockResolvedValue({ verified: true }),
+    sessionResendVerifyCode: jest.fn().mockResolvedValue(undefined),
+  };
+  return {
+    ...jest.requireActual('../../../models'),
+    useClientInfoState: jest.fn(),
+    useProductInfoState: jest.fn(),
+    useAccount: jest.fn(),
+    useAuthClient: () => mockAuthClient,
+  };
+});
 
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
@@ -179,6 +181,15 @@ describe('ThirdPartyAuthCallback component', () => {
     mockHandleNavigation = jest.fn().mockResolvedValue({ error: null });
     (handleNavigation as jest.Mock).mockReturnValue(mockHandleNavigation);
     (ensureCanLinkAcountOrRedirect as jest.Mock).mockResolvedValue(true);
+    // useAuthClient returns a stable mock; restore its implementations here
+    // because afterEach's resetAllMocks() wipes them between tests.
+    const authClient = useAuthClient();
+    (authClient.checkTotpTokenExists as jest.Mock).mockResolvedValue({
+      verified: true,
+    });
+    (authClient.sessionResendVerifyCode as jest.Mock).mockResolvedValue(
+      undefined
+    );
     mockNavigateWithQuery.mockClear();
     mockCurrentAccount();
   });
@@ -277,6 +288,7 @@ describe('ThirdPartyAuthCallback component', () => {
         supportsKeysOptionalLogin: false,
         queryParams: '?',
         redirectTo: redirectTo,
+        authClient: useAuthClient(),
         signinData: {
           sessionToken: MOCK_SESSION_TOKEN,
           uid: '123',

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -138,6 +138,7 @@ const ThirdPartyAuthCallback = ({
         // password and keys are available.
         handleFxaLogin: isFirefoxNonSync && !deferKeysUntilPasswordSet,
         handleFxaOAuthLogin: isFirefoxNonSync && !deferKeysUntilPasswordSet,
+        authClient,
       };
 
       const { error: navError } = await handleNavigation(navigationOptions);
@@ -155,6 +156,7 @@ const ThirdPartyAuthCallback = ({
       webRedirectCheck,
       ftlMsgResolver,
       useFxAStatusResult.supportsKeysOptionalLogin,
+      authClient,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
@@ -156,6 +156,7 @@ const SigninPasskeyFallbackContainer = ({
         // messages; navigating the WebView away would interrupt it and leave
         // Sync paused. Desktop finishes by navigating.
         performNavigation: !integration.isFirefoxMobileClient(),
+        authClient,
       });
       if (navError) {
         GleanMetrics.passkeyEnterPassword.submitFrontendError({

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -295,6 +295,7 @@ const SigninPasswordlessCode = ({
           integration.isFirefoxMobileClient() && isSessionVerified
         ),
         isPasswordlessOtpSignin: true,
+        authClient,
       };
 
       // For existing users signing into Sync (signin flow), show merge warning

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -29,6 +29,14 @@ jest.mock('../../../lib/hooks/useNavigateWithQuery', () => ({
   useNavigateWithQuery: () => mockNavigateWithQuery,
 }));
 
+const mockSessionResendVerifyCode = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../models', () => ({
+  ...jest.requireActual('../../../models'),
+  useAuthClient: () => ({
+    sessionResendVerifyCode: mockSessionResendVerifyCode,
+  }),
+}));
+
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
   default: {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -5,7 +5,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { isWebIntegration, useFtlMsgResolver } from '../../../models';
+import {
+  isWebIntegration,
+  useAuthClient,
+  useFtlMsgResolver,
+} from '../../../models';
 import { BackupCodesImage } from '../../../components/images';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormVerifyCode, {
@@ -55,6 +59,7 @@ const SigninRecoveryCode = ({
     'Backup authentication code required'
   );
   const location = useLocation();
+  const authClient = useAuthClient();
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
@@ -109,6 +114,7 @@ const SigninRecoveryCode = ({
       handleFxaLogin: true,
       handleFxaOAuthLogin: true,
       performNavigation: !integration.isFirefoxMobileClient(),
+      authClient,
     };
 
     const { error } = await handleNavigation(navigationOptions);
@@ -129,6 +135,7 @@ const SigninRecoveryCode = ({
     uid,
     unwrapBKey,
     ftlMsgResolver,
+    authClient,
   ]);
 
   const localizedInvalidCodeError = getLocalizedErrorMessage(

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
@@ -130,6 +130,7 @@ const SigninRecoveryPhoneContainer = ({
         handleFxaLogin: true,
         handleFxaOAuthLogin: true,
         performNavigation: !integration.isFirefoxMobileClient(),
+        authClient,
       };
 
       await handleNavigation(navigationOptions);

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -7,6 +7,7 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import {
   isWebIntegration,
+  useAuthClient,
   useFtlMsgResolver,
   useSession,
 } from '../../../models';
@@ -62,6 +63,7 @@ const SigninTokenCode = ({
   const [resendCountdown, setResendCountdown] = useState<number>(0);
   const { isThrottled, startThrottle } = useThrottle();
 
+  const authClient = useAuthClient();
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const redirectTo =
     isWebIntegration(integration) && webRedirectCheck?.isValid
@@ -186,6 +188,7 @@ const SigninTokenCode = ({
           handleFxaLogin: false,
           handleFxaOAuthLogin: true,
           performNavigation: !integration.isFirefoxMobileClient(),
+          authClient,
         };
 
         await GleanMetrics.isDone();
@@ -228,6 +231,7 @@ const SigninTokenCode = ({
       showInlineRecoveryKeySetup,
       onSessionVerified,
       startThrottle,
+      authClient,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -5,7 +5,12 @@
 import React, { useEffect, useState } from 'react';
 import { Link, RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useAlertBar, useFtlMsgResolver, useSession } from '../../../models';
+import {
+  useAlertBar,
+  useAuthClient,
+  useFtlMsgResolver,
+  useSession,
+} from '../../../models';
 import { logViewEvent } from '../../../lib/metrics';
 import { MozServices } from '../../../lib/types';
 import firefox from '../../../lib/channels/firefox';
@@ -61,6 +66,7 @@ export const SigninTotpCode = ({
   const session = useSession();
   const isSessionAALUpgrade = signinState.isSessionAALUpgrade;
   const alertBar = useAlertBar();
+  const authClient = useAuthClient();
 
   const [bannerError, setBannerError] = useState<string>('');
 
@@ -186,6 +192,7 @@ export const SigninTotpCode = ({
         handleFxaLogin: true,
         handleFxaOAuthLogin: true,
         performNavigation: !integration.isFirefoxMobileClient(),
+        authClient,
       };
 
       const { error: navError } = await handleNavigation(navigationOptions);

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -5,10 +5,12 @@
 import { LocationProvider } from '@reach/router';
 import { OAuthNativeServices } from '@fxa/accounts/oauth';
 import {
+  AppContext,
   IntegrationData,
   IntegrationType,
   RelierCmsInfo,
 } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
 import { SigninTotpCode, SigninTotpCodeProps } from '.';
 import {
   MOCK_EMAIL,
@@ -116,17 +118,19 @@ export const Subject = ({
   supportsKeysOptionalLogin?: boolean;
 }) => {
   return (
-    <LocationProvider>
-      <SigninTotpCode
-        {...{
-          finishOAuthFlowHandler,
-          integration,
-          serviceName,
-          signinState,
-          submitTotpCode,
-          useFxAStatusResult: mockUseFxAStatus({ supportsKeysOptionalLogin }),
-        }}
-      />
-    </LocationProvider>
+    <AppContext.Provider value={mockAppContext()}>
+      <LocationProvider>
+        <SigninTotpCode
+          {...{
+            finishOAuthFlowHandler,
+            integration,
+            serviceName,
+            signinState,
+            submitTotpCode,
+            useFxAStatusResult: mockUseFxAStatus({ supportsKeysOptionalLogin }),
+          }}
+        />
+      </LocationProvider>
+    </AppContext.Provider>
   );
 };

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -52,6 +52,14 @@ jest.mock('@reach/router', () => ({
   navigate: jest.fn(),
 }));
 
+const mockSessionResendVerifyCode = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../models', () => ({
+  ...jest.requireActual('../../../models'),
+  useAuthClient: () => ({
+    sessionResendVerifyCode: mockSessionResendVerifyCode,
+  }),
+}));
+
 const email = MOCK_EMAIL;
 const hasLinkedAccount = false;
 const hasPassword = true;

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -17,6 +17,7 @@ import FormVerifyCode, {
 import {
   isWebIntegration,
   useAlertBar,
+  useAuthClient,
   useFtlMsgResolver,
 } from '../../../models';
 import LinkExternal from 'fxa-react/components/LinkExternal';
@@ -59,6 +60,7 @@ export const SigninUnblock = ({
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
+  const authClient = useAuthClient();
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const redirectTo =
@@ -152,6 +154,7 @@ export const SigninUnblock = ({
         performNavigation: !(
           integration.isFirefoxMobileClient() && isFullyVerified
         ),
+        authClient,
       };
 
       // If the web redirect is invalid, this shows an "Invalid redirect" message in alertBar

--- a/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
@@ -12,7 +12,11 @@ import CardHeader from '../../../../components/CardHeader';
 import TermsPrivacyAgreement from '../../../../components/TermsPrivacyAgreement';
 import { AuthUiErrors } from '../../../../lib/auth-errors/auth-errors';
 import GleanMetrics from '../../../../lib/glean';
-import { useFtlMsgResolver, isWebIntegration } from '../../../../models';
+import {
+  useFtlMsgResolver,
+  isWebIntegration,
+  useAuthClient,
+} from '../../../../models';
 import { SigninCachedProps } from '../../interfaces';
 import { handleNavigation, ensureCanLinkAcountOrRedirect } from '../../utils';
 import { useWebRedirect } from '../../../../lib/hooks/useWebRedirect';
@@ -44,6 +48,7 @@ const SigninCached = ({
   onSessionExpired,
   supportsKeysOptionalLogin,
 }: SigninCachedProps & RouteComponentProps) => {
+  const authClient = useAuthClient();
   const config = useConfig();
   const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
@@ -163,6 +168,7 @@ const SigninCached = ({
         // Redirect these passwordless users to set_password after session
         // verification.
         isSignInWithThirdPartyAuth: deferKeysUntilPasswordSet,
+        authClient,
       };
       const { error: navError } = await handleNavigation(navigationOptions);
       if (navError) {
@@ -202,6 +208,7 @@ const SigninCached = ({
     setLocalizedBannerError,
     hasPassword,
     onSessionExpired,
+    authClient,
   ]);
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -1014,8 +1014,8 @@ describe('signin container', () => {
         mockAuthClient.passwordChangeFinish = jest.fn().mockResolvedValue({});
         mockAuthClient.accountEmails = jest.fn().mockResolvedValue({
           original: MOCK_EMAIL,
-          primary: MOCK_EMAIL
-        })
+          primary: MOCK_EMAIL,
+        });
 
         render();
 
@@ -1107,8 +1107,8 @@ describe('signin container', () => {
           });
         mockAuthClient.accountEmails = jest.fn().mockResolvedValue({
           primary: MOCK_EMAIL,
-          original: MOCK_EMAIL
-        })
+          original: MOCK_EMAIL,
+        });
 
         render();
 
@@ -1159,8 +1159,8 @@ describe('signin container', () => {
         });
         mockAuthClient.accountEmails = jest.fn().mockResolvedValue({
           oiginal: MOCK_EMAIL,
-          primary: MOCK_EMAIL
-        })
+          primary: MOCK_EMAIL,
+        });
 
         render();
 
@@ -1218,7 +1218,7 @@ describe('signin container', () => {
         mockAuthClient.accountEmails = jest.fn().mockResolvedValue({
           original: MOCK_EMAIL,
           primary: MOCK_EMAIL,
-        })
+        });
 
         render();
 
@@ -1266,7 +1266,7 @@ describe('signin container', () => {
         mockAuthClient.accountEmails = jest.fn().mockResolvedValue({
           original: MOCK_EMAIL,
           primary: MOCK_EMAIL,
-        })
+        });
 
         render();
 
@@ -1455,7 +1455,10 @@ describe('signin container', () => {
         expect(mockAuthClient.sessionStatus).toHaveBeenCalledWith(
           MOCK_SESSION_TOKEN
         );
-        expect(mockSession.sendVerificationCode).toHaveBeenCalled();
+        // cachedSignIn no longer sends the verification code; the code is now
+        // sent later in handleNavigation, just before navigating to the
+        // verification page. See FXA-12972.
+        expect(mockSession.sendVerificationCode).not.toHaveBeenCalled();
         expect(handlerResult?.data?.verificationMethod).toEqual(
           VerificationMethods.EMAIL_OTP
         );
@@ -1490,7 +1493,10 @@ describe('signin container', () => {
         const handlerResult =
           await currentSigninProps?.cachedSigninHandler(MOCK_SESSION_TOKEN);
 
-        expect(mockSession.sendVerificationCode).toHaveBeenCalled();
+        // cachedSignIn no longer sends the verification code; the code is now
+        // sent later in handleNavigation, just before navigating to the
+        // verification page. See FXA-12972.
+        expect(mockSession.sendVerificationCode).not.toHaveBeenCalled();
         expect(handlerResult?.data?.verificationMethod).toEqual(
           VerificationMethods.EMAIL_OTP
         );

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -572,7 +572,8 @@ const SigninContainer = ({
           credentials.credentialStatus?.upgradeNeeded === true &&
           credentials.v2Credentials
         ) {
-          const { sessionToken, emailVerified, sessionVerified } = result.data.signIn;
+          const { sessionToken, emailVerified, sessionVerified } =
+            result.data.signIn;
 
           // To simplify this process. Fetch the original account sign in email.
           const emails = await authClient.accountEmails(sessionToken);
@@ -581,7 +582,10 @@ const SigninContainer = ({
           // Update the v1Credentials object to make sure the authPW is in fact correct. It
           // needs to be derived from the original account email, not the current primary.
           if (emails.original !== email) {
-            credentials.v1Credentials = await getCredentials(emails.original, password);
+            credentials.v1Credentials = await getCredentials(
+              emails.original,
+              password
+            );
           }
 
           sensitiveDataClient.KeyStretchUpgradeData = {
@@ -628,9 +632,8 @@ const SigninContainer = ({
   );
 
   const cachedSigninHandler: CachedSigninHandler = useCallback(
-    async (sessionToken: hexstring) =>
-      cachedSignIn(sessionToken, authClient, session),
-    [authClient, session]
+    async (sessionToken: hexstring) => cachedSignIn(sessionToken, authClient),
+    [authClient]
   );
 
   const sendUnblockEmailHandler = useCallback(
@@ -769,14 +772,18 @@ export async function trySignIn(
 ) {
   try {
     const authPW = v2Credentials?.authPW || v1Credentials.authPW;
-    const response = await authClient.signInWithAuthPW({ primary: email }, authPW, {
-      verificationMethod: options.verificationMethod,
-      keys: options.keys,
-      service: options.service,
-      metricsContext: options.metricsContext,
-      unblockCode: options.unblockCode,
-      originalLoginEmail: options.originalLoginEmail,
-    });
+    const response = await authClient.signInWithAuthPW(
+      { primary: email },
+      authPW,
+      {
+        verificationMethod: options.verificationMethod,
+        keys: options.keys,
+        service: options.service,
+        metricsContext: options.metricsContext,
+        unblockCode: options.unblockCode,
+        originalLoginEmail: options.originalLoginEmail,
+      }
+    );
 
     if (response) {
       const unwrapBKey = v2Credentials

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -171,6 +171,7 @@ const Signin = ({
             integration.isFirefoxMobileClient() && isFullyVerified
           ),
           isServiceWithEmailVerification,
+          authClient,
         };
 
         const { error: navError } = await handleNavigation(navigationOptions);
@@ -275,6 +276,7 @@ const Signin = ({
       webRedirectCheck,
       sensitiveDataClient,
       isServiceWithEmailVerification,
+      authClient,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -13,6 +13,7 @@ import { MozServices } from '../../lib/types';
 import { Integration } from '../../models';
 import { QueryParams } from '../..';
 import { UseFxAStatusResult } from '../../lib/hooks/useFxAStatus';
+import AuthClient from 'fxa-auth-client/browser';
 
 export interface AvatarResponse {
   account: {
@@ -286,6 +287,7 @@ export interface NavigationOptions {
   // with accountHasTotp to drive the AAL2-RP TOTP redirect in utils.ts.
   isPasskeySession?: boolean;
   accountHasTotp?: boolean;
+  authClient: Pick<AuthClient, 'sessionResendVerifyCode'>;
 }
 
 export interface OAuthSigninResult {

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -352,6 +352,85 @@ describe('Signin utils', () => {
       });
     });
 
+    describe('email OTP resend before /signin_token_code', () => {
+      it('resends the email OTP code when navigating to /signin_token_code with an EMAIL_OTP verification method', async () => {
+        const sessionResendVerifyCode = jest.fn().mockResolvedValue({});
+        const navigationOptions = createBaseNavigationOptions({
+          signinData: {
+            ...createBaseNavigationOptions().signinData,
+            emailVerified: true,
+            sessionVerified: false,
+            verificationMethod: VerificationMethods.EMAIL_OTP,
+            verificationReason: VerificationReasons.SIGN_IN,
+          },
+          isServiceWithEmailVerification: true,
+          integration: createMockSigninOAuthIntegration(),
+          authClient: { sessionResendVerifyCode },
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(sessionResendVerifyCode).toHaveBeenCalledWith(
+          MOCK_SESSION_TOKEN
+        );
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/signin_token_code',
+          expect.any(Object)
+        );
+      });
+
+      it('does not resend the email OTP code when the verification method is not EMAIL_OTP', async () => {
+        const sessionResendVerifyCode = jest.fn().mockResolvedValue({});
+        const navigationOptions = createBaseNavigationOptions({
+          signinData: {
+            ...createBaseNavigationOptions().signinData,
+            emailVerified: true,
+            sessionVerified: false,
+            verificationMethod: VerificationMethods.EMAIL,
+            verificationReason: VerificationReasons.SIGN_IN,
+          },
+          isServiceWithEmailVerification: true,
+          integration: createMockSigninOAuthIntegration(),
+          authClient: { sessionResendVerifyCode },
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(sessionResendVerifyCode).not.toHaveBeenCalled();
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/signin_token_code',
+          expect.any(Object)
+        );
+      });
+
+      it('does not resend the email OTP code when navigating to a page other than /signin_token_code', async () => {
+        const sessionResendVerifyCode = jest.fn().mockResolvedValue({});
+        const navigationOptions = createBaseNavigationOptions({
+          signinData: {
+            ...createBaseNavigationOptions().signinData,
+            emailVerified: false,
+            sessionVerified: false,
+            verificationMethod: VerificationMethods.EMAIL_OTP,
+            verificationReason: VerificationReasons.SIGN_IN,
+          },
+          isServiceWithEmailVerification: true,
+          integration: createMockSigninOAuthIntegration(),
+          authClient: { sessionResendVerifyCode },
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(sessionResendVerifyCode).not.toHaveBeenCalled();
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/confirm_signup_code',
+          expect.any(Object)
+        );
+      });
+    });
+
     describe('third party auth with non-Sync services', () => {
       it('sends fxaOAuthLogin and navigates to settings when the service does not need keys', async () => {
         const fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -352,7 +352,7 @@ describe('Signin utils', () => {
       });
     });
 
-    describe('email OTP resend before /signin_token_code', () => {
+    describe('email OTP resend before verification pages', () => {
       it('resends the email OTP code when navigating to /signin_token_code with an EMAIL_OTP verification method', async () => {
         const sessionResendVerifyCode = jest.fn().mockResolvedValue({});
         const navigationOptions = createBaseNavigationOptions({
@@ -376,6 +376,31 @@ describe('Signin utils', () => {
         );
         expect(navigateSpy).toHaveBeenCalledWith(
           '/signin_token_code',
+          expect.any(Object)
+        );
+      });
+
+      it('resends the email OTP code when navigating to /confirm_signup_code with an EMAIL_OTP verification method', async () => {
+        const sessionResendVerifyCode = jest.fn().mockResolvedValue({});
+        const navigationOptions = createBaseNavigationOptions({
+          signinData: {
+            ...createBaseNavigationOptions().signinData,
+            emailVerified: false,
+            sessionVerified: false,
+            verificationMethod: VerificationMethods.EMAIL_OTP,
+            verificationReason: VerificationReasons.SIGN_UP,
+          },
+          isServiceWithEmailVerification: true,
+          integration: createMockSigninOAuthIntegration(),
+          authClient: { sessionResendVerifyCode },
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(sessionResendVerifyCode).toHaveBeenCalledWith(MOCK_SESSION_TOKEN);
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/confirm_signup_code',
           expect.any(Object)
         );
       });
@@ -405,14 +430,14 @@ describe('Signin utils', () => {
         );
       });
 
-      it('does not resend the email OTP code when navigating to a page other than /signin_token_code', async () => {
+      it('does not resend the email OTP code when navigating to a non-email verification page such as /signin_totp_code', async () => {
         const sessionResendVerifyCode = jest.fn().mockResolvedValue({});
         const navigationOptions = createBaseNavigationOptions({
           signinData: {
             ...createBaseNavigationOptions().signinData,
-            emailVerified: false,
+            emailVerified: true,
             sessionVerified: false,
-            verificationMethod: VerificationMethods.EMAIL_OTP,
+            verificationMethod: VerificationMethods.TOTP_2FA,
             verificationReason: VerificationReasons.SIGN_IN,
           },
           isServiceWithEmailVerification: true,
@@ -425,7 +450,7 @@ describe('Signin utils', () => {
         expect(result.error).toBeUndefined();
         expect(sessionResendVerifyCode).not.toHaveBeenCalled();
         expect(navigateSpy).toHaveBeenCalledWith(
-          '/confirm_signup_code',
+          '/signin_totp_code',
           expect.any(Object)
         );
       });

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -8,7 +8,6 @@ import { NavigationOptions, SigninLocationState } from './interfaces';
 import type { SetPasswordLocationState } from '../PostVerify/SetPassword/interfaces';
 import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import {
-  useSession,
   isOAuthIntegration,
   isOAuthNativeIntegration,
   useAuthClient,
@@ -137,19 +136,14 @@ export function getSyncNavigate(
 
 export const cachedSignIn = async (
   sessionToken: string,
-  authClient: ReturnType<typeof useAuthClient>,
-  session: ReturnType<typeof useSession>,
-  isOauthPromptNone = false
+  authClient: ReturnType<typeof useAuthClient>
 ) => {
   try {
     // retrieves the account's authentication methods only
     // authenticatorAssuranceLevel reflects account AAL
     // and does not reflect the token's AAL (==> not useful here)
-    const {
-      authenticationMethods,
-    }: {
-      authenticationMethods: AuthenticationMethods[];
-    } = await authClient.accountProfile(sessionToken);
+    const { authenticationMethods } =
+      await authClient.accountProfile(sessionToken);
 
     const totpIsActive = authenticationMethods.includes(
       AuthenticationMethods.OTP
@@ -166,7 +160,8 @@ export const cachedSignIn = async (
     if (!emailVerified) {
       verificationReason = VerificationReasons.SIGN_UP;
       verificationMethod = VerificationMethods.EMAIL_OTP;
-      !isOauthPromptNone && (await session.sendVerificationCode());
+      // We should send the code prior to nav. That couples with an actual navigation action, where it belongs.
+      // !isOauthPromptNone && (await session.sendVerificationCode());
     } else if (!sessionVerified) {
       // we are inferring verification method and verification reason here
       // ideally we would check the server directly to allow for more verification reasons
@@ -174,8 +169,11 @@ export const cachedSignIn = async (
       if (totpIsActive) {
         verificationMethod = VerificationMethods.TOTP_2FA;
       } else {
+        // Note when using this method, the expectation is that we will send the user
+        // a verification code, if and only if the navigation handler directs them to
+        // a verification code page. There are some RPs that require email_otp verification,
+        // so for these RPs, we can just pass the user straight through.
         verificationMethod = VerificationMethods.EMAIL_OTP;
-        !isOauthPromptNone && (await session.sendVerificationCode());
       }
     }
 
@@ -293,6 +291,19 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
       !to?.includes('signin_totp_code')
     ) {
       sendFxaLogin(navigationOptions);
+    }
+
+    // If we are about to direct a user to /signin_totp_code, where they will be prompoted for a
+    // totp code and we know their session isn't fully verified then send them an otp code.
+    if (
+      to?.includes('signin_token_code') &&
+      navigationOptions.signinData.sessionToken &&
+      navigationOptions.signinData.verificationMethod ===
+        VerificationMethods.EMAIL_OTP
+    ) {
+      await navigationOptions.authClient.sessionResendVerifyCode(
+        navigationOptions.signinData.sessionToken
+      );
     }
 
     if (

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -293,10 +293,12 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
       sendFxaLogin(navigationOptions);
     }
 
-    // If we are about to direct a user to /signin_totp_code, where they will be prompoted for a
-    // totp code and we know their session isn't fully verified then send them an otp code.
+    // If we are about to direct a user to an email-OTP verification page
+    // (/signin_token_code for an unverified session, or /confirm_signup_code for an
+    // unverified email) and we know their session isn't fully verified, then send them
+    // an otp code. Sending here couples the email with the actual navigation action.
     if (
-      to?.includes('signin_token_code') &&
+      (to?.includes('signin_token_code') || to?.includes('confirm_signup_code')) &&
       navigationOptions.signinData.sessionToken &&
       navigationOptions.signinData.verificationMethod ===
         VerificationMethods.EMAIL_OTP


### PR DESCRIPTION
## Because

- Users of non-Sync OAuth RPs (e.g. SUMO) were receiving `verifyLoginCode` emails on signin even though the auth-server had correctly decided the session did not need verification (`mustVerify=false`). 
- We ultimately traced this back to `cachedSignIn` in fxa-settings firing `POST /session/resend_code` based solely on `sessionVerified=false` flag and ignoring the `mustVerify` flag. 
- The React rewrite dropped a `mustVerify` guard that fxa-content-server still had at `views/base.js`#`checkAuthorization`. 

## This pull request

- Moves the logic for sending the email into the front end. This should ensure that the code is only sent when the user is directed to a page requiring a code. 
- By moving the responsibility to the front end, we don't have to worry as much about the server side and client getting out of sync.


## Issue that this pull request solves

Closes: FXA-12972

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
  - `packages/fxa-settings/src/pages/Signin/utils.ts` — the front end fix (one new `&& mustVerify` guard).
  - `packages/fxa-auth-server/lib/routes/session.js` — the new field on `/session/status`.
- Suggested review order: auth-server route change → auth-client type → fxa-settings gate → unit tests → remote tests.
- Risky/complex parts: no end-to-end functional smoke test was added. See comments below...

## Other information

Tracking this bug down was a little twisty, so a full diagnosis of problem is attached to FXA-12972

We also tried to create a smoke-test to cover this edge case but could not, since the state hinged on the `signinConfirmation.skipForNewAccounts` option which is set to 48 hours currently. Because this time lapse is quite large, there's no really a good way to trip this state in a functional test. The interactions between these flags and options (mustVerify, sessionVerified, accountVerified, lockedAt, skipForNewAccounts, etc...) is pretty complex, so it'd be worth while clearly demarcating these states. 

The unit-level coverage proves the fix; however, in order to get functional test coverage we need either a provisioned long-lived fixture account on each environment or an admin-API path to alter an existing account state. A follow spike was added to look into how to make get better test coverage around this.

Also worth noting that based on feedback, we decided not expose the mustVerify flag to the front end, and instead pivoted to moving the send logic entirely to the front end.