### PR TITLE
fix(payments-next): Prevent accidental email send on failed cart

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -312,12 +312,15 @@ describe('CartService', () => {
       expect(cartManager.finishErrorCart).toHaveBeenCalled();
     });
 
-    it('cancels a created subscription', async () => {
+    it('cancels and stamps suppression metadata for a created subscription with paid zero-cost invoice', async () => {
       const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({ status: 'paid', total: 0 })
+      );
       const mockSubscription = StripeResponseFactory(
         StripeSubscriptionFactory({
           customer: mockCustomer.id,
-          latest_invoice: null,
+          latest_invoice: mockInvoice.id,
         })
       );
       const mockCart = ResultCartFactory({
@@ -336,6 +339,10 @@ describe('CartService', () => {
       jest
         .spyOn(subscriptionManager, 'retrieve')
         .mockResolvedValue(mockSubscription);
+      jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
       jest
         .spyOn(subscriptionManager, 'cancel')
         .mockResolvedValue(mockSubscription);
@@ -347,6 +354,14 @@ describe('CartService', () => {
         cartService.finalizeProcessingCart(mockCart.id)
       ).rejects.toThrow(Error);
 
+      expect(subscriptionManager.update).toHaveBeenCalledWith(
+        mockSubscription.id,
+        {
+          metadata: {
+            suppress_cancellation_email: 'true',
+          },
+        }
+      );
       expect(subscriptionManager.cancel).toHaveBeenCalledWith(
         mockSubscription.id,
         {
@@ -357,12 +372,15 @@ describe('CartService', () => {
       );
     });
 
-    it('gracefully handles subscription not found during cancel', async () => {
+    it('gracefully handles subscription not found during cancel of paid zero-cost cart', async () => {
       const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({ status: 'paid', total: 0 })
+      );
       const mockSubscription = StripeResponseFactory(
         StripeSubscriptionFactory({
           customer: mockCustomer.id,
-          latest_invoice: null,
+          latest_invoice: mockInvoice.id,
         })
       );
       const mockCart = ResultCartFactory({
@@ -386,6 +404,10 @@ describe('CartService', () => {
       jest
         .spyOn(subscriptionManager, 'retrieve')
         .mockResolvedValue(mockSubscription);
+      jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
       jest.spyOn(subscriptionManager, 'cancel').mockRejectedValue(stripeError);
       jest
         .spyOn(paymentIntentManager, 'retrieve')
@@ -400,10 +422,13 @@ describe('CartService', () => {
 
     it('cancels a created subscription with async local storage', async () => {
       const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({ status: 'paid', total: 0 })
+      );
       const mockSubscription = StripeResponseFactory(
         StripeSubscriptionFactory({
           customer: mockCustomer.id,
-          latest_invoice: null,
+          latest_invoice: mockInvoice.id,
         })
       );
       const mockCart = ResultCartFactory({
@@ -429,6 +454,10 @@ describe('CartService', () => {
       jest
         .spyOn(subscriptionManager, 'retrieve')
         .mockResolvedValue(mockSubscription);
+      jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
       jest
         .spyOn(subscriptionManager, 'cancel')
         .mockResolvedValue(mockSubscription);
@@ -440,6 +469,14 @@ describe('CartService', () => {
         cartService.finalizeProcessingCart(mockCart.id)
       ).rejects.toThrow(Error);
 
+      expect(subscriptionManager.update).toHaveBeenCalledWith(
+        mockSubscription.id,
+        {
+          metadata: {
+            suppress_cancellation_email: 'true',
+          },
+        }
+      );
       expect(subscriptionManager.cancel).toHaveBeenCalledWith(
         mockSubscription.id,
         {
@@ -448,6 +485,50 @@ describe('CartService', () => {
           },
         }
       );
+    });
+
+    it('does not cancel the subscription when the invoice is voidable (relies on invoice void to expire)', async () => {
+      const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({ status: 'open' })
+      );
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockCustomer.id,
+          latest_invoice: mockInvoice.id,
+        })
+      );
+      const mockCart = ResultCartFactory({
+        state: CartState.PROCESSING,
+        stripeSubscriptionId: mockSubscription.id,
+        stripeCustomerId: mockCustomer.id,
+        eligibilityStatus: CartEligibilityStatus.CREATE,
+      });
+
+      jest
+        .spyOn(cartManager, 'fetchCartById')
+        .mockRejectedValueOnce(new Error('test'))
+        .mockResolvedValue(mockCart);
+      jest.spyOn(cartManager, 'finishErrorCart').mockResolvedValue();
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
+      jest.spyOn(invoiceManager, 'void').mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'cancel')
+        .mockResolvedValue(mockSubscription);
+
+      await expect(
+        cartService.finalizeProcessingCart(mockCart.id)
+      ).rejects.toThrow(Error);
+
+      expect(invoiceManager.void).toHaveBeenCalledWith(mockInvoice.id);
+      expect(subscriptionManager.update).not.toHaveBeenCalled();
+      expect(subscriptionManager.cancel).not.toHaveBeenCalled();
     });
 
     it('finalizes and voids a draft invoice', async () => {

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -26,6 +26,7 @@ import {
   getSubplatInterval,
   SetupIntentManager,
   PromotionCodeError,
+  STRIPE_SUBSCRIPTION_METADATA,
   SubPlatPaymentMethodType,
 } from '@fxa/payments/customer';
 import {
@@ -280,34 +281,47 @@ export class CartService {
             }
           }
 
+          const isZeroPaidInvoice =
+            invoice?.status === 'paid' && invoice.total === 0;
+
           if (cart.eligibilityStatus === CartEligibilityStatus.CREATE) {
-            try {
-              await this.subscriptionManager.cancel(subscriptionId, {
-                cancellation_details: {
-                  comment: 'Automatic Cancellation: Cart checkout failed.',
-                },
-              });
-            } catch (e) {
-              if (
-                e.code === 'resource_missing' ||
-                e.message?.startsWith('No such subscription')
-              ) {
-                this.log.log(
-                  'cartService.wrapWithCartCatch.subscriptionNotFound',
-                  {
+            if (isZeroPaidInvoice) {
+              try {
+                await this.subscriptionManager.update(subscriptionId, {
+                  metadata: {
+                    [STRIPE_SUBSCRIPTION_METADATA.SuppressCancellationEmail]:
+                      'true',
+                  },
+                });
+                await this.subscriptionManager.cancel(subscriptionId, {
+                  cancellation_details: {
+                    comment: 'Automatic Cancellation: Cart checkout failed.',
+                  },
+                });
+              } catch (e) {
+                if (
+                  e.code === 'resource_missing' ||
+                  e.message?.startsWith('No such subscription')
+                ) {
+                  this.log.log(
+                    'cartService.wrapWithCartCatch.subscriptionNotFound',
+                    {
+                      subscriptionId,
+                      eligibilityStatus: cart.eligibilityStatus,
+                      offeringId: cart.offeringConfigId,
+                      interval: cart.interval,
+                    }
+                  );
+                  this.statsd.increment(
+                    'subscription_deletion_failed_not_found'
+                  );
+                } else {
+                  throw new CartSubscriptionDeletionFailedError(
+                    cartId,
                     subscriptionId,
-                    eligibilityStatus: cart.eligibilityStatus,
-                    offeringId: cart.offeringConfigId,
-                    interval: cart.interval,
-                  }
-                );
-                this.statsd.increment('subscription_deletion_failed_not_found');
-              } else {
-                throw new CartSubscriptionDeletionFailedError(
-                  cartId,
-                  subscriptionId,
-                  e
-                );
+                    e
+                  );
+                }
               }
             }
           } else {

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -1055,10 +1055,11 @@ describe('CheckoutService', () => {
           );
         });
 
-        it('calls createAndConfirm', async () => {
+        it('calls createAndConfirm with subscription_id metadata', async () => {
           expect(setupIntentManager.createAndConfirm).toHaveBeenCalledWith(
             mockCustomer.id,
-            mockConfirmationToken.id
+            mockConfirmationToken.id,
+            { subscription_id: mockSubscription.id }
           );
         });
 
@@ -1105,6 +1106,9 @@ describe('CheckoutService', () => {
           jest
             .spyOn(setupIntentManager, 'createAndConfirm')
             .mockResolvedValue(mockSetupIntent);
+          jest
+            .spyOn(setupIntentManager, 'update')
+            .mockResolvedValue(mockSetupIntent);
         });
 
         beforeEach(async () => {
@@ -1122,6 +1126,22 @@ describe('CheckoutService', () => {
             mockPendingSetupIntentId,
             mockConfirmationToken.id
           );
+        });
+
+        it('stamps subscription_id metadata on the pending setup intent before confirming', () => {
+          expect(setupIntentManager.update).toHaveBeenCalledWith(
+            mockPendingSetupIntentId,
+            {
+              metadata: {
+                subscription_id: mockSubscriptionWithPendingSetup.id,
+              },
+            }
+          );
+          const updateOrder = (setupIntentManager.update as jest.Mock).mock
+            .invocationCallOrder[0];
+          const confirmOrder = (setupIntentManager.confirm as jest.Mock).mock
+            .invocationCallOrder[0];
+          expect(updateOrder).toBeLessThan(confirmOrder);
         });
 
         it('does not call createAndConfirm', () => {
@@ -1425,7 +1445,8 @@ describe('CheckoutService', () => {
         it('creates SetupIntent for trial subscription (zero-amount invoice)', () => {
           expect(setupIntentManager.createAndConfirm).toHaveBeenCalledWith(
             mockCustomer.id,
-            mockConfirmationToken.id
+            mockConfirmationToken.id,
+            { subscription_id: mockTrialSubscription.id }
           );
         });
 

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -27,6 +27,7 @@ import {
   PromotionCodeManager,
   retrieveSubscriptionItem,
   STRIPE_CUSTOMER_METADATA,
+  STRIPE_SETUP_INTENT_METADATA,
   STRIPE_SUBSCRIPTION_METADATA,
   SubplatInterval,
   SubscriptionManager,
@@ -488,7 +489,6 @@ export class CheckoutService {
       await this.freeTrialManager.recordFreeTrial(uid, freeTrial.internalName);
     }
 
-    // Get payment/setup intent for subscription
     let intent: StripePaymentIntent | StripeSetupIntent | undefined;
     try {
       assert(
@@ -511,6 +511,14 @@ export class CheckoutService {
           }
         );
       } else if (subscription.pending_setup_intent) {
+
+        // Subscription metadata is required by welcome email dispatcher for zero-cost subscriptions
+        await this.setupIntentManager.update(subscription.pending_setup_intent, {
+          metadata: {
+            [STRIPE_SETUP_INTENT_METADATA.SubscriptionId]: subscription.id,
+          },
+        });
+
         intent = await this.setupIntentManager.confirm(
           subscription.pending_setup_intent,
           confirmationTokenId
@@ -522,7 +530,10 @@ export class CheckoutService {
       } else {
         intent = await this.setupIntentManager.createAndConfirm(
           customer.id,
-          confirmationTokenId
+          confirmationTokenId,
+          {
+            [STRIPE_SETUP_INTENT_METADATA.SubscriptionId]: subscription.id,
+          }
         );
 
         this.statsd.increment('checkout_stripe_payment_setupintent_status', {

--- a/libs/payments/customer/src/lib/setupIntent.manager.spec.ts
+++ b/libs/payments/customer/src/lib/setupIntent.manager.spec.ts
@@ -61,6 +61,57 @@ describe('SetupIntentManager', () => {
       });
       expect(result).toEqual(mockResponse);
     });
+
+    it('should pass metadata through to setupIntentCreate when provided', async () => {
+      const mockConfirmationToken = 'confirmToken';
+      const mockCustomerId = 'cus_12345';
+      const mockResponse = StripeResponseFactory(StripeSetupIntentFactory());
+
+      jest
+        .spyOn(stripeClient, 'setupIntentCreate')
+        .mockResolvedValue(mockResponse);
+
+      await setupIntentManager.createAndConfirm(
+        mockCustomerId,
+        mockConfirmationToken,
+        { subscription_id: 'sub_abc' }
+      );
+
+      expect(stripeClient.setupIntentCreate).toHaveBeenCalledWith({
+        customer: mockCustomerId,
+        confirm: true,
+        confirmation_token: mockConfirmationToken,
+        automatic_payment_methods: {
+          enabled: true,
+          allow_redirects: 'never',
+        },
+        use_stripe_sdk: true,
+        metadata: { subscription_id: 'sub_abc' },
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should update a setup intent', async () => {
+      const mockSetupIntentId = 'seti_12345';
+      const mockResponse = StripeResponseFactory(StripeSetupIntentFactory());
+      const params = { metadata: { subscription_id: 'sub_abc' } };
+
+      jest
+        .spyOn(stripeClient, 'setupIntentUpdate')
+        .mockResolvedValue(mockResponse);
+
+      const result = await setupIntentManager.update(
+        mockSetupIntentId,
+        params
+      );
+
+      expect(stripeClient.setupIntentUpdate).toHaveBeenCalledWith(
+        mockSetupIntentId,
+        params
+      );
+      expect(result).toEqual(mockResponse);
+    });
   });
 
   describe('confirm', () => {

--- a/libs/payments/customer/src/lib/setupIntent.manager.ts
+++ b/libs/payments/customer/src/lib/setupIntent.manager.ts
@@ -3,14 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Injectable } from '@nestjs/common';
+import { Stripe } from 'stripe';
 import { StripeClient } from '@fxa/payments/stripe';
 import { SetupIntentCancelInvalidStatusError } from './customer.error';
+import type { StripeSetupIntentMetadataInput } from './types';
 
 @Injectable()
 export class SetupIntentManager {
   constructor(private stripeClient: StripeClient) {}
 
-  async createAndConfirm(customerId: string, confirmationToken: string) {
+  async createAndConfirm(
+    customerId: string,
+    confirmationToken: string,
+    metadata?: StripeSetupIntentMetadataInput
+  ) {
     return this.stripeClient.setupIntentCreate({
       customer: customerId,
       confirm: true,
@@ -20,6 +26,7 @@ export class SetupIntentManager {
         allow_redirects: 'never',
       },
       use_stripe_sdk: true,
+      ...(metadata ? { metadata } : {}),
     });
   }
 
@@ -27,6 +34,15 @@ export class SetupIntentManager {
     return this.stripeClient.setupIntentConfirm(setupIntentId, {
       confirmation_token: confirmationTokenId,
     });
+  }
+
+  async update(
+    setupIntentId: string,
+    params: Omit<Stripe.SetupIntentUpdateParams, 'metadata'> & {
+      metadata?: StripeSetupIntentMetadataInput;
+    }
+  ) {
+    return this.stripeClient.setupIntentUpdate(setupIntentId, params);
   }
 
   async retrieve(setupIntentId: string) {

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -182,6 +182,7 @@ export enum STRIPE_SUBSCRIPTION_METADATA {
   AutoCancelledRedundantFor = 'autoCancelledRedundantFor',
   RedundantCancellation = 'redundantCancellation',
   CancelledForCustomerAt = 'cancelled_for_customer_at',
+  SuppressCancellationEmail = 'suppress_cancellation_email',
   UtmCampaign = 'utm_campaign',
   UtmContent = 'utm_content',
   UtmMedium = 'utm_medium',
@@ -204,6 +205,14 @@ export enum STRIPE_INVOICE_METADATA {
 export type StripeInvoiceMetadata = StripeMetadata<STRIPE_INVOICE_METADATA>;
 export type StripeInvoiceMetadataInput =
   StripeMetadataInput<STRIPE_INVOICE_METADATA>;
+
+export enum STRIPE_SETUP_INTENT_METADATA {
+  SubscriptionId = 'subscription_id',
+}
+export type StripeSetupIntentMetadata =
+  StripeMetadata<STRIPE_SETUP_INTENT_METADATA>;
+export type StripeSetupIntentMetadataInput =
+  StripeMetadataInput<STRIPE_SETUP_INTENT_METADATA>;
 
 // Duplicated as enum SubplatInterval in @fxa/payments/metrics — keep in sync.
 export enum SubplatInterval {

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -490,6 +490,18 @@ export class StripeClient {
   }
 
   @CaptureTimingWithStatsD()
+  async setupIntentUpdate(
+    setupIntentId: string,
+    params?: Stripe.SetupIntentUpdateParams
+  ) {
+    const result = await this.stripe.setupIntents.update(setupIntentId, {
+      ...params,
+      expand: undefined,
+    });
+    return result as StripeResponse<StripeSetupIntent>;
+  }
+
+  @CaptureTimingWithStatsD()
   async confirmationTokenRetrieve(confirmationTokenId: string) {
     const result =
       await this.stripe.confirmationTokens.retrieve(confirmationTokenId);

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -15,10 +15,7 @@ import Container from 'typedi';
 
 import { ConfigType } from '../../../config';
 import SUBSCRIPTIONS_DOCS from '../../../docs/swagger/subscriptions-api';
-import {
-  reportSentryError,
-  reportSentryMessage,
-} from '../../../lib/sentry';
+import { reportSentryError, reportSentryMessage } from '../../../lib/sentry';
 import { AppError as error } from '@fxa/accounts/errors';
 import { PayPalHelper, RefusedError } from '../../payments/paypal';
 import { RefundType } from '@fxa/payments/paypal';
@@ -47,7 +44,7 @@ import { FirestoreStripeErrorBuilder } from 'fxa-shared/payments/stripe-firestor
 // replaced Plans, but since it is backwards compatible, we haven't needed to
 // update our plans handling code.  Prices should be treated in the same
 // fashion as plans, so it's on this list.
-const BYPASS_LATEST_FETCH_TYPES = ['plan', 'price', 'product'];
+const BYPASS_LATEST_FETCH_TYPES = ['plan', 'price', 'product', 'setup_intent'];
 const BYPASS_LATEST_FETCH_EVENTS = [
   'invoice.upcoming',
   'payment_method.detached',
@@ -185,6 +182,9 @@ export class StripeWebhookHandler extends StripeHandler {
         break;
       case 'invoice.paid':
         await this.handleInvoicePaidEvent(request, event);
+        break;
+      case 'setup_intent.succeeded':
+        await this.handleSetupIntentSucceededEvent(request, event);
         break;
       case 'invoice.payment_failed':
         await this.handleInvoicePaymentFailedEvent(request, event);
@@ -456,22 +456,21 @@ export class StripeWebhookHandler extends StripeHandler {
 
       const uid = customer.metadata.userid;
       const account = await Account.findByUid(uid, { include: ['emails'] });
+      const suppressCancellationEmail =
+        subscription.metadata['suppress_cancellation_email'] === 'true';
+      if (suppressCancellationEmail) {
+        this.log.info('subscription.deleted.emailSuppressed', {
+          subscriptionId: subscription.id,
+          customerId: subscription.customer,
+        });
+      }
       if (
-        // When SubPlat cannot collect a PayPal customer's first payment while
-        // attempting to subscribe to a product, the subscription is canceled.
-        // (At the time of writing, this is happening in
-        // `_createPaypalBillingAgreementAndSubscription` of the
-        // `PayPalHandler` route handler.)  We should not send an email in that
-        // case.
-        //
-        // If we can retreive the subscription and customer, but the account record
-        // cannot be retrieved from the db, the user has deleted their Mozilla
-        // account which subsequently deletes their subscription from stripe.
-        !account ||
-        !(
-          subscription.collection_method === 'send_invoice' &&
-          account.verifierSetAt <= 0
-        )
+        !suppressCancellationEmail &&
+        (!account ||
+          !(
+            subscription.collection_method === 'send_invoice' &&
+            account.verifierSetAt <= 0
+          ))
       ) {
         await this.sendSubscriptionDeletedEmail(subscription);
       }
@@ -657,6 +656,144 @@ export class StripeWebhookHandler extends StripeHandler {
     if (invalidCustomer) {
       const err = Object.assign(
         new Error('Invoice paid on invalid customer.'),
+        deletedData
+      );
+      reportSentryError(err, request);
+      return;
+    }
+
+    // invoice.paid fires before the SetupIntent confirms on the Stripe-card
+    // flow; handleSetupIntentSucceededEvent emails after the SetupIntent has
+    // had a chance to fail. PayPal (send_invoice) has no SetupIntent and
+    // still emails from here.
+    if (
+      invoice.amount_due === 0 &&
+      invoice.collection_method !== 'send_invoice'
+    ) {
+      return;
+    }
+
+    try {
+      await this.sendSubscriptionInvoiceEmail(invoice);
+    } catch (err) {
+      reportSentryError(err, request);
+      return;
+    }
+  }
+
+  /**
+   * Handle `setup_intent.succeeded` Stripe webhook events.
+   *
+   * Used to send welcome/first-invoice emails for $0 subscriptions, where
+   * `invoice.paid` fires too early to be a reliable trigger.
+   *
+   * The SetupIntent is stamped with a `subscription_id` metadata key at
+   * creation time in `checkout.service.ts`; we use it to locate the
+   * subscription and its paid invoice, then dispatch the same emails the
+   * `invoice.paid` handler would for non-zero invoices.
+   *
+   * SetupIntents not tied to a checkout subscription (e.g. the
+   * manage-payment-method flow) are silently ignored.
+   */
+  async handleSetupIntentSucceededEvent(
+    request: AuthRequest,
+    event: Stripe.Event
+  ) {
+    const setupIntent = event.data.object as Stripe.SetupIntent;
+    const subscriptionId = setupIntent.metadata?.['subscription_id'];
+    if (!subscriptionId) {
+      return;
+    }
+
+    const reportUnexpectedState = (reason: string, extra: object = {}) => {
+      Sentry.withScope((scope) => {
+        scope.setContext('setupIntentSucceeded', {
+          eventId: event.id,
+          setupIntentId: setupIntent.id,
+          subscriptionId,
+          reason,
+          ...extra,
+        });
+        reportSentryMessage(
+          `setup_intent.succeeded unexpected state: ${reason}`,
+          'warning' as SeverityLevel
+        );
+      });
+      this.log.warn('handleSetupIntentSucceededEvent.unexpectedState', {
+        eventId: event.id,
+        setupIntentId: setupIntent.id,
+        subscriptionId,
+        reason,
+      });
+    };
+
+    let subscription: Stripe.Subscription;
+    try {
+      subscription =
+        await this.stripeHelper.expandResource<Stripe.Subscription>(
+          subscriptionId,
+          SUBSCRIPTIONS_RESOURCE
+        );
+    } catch (err) {
+      reportUnexpectedState('subscription_not_found', {
+        error: err?.message,
+      });
+      return;
+    }
+    if (!subscription) {
+      reportUnexpectedState('subscription_not_found');
+      return;
+    }
+    if (!ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)) {
+      reportUnexpectedState('subscription_not_active', {
+        status: subscription.status,
+      });
+      return;
+    }
+    if (!subscription.latest_invoice) {
+      reportUnexpectedState('subscription_has_no_invoice');
+      return;
+    }
+
+    const invoice = await this.stripeHelper.expandResource<Stripe.Invoice>(
+      subscription.latest_invoice,
+      INVOICES_RESOURCE
+    );
+    if (!invoice || invoice.status !== 'paid') {
+      reportUnexpectedState('invoice_not_paid', {
+        status: invoice?.status,
+        invoiceId: invoice?.id,
+      });
+      return;
+    }
+
+    const customer = await this.stripeHelper.expandResource(
+      invoice.customer,
+      CUSTOMER_RESOURCE
+    );
+    let invalidCustomer = false;
+    const deletedData: Record<string, any> = {
+      customerId: invoice.customer,
+      invoiceId: invoice.id,
+    };
+    if (!customer || customer.deleted) {
+      invalidCustomer = true;
+      deletedData.reason = 'customer_deleted';
+    } else {
+      const uid = customer.metadata?.userid;
+      if (!uid) {
+        invalidCustomer = true;
+        deletedData.reason = 'no_userid';
+      } else {
+        deletedData.userId = uid;
+        deletedData.reason = 'fxa_deleted';
+        const account = await Account.findByUid(uid);
+        invalidCustomer = !account;
+      }
+    }
+    if (invalidCustomer) {
+      const err = Object.assign(
+        new Error('SetupIntent succeeded for invalid customer.'),
         deletedData
       );
       reportSentryError(err, request);
@@ -898,7 +1035,8 @@ export class StripeWebhookHandler extends StripeHandler {
 
   /**
    * Send out the appropriate invoice email, depending on whether it's the
-   * initial or a subsequent invoice.
+   * initial or a subsequent invoice. Callers are responsible for any
+   * zero-total filtering (see handleInvoicePaidEvent).
    */
   async sendSubscriptionInvoiceEmail(invoice: Stripe.Invoice) {
     const invoiceDetails =

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhooks.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhooks.spec.ts
@@ -218,6 +218,7 @@ describe('StripeWebhookHandler', () => {
         'handleInvoiceCreatedEvent',
         'handleInvoiceUpcomingEvent',
         'handleTaxRateCreatedOrUpdatedEvent',
+        'handleSetupIntentSucceededEvent',
       ];
       const handlerStubs: any = {};
 
@@ -521,6 +522,25 @@ describe('StripeWebhookHandler', () => {
 
       describe('when the event.type is invoice.paid', () => {
         itOnlyCallsThisHandler('handleInvoicePaidEvent', eventInvoicePaid);
+      });
+
+      describe('when the event.type is setup_intent.succeeded', () => {
+        itOnlyCallsThisHandler(
+          'handleSetupIntentSucceededEvent',
+          {
+            id: 'evt_setup_intent_succeeded_routing',
+            type: 'setup_intent.succeeded',
+            data: {
+              object: {
+                id: 'seti_routing_test',
+                object: 'setup_intent',
+                metadata: {},
+              },
+            },
+          },
+          false,
+          false
+        );
       });
 
       describe('when the event.type is invoice.payment_failed', () => {
@@ -1114,6 +1134,36 @@ describe('StripeWebhookHandler', () => {
           StripeWebhookHandlerInstance.paypalHelper
             .conditionallyRemoveBillingAgreement
         ).toHaveBeenCalledWith(customerFixture);
+      });
+
+      it('skips the cancellation email when subscription metadata has suppress_cancellation_email=true', async () => {
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+          customerFixture
+        );
+        const deletedEvent = deepCopy(subscriptionDeleted);
+        deletedEvent.data.object.metadata = {
+          ...(deletedEvent.data.object.metadata || {}),
+          suppress_cancellation_email: 'true',
+        };
+        const sendSubscriptionDeletedEmailStub = jest
+          .spyOn(StripeWebhookHandlerInstance, 'sendSubscriptionDeletedEmail')
+          .mockResolvedValue({ uid: UID, email: TEST_EMAIL });
+        const account = { email: customerFixture.email };
+        jest
+          .spyOn(authDbModule.Account, 'findByUid')
+          .mockResolvedValue(account);
+
+        await StripeWebhookHandlerInstance.handleSubscriptionDeletedEvent(
+          {},
+          deletedEvent
+        );
+
+        expect(sendSubscriptionDeletedEmailStub).not.toHaveBeenCalled();
+        // The rest of the handler still runs.
+        expect(mockCapabilityService.stripeUpdate).toHaveBeenCalledWith({
+          sub: deletedEvent.data.object,
+          uid: customerFixture.metadata.userid,
+        });
       });
 
       it('sends subscriptionReplaced email if metadata includes redundantCancellation', async () => {
@@ -1858,6 +1908,77 @@ describe('StripeWebhookHandler', () => {
         );
       });
 
+      it('does not send an email when invoice amount_due is 0 on a $0 invoice and collection_method is charge_automatically (Stripe card)', async () => {
+        const paidEvent = deepCopy(eventInvoicePaid);
+        paidEvent.data.object.total = 0;
+        paidEvent.data.object.amount_due = 0;
+        paidEvent.data.object.collection_method = 'charge_automatically';
+        const customer = deepCopy(customerFixture);
+        const sendSubscriptionInvoiceEmailStub = jest
+          .spyOn(StripeWebhookHandlerInstance, 'sendSubscriptionInvoiceEmail')
+          .mockResolvedValue(true);
+        const account = { email: customerFixture.email };
+        jest
+          .spyOn(authDbModule.Account, 'findByUid')
+          .mockResolvedValue(account);
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+          customer
+        );
+        await StripeWebhookHandlerInstance.handleInvoicePaidEvent(
+          {},
+          paidEvent
+        );
+        expect(sendSubscriptionInvoiceEmailStub).not.toHaveBeenCalled();
+      });
+
+      it('does not send an email when amount_due is 0 from a customer credit balance covering a non-zero total (Stripe card)', async () => {
+        const paidEvent = deepCopy(eventInvoicePaid);
+        paidEvent.data.object.total = 500;
+        paidEvent.data.object.amount_due = 0;
+        paidEvent.data.object.collection_method = 'charge_automatically';
+        const customer = deepCopy(customerFixture);
+        const sendSubscriptionInvoiceEmailStub = jest
+          .spyOn(StripeWebhookHandlerInstance, 'sendSubscriptionInvoiceEmail')
+          .mockResolvedValue(true);
+        const account = { email: customerFixture.email };
+        jest
+          .spyOn(authDbModule.Account, 'findByUid')
+          .mockResolvedValue(account);
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+          customer
+        );
+        await StripeWebhookHandlerInstance.handleInvoicePaidEvent(
+          {},
+          paidEvent
+        );
+        expect(sendSubscriptionInvoiceEmailStub).not.toHaveBeenCalled();
+      });
+
+      it('sends an email when invoice amount_due is 0 and collection_method is send_invoice (PayPal)', async () => {
+        const paidEvent = deepCopy(eventInvoicePaid);
+        paidEvent.data.object.total = 0;
+        paidEvent.data.object.amount_due = 0;
+        paidEvent.data.object.collection_method = 'send_invoice';
+        const customer = deepCopy(customerFixture);
+        const sendSubscriptionInvoiceEmailStub = jest
+          .spyOn(StripeWebhookHandlerInstance, 'sendSubscriptionInvoiceEmail')
+          .mockResolvedValue(true);
+        const account = { email: customerFixture.email };
+        jest
+          .spyOn(authDbModule.Account, 'findByUid')
+          .mockResolvedValue(account);
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+          customer
+        );
+        await StripeWebhookHandlerInstance.handleInvoicePaidEvent(
+          {},
+          paidEvent
+        );
+        expect(sendSubscriptionInvoiceEmailStub).toHaveBeenCalledWith(
+          paidEvent.data.object
+        );
+      });
+
       it('reports a sentry error for a customer missing a firefox account', async () => {
         const paidEvent = deepCopy(eventInvoicePaid);
         const customer = deepCopy(customerFixture);
@@ -1883,6 +2004,149 @@ describe('StripeWebhookHandler', () => {
             invoiceId: paidEvent.data.object.id,
             userId: customer.metadata.userid,
           }),
+          expect.anything()
+        );
+      });
+    });
+
+    describe('handleSetupIntentSucceededEvent', () => {
+      const makeEvent = (metadata: Record<string, string> | null) => ({
+        id: 'evt_setup_intent_test',
+        type: 'setup_intent.succeeded',
+        data: {
+          object: {
+            id: 'seti_test_123',
+            object: 'setup_intent',
+            metadata,
+          },
+        },
+      });
+
+      const mockSubscription = {
+        id: 'sub_test_123',
+        status: 'active',
+        latest_invoice: 'in_test_123',
+        customer: 'cus_test_123',
+      };
+      const mockInvoice = {
+        id: 'in_test_123',
+        status: 'paid',
+        customer: 'cus_test_123',
+        subscription: 'sub_test_123',
+        total: 0,
+        billing_reason: 'subscription_create',
+      };
+
+      it('silently no-ops when SetupIntent has no subscription_id metadata', async () => {
+        const event = makeEvent(null);
+        const dispatchStub = jest
+          .spyOn(
+            StripeWebhookHandlerInstance,
+            'sendSubscriptionInvoiceEmail'
+          )
+          .mockResolvedValue(undefined);
+        const sentryMod = require('../../sentry');
+        const reportMessage = jest
+          .spyOn(sentryMod, 'reportSentryMessage')
+          .mockReturnValue(undefined);
+
+        await StripeWebhookHandlerInstance.handleSetupIntentSucceededEvent(
+          {},
+          event
+        );
+
+        expect(dispatchStub).not.toHaveBeenCalled();
+        expect(reportMessage).not.toHaveBeenCalled();
+      });
+
+      it('dispatches the welcome emails when subscription is active and invoice is paid', async () => {
+        const event = makeEvent({ subscription_id: mockSubscription.id });
+        const dispatchStub = jest
+          .spyOn(
+            StripeWebhookHandlerInstance,
+            'sendSubscriptionInvoiceEmail'
+          )
+          .mockResolvedValue(undefined);
+
+        const customer = deepCopy(customerFixture);
+        const account = { email: customer.email };
+        jest
+          .spyOn(authDbModule.Account, 'findByUid')
+          .mockResolvedValue(account);
+        StripeWebhookHandlerInstance.stripeHelper.expandResource = jest
+          .fn()
+          .mockImplementation((id) => {
+            if (id === mockSubscription.id) return mockSubscription;
+            if (id === mockInvoice.id) return mockInvoice;
+            return customer;
+          });
+
+        await StripeWebhookHandlerInstance.handleSetupIntentSucceededEvent(
+          {},
+          event
+        );
+
+        expect(dispatchStub).toHaveBeenCalledWith(mockInvoice);
+      });
+
+      it('reports a Sentry warning when the subscription is not active', async () => {
+        const event = makeEvent({ subscription_id: mockSubscription.id });
+        const dispatchStub = jest
+          .spyOn(
+            StripeWebhookHandlerInstance,
+            'sendSubscriptionInvoiceEmail'
+          )
+          .mockResolvedValue(undefined);
+        const sentryMod = require('../../sentry');
+        const reportMessage = jest
+          .spyOn(sentryMod, 'reportSentryMessage')
+          .mockReturnValue(undefined);
+
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+          { ...mockSubscription, status: 'incomplete' }
+        );
+
+        await StripeWebhookHandlerInstance.handleSetupIntentSucceededEvent(
+          {},
+          event
+        );
+
+        expect(dispatchStub).not.toHaveBeenCalled();
+        expect(reportMessage).toHaveBeenCalledWith(
+          expect.stringContaining('subscription_not_active'),
+          expect.anything()
+        );
+      });
+
+      it('reports a Sentry warning when the latest invoice is not paid', async () => {
+        const event = makeEvent({ subscription_id: mockSubscription.id });
+        const dispatchStub = jest
+          .spyOn(
+            StripeWebhookHandlerInstance,
+            'sendSubscriptionInvoiceEmail'
+          )
+          .mockResolvedValue(undefined);
+        const sentryMod = require('../../sentry');
+        const reportMessage = jest
+          .spyOn(sentryMod, 'reportSentryMessage')
+          .mockReturnValue(undefined);
+
+        StripeWebhookHandlerInstance.stripeHelper.expandResource = jest
+          .fn()
+          .mockImplementation((id) => {
+            if (id === mockSubscription.id) return mockSubscription;
+            if (id === mockInvoice.id) return { ...mockInvoice, status: 'open' };
+            return undefined;
+          });
+
+        await StripeWebhookHandlerInstance.handleSetupIntentSucceededEvent(
+          {},
+          event
+        );
+
+        expect(dispatchStub).not.toHaveBeenCalled();
+        expect(reportMessage).toHaveBeenCalledWith(
+          expect.stringContaining('invoice_not_paid'),
           expect.anything()
         );
       });


### PR DESCRIPTION
Because:

* A customer who hits a payment error during a $0 upfront checkout (free trial or full-coupon) was receiving three emails: welcome, payment confirmed, and subscription cancelled. They should receive zero.
* Root cause: Stripe immediately marks $0 invoices as `paid` on creation, so the existing `invoice.paid` handler fired welcome emails before the SetupIntent had a chance to fail.

This commit:

* Routes $0 welcome/first-invoice emails off `setup_intent.succeeded` instead of `invoice.paid`, so the emails only fire after the SetupIntent actually confirms.
*  Gates `sendSubscriptionInvoiceEmail` on `invoice.total !== 0` to keep the legacy path correct.
* Stamps `subscription_id` metadata on the SetupIntent during checkout so the new webhook handler can find the subscription. Metadata is set before `confirm()` on the pending-setup-intent branch to avoid a race with Stripe's synchronous webhook firing.
* On $0 checkout failure, cart cleanup stamps a `suppress_cancellation_email` flag on the subscription before cancelling; the `customer.subscription.deleted` handler honors it so no cancellation email is sent for an already-failed cart.
*  Adds `SetupIntentManager.update()` and the matching `StripeClient` wrapper.
* Adds unit-test coverage for the new handler, the suppression flag, the $0 cleanup branch, and the SetupIntent metadata ordering.

Closes #PAY-3675

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
