### PR TITLE
chore(settings): Move oauthweb integration sentry extras to tags

### DIFF
--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
@@ -199,11 +199,13 @@ describe('models/integrations/oauth-relier', function () {
         expect(capturedError).toBeInstanceOf(OAuthError);
         expect(capturedError.errno).toBe(OAUTH_ERRORS.INVALID_PARAMETER.errno);
         expect(sentryContext).toEqual({
-          tags: { area: 'OAuthWebIntegration.getPermissions' },
+          tags: {
+            area: 'OAuthWebIntegration.getPermissions',
+            service: 'test-service',
+            clientId: 'a1b2c3d4e5f6789012345678901234567890abcd',
+          },
           extra: {
             scope,
-            clientId: 'a1b2c3d4e5f6789012345678901234567890abcd',
-            service: 'test-service',
             trusted,
             wantsConsent,
           },

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -225,14 +225,16 @@ export class OAuthWebIntegration extends GenericIntegration<
       // in app/index. We check the integration type and present
       // an OAuthDataError component.
       Sentry.captureException(err, {
-        tags: { area: 'OAuthWebIntegration.getPermissions' },
+        tags: {
+          area: 'OAuthWebIntegration.getPermissions',
+          clientId: this.data.clientId,
+          service: this.data.service,
+        },
         extra: {
           scope: this.data.scope,
-          clientId: this.data.clientId,
           trusted: this.isTrusted(),
           wantsConsent: this.wantsConsent(),
           clientInfo: this.clientInfo,
-          service: this.data.service,
         },
       });
       throw err;


### PR DESCRIPTION
Because:
 - We are using extra for a sentry error, and this doesn't allow grouping the sentry errors by values

This Commit:
 - Moves clientId and service to the sentry tags so we can group by them in Sentry

Relates to: FXA-12759

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
