### PR TITLE
test(functional): disable flaky vpn integration spec via test.fixme

### DIFF
--- a/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
@@ -10,40 +10,41 @@ import {
 } from '../../lib/query-params';
 
 test.describe('vpn integration', () => {
-  test('authorization flow - user already signed into Firefox', async ({
-    syncOAuthBrowserPages: { page, signin },
-    testAccountTracker,
-  }) => {
-    const { email, password } = await testAccountTracker.signUp();
+  // Disabled while we investigate the flaky cached-signin -> WebChannel race.
+  test.fixme(
+    'authorization flow - user already signed into Firefox',
+    async ({ syncOAuthBrowserPages: { page, signin }, testAccountTracker }) => {
+      const { email, password } = await testAccountTracker.signUp();
 
-    // First, sign into Sync with Fenix (Android) client ID
-    await signin.goto('/authorization', syncMobileOAuthFenixQueryParams);
-    await signin.fillOutEmailFirstForm(email);
-    await signin.fillOutPasswordForm(password);
+      // First, sign into Sync with Fenix (Android) client ID
+      await signin.goto('/authorization', syncMobileOAuthFenixQueryParams);
+      await signin.fillOutEmailFirstForm(email);
+      await signin.fillOutPasswordForm(password);
 
-    // Wait for Sync sign-in to complete, then clear events for the
-    // VPN scope check later in the test
-    await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
-    await signin.clearWebChannelEvents();
+      // Wait for Sync sign-in to complete, then clear events for the
+      // VPN scope check later in the test
+      await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+      await signin.clearWebChannelEvents();
 
-    // Now navigate to VPN authorization — user is already signed into Firefox
-    await signin.goto('/authorization', vpnMobileOAuthQueryParams);
+      // Now navigate to VPN authorization — user is already signed into Firefox
+      await signin.goto('/authorization', vpnMobileOAuthQueryParams);
 
-    // User is already signed in — cached signin view, no password required
-    await expect(signin.cachedSigninHeading).toBeVisible();
-    await expect(page.getByText(email)).toBeVisible();
+      // User is already signed in — cached signin view, no password required
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(email)).toBeVisible();
 
-    await signin.signInButton.click();
+      await signin.signInButton.click();
 
-    // Verify fxaOAuthLogin was sent with VPN scopes
-    await signin.checkWebChannelMessageScopes(
-      FirefoxCommand.OAuthLogin,
-      'https://identity.mozilla.com/apps/vpn'
-    );
+      // Verify fxaOAuthLogin was sent with VPN scopes
+      await signin.checkWebChannelMessageScopes(
+        FirefoxCommand.OAuthLogin,
+        'https://identity.mozilla.com/apps/vpn'
+      );
 
-    // Verify services data includes vpn
-    await signin.checkWebChannelMessageServices(FirefoxCommand.Login, {
-      vpn: {},
-    });
-  });
+      // Verify services data includes vpn
+      await signin.checkWebChannelMessageServices(FirefoxCommand.Login, {
+        vpn: {},
+      });
+    }
+  );
 });


### PR DESCRIPTION
## Because

- The vpn integration "authorization flow - user already signed into Firefox" test fails intermittently in CI on the cached-signin click, blocking unrelated PRs.

## This pull request

- Marks the single test in tests/misc/vpnIntegration.spec.ts with test.fixme so Playwright reports it as expected-failing and the pipeline stays green while the root cause is investigated on a separate branch.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
