### PR TITLE
chore(ci): remove redundant Compile jobs from CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,23 +316,6 @@ commands:
           name: Linting
           command: npx nx << parameters.nx_run >> --parallel=1 -t lint
 
-  compile:
-    parameters:
-      nx_run:
-        type: string
-        default: run-many
-    steps:
-      - run:
-          name: Pre building shared libraries
-          command: NODE_OPTIONS="--max-old-space-size=7168" npx nx run-many -t build --projects=tag:scope:shared:lib --parallel=2 --verbose
-          environment:
-            NODE_ENV: test
-      - run:
-          name: Compiling TypeScript
-          command: NODE_OPTIONS="--max-old-space-size=7168" npx nx << parameters.nx_run >> --parallel=1 -t compile
-          environment:
-            NODE_ENV: test
-
   check-playwright-test-count:
     parameters:
       project:
@@ -690,19 +673,6 @@ jobs:
       - lint:
           nx_run: << parameters.nx_run >>
 
-  compile:
-    parameters:
-      nx_run:
-        type: string
-        default: run-many
-    executor: default-executor
-    resource_class: large
-    steps:
-      - git-checkout
-      - restore-workspace
-      - compile:
-          nx_run: << parameters.nx_run >>
-
   # Runs unit tests in parallel across packages with changes.
   unit-test:
     parameters:
@@ -923,13 +893,6 @@ workflows:
             - Init (PR)
           post-steps:
             - fail-fast
-      - compile:
-          name: Compile (PR)
-          nx_run: affected --base=main --head=$CIRCLE_SHA1
-          requires:
-            - Init (PR)
-          post-steps:
-            - fail-fast
       - unit-test:
           name: Unit Test (PR)
           resource_class: xlarge
@@ -995,7 +958,6 @@ workflows:
           job_type: build
           requires:
             - Lint (PR)
-            - Compile (PR)
             - Unit Test (PR)
             - Integration Test - Frontends (PR)
             - Integration Test - Servers (PR)
@@ -1103,15 +1065,6 @@ workflows:
             - Init
       - lint:
           name: Lint
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
-          requires:
-            - Init
-      - compile:
-          name: Compile
           filters:
             branches:
               ignore: /.*/
@@ -1243,11 +1196,6 @@ workflows:
           nx_run: run-many --skipRemoteCache
           requires:
             - Init (nightly)
-      - compile:
-          name: Compile (nightly)
-          nx_run: run-many --skipRemoteCache
-          requires:
-            - Init (nightly)
       - unit-test:
           name: Unit Test (nightly)
           resource_class: xlarge
@@ -1312,7 +1260,6 @@ workflows:
           job_type: build
           requires:
             - Lint (nightly)
-            - Compile (nightly)
             - Unit Test (nightly)
             - Integration Test - Frontends (nightly)
             - Integration Test - Servers (nightly)


### PR DESCRIPTION
Because:

- The `Compile` jobs are redundant with `ts-build` and waste CI resources.

This commit:

- Removes `Compile (PR)`, `Compile`, and `Compile (nightly)` job invocations from the `test_pull_request`, `test_and_deploy_tag`, and `nightly` workflows.
- Drops `Compile (PR)` / `Compile (nightly)` from the `Tests Complete` on-complete dependency lists.
- Removes the now-unused `compile` reusable command and job definitions.

Closes: FXA-13739

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
