### PR TITLE
chore(settings): remove redundant React imports

### DIFF
--- a/packages/fxa-settings/.storybook/design-guide/Header.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/Header.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 
 const Header = () => {

--- a/packages/fxa-settings/.storybook/design-guide/Page.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/Page.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Header from './Header';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 

--- a/packages/fxa-settings/.storybook/design-guide/Snippet.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/Snippet.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-
 const Snippet = ({ moarClasses = '', children }) => (
   <code className={`bg-grey-100 text-sm px-1 rounded-sm ${moarClasses}`}>
     {children}

--- a/packages/fxa-settings/.storybook/design-guide/main.stories.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/main.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import tailwindConfig from '../../../fxa-react/configs/tailwind';
 import resolveConfig from 'tailwindcss/resolveConfig';

--- a/packages/fxa-settings/.storybook/design-guide/pages/Breakpoints.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/pages/Breakpoints.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Page from '../Page';
 import Copiable from '../Copiable';
 import LinkExternal from 'fxa-react/components/LinkExternal';

--- a/packages/fxa-settings/.storybook/design-guide/pages/Colors.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/pages/Colors.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Page from '../Page';
 import Copiable from '../Copiable';
 import Snippet from '../Snippet';

--- a/packages/fxa-settings/.storybook/design-guide/pages/Introduction.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/pages/Introduction.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Page from '../Page';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import Copiable from '../Copiable';

--- a/packages/fxa-settings/.storybook/design-guide/pages/Spacing.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/pages/Spacing.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Page from '../Page';
 import Copiable from '../Copiable';
 import Snippet from '../Snippet';

--- a/packages/fxa-settings/.storybook/preview.tsx
+++ b/packages/fxa-settings/.storybook/preview.tsx
@@ -4,7 +4,7 @@
 
 import '../src/styles/tailwind.out.css';
 import './design-guide/design-guide.css';
-import React, { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import type { Decorator } from '@storybook/react';
 import { ThemeProvider, useTheme } from '../src/models/contexts/ThemeContext';
 
@@ -13,7 +13,7 @@ const ThemeSync = ({
   children,
 }: {
   theme: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) => {
   const { setThemePreference } = useTheme();
   useEffect(() => {

--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.test.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/mocks.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import AlternativeAuthOptions, { AlternativeAuthOptionsProps } from '.';
 import Banner from '../Banner';

--- a/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AppLayout from './index';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import AppLayout from '.';

--- a/packages/fxa-settings/src/components/Banner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Banner/index.test.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Banner from './index';
 import { BannerProps } from './interfaces';

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { BannerProps } from './interfaces';
 import {
   CheckmarkCircleOutlineCurrentIcon,

--- a/packages/fxa-settings/src/components/BoxButton/index.stories.tsx
+++ b/packages/fxa-settings/src/components/BoxButton/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import { ReactNode } from 'react';
 import { Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withLocalization } from 'fxa-react/lib/storybooks';
@@ -23,7 +23,7 @@ export default {
   },
 } as Meta;
 
-const Container = ({ children }: { children: React.ReactNode }) => (
+const Container = ({ children }: { children: ReactNode }) => (
   <div className="card mx-auto max-w-md">{children}</div>
 );
 

--- a/packages/fxa-settings/src/components/BoxButton/index.test.tsx
+++ b/packages/fxa-settings/src/components/BoxButton/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/BrandMessaging/index.stories.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { BrandMessaging } from '.';

--- a/packages/fxa-settings/src/components/BrandMessaging/index.test.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { BrandMessaging, bannerClosedLocalStorageKey } from '.';

--- a/packages/fxa-settings/src/components/ButtonBack/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ButtonBack/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import AppLayout from '../AppLayout';

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/RecoveryKeyPDF.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/RecoveryKeyPDF.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   Document,
   Font,

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/VectorImagesForPdf.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/VectorImagesForPdf.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Svg, Path, Rect, Circle } from '@react-pdf/renderer';
 
 /*

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
 import ButtonDownloadRecoveryKeyPDF from '.';

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { ButtonDownloadRecoveryKeyPDF, getFilename } from '.';

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RelierCmsInfo, useAlertBar, useFtlMsgResolver } from '../../models';
 import { pdf } from '@react-pdf/renderer';
 import { saveAs } from 'file-saver';

--- a/packages/fxa-settings/src/components/ButtonPasskeySignin/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ButtonPasskeySignin/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import { useState } from 'react';
 import ButtonPasskeySignin from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Meta } from '@storybook/react';
@@ -15,7 +15,7 @@ export default {
 } as Meta;
 
 export const Default = () => {
-  const [isLoading, setIsLoading] = React.useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleClick = () => {
     action('clicked')();

--- a/packages/fxa-settings/src/components/ButtonPasskeySignin/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonPasskeySignin/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/ButtonPasskeySignin/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonPasskeySignin/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { PasskeyIcon } from '../Icons';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import BoxButton from '../BoxButton';

--- a/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import { ComponentProps } from 'react';
 import CardHeader from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
@@ -23,7 +23,7 @@ export default {
 } as Meta;
 
 const storyWithProps = (
-  props: React.ComponentProps<typeof CardHeader>,
+  props: ComponentProps<typeof CardHeader>,
   storyName?: string
 ) => {
   const story = () => (

--- a/packages/fxa-settings/src/components/CardHeader/index.test.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import CardHeader from '.';

--- a/packages/fxa-settings/src/components/CardLoadingSpinner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CardLoadingSpinner/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { CardLoadingSpinner } from './';
 import { SpinnerType } from 'fxa-react/components/LoadingSpinner';

--- a/packages/fxa-settings/src/components/CardLoadingSpinner/index.test.tsx
+++ b/packages/fxa-settings/src/components/CardLoadingSpinner/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { SpinnerType } from 'fxa-react/components/LoadingSpinner';
 import { CardLoadingSpinner } from './';

--- a/packages/fxa-settings/src/components/CardLoadingSpinner/index.tsx
+++ b/packages/fxa-settings/src/components/CardLoadingSpinner/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LoadingSpinner, {
   SpinnerType,
 } from 'fxa-react/components/LoadingSpinner';

--- a/packages/fxa-settings/src/components/ChooseNewsletters/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ChooseNewsletters from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/ChooseNewsletters/index.test.tsx
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';

--- a/packages/fxa-settings/src/components/CmsButtonWithFallback/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CmsButtonWithFallback/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import CmsButtonWithFallback from '.';
 

--- a/packages/fxa-settings/src/components/CmsButtonWithFallback/index.test.tsx
+++ b/packages/fxa-settings/src/components/CmsButtonWithFallback/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CmsButtonWithFallback from '.';

--- a/packages/fxa-settings/src/components/CmsLogo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CmsLogo/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import CmsLogo from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
@@ -22,45 +21,31 @@ export default {
 
 // Sample logo data for stories
 const mockMozillaLogo = {
-  logoUrl: 'https://gist.githubusercontent.com/dschom/857ebb2abd5f75937f211f1fd6bbf9a8/raw/33037c8905757a594e07eb29818d8519447fdec0/nightly-logo.svg',
+  logoUrl:
+    'https://gist.githubusercontent.com/dschom/857ebb2abd5f75937f211f1fd6bbf9a8/raw/33037c8905757a594e07eb29818d8519447fdec0/nightly-logo.svg',
   logoAltText: 'Mozilla',
 };
 
 const mockFirefoxLogo = {
-  logoUrl: 'https://gist.githubusercontent.com/dschom/c754b76333cda59f50845fe9b0ff6d52/raw/157b0af53142b24e0ddae936c711c010428e7bba/foxy-logo.svg',
+  logoUrl:
+    'https://gist.githubusercontent.com/dschom/c754b76333cda59f50845fe9b0ff6d52/raw/157b0af53142b24e0ddae936c711c010428e7bba/foxy-logo.svg',
   logoAltText: 'Firefox',
 };
 
 export const DesktopLeftAligned = () => (
-  <CmsLogo
-    isMobile={false}
-    logoPosition="left"
-    logos={[mockMozillaLogo]}
-  />
+  <CmsLogo isMobile={false} logoPosition="left" logos={[mockMozillaLogo]} />
 );
 
 export const DesktopCenterAligned = () => (
-  <CmsLogo
-    isMobile={false}
-    logoPosition="center"
-    logos={[mockMozillaLogo]}
-  />
+  <CmsLogo isMobile={false} logoPosition="center" logos={[mockMozillaLogo]} />
 );
 
 export const MobileHidden = () => (
-  <CmsLogo
-    isMobile={true}
-    logoPosition="left"
-    logos={[mockMozillaLogo]}
-  />
+  <CmsLogo isMobile={true} logoPosition="left" logos={[mockMozillaLogo]} />
 );
 
 export const NoLogo = () => (
-  <CmsLogo
-    isMobile={false}
-    logoPosition="left"
-    logos={[]}
-  />
+  <CmsLogo isMobile={false} logoPosition="left" logos={[]} />
 );
 
 export const InvalidLogo = () => (
@@ -84,22 +69,14 @@ export const MultipleLogos = () => (
 );
 
 export const FirefoxLogo = () => (
-  <CmsLogo
-    isMobile={false}
-    logoPosition="center"
-    logos={[mockFirefoxLogo]}
-  />
+  <CmsLogo isMobile={false} logoPosition="center" logos={[mockFirefoxLogo]} />
 );
 
 export const Comparison = () => (
   <div className="space-y-8">
     <div>
       <h3 className="text-lg font-semibold mb-4">Left Aligned (Desktop)</h3>
-      <CmsLogo
-        isMobile={false}
-        logoPosition="left"
-        logos={[mockMozillaLogo]}
-      />
+      <CmsLogo isMobile={false} logoPosition="left" logos={[mockMozillaLogo]} />
     </div>
 
     <div>
@@ -113,22 +90,18 @@ export const Comparison = () => (
 
     <div>
       <h3 className="text-lg font-semibold mb-4">Mobile (Hidden)</h3>
-      <p className="text-sm text-gray-600 mb-2">Logo is hidden on mobile devices</p>
-      <CmsLogo
-        isMobile={true}
-        logoPosition="left"
-        logos={[mockMozillaLogo]}
-      />
+      <p className="text-sm text-gray-600 mb-2">
+        Logo is hidden on mobile devices
+      </p>
+      <CmsLogo isMobile={true} logoPosition="left" logos={[mockMozillaLogo]} />
     </div>
 
     <div>
       <h3 className="text-lg font-semibold mb-4">No Logo</h3>
-      <p className="text-sm text-gray-600 mb-2">When no valid logo is provided</p>
-      <CmsLogo
-        isMobile={false}
-        logoPosition="center"
-        logos={[]}
-      />
+      <p className="text-sm text-gray-600 mb-2">
+        When no valid logo is provided
+      </p>
+      <CmsLogo isMobile={false} logoPosition="center" logos={[]} />
     </div>
   </div>
 );

--- a/packages/fxa-settings/src/components/CmsLogo/index.test.tsx
+++ b/packages/fxa-settings/src/components/CmsLogo/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import CmsLogo from '.';
 
@@ -25,18 +24,18 @@ describe('CmsLogo', () => {
 
     const img = screen.getByRole('img');
     const wrapper = img.parentElement;
-    
+
     expect(img).toBeInTheDocument();
     expect(img.getAttribute('alt')).toEqual('foo');
     expect(img.getAttribute('src')).toEqual('/foo.svg');
     expect(img).toHaveClass('max-h-[40px]');
     expect(img).not.toHaveClass('max-h-[160px]');
     expect(img).not.toHaveClass('mx-auto');
-    
+
     expect(wrapper).toHaveClass('text-left');
     expect(wrapper).toHaveClass('mb-4');
     expect(wrapper).not.toHaveClass('text-center');
-    
+
     expect(container).toMatchSnapshot();
   });
 
@@ -58,18 +57,18 @@ describe('CmsLogo', () => {
 
     const img = screen.getByRole('img');
     const wrapper = img.parentElement;
-    
+
     expect(img).toBeInTheDocument();
     expect(img.getAttribute('alt')).toEqual('foo');
     expect(img.getAttribute('src')).toEqual('/foo.svg');
     expect(img).toHaveClass('max-h-[160px]');
     expect(img).toHaveClass('mx-auto');
     expect(img).not.toHaveClass('max-h-[40px]');
-    
+
     expect(wrapper).toHaveClass('text-center');
     expect(wrapper).toHaveClass('mb-4');
     expect(wrapper).not.toHaveClass('text-left');
-    
+
     expect(container).toMatchSnapshot();
   });
 

--- a/packages/fxa-settings/src/components/CmsLogo/index.tsx
+++ b/packages/fxa-settings/src/components/CmsLogo/index.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-
 const CmsLogo = (opts: {
   isMobile: boolean;
   logoPosition: 'left' | 'center';
@@ -21,12 +19,16 @@ const CmsLogo = (opts: {
   return (
     <>
       {!opts.isMobile && logo && (
-        <div className={`mb-4 ${opts.logoPosition === 'center' ? 'text-center' : 'text-left'}`}>
+        <div
+          className={`mb-4 ${opts.logoPosition === 'center' ? 'text-center' : 'text-left'}`}
+        >
           <img
             src={logo.logoUrl}
             alt={logo.logoAltText}
             className={`${
-              opts.logoPosition === 'center' ? 'max-h-[160px] mx-auto' : 'max-h-[40px]'
+              opts.logoPosition === 'center'
+                ? 'max-h-[160px] mx-auto'
+                : 'max-h-[40px]'
             }`}
           />
         </div>

--- a/packages/fxa-settings/src/components/DarkModeToggle/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DarkModeToggle/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { DarkModeToggle } from './index';

--- a/packages/fxa-settings/src/components/DataBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Subject } from './mocks';

--- a/packages/fxa-settings/src/components/DataBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';

--- a/packages/fxa-settings/src/components/DataBlock/mocks.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import DataBlock, { DataBlockProps } from '.';
 import { MOCK_EMAIL } from '../../pages/mocks';
 

--- a/packages/fxa-settings/src/components/DataBlockInline/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DataBlockInline/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Subject } from './mocks';

--- a/packages/fxa-settings/src/components/DataBlockInline/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataBlockInline/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';

--- a/packages/fxa-settings/src/components/DataBlockInline/mocks.tsx
+++ b/packages/fxa-settings/src/components/DataBlockInline/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import DataBlockInline, { DataBlockInlineProps } from '.';
 
 export const Subject = ({

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import DeviceInfoBlock from '.';
 import { RemoteMetadata } from '../../lib/types';
 import AppLayout from '../AppLayout';

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import DeviceInfoBlock from '.';

--- a/packages/fxa-settings/src/components/DeviceInfoBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DeviceInfoBlock/index.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FtlMsg } from 'fxa-react/lib/utils';
-import React from 'react';
 import { RemoteMetadata } from '../../lib/types';
 
 // Remote metadata is obtained from pairing channel

--- a/packages/fxa-settings/src/components/ErrorBoundaries/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ErrorBoundaries/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { AppError } from '.';
 import { UrlQueryData } from '../../lib/model-data';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/FormChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import FormChoice from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/FormChoice/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import FormChoice, { FormChoiceProps } from '.';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { commonFormChoiceProps } from './mocks';

--- a/packages/fxa-settings/src/components/FormChoice/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { CHOICES } from '.';
 import {
   BackupAuthenticationCodesImage,

--- a/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Subject } from './mocks';
 import { LocationProvider } from '@reach/router';
 import FormPassword from '.';

--- a/packages/fxa-settings/src/components/FormPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { typeByTestIdFn } from '../../lib/test-utils';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Subject } from './mocks';
 import AppLayout from '../AppLayout';
 import FormPasswordInline from '.';

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { useForm } from 'react-hook-form';
 import FormPasswordWithInlineCriteria, { PasswordFormType } from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';

--- a/packages/fxa-settings/src/components/FormPhoneNumber/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormPhoneNumber/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import FormPhoneNumber from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FormPhoneNumber from '.';
@@ -12,12 +11,13 @@ const mockSubmit = jest.fn();
 
 describe('FormPhoneNumber', () => {
   async function render() {
-      await act(() => {renderWithLocalizationProvider(
+    await act(() => {
+      renderWithLocalizationProvider(
         <FormPhoneNumber
           localizedCTAText="Send code"
           submitPhoneNumber={mockSubmit}
         />
-      )
+      );
     });
   }
 

--- a/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
+++ b/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FormSetupAccountProps } from './interfaces';
 import FormPasswordWithInlineCriteria from '../FormPasswordWithInlineCriteria';
 

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import FormVerifyCode from '.';
 import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import FormVerifyTotp from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import React from 'react';
 import Subject from './mocks';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';

--- a/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Meta } from '@storybook/react';
 import GetDataTrio, {
   GetDataCopySingleton,

--- a/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import GetDataTrio from './index';

--- a/packages/fxa-settings/src/components/HeadingPrimary/index.stories.tsx
+++ b/packages/fxa-settings/src/components/HeadingPrimary/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { HeadingPrimary } from '.';
 import { Meta } from '@storybook/react';
 

--- a/packages/fxa-settings/src/components/IconListItem/index.stories.tsx
+++ b/packages/fxa-settings/src/components/IconListItem/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import {

--- a/packages/fxa-settings/src/components/IconListItem/index.test.tsx
+++ b/packages/fxa-settings/src/components/IconListItem/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { KeyIconListItem } from '.';

--- a/packages/fxa-settings/src/components/IconListItem/index.tsx
+++ b/packages/fxa-settings/src/components/IconListItem/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { ReactComponent as IconFolder } from './icon-folder.svg';
 import { ReactComponent as IconGlobe } from './icon-globe.svg';
 import { ReactComponent as IconKey } from './icon-key.svg';

--- a/packages/fxa-settings/src/components/Icons/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Icons/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 
 import {

--- a/packages/fxa-settings/src/components/Icons/index.tsx
+++ b/packages/fxa-settings/src/components/Icons/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { ImageProps, PreparedImage as PreparedIcon } from '../PreparedImage';
 import { ReactComponent as AlertFull } from './icon_alert_triangle_full_yellow.min.svg';
 import { ReactComponent as AlertOutlineCurrent } from './icon_alert_triangle_outline_current.min.svg';

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InlineRecoveryKeySetupCreate from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/mocks.tsx
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/mocks.tsx
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import InlineRecoveryKeySetupCreate, { InlineRecoveryKeySetupCreateProps } from '.';
+import InlineRecoveryKeySetupCreate, {
+  InlineRecoveryKeySetupCreateProps,
+} from '.';
 import AppLayout from '../AppLayout';
 
 export const Subject = (props: Partial<InlineRecoveryKeySetupCreateProps>) => (

--- a/packages/fxa-settings/src/components/InputCheckboxBlue/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputCheckboxBlue/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InputCheckboxBlue from './index';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/InputCheckboxBlue/index.test.tsx
+++ b/packages/fxa-settings/src/components/InputCheckboxBlue/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import InputCheckboxBlue from '.';

--- a/packages/fxa-settings/src/components/InputPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import InputPassword from '.';

--- a/packages/fxa-settings/src/components/InputPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import InputPassword from '.';

--- a/packages/fxa-settings/src/components/InputPassword/mocks.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InputPassword from '.';
 
 export const SubjectWithPairedInputs = () => {

--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InputPhoneNumber from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { extendedCountryOptions, Subject } from './mocks';

--- a/packages/fxa-settings/src/components/InputPhoneNumber/mocks.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InputPhoneNumber, { defaultCountries, phoneNorthAmerica } from '.';
 import { useForm } from 'react-hook-form';
 import AppLayout from '../AppLayout';

--- a/packages/fxa-settings/src/components/InputText/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import InputText from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/InputText/index.test.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, cleanup } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import InputText from '.';

--- a/packages/fxa-settings/src/components/LegalWithMarkdown/index.test.tsx
+++ b/packages/fxa-settings/src/components/LegalWithMarkdown/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Subject } from './mocks';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/LinkDamaged/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import {
   ReportSigninLinkDamaged,

--- a/packages/fxa-settings/src/components/LinkDamaged/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import {

--- a/packages/fxa-settings/src/components/LinkDamaged/index.tsx
+++ b/packages/fxa-settings/src/components/LinkDamaged/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import CardHeader from '../CardHeader';
 import AppLayout from '../AppLayout';

--- a/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { StoryFn } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/LinkExpired/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { LinkExpired, LinkExpiredProps } from '.';
 import { ResendStatus } from 'fxa-settings/src/lib/types';

--- a/packages/fxa-settings/src/components/LinkExpired/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import CardHeader from '../CardHeader';
 import AppLayout from '../AppLayout';

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LinkRememberPassword from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import LinkRememberPassword, { LinkRememberPasswordProps } from '.';

--- a/packages/fxa-settings/src/components/LinkUsed/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkUsed/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import LinkUsed from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/LinkUsed/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkUsed/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import LinkUsed from '.';

--- a/packages/fxa-settings/src/components/LinkUsed/index.tsx
+++ b/packages/fxa-settings/src/components/LinkUsed/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import CardHeader from '../CardHeader';
 import AppLayout from '../AppLayout';

--- a/packages/fxa-settings/src/components/MarkdownLegal/index.tsx
+++ b/packages/fxa-settings/src/components/MarkdownLegal/index.tsx
@@ -5,7 +5,6 @@
 /* eslint-disable jsx-a11y/heading-has-content */
 
 import LinkExternal from 'fxa-react/components/LinkExternal';
-import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 

--- a/packages/fxa-settings/src/components/OAuthClientFeatureFlag/index.test.tsx
+++ b/packages/fxa-settings/src/components/OAuthClientFeatureFlag/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import { OAuthClientFeatureFlag } from '.';
 

--- a/packages/fxa-settings/src/components/OAuthDataError/index.stories.tsx
+++ b/packages/fxa-settings/src/components/OAuthDataError/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import OAuthDataError from './index';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';

--- a/packages/fxa-settings/src/components/PasswordInfoBalloon/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PasswordInfoBalloon/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import PasswordInfoBalloon from '.';

--- a/packages/fxa-settings/src/components/PasswordInfoBalloon/index.test.tsx
+++ b/packages/fxa-settings/src/components/PasswordInfoBalloon/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';

--- a/packages/fxa-settings/src/components/PasswordInfoBalloon/index.tsx
+++ b/packages/fxa-settings/src/components/PasswordInfoBalloon/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { KeyIconListItem } from '../IconListItem';
 

--- a/packages/fxa-settings/src/components/PasswordStrengthInline/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PasswordStrengthInline/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import PasswordStrengthInline, { PasswordStrengthInlineProps } from '.';

--- a/packages/fxa-settings/src/components/PasswordStrengthInline/index.test.tsx
+++ b/packages/fxa-settings/src/components/PasswordStrengthInline/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import PasswordStrengthInline from '.';

--- a/packages/fxa-settings/src/components/PreparedImage/index.test.tsx
+++ b/packages/fxa-settings/src/components/PreparedImage/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { HeartsVerifiedImage } from '../images';

--- a/packages/fxa-settings/src/components/PromoQrMobile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PromoQrMobile/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import {
   LocationProvider,

--- a/packages/fxa-settings/src/components/PromoQrMobile/index.test.tsx
+++ b/packages/fxa-settings/src/components/PromoQrMobile/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { createHistory, createMemorySource } from '@reach/router';
 import { PromoQrMobile, PromoQrMobileIntegration } from '.';

--- a/packages/fxa-settings/src/components/PromotionBanner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PromotionBanner/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import PromotionBanner, {

--- a/packages/fxa-settings/src/components/PromotionBanner/index.test.tsx
+++ b/packages/fxa-settings/src/components/PromotionBanner/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import PromotionBanner, {

--- a/packages/fxa-settings/src/components/Ready/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Ready, { ReadyProps } from '.';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';

--- a/packages/fxa-settings/src/components/Ready/index.test.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.stories.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import RecoveryKeySetupDownload from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.test.tsx
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';
-import { MOCK_CMS_INFO, MOCK_RECOVERY_KEY_WITH_SPACES } from '../../pages/mocks';
+import {
+  MOCK_CMS_INFO,
+  MOCK_RECOVERY_KEY_WITH_SPACES,
+} from '../../pages/mocks';
 
 describe('RecoveryKeySetupDownload', () => {
   it('renders as expected', async () => {
@@ -42,10 +44,10 @@ describe('RecoveryKeySetupDownload', () => {
   // so we have a separate test that targets just the thing that
   // cms is passed through to, the `Download and continue` button.
   it('renders button with CMS passthrough', () => {
-    renderWithLocalizationProvider(
-      <Subject cmsInfo={MOCK_CMS_INFO} />
-    );
-    const cmsButton = screen.getByRole('button', { name: 'Download and continue' });
+    renderWithLocalizationProvider(<Subject cmsInfo={MOCK_CMS_INFO} />);
+    const cmsButton = screen.getByRole('button', {
+      name: 'Download and continue',
+    });
     expect(cmsButton).toMatchSnapshot();
   });
 });

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/mocks.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import RecoveryKeySetupDownload, { RecoveryKeySetupDownloadProps } from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 import { MOCK_RECOVERY_KEY_WITH_SPACES } from '../../pages/mocks';

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.stories.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import RecoveryKeySetupHint from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.test.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { logViewEvent } from '../../lib/metrics';
 import { Account } from '../../models';

--- a/packages/fxa-settings/src/components/ResetPasswordWarning/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ResetPasswordWarning/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import ResetPasswordWarning from '.';

--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { AlertBar } from './index';
 import { alertContent, alertType, alertVisible } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import AlertBar from '.';

--- a/packages/fxa-settings/src/components/Settings/Avatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Avatar/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Avatar from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/Avatar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Avatar/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import Avatar from '.';

--- a/packages/fxa-settings/src/components/Settings/Avatar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Avatar/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import defaultAvatar from './avatar-default.svg';

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import BentoMenu from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import BentoMenu from '.';

--- a/packages/fxa-settings/src/components/Settings/ButtonIcon/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ButtonIcon/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ButtonIcon, { ButtonIconTrash, ButtonIconReload } from '.';
 import { StoryFn } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/ButtonIcon/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ButtonIcon/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { ReactComponent as TrashIcon } from './trash-icon.svg';

--- a/packages/fxa-settings/src/components/Settings/Checkbox/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Checkbox/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Checkbox from './index';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/Checkbox/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Checkbox/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import Checkbox from './index';

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { ConnectAnotherDevicePromo } from '.';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import ConnectAnotherDevicePromo from '.';
 import { renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/storeImageLoader.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/storeImageLoader.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-
 import daApple from './apple-app-store-button/da.svg';
 import deApple from './apple-app-store-button/de.svg';
 import enApple from './apple-app-store-button/en.svg';

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 import ConnectedServices, { sortAndFilterConnectedClients } from '.';
 import { OAuthNativeClients } from '@fxa/accounts/oauth';

--- a/packages/fxa-settings/src/components/Settings/ContentSkip/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ContentSkip/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import ContentSkip from '.';

--- a/packages/fxa-settings/src/components/Settings/ContentSkip/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ContentSkip/index.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-
 export const ContentSkip = () => (
   <a
     href="#main"

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { DataCollection } from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { DataCollection } from '.';
 import {

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import DropDownAvatarMenu from '.';

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent, act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import {

--- a/packages/fxa-settings/src/components/Settings/FlowContainer/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { FlowContainer } from '.';

--- a/packages/fxa-settings/src/components/Settings/FlowContainer/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 import FlowContainer from './index';
 import { renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/FlowContainer/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/mocks.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-
 export const MOCK_TITLE = 'Flow container title';
 
 export const MOCK_SUBTITLE = 'Subtitle';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FlowRecoveryKeyConfirmPwd } from '.';
 import { Meta } from '@storybook/react';
 import { Account, AppContext, useFtlMsgResolver } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { logViewEvent } from '../../../lib/metrics';
 import FlowRecoveryKeyConfirmPwd from './';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import FlowRecoveryKeyDownload from '.';
 import { Meta } from '@storybook/react';
 import { useFtlMsgResolver } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { logViewEvent } from '../../../lib/metrics';
 import FlowRecoveryKeyDownload from './';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import FlowContainer from '../FlowContainer';
 import ProgressBar from '../ProgressBar';
 import { logViewEvent } from '../../../lib/metrics';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import FlowRecoveryKeyHint from '.';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { logViewEvent } from '../../../lib/metrics';
 import { Account, AppContext } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import FlowRecoveryKeyInfo from '.';
 import { Meta } from '@storybook/react';
 import { useFtlMsgResolver } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { logViewEvent } from '../../../lib/metrics';
 import FlowRecoveryKeyInfo from './';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import FlowSetup2faComplete from './index';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { action } from '@storybook/addon-actions';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { BackupRecoveryPhoneCodeImage } from '../../images';
 import LinkExternal from 'fxa-react/components/LinkExternal';

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import FlowSetupRecoveryPhoneConfirmCode from '.';
 import '@testing-library/jest-dom';

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act, screen, waitFor } from '@testing-library/react';
 import FlowSetupRecoveryPhoneSubmitNumber from '.';
 import '@testing-library/jest-dom';
@@ -90,7 +89,7 @@ describe('FlowSetupRecoveryPhoneSubmitNumber', () => {
     await waitFor(() => expect(mockVerifyPhoneNumber).toHaveBeenCalledTimes(1));
     expect(mockNavigateForward).toHaveBeenCalledTimes(1);
   });
-   test('handles error during number verification', async () => {
+  test('handles error during number verification', async () => {
     mockVerifyPhoneNumber.mockRejectedValueOnce(new Error('error'));
     const user = userEvent.setup();
     await renderWith();

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { HeaderLockup } from '.';

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import HeaderLockup from '.';
 import { userEvent } from '@testing-library/user-event';

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/LinkedAccount.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/LinkedAccount.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-
 import { Localized } from '@fluent/react';
 import { ReactComponent as GoogleIcon } from './google.svg';
 import { ReactComponent as AppleIcon } from './apple.svg';

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LinkedAccounts } from '.';

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import { action } from '@storybook/addon-actions';

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/Modal/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback } from 'react';
+import { MouseEvent, ReactNode, useCallback } from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { useBooleanState } from 'fxa-react/lib/hooks';
@@ -16,12 +16,12 @@ type ModalToggleChildrenProps = {
   showModal: () => void;
 };
 type ModalToggleProps = {
-  children: (props: ModalToggleChildrenProps) => React.ReactNode | null;
+  children: (props: ModalToggleChildrenProps) => ReactNode | null;
 };
 const ModalToggle = ({ children }: ModalToggleProps) => {
   const [modalRevealed, showModal, hideModal] = useBooleanState(true);
   const onClick = useCallback(
-    (ev: React.MouseEvent) => {
+    (ev: MouseEvent) => {
       ev.stopPropagation();
       showModal();
     },

--- a/packages/fxa-settings/src/components/Settings/Modal/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.test.tsx
@@ -2,18 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import Modal from './index';
 import { renderWithRouter } from '../../../models/mocks';
 
 it('renders as expected', () => {
   const onDismiss = jest.fn();
-  const ariaLabelledBy="modal-header";
-  const ariaDescribedBy="modal-description";
+  const ariaLabelledBy = 'modal-header';
+  const ariaDescribedBy = 'modal-description';
 
   renderWithRouter(
-    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
+    <Modal
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+      {...{ onDismiss }}
+    >
       <div data-testid="children">Hi mom</div>
     </Modal>
   );
@@ -22,14 +25,23 @@ it('renders as expected', () => {
     'title',
     'Close'
   );
-  expect(screen.getByTestId('modal-information')).toHaveAttribute('aria-labelledby', ariaLabelledBy);
-  expect(screen.getByTestId('modal-information')).toHaveAttribute('aria-describedby', ariaDescribedBy);
-  expect(screen.getByTestId('modal-information')).toHaveAttribute('role', "dialog")
+  expect(screen.getByTestId('modal-information')).toHaveAttribute(
+    'aria-labelledby',
+    ariaLabelledBy
+  );
+  expect(screen.getByTestId('modal-information')).toHaveAttribute(
+    'aria-describedby',
+    ariaDescribedBy
+  );
+  expect(screen.getByTestId('modal-information')).toHaveAttribute(
+    'role',
+    'dialog'
+  );
 });
 
 it('renders confirm button as a link if route is passed', () => {
-  const ariaLabelledBy="modal-with-confirm-header";
-  const ariaDescribedBy="modal-with-confirm-description";
+  const ariaLabelledBy = 'modal-with-confirm-header';
+  const ariaDescribedBy = 'modal-with-confirm-description';
   const route = '/some/route';
   const onDismiss = jest.fn();
   renderWithRouter(
@@ -51,8 +63,8 @@ it('renders confirm button as a link if route is passed', () => {
 });
 
 it('does not render the cancel button if hasCancelButton is set to false', () => {
-  const ariaLabelledBy="no-cancel-modal-header"
-  const ariaDescribedBy="no-cancel-modal-description"
+  const ariaLabelledBy = 'no-cancel-modal-header';
+  const ariaDescribedBy = 'no-cancel-modal-description';
   const onDismiss = jest.fn();
   renderWithRouter(
     <Modal
@@ -72,8 +84,8 @@ it('does not render the cancel button if hasCancelButton is set to false', () =>
 });
 
 it('accepts an alternate className', () => {
-  const ariaLabelledBy="barquux-modal-header";
-  const ariaDescribedBy="barquux-modal-description";
+  const ariaLabelledBy = 'barquux-modal-header';
+  const ariaDescribedBy = 'barquux-modal-description';
   const onDismiss = jest.fn();
   renderWithRouter(
     <Modal
@@ -94,11 +106,15 @@ it('accepts an alternate className', () => {
 });
 
 it('calls onDismiss on click outside', () => {
-  const ariaLabelledBy="some-modal-header";
-  const ariaDescribedBy="some-modal-description";
+  const ariaLabelledBy = 'some-modal-header';
+  const ariaDescribedBy = 'some-modal-description';
   const onDismiss = jest.fn();
   const { container } = renderWithRouter(
-    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
+    <Modal
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+      {...{ onDismiss }}
+    >
       <div data-testid="children">
         <h4 id={ariaLabelledBy}>Message for mom</h4>
         <p id={ariaDescribedBy}>Hi mom</p>
@@ -112,11 +128,15 @@ it('calls onDismiss on click outside', () => {
 });
 
 it('calls onDismiss on esc key press', () => {
-  const ariaLabelledBy="use-esc-modal-header";
-  const ariaDescribedBy="use-esc-modal-description";
+  const ariaLabelledBy = 'use-esc-modal-header';
+  const ariaDescribedBy = 'use-esc-modal-description';
   const onDismiss = jest.fn();
   renderWithRouter(
-    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
+    <Modal
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+      {...{ onDismiss }}
+    >
       <div data-testid="children">
         <h4 id={ariaLabelledBy}>Message for mom</h4>
         <p id={ariaDescribedBy}>Hi mom</p>
@@ -128,11 +148,15 @@ it('calls onDismiss on esc key press', () => {
 });
 
 it('shifts focus to the tab fence when opened', () => {
-  const ariaLabelledBy="tab-focus-modal-header";
-  const ariaDescribedBy="tab-focus-modal-description";
+  const ariaLabelledBy = 'tab-focus-modal-header';
+  const ariaDescribedBy = 'tab-focus-modal-description';
   const onDismiss = jest.fn();
   renderWithRouter(
-    <Modal headerId={ariaLabelledBy} descId={ariaDescribedBy} {...{ onDismiss }}>
+    <Modal
+      headerId={ariaLabelledBy}
+      descId={ariaDescribedBy}
+      {...{ onDismiss }}
+    >
       <div data-testid="children">
         <h4 id={ariaLabelledBy}>Message for mom</h4>
         <p id={ariaDescribedBy}>Hi mom</p>

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import { useBooleanState } from 'fxa-react/lib/hooks';

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.stories.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback } from 'react';
+import { MouseEvent, ReactNode, useCallback } from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { useBooleanState } from 'fxa-react/lib/hooks';
@@ -26,12 +26,12 @@ type ModalToggleChildrenProps = {
   showModal: () => void;
 };
 type ModalToggleProps = {
-  children: (props: ModalToggleChildrenProps) => React.ReactNode | null;
+  children: (props: ModalToggleChildrenProps) => ReactNode | null;
 };
 const ModalToggle = ({ children }: ModalToggleProps) => {
   const [modalRevealed, showModal, hideModal] = useBooleanState(true);
   const onClick = useCallback(
-    (ev: React.MouseEvent) => {
+    (ev: MouseEvent) => {
       ev.preventDefault();
       showModal();
     },

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import 'mutationobserver-shim';
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {

--- a/packages/fxa-settings/src/components/Settings/Nav/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { getDefault, Config } from '../../../lib/config';
 import { Nav } from '.';

--- a/packages/fxa-settings/src/components/Settings/Nav/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Account, AppContext } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/Page2faChange/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faChange/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/Page2faChange/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faChange/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   MOCK_ACCOUNT,
   mockAppContext,

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceBackupCodes/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceBackupCodes/index.stories.tsx
@@ -8,7 +8,6 @@ import {
   MOCK_ACCOUNT,
   mockSession,
 } from 'fxa-settings/src/models/mocks';
-import React from 'react';
 import { Page2faReplaceBackupCodes } from '.';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Meta } from '@storybook/react';
 

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   MOCK_ACCOUNT,
   mockAppContext,

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import PageAvatar from './';

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 
 import { Account, AppContext } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { PageChangePassword } from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import 'mutationobserver-shim';
-import React from 'react';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { SETTINGS_PATH } from '../../../constants';
 import {

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { PageCreatePassword } from '.';
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   logViewEvent,
   settingsViewName,

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { PageDeleteAccount } from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import 'mutationobserver-shim';
 import {
   screen,

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { LocationProvider } from '@reach/router';
-import React from 'react';
 import { PageDisplayName } from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import 'mutationobserver-shim';
-import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 import PageDisplayName from '.';
 import {

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/SecurityEvent.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/SecurityEvent.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
 enum SecurityEventName {

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { PageRecentActivity } from '.';
 import { MOCK_SECURITY_EVENTS } from './mocks';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
@@ -5,7 +5,6 @@
 import 'mutationobserver-shim';
 import { act, screen } from '@testing-library/react';
 import { renderWithRouter, mockAppContext } from '../../../models/mocks';
-import React from 'react';
 import PageRecentActivity from '.';
 import { Account, AppContext } from '../../../models';
 import { MOCK_SECURITY_EVENTS } from './mocks';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { PageRecoveryKeyCreate } from '.';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { PageRecoveryKeyCreate } from '.';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { PageRecoveryPhoneRemove } from '.';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { PageRecoveryPhoneRemove } from '.';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import PageRecoveryPhoneSetup from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../models/mocks';
 import { Subject } from './mocks';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 import PageRecoveryPhoneSetup from '.';

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { PageSecondaryEmailAdd } from '.';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';
 import { PageSecondaryEmailAdd, MfaGuardPageSecondaryEmailAdd } from '.';

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { PageSecondaryEmailVerify } from '.';
 import { WindowLocation, LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import 'mutationobserver-shim';
-import React from 'react';
 import { screen, fireEvent, act } from '@testing-library/react';
 import {
   mockAppContext,

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Account } from '../../../models/Account';
 
 import { PageSettings } from '.';

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import PageSettings from '.';

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import ProductPromo, { ProductPromoProps } from '.';

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import ProductPromo, { getProductPromoData } from '.';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { ReactComponent as VpnTextLogo } from './vpn-text-logo.svg';
 import { FtlMsg } from 'fxa-react/lib/utils';

--- a/packages/fxa-settings/src/components/Settings/Profile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Profile/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Profile } from '.';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/Profile/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Profile/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Profile } from '.';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';
 import { AppContext } from '../../../models';

--- a/packages/fxa-settings/src/components/Settings/ProgressBar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProgressBar/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/ProgressBar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProgressBar/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import ProgressBar from '.';

--- a/packages/fxa-settings/src/components/Settings/ProgressBar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProgressBar/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { useFtlMsgResolver } from '../../../models';
 
 export type ProgressBarProps = {

--- a/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { Security } from '.';
 import { AppContext } from 'fxa-settings/src/models';

--- a/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import Security from '.';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/SettingsLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SettingsLayout/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SettingsLayout from './index';
 import { Meta } from '@storybook/react';
 import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/SettingsLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SettingsLayout/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../models/mocks';
 import { SETTINGS_PATH } from '../../../constants';

--- a/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Nav, { NavRefProps } from '../Nav';
 import ProductPromo, { VpnPromoData } from '../ProductPromo';
 

--- a/packages/fxa-settings/src/components/Settings/SignoutSync/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SignoutSync from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Settings/SignoutSync/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SignoutSync from '.';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/Settings/SignoutSync/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import CardHeader from '../../CardHeader';

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
 import SubRow, {
   BackupCodesSubRow,

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SubRow, {

--- a/packages/fxa-settings/src/components/Settings/Switch/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Switch/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import Switch from '.';

--- a/packages/fxa-settings/src/components/Settings/Switch/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Switch/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Localized } from '@fluent/react';
-import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import Switch from '.';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/Settings/Switch/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Switch/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Localized, LocalizedProps, useLocalization } from '@fluent/react';
 import { ReactElement } from 'react';
 
@@ -36,8 +35,8 @@ export const Switch = ({
           isSubmitting
             ? l10n.getString('switch-submitting', null, 'Submitting…')
             : isOn
-            ? l10n.getString('switch-turn-off', null, 'Turn off')
-            : l10n.getString('switch-turn-on', null, 'Turn on')
+              ? l10n.getString('switch-turn-off', null, 'Turn off')
+              : l10n.getString('switch-turn-on', null, 'Turn on')
         }
         onClick={handler}
         type="button"

--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import UnitRow from '.';
 import { renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import UnitRow, { UnitRowProps } from '../UnitRow';
 import {
   useAccount,

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import UnitRowRecoveryKey from '.';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { UnitRowSecondaryEmail } from '.';

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import 'mutationobserver-shim';
-import React from 'react';
 import { screen, fireEvent, act, waitFor } from '@testing-library/react';
 import {
   renderWithRouter,

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { mockAppContext, mockSettingsContext } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 import UnitRowTwoStepAuth from '.';

--- a/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import 'mutationobserver-shim';
-import React from 'react';
 import { screen, act } from '@testing-library/react';
 import {
   mockAppContext,
@@ -70,7 +69,10 @@ it('calls onError when session status check is rate limited', async () => {
             session: mockSession(false),
             authClient: {
               sessionStatus: () => {
-                const err = Object.assign(new Error("You've tried too many times. Try again later."), { errno: 114 });
+                const err = Object.assign(
+                  new Error("You've tried too many times. Try again later."),
+                  { errno: 114 }
+                );
                 throw err;
               },
             } as unknown as AuthClient,

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import TermsPrivacyAgreement, { LegalTerms } from '.';
 import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import TermsPrivacyAgreement, { LegalTerms } from '.';

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { Link } from '@reach/router';
 import LinkExternal from 'fxa-react/components/LinkExternal';

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ThirdPartyAuth from '.';
 import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/mocks.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ThirdPartyAuth, { ThirdPartyAuthProps } from '.';
 import { AppContext } from '../../models';
 import { mockAppContext } from '../../models/mocks';

--- a/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import Tooltip from './index';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/components/Tooltip/index.test.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import Tooltip from '.';

--- a/packages/fxa-settings/src/components/Tooltip/index.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import classNames from 'classnames';
 
 export type TooltipType = 'default' | 'error';

--- a/packages/fxa-settings/src/components/images/index.stories.tsx
+++ b/packages/fxa-settings/src/components/images/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 
 import {

--- a/packages/fxa-settings/src/models/contexts/NimbusContext.test.tsx
+++ b/packages/fxa-settings/src/models/contexts/NimbusContext.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { NimbusProvider, useNimbusContext } from './NimbusContext';
 import { AppContext, AppContextValue } from './AppContext';
@@ -16,17 +15,27 @@ jest.mock('../../lib/nimbus');
 jest.mock('@sentry/react');
 jest.mock('../../lib/hooks/useLocalStorageSync');
 
-const mockUseDynamicLocalization = useDynamicLocalization as jest.MockedFunction<typeof useDynamicLocalization>;
-const mockInitializeNimbus = initializeNimbus as jest.MockedFunction<typeof initializeNimbus>;
-const mockSentryCaptureException = Sentry.captureException as jest.MockedFunction<typeof Sentry.captureException>;
-const mockUseLocalStorageSync = useLocalStorageSync as jest.MockedFunction<typeof useLocalStorageSync>;
+const mockUseDynamicLocalization =
+  useDynamicLocalization as jest.MockedFunction<typeof useDynamicLocalization>;
+const mockInitializeNimbus = initializeNimbus as jest.MockedFunction<
+  typeof initializeNimbus
+>;
+const mockSentryCaptureException =
+  Sentry.captureException as jest.MockedFunction<
+    typeof Sentry.captureException
+  >;
+const mockUseLocalStorageSync = useLocalStorageSync as jest.MockedFunction<
+  typeof useLocalStorageSync
+>;
 
 const TestComponent = () => {
   const { experiments, loading, error } = useNimbusContext();
   return (
     <div>
       <div data-testid="loading">{loading.toString()}</div>
-      <div data-testid="experiments">{experiments ? 'has-experiments' : 'no-experiments'}</div>
+      <div data-testid="experiments">
+        {experiments ? 'has-experiments' : 'no-experiments'}
+      </div>
       <div data-testid="error">{error ? error.message : 'no-error'}</div>
     </div>
   );
@@ -34,12 +43,14 @@ const TestComponent = () => {
 
 const mockAppContext = {
   config: {
-    nimbus: { enabled: true, preview: false }
+    nimbus: { enabled: true, preview: false },
   } as AppContextValue['config'],
-  uniqueUserId: 'test-user-id'
+  uniqueUserId: 'test-user-id',
 } as Partial<AppContextValue>;
 
-const renderWithProviders = (appContext: Partial<AppContextValue> = mockAppContext) => {
+const renderWithProviders = (
+  appContext: Partial<AppContextValue> = mockAppContext
+) => {
   return render(
     <AppContext.Provider value={appContext as AppContextValue}>
       <NimbusProvider>
@@ -56,7 +67,7 @@ describe('NimbusContext', () => {
       currentLocale: 'en-US',
       switchLanguage: jest.fn(),
       clearLanguagePreference: jest.fn(),
-      isLoading: false
+      isLoading: false,
     });
     // Mock useLocalStorageSync to return undefined by default (no account)
     mockUseLocalStorageSync.mockImplementation((key: string) => {
@@ -70,7 +81,7 @@ describe('NimbusContext', () => {
     });
     Object.defineProperty(window, 'location', {
       value: { search: '' },
-      writable: true
+      writable: true,
     });
   });
 
@@ -79,7 +90,9 @@ describe('NimbusContext', () => {
       render(<TestComponent />);
 
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
-      expect(screen.getByTestId('experiments')).toHaveTextContent('no-experiments');
+      expect(screen.getByTestId('experiments')).toHaveTextContent(
+        'no-experiments'
+      );
       expect(screen.getByTestId('error')).toHaveTextContent('no-error');
     });
   });
@@ -90,7 +103,9 @@ describe('NimbusContext', () => {
 
       expect(() => {
         render(
-          <AppContext.Provider value={{ uniqueUserId: 'test' } as AppContextValue}>
+          <AppContext.Provider
+            value={{ uniqueUserId: 'test' } as AppContextValue}
+          >
             <NimbusProvider>
               <TestComponent />
             </NimbusProvider>
@@ -104,7 +119,9 @@ describe('NimbusContext', () => {
     it('does not fetch when nimbus is disabled', async () => {
       const disabledConfig: Partial<AppContextValue> = {
         ...mockAppContext,
-        config: { nimbus: { enabled: false, preview: false } } as AppContextValue['config']
+        config: {
+          nimbus: { enabled: false, preview: false },
+        } as AppContextValue['config'],
       };
 
       renderWithProviders(disabledConfig);
@@ -116,7 +133,7 @@ describe('NimbusContext', () => {
     it('does not fetch when uniqueUserId is missing', async () => {
       const noUserIdConfig: Partial<AppContextValue> = {
         ...mockAppContext,
-        uniqueUserId: undefined
+        uniqueUserId: undefined,
       };
 
       renderWithProviders(noUserIdConfig);
@@ -129,7 +146,8 @@ describe('NimbusContext', () => {
       const accountUid = 'test-account-uid';
       mockUseLocalStorageSync.mockImplementation((key: string) => {
         if (key === 'currentAccountUid') return accountUid;
-        if (key === 'accounts') return { [accountUid]: { metricsEnabled: false } };
+        if (key === 'accounts')
+          return { [accountUid]: { metricsEnabled: false } };
         return undefined;
       });
 
@@ -138,19 +156,22 @@ describe('NimbusContext', () => {
       await waitFor(() => {
         expect(mockInitializeNimbus).not.toHaveBeenCalled();
       });
-      expect(screen.getByTestId('experiments')).toHaveTextContent('no-experiments');
+      expect(screen.getByTestId('experiments')).toHaveTextContent(
+        'no-experiments'
+      );
     });
 
     it('fetches when metrics are enabled via localStorage', async () => {
       const accountUid = 'test-account-uid';
       mockUseLocalStorageSync.mockImplementation((key: string) => {
         if (key === 'currentAccountUid') return accountUid;
-        if (key === 'accounts') return { [accountUid]: { metricsEnabled: true } };
+        if (key === 'accounts')
+          return { [accountUid]: { metricsEnabled: true } };
         return undefined;
       });
       mockInitializeNimbus.mockResolvedValue({
         features: { 'test-feature': { enabled: true } },
-        nimbusUserId: 'test-user-id'
+        nimbusUserId: 'test-user-id',
       });
 
       renderWithProviders();
@@ -158,39 +179,44 @@ describe('NimbusContext', () => {
       await waitFor(() => {
         expect(mockInitializeNimbus).toHaveBeenCalled();
       });
-      expect(screen.getByTestId('experiments')).toHaveTextContent('has-experiments');
+      expect(screen.getByTestId('experiments')).toHaveTextContent(
+        'has-experiments'
+      );
     });
 
     it('fetches experiments successfully', async () => {
       const mockExperiments: NimbusResult = {
         features: { 'test-feature': { enabled: true } },
-        nimbusUserId: 'test-user-id'
+        nimbusUserId: 'test-user-id',
       };
       mockInitializeNimbus.mockResolvedValue(mockExperiments);
 
       renderWithProviders();
 
-      expect(mockInitializeNimbus).toHaveBeenCalledWith(
-        'test-user-id',
-        false,
-        { language: 'en', region: 'us' }
-      );
+      expect(mockInitializeNimbus).toHaveBeenCalledWith('test-user-id', false, {
+        language: 'en',
+        region: 'us',
+      });
 
       await screen.findByTestId('experiments');
-      expect(screen.getByTestId('experiments')).toHaveTextContent('has-experiments');
+      expect(screen.getByTestId('experiments')).toHaveTextContent(
+        'has-experiments'
+      );
     });
 
     it('handles API response with lowercase features', async () => {
       const mockExperiments: NimbusResult = {
         features: { 'test-feature': { enabled: true } },
-        nimbusUserId: 'test-user-id'
+        nimbusUserId: 'test-user-id',
       };
       mockInitializeNimbus.mockResolvedValue(mockExperiments);
 
       renderWithProviders();
 
       await screen.findByTestId('experiments');
-      expect(screen.getByTestId('experiments')).toHaveTextContent('has-experiments');
+      expect(screen.getByTestId('experiments')).toHaveTextContent(
+        'has-experiments'
+      );
     });
 
     it('handles null response', async () => {
@@ -199,7 +225,9 @@ describe('NimbusContext', () => {
       renderWithProviders();
 
       await screen.findByTestId('experiments');
-      expect(screen.getByTestId('experiments')).toHaveTextContent('no-experiments');
+      expect(screen.getByTestId('experiments')).toHaveTextContent(
+        'no-experiments'
+      );
     });
 
     it('handles fetch error without duplicate error handling', async () => {
@@ -216,7 +244,9 @@ describe('NimbusContext', () => {
     it('handles preview mode from config', async () => {
       const previewConfig: Partial<AppContextValue> = {
         ...mockAppContext,
-        config: { nimbus: { enabled: true, preview: true } } as AppContextValue['config']
+        config: {
+          nimbus: { enabled: true, preview: true },
+        } as AppContextValue['config'],
       };
 
       renderWithProviders(previewConfig);
@@ -233,7 +263,7 @@ describe('NimbusContext', () => {
     it('handles preview mode from URL params', async () => {
       Object.defineProperty(window, 'location', {
         value: { search: '?nimbusPreview=true' },
-        writable: true
+        writable: true,
       });
 
       renderWithProviders();
@@ -250,7 +280,7 @@ describe('NimbusContext', () => {
     it('cleans up on unmount', async () => {
       mockInitializeNimbus.mockResolvedValue({
         features: { 'test-feature': { enabled: true } },
-        nimbusUserId: 'test-user-id'
+        nimbusUserId: 'test-user-id',
       });
 
       const { unmount } = renderWithProviders();

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AuthClient from 'fxa-auth-client/browser';
 import { AccountData, ProfileInfo, Session } from '.';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Authorization/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';
 import AuthorizationContainer from './container';

--- a/packages/fxa-settings/src/pages/Clear/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Clear/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Clear from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Clear/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Clear/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Clear from '.';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Clear/index.tsx
+++ b/packages/fxa-settings/src/pages/Clear/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AppLayout from '../../components/AppLayout';
 import { RouteComponentProps } from '@reach/router';
 

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ConnectAnotherDevice, { Devices } from '.';
 import AppLayout from '../../components/AppLayout';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { MOCK_ACCOUNT, renderWithRouter } from '../../models/mocks';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import CookiesDisabled from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import CookiesDisabled, { viewName } from '.';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Index from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { createMockIndexOAuthNativeIntegration, Subject } from './mocks';

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { render } from '@testing-library/react';
-import React from 'react';
 import InlineRecoveryKeySetupContainer from './container';
 import * as InlineRecoveryKeySetupModule from '.';
 import * as ModelsModule from '../../models';

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InlineRecoveryKeySetup from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
@@ -18,6 +17,6 @@ export const StepOne = () => <Subject />;
 export const StepTwo = () => <Subject currentStep={2} />;
 export const StepThree = () => <Subject currentStep={3} />;
 
-export const StepOneWithCms = () => <Subject cms={true}/>;
-export const StepTwoWithCms = () => <Subject currentStep={2} cms={true}/>;
-export const StepThreeWithCms = () => <Subject currentStep={3} cms={true}/>;
+export const StepOneWithCms = () => <Subject cms={true} />;
+export const StepTwoWithCms = () => <Subject currentStep={2} cms={true} />;
+export const StepThreeWithCms = () => <Subject currentStep={3} cms={true} />;

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import InlineRecoveryKeySetupCreate from '../../components/InlineRecoveryKeySetupCreate';
 import RecoveryKeySetupDownload from '../../components/RecoveryKeySetupDownload';

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/mocks.tsx
@@ -2,11 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InlineRecoveryKeySetup from '.';
-import { MOCK_CMS_INFO, MOCK_EMAIL, MOCK_RECOVERY_KEY_WITH_SPACES } from '../mocks';
+import {
+  MOCK_CMS_INFO,
+  MOCK_EMAIL,
+  MOCK_RECOVERY_KEY_WITH_SPACES,
+} from '../mocks';
 
-export const Subject = ({ currentStep = 1, cms = false }: { currentStep?: number, cms?: boolean }) => (
+export const Subject = ({
+  currentStep = 1,
+  cms = false,
+}: {
+  currentStep?: number;
+  cms?: boolean;
+}) => (
   <InlineRecoveryKeySetup
     {...{ currentStep }}
     createRecoveryKeyHandler={() =>

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InlineRecoverySetup from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import InlineTotpSetup from '.';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';

--- a/packages/fxa-settings/src/pages/Legal/Privacy/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Privacy/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LegalPrivacy from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Legal/Privacy/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Privacy/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LegalPrivacy, { viewName } from '.';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Legal/Terms/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Terms/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LegalTerms from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Legal/Terms/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Terms/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import LegalTerms, { viewName } from '.';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Legal/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Legal/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Legal from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Legal/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Legal/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Legal, { viewName } from '.';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Legal/index.tsx
+++ b/packages/fxa-settings/src/pages/Legal/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AppLayout from '../../components/AppLayout';
 import { Link, RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';

--- a/packages/fxa-settings/src/pages/Pair/AuthAllow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthAllow/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AuthAllow from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AuthComplete from '.';
 import { Meta } from '@storybook/react';
 import { MOCK_ERROR } from './mocks';

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import AuthComplete, { viewName } from '.';

--- a/packages/fxa-settings/src/pages/Pair/AuthTotp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthTotp/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AuthTotp from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AuthWaitForSupp from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthWaitForSupp/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import AuthWaitForSupp, { viewName } from '.';

--- a/packages/fxa-settings/src/pages/Pair/Failure/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Failure/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import PairFailure from '.';
 import { Meta } from '@storybook/react';
 import { MOCK_ERROR } from './mock';

--- a/packages/fxa-settings/src/pages/Pair/Failure/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Failure/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';

--- a/packages/fxa-settings/src/pages/Pair/Failure/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Failure/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import CardHeader from '../../../components/CardHeader';

--- a/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Pair from '.';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/pages/Pair/Success/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Success/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import PairSuccess from '.';
 import { Meta } from '@storybook/react';
 import { MOCK_ERROR } from './mocks';

--- a/packages/fxa-settings/src/pages/Pair/Success/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Success/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';

--- a/packages/fxa-settings/src/pages/Pair/Success/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Success/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import CardHeader from '../../../components/CardHeader';

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Supp from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import Supp from '.';

--- a/packages/fxa-settings/src/pages/Pair/SuppAllow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppAllow/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SuppAllow from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Pair/SuppAllow/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppAllow/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent, act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import SuppAllow from '.';

--- a/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SuppWaitForAuth from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/SuppWaitForAuth/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import SuppWaitForAuth, { viewName } from '.';

--- a/packages/fxa-settings/src/pages/Pair/Unsupported/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Unsupported/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import PairUnsupported from '.';
 import { Meta } from '@storybook/react';
 import { MOCK_ERROR } from './mock';

--- a/packages/fxa-settings/src/pages/Pair/Unsupported/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Unsupported/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { usePageViewEvent } from '../../../lib/metrics';

--- a/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Subject } from './mocks';

--- a/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';

--- a/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import AppLayout from '../../../components/AppLayout';
 import Banner from '../../../components/Banner';

--- a/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/mocks.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ServiceWelcome/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   createHistory,
   createMemorySource,

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import SetPassword from '.';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { createMockIntegration, Subject } from './mocks';

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import AppLayout from '../../../components/AppLayout';
 import { FormSetupAccount } from '../../../components/FormSetupAccount';

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SetPassword from '.';
 import { LocationProvider } from '@reach/router';
 import {

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -7,7 +7,6 @@ import { OAuthNativeClients, OAuthNativeServices } from '@fxa/accounts/oauth';
 import * as utils from 'fxa-react/lib/utils';
 import * as CacheModule from '../../../lib/cache';
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import ThirdPartyAuthCallback from '.';

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import AccountRecoveryConfirmKey from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';
 import { screen, waitFor } from '@testing-library/react';

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import CompleteResetPasswordContainer from './container';
 import { mockOAuthNativeSigninIntegration } from '../../Signin/SigninTotpCode/mocks';

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { createMockWebIntegration, Subject } from './mocks';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/container.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ConfirmBackupCodeResetPassword from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Subject } from './mocks';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import ConfirmResetPassword from '.';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.test.tsx
@@ -4,7 +4,6 @@
 
 // TODO in FXA-7890 import tests from previous design and update
 
-import React from 'react';
 import { Subject } from './mocks';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ConfirmTotpResetPassword from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.test.tsx
@@ -4,7 +4,6 @@
 
 // TODO in FXA-7890 import tests from previous design and update
 
-import React from 'react';
 import { Subject } from './mocks';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ResetPassword from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import GleanMetrics from '../../../lib/glean';
 import { Subject } from './mocks';
@@ -59,7 +58,9 @@ describe('ResetPassword', () => {
         user.type(screen.getByRole('textbox'), `${MOCK_EMAIL} `)
       );
 
-      await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
+      await waitFor(() =>
+        user.click(screen.getByRole('button', { name: 'Continue' }))
+      );
 
       expect(mockRequestResetPasswordCode).toHaveBeenCalledWith(MOCK_EMAIL);
 
@@ -79,7 +80,9 @@ describe('ResetPassword', () => {
         user.type(screen.getByRole('textbox'), ` ${MOCK_EMAIL}`)
       );
 
-      await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
+      await waitFor(() =>
+        user.click(screen.getByRole('button', { name: 'Continue' }))
+      );
 
       expect(mockRequestResetPasswordCode).toHaveBeenCalledWith(MOCK_EMAIL);
       expect(GleanMetrics.passwordReset.view).toHaveBeenCalledTimes(1);
@@ -94,7 +97,9 @@ describe('ResetPassword', () => {
         );
 
         await expect(screen.getByRole('heading', { level: 1 })).toBeVisible();
-        await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
+        await waitFor(() =>
+          user.click(screen.getByRole('button', { name: 'Continue' }))
+        );
 
         expect(screen.getByText('Valid email required')).toBeVisible();
         expect(mockRequestResetPasswordCode).not.toHaveBeenCalled();
@@ -111,7 +116,9 @@ describe('ResetPassword', () => {
         await expect(screen.getByRole('heading', { level: 1 })).toBeVisible();
         await waitFor(() => user.type(screen.getByRole('textbox'), 'boop'));
 
-        await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
+        await waitFor(() =>
+          user.click(screen.getByRole('button', { name: 'Continue' }))
+        );
 
         expect(screen.getByText('Valid email required')).toBeVisible();
         expect(mockRequestResetPasswordCode).not.toHaveBeenCalled();

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ResetPasswordConfirmed from '.';
 import { MozServices } from '../../../lib/types';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import ResetPasswordConfirmed from '.';
@@ -22,7 +21,9 @@ describe('ResetPasswordConfirmed', () => {
     expect(
       screen.getByText('Your password has been reset')
     ).toBeInTheDocument();
-    const submitButton = screen.getByRole('button', { name: 'Continue to Mozilla Monitor' });
+    const submitButton = screen.getByRole('button', {
+      name: 'Continue to Mozilla Monitor',
+    });
     expect(submitButton).toHaveTextContent('Continue to Mozilla Monitor');
     expect(submitButton).toHaveAttribute(
       'data-glean-id',
@@ -50,7 +51,9 @@ describe('ResetPasswordConfirmed', () => {
         serviceName={MozServices.Monitor}
       />
     );
-    user.click(screen.getByRole('button', { name: 'Continue to Mozilla Monitor' }));
+    user.click(
+      screen.getByRole('button', { name: 'Continue to Mozilla Monitor' })
+    );
     await waitFor(() => expect(mockContinueHandler).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import AppLayout from '../../../components/AppLayout';
 import { ResetPasswordConfirmedProps } from './interfaces';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import ResetPasswordRecoveryChoice from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.test.tsx
@@ -4,7 +4,6 @@
 
 import * as ReachRouterModule from '@reach/router';
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor, within } from '@testing-library/react';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { act } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import ResetPasswordRecoveryPhone from '.';
 import { getHandledError } from '../../../lib/error-utils';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import ResetPasswordRecoveryPhone from '.';
 import { ResetPasswordRecoveryPhoneProps } from './interfaces';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ResetPasswordWithRecoveryKeyVerified from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import ResetPasswordWithRecoveryKeyVerified, { viewName } from '.';
 import { logViewEvent } from '../../../lib/metrics';

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.test.tsx
@@ -6,7 +6,6 @@ import * as UseValidateModule from '../../../lib/hooks/useValidate';
 import * as ModelsModule from '../../../models';
 import * as ReactUtils from 'fxa-react/lib/utils';
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import AuthClient from 'fxa-auth-client/browser';
 import CompleteSigninContainer from './container';

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import CompleteSignin from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import CompleteSignin from '.';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { FtlMsg } from 'fxa-react/lib/utils';

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
@@ -6,7 +6,6 @@
  * TIP - See signup/container.test.tsx for helpful tips about writing container tests
  */
 
-import React from 'react';
 import * as ReportSigninModule from './index';
 import * as LinkDamagedModule from '../../../components/LinkDamaged';
 import * as UseValidateModule from '../../../lib/hooks/useValidate';

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ReportSignin from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import ReportSignin, { viewName } from '.';

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { RouteComponentProps } from '@reach/router';

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninBounced from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import { MOCK_ACCOUNT, renderWithRouter } from '../../../models/mocks';
 import SigninBounced, { viewName } from '.';

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninConfirmed from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
@@ -36,10 +35,14 @@ export const IsSync = () => (
 
 export const IsSyncWithCms = () => (
   <LocationProvider>
-    <SigninConfirmed isSignedIn={false} serviceName={MozServices.FirefoxSync}
-                     integration={createMockSigninOAuthIntegration({
-                       cmsInfo: MOCK_CMS_INFO
-                     }) as any}
+    <SigninConfirmed
+      isSignedIn={false}
+      serviceName={MozServices.FirefoxSync}
+      integration={
+        createMockSigninOAuthIntegration({
+          cmsInfo: MOCK_CMS_INFO,
+        }) as any
+      }
     />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
 import { MozServices } from '../../../lib/types';
@@ -22,13 +21,15 @@ const SigninConfirmed = ({
   continueHandler,
   isSignedIn,
   serviceName,
-  integration
+  integration,
 }: SigninConfirmedProps & RouteComponentProps) => {
   const cmsInfo = integration?.getCmsInfo?.();
 
   return (
     <AppLayout cmsInfo={cmsInfo}>
-      <Ready {...{ continueHandler, isSignedIn, viewName, serviceName, integration }} />
+      <Ready
+        {...{ continueHandler, isSignedIn, viewName, serviceName, integration }}
+      />
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninPasskeyFallback from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../../models/mocks';

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Subject, createMockWebIntegration } from './mocks';

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { OAuthNativeClients, OAuthNativeServices } from '@fxa/accounts/oauth';
 import {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import SigninRecoveryChoice from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
@@ -41,7 +40,7 @@ export const DefaultWithCms = () => (
       lastFourPhoneDigits="1234"
       numBackupCodes={4}
       signinState={MOCK_SIGNIN_LOCATION_STATE}
-      integration={createMockSigninOAuthIntegration({ cmsInfo: MOCK_CMS_INFO})}
+      integration={createMockSigninOAuthIntegration({ cmsInfo: MOCK_CMS_INFO })}
     />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
@@ -4,7 +4,6 @@
 
 import * as ReachRouterModule from '@reach/router';
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor, within } from '@testing-library/react';

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninRecoveryCode from '.';
 import { Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.test.tsx
@@ -2,14 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import SigninRecoveryPhone from './index';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { HandledError } from '../../../lib/error-utils';
-import { createMockSigninWebIntegration, mockSigninLocationState } from '../mocks';
+import {
+  createMockSigninWebIntegration,
+  mockSigninLocationState,
+} from '../mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
 
 describe('SigninRecoveryPhone', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import SigninRecoveryPhone from '.';
 import { SigninRecoveryPhoneProps } from './interfaces';

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninReported from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';

--- a/packages/fxa-settings/src/pages/Signin/SigninReported/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninReported/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { RouteComponentProps } from '@reach/router';

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninTokenCode from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import {
   IntegrationType,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninTotpCode from '.';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -4,7 +4,6 @@
 
 import * as ReactUtils from 'fxa-react/lib/utils';
 
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import GleanMetrics from '../../../lib/glean';

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { OAuthNativeServices } from '@fxa/accounts/oauth';
 import {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SigninUnblock from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import * as utils from 'fxa-react/lib/utils';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Signin from '.';
 import { Meta, StoryObj } from '@storybook/react';
 import {

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   fireEvent,
   screen,

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Signin from '.';
 import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import ConfirmSignupCode from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { LocationProvider } from '@reach/router';
 import ConfirmSignupCode from '.';
 import { OAuthNativeClients, OAuthNativeServices } from '@fxa/accounts/oauth';

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import PrimaryEmailVerified, { PrimaryEmailVerifiedProps } from '.';
 import { Meta } from '@storybook/react';
 import { MOCK_SERVICE } from './mocks';

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import PrimaryEmailVerified, { viewName } from '.';

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready from '../../../components/Ready';
 import { MozServices } from '../../../lib/types';
@@ -20,7 +19,7 @@ export const viewName = 'primary-email-verified';
 const PrimaryEmailVerified = ({
   serviceName,
   isSignedIn,
-  integration
+  integration,
 }: PrimaryEmailVerifiedProps & RouteComponentProps) => {
   const cmsInfo = integration?.getCmsInfo?.();
 

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import SignupConfirmed from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
@@ -36,9 +35,10 @@ export const IsSync = () => (
 
 export const IsSyncWithCms = () => (
   <LocationProvider>
-    <SignupConfirmed isSignedIn={false}
-                     serviceName={MozServices.FirefoxSync}
-                     integration={createMockIntegrationWithCms()}
+    <SignupConfirmed
+      isSignedIn={false}
+      serviceName={MozServices.FirefoxSync}
+      integration={createMockIntegrationWithCms()}
     />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider'; // import { getFtlBundle, testAllL10n, testL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import Ready, { ReadyBaseIntegration } from '../../../components/Ready';
 import AppLayout from '../../../components/AppLayout';
@@ -27,7 +26,9 @@ const SignupConfirmed = ({
 
   return (
     <AppLayout cmsInfo={cmsInfo}>
-      <Ready {...{ continueHandler, isSignedIn, viewName, serviceName, integration }} />
+      <Ready
+        {...{ continueHandler, isSignedIn, viewName, serviceName, integration }}
+      />
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { createMockIntegration } from './mocks';

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import AppLayout from '../../../components/AppLayout';
 import Banner from '../../../components/Banner';

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/mocks.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   SignupConfirmedSyncIntegration,
   SignupConfirmedSyncProps,

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import Signup from '.';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import {
   act,
   cleanup,

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { isEmailMask } from 'fxa-shared/email/helpers';
 import { useCallback, useEffect, useState } from 'react';

--- a/packages/fxa-settings/src/pages/WebAuthnHelpersExample/fieldGuides.tsx
+++ b/packages/fxa-settings/src/pages/WebAuthnHelpersExample/fieldGuides.tsx
@@ -10,8 +10,6 @@
  *   JsonResponseGuide — response field descriptions, shown in JSON mode after a call
  */
 
-import React from 'react';
-
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type FieldSpec = {

--- a/packages/fxa-settings/src/pages/WebAuthnHelpersExample/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/WebAuthnHelpersExample/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { Meta } from '@storybook/react';
 import { WebAuthnHelpersExample } from '.';
 


### PR DESCRIPTION
## Because

- The `jsx: react-jsx` transform means `import React from 'react'` is no longer needed for JSX
- The recent Storybook upgrade dropped the last build constraint that still required it

## This pull request

- Drops the default `import React from 'react';` line from files in `packages/fxa-settings` where the `React` namespace wasn't used
- Rewrites `React.*` references as named imports in six stories that still relied on the namespace: `BoxButton`, `ButtonPasskeySignin`, `CardHeader`, `Settings/Modal`, `Settings/ModalVerifySession`, and `.storybook/preview.tsx`
- Some unrelated files got minor Prettier reformatting from the repo's `lint-staged` hook on commit

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13744

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
