### PR TITLE
refactor(functional-tests): Prevent CORS failures on Stripe/hCaptcha from WAF header

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -35,6 +35,42 @@ export type TestOptions = {
 };
 export type WorkerOptions = { targetName: TargetName; target: ServerTarget };
 
+const CI_WAF_TOKEN = process.env.CI_WAF_TOKEN;
+
+/**
+ * Adds a route handler that injects the WAF bypass header on requests to
+ * FXA-owned domains only, leaving third-party origins (Stripe, hCaptcha)
+ * untouched. No-op when CI_WAF_TOKEN is unset.
+ */
+async function addWafBypassHeader(page: Page, target: BaseTarget) {
+  if (!CI_WAF_TOKEN) {
+    if (target.name === 'stage' || target.name === 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `⚠ CI_WAF_TOKEN is not set for target "${target.name}". Requests may be blocked by the WAF.`
+      );
+    }
+    return;
+  }
+  const fxaDomains = [
+    new URL(target.contentServerUrl).host,
+    new URL(target.authServerUrl).host,
+    new URL(target.paymentsNextUrl).host,
+    new URL(target.relierUrl).host,
+  ];
+  const pattern = new RegExp(
+    fxaDomains.map((d) => d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  );
+  await page.route(pattern, async (route) => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        'fxa-ci': CI_WAF_TOKEN,
+      },
+    });
+  });
+}
+
 export const test = base.extend<TestOptions, WorkerOptions>({
   targetName: ['local', { scope: 'worker', option: true }],
 
@@ -46,6 +82,11 @@ export const test = base.extend<TestOptions, WorkerOptions>({
     },
     { scope: 'worker', auto: true },
   ],
+
+  page: async ({ page, target }, use) => {
+    await addWafBypassHeader(page, target);
+    await use(page);
+  },
 
   pages: async ({ target, page }, use) => {
     const pages = createPages(page, target);
@@ -130,6 +171,7 @@ export const test = base.extend<TestOptions, WorkerOptions>({
 export async function newPages(browser: Browser, target: BaseTarget) {
   const context = await browser.newContext();
   const page = await context.newPage();
+  await addWafBypassHeader(page, target);
   return createPages(page, target);
 }
 

--- a/packages/functional-tests/lib/targets/base.ts
+++ b/packages/functional-tests/lib/targets/base.ts
@@ -70,8 +70,10 @@ export abstract class BaseTarget {
           `${process.env.AUTH_CLIENT_KEY_STRETCH_VERSION}, is it set correctly?`
       );
     }
+    const ciWafToken = process.env.CI_WAF_TOKEN;
     return new AuthClient(this.authServerUrl, {
       keyStretchVersion: keyStretchVersion as SaltVersion,
+      ...(ciWafToken && { defaultHeaders: { 'fxa-ci': ciWafToken } }),
     });
   }
 

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -10,16 +10,6 @@ import { TargetNames } from './lib/targets';
 import { getFirefoxUserPrefs } from './lib/targets/firefoxUserPrefs';
 
 const CI = !!process.env.CI;
-const CI_WAF_TOKEN = process.env.CI_WAF_TOKEN;
-
-/**
- * Returns a header used for WAF bypass.
- *
- * Requires `CI_WAF_TOKEN` set in CircleCI, or local environment, and corresponding WAF condition set for target rule
- */
-function getCIHeader(): Record<string, string> {
-  return CI_WAF_TOKEN ? { 'fxa-ci': CI_WAF_TOKEN } : {};
-}
 
 // If using the CircleCI parallelism feature, assure that the JUNIT XML report
 // has a unique name
@@ -74,7 +64,6 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
 
   use: {
     viewport: { width: 1280, height: 720 },
-    extraHTTPHeaders: getCIHeader(),
   },
   projects: [
     ...TargetNames.map(

--- a/packages/functional-tests/tests/settings/redirect.spec.ts
+++ b/packages/functional-tests/tests/settings/redirect.spec.ts
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, Page, test } from '../../lib/fixtures/standard';
+import { expect, Page, test, newPages } from '../../lib/fixtures/standard';
 import { EmailType } from '../../lib/email';
 import { getTotpCode } from '../../lib/totp';
-import { create as createPages } from '../../pages';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
@@ -25,14 +24,11 @@ test.describe('severity-2 #smoke', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const browser = context.browser()!;
-      const secondContext = await browser.newContext();
-      const secondPage = await secondContext.newPage();
-
-      const secondPages = createPages(secondPage, target);
+      const secondPages = await newPages(browser, target);
 
       await signInAccount(
         target,
-        secondPage,
+        secondPages.page,
         secondPages.signin,
         secondPages.settings,
         credentials
@@ -62,7 +58,7 @@ test.describe('severity-2 #smoke', () => {
       // Error alert caused by insufficient AAL error should not linger (see FXA-12707)
       await expect(page.getByText(/Insufficient AAL/)).toBeHidden();
       await settings.disconnectTotp();
-      await secondContext.close();
+      await secondPages.page.context().close();
     });
 
     test('redirects to signin_totp_code when AAL is insufficient on refresh', async ({
@@ -77,14 +73,11 @@ test.describe('severity-2 #smoke', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const browser = context.browser()!;
-      const secondContext = await browser.newContext();
-      const secondPage = await secondContext.newPage();
-
-      const secondPages = createPages(secondPage, target);
+      const secondPages = await newPages(browser, target);
 
       await signInAccount(
         target,
-        secondPage,
+        secondPages.page,
         secondPages.signin,
         secondPages.settings,
         credentials
@@ -112,7 +105,7 @@ test.describe('severity-2 #smoke', () => {
 
       await expect(page).toHaveURL(/settings/);
       await settings.disconnectTotp();
-      await secondContext.close();
+      await secondPages.page.context().close();
     });
 
     test('redirects to email first when not signed in', async ({

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -340,6 +340,7 @@ export default class AuthClient {
   private timeout: number;
   private keyStretchVersion: SaltVersion;
   private requireHeaders: boolean;
+  private defaultHeaders: Record<string, string>;
   private errorHandler: (error: unknown) => Promise<void>;
 
   constructor(
@@ -348,6 +349,7 @@ export default class AuthClient {
       timeout?: number;
       keyStretchVersion?: SaltVersion;
       requireHeaders?: boolean;
+      defaultHeaders?: Record<string, string>;
       errorHandler?: (error: unknown) => Promise<void>;
     } = {}
   ) {
@@ -360,6 +362,7 @@ export default class AuthClient {
     this.localtimeOffsetMsec = 0;
     this.timeout = options.timeout || 30000;
     this.requireHeaders = options.requireHeaders === true;
+    this.defaultHeaders = options.defaultHeaders || {};
     this.errorHandler =
       options.errorHandler ||
       (async (e) => {
@@ -394,6 +397,12 @@ export default class AuthClient {
         return;
       } else {
         extraHeaders = new Headers();
+      }
+    }
+
+    for (const [key, value] of Object.entries(this.defaultHeaders)) {
+      if (!extraHeaders.has(key)) {
+        extraHeaders.set(key, value);
       }
     }
 


### PR DESCRIPTION
## Because

- While writing payments functional test, the Playwright trace console showed hundreds of CORS errors from Stripe/hCaptcha rejecting the fxa-ci header from extraHTTPHeaders: getCIHeader().
- The global extraHTTPHeaders sent the fxa-ci header to all domains including Stripe (r.stripe.com, m.stripe.com) and hCaptcha. These external services don't allow fxa-ci in their CORS preflight, causing requests to fail with Request header field fxa-ci is not allowed by Access-Control-Allow-Headers.

## This pull request

- Moves the fxa-ci WAF bypass header from a global Playwright extraHTTPHeaders (sent on every request) to a route handler that only adds it to FXA domains (content server, auth server, payments-next, relier).

## Issue that this pull request solves

Closes: PAY-3711

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.