### PR TITLE
bug(auth): Fix error during account delete

### DIFF
--- a/packages/fxa-auth-server/lib/db.ts
+++ b/packages/fxa-auth-server/lib/db.ts
@@ -239,7 +239,19 @@ export const createDB = (
 
     async checkPassword(uid: string, verifyHash: string) {
       log.trace('DB.checkPassword', { uid, verifyHash });
-      const result = await Account.checkPassword(uid, verifyHash);
+      let result;
+      try {
+        result = await Account.checkPassword(uid, verifyHash);
+      } catch (err) {
+        // Concurrent /account/destroy can delete the row between the route's
+        // accountRecord() and this read. Translate to ACCOUNT_UNKNOWN to
+        // match the pattern in db.account() / db.accountRecord().
+        if (isNotFoundError(err)) {
+          this.metrics?.increment('db.checkPassword.notFound');
+          throw error.unknownAccount();
+        }
+        throw err;
+      }
 
       if (result.v1) {
         this.metrics?.increment('check.password.v1.success');

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -4235,6 +4235,37 @@ describe('/account/destroy', () => {
     expect(glean.account.deleteComplete).not.toHaveBeenCalled();
   });
 
+  it('should surface ACCOUNT_UNKNOWN and skip deletion when checkPassword races a concurrent destroy', async () => {
+    // Reproduce FXA-11660: the row is deleted by a concurrent /account/destroy
+    // between accountRecord() and checkPassword(). DB.checkPassword translates
+    // the resulting notFound into ACCOUNT_UNKNOWN; the route must propagate it
+    // without enqueueing follow-up work or claiming success.
+    const accountRoutes = makeRoutes({
+      checkPassword: () => Promise.reject(error.unknownAccount()),
+      config: {
+        subscriptions: { enabled: true, paypalNvpSigCredentials: { enabled: true } },
+        accountDestroy: { requireVerifiedAccount: false },
+        domain: 'wibble',
+      },
+      db: mockDB,
+      log: mockLog,
+      push: mockPush,
+      pushbox: mockPushbox,
+      customs: mockCustoms,
+    });
+    const route = getRoute(accountRoutes, '/account/destroy');
+
+    await expect(runTest(route, mockRequest)).rejects.toMatchObject({
+      errno: error.ERRNO.ACCOUNT_UNKNOWN,
+      output: { statusCode: 400 },
+    });
+
+    expect(mockDB.accountRecord).toHaveBeenCalledTimes(1);
+    expect(mockAccountQuickDelete).not.toHaveBeenCalled();
+    expect(mockAccountTasksDeleteAccount).not.toHaveBeenCalled();
+    expect(glean.account.deleteComplete).not.toHaveBeenCalled();
+  });
+
   it('should delete the passwordless account', () => {
     mockDB = { ...mocks.mockDB({ email, uid, verifierSetAt: 0 }) };
     mockRequest = mocks.mockRequest({

--- a/packages/fxa-shared/db/models/auth/account.ts
+++ b/packages/fxa-shared/db/models/auth/account.ts
@@ -429,9 +429,16 @@ export class Account extends BaseAuthModel {
   }
 
   static async checkPassword(uid: string, verifyHash: string) {
-    let [account] = await Account.query()
+    const [account] = await Account.query()
       .select('verifyHash', 'verifyHashVersion2')
       .where('uid', uuidTransformer.to(uid));
+
+    // The row can disappear between an upstream accountRecord() lookup and
+    // this read when concurrent /account/destroy requests race; surface a
+    // typed not-found instead of letting `account.verifyHash` throw.
+    if (!account) {
+      throw notFound();
+    }
 
     const v1 = account.verifyHash === verifyHash;
     const v2 = account.verifyHashVersion2 === verifyHash;


### PR DESCRIPTION
## Because

- Sentry [FXA-AUTH-23B](https://mozilla.sentry.io/issues/FXA-AUTH-23B) has fired 1,593 times since 2025-02-21, impacting 169 users. `POST /v1/account/destroy` returns 500 with `TypeError: Cannot read properties of undefined (reading 'verifyHash')` when two destroy requests for the same account race: the first deletes the row between the second's `accountRecord()` lookup and its password check, so `Account.checkPassword` reads `verifyHash` off `undefined`.

## This pull request

- Guards `Account.checkPassword` (`packages/fxa-shared/db/models/auth/account.ts`) — throws `notFound()` when the row is missing instead of letting `account.verifyHash` blow up. Matches the existing pattern in this file (`consumeRecoveryCode`).
- Translates the `notFound` to `error.unknownAccount()` at the `DB.checkPassword` boundary (`packages/fxa-auth-server/lib/db.ts`) — same pattern already used by `db.account()` / `db.accountRecord()`, so all callers (`/account/destroy`, `/account/reauth`, password change/forgot, `/session/reauth`) see one well-known error shape.
- Adds a unit test in `lib/routes/account.spec.ts` covering the race: response is 400 `ACCOUNT_UNKNOWN`, no `quickDelete`, no Glean success event.


## Issue that this pull request solves

Closes: FXA-11660

## Checklist

_Put an \`x\` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
  - \`packages/fxa-shared/db/models/auth/account.ts\` — the guard
  - \`packages/fxa-auth-server/lib/db.ts\` — the error translation
- Suggested review order: shared model first, then db.ts wiring, then the new test.
- Risky or complex parts: confirm the \`unknownAccount\` shape is acceptable for the other callers of \`db.checkPassword\` (reauth, password change/forgot, session reauth) — they previously couldn't see this error at all, so any caller-specific handling would be new behavior. None looked impacted in my read.

## Other information (Optional)

**Out of scope:** The underlying race itself is not addressed. Instead we fail gracefully. Two truly concurrent destroys still both pass auth before one deletes; they just no longer 500. A real fix (per-uid lock or `SELECT ... FOR UPDATE` at destroy entry) might be worth a follow up. But is also more complicated and a bit riskier.