### PR TITLE
feat(auth): Create backfill script for accountAuthorzations table

### DIFF
--- a/packages/fxa-auth-server/scripts/backfill-account-authorizations/backfill-account-authorizations.spec.ts
+++ b/packages/fxa-auth-server/scripts/backfill-account-authorizations/backfill-account-authorizations.spec.ts
@@ -1,0 +1,699 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { StatsD } from 'hot-shots';
+
+import {
+  ServiceConfig,
+  UpsertRow,
+  buildServiceConfig,
+  inferServiceForToken,
+  resolveTargetRows,
+  batchUpsert,
+  fetchBatch,
+  estimateTotalTokens,
+  withRetry,
+  run,
+} from './backfill-account-authorizations';
+
+const VPN_SCOPE = 'https://identity.mozilla.com/apps/vpn';
+const SMARTWINDOW_SCOPE = 'https://identity.mozilla.com/apps/smartwindow';
+const RELAY_SCOPE = 'https://identity.mozilla.com/apps/relay';
+const SYNC_SCOPE = 'https://identity.mozilla.com/apps/oldsync';
+
+const VPN_ALLOWED_CLIENT_ID = '1111222233334444';
+const VPN_OTHER_CLIENT_ID = '9999888877776666';
+const SMART_CLIENT_ID = 'abababababababab';
+
+function makeLog() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+function makeQuery(results: any[] = []) {
+  return jest.fn().mockResolvedValue(results);
+}
+
+function defaultCfg(
+  overrides: {
+    scopes?: Record<string, string>;
+    allowed?: Record<string, string[]>;
+  } = {}
+): ServiceConfig {
+  return buildServiceConfig(
+    overrides.scopes ?? {
+      vpn: VPN_SCOPE,
+      smartwindow: SMARTWINDOW_SCOPE,
+      relay: RELAY_SCOPE,
+      sync: SYNC_SCOPE,
+    },
+    overrides.allowed ?? { vpn: [VPN_ALLOWED_CLIENT_ID] }
+  );
+}
+
+function makeToken(
+  overrides: Partial<{
+    userId: Buffer;
+    clientId: Buffer;
+    scope: string;
+    createdAt: Date;
+    token: Buffer;
+  }> = {}
+) {
+  return {
+    token: Buffer.alloc(32, 0x01),
+    userId: Buffer.alloc(16, 0xaa),
+    clientId: Buffer.from(VPN_ALLOWED_CLIENT_ID, 'hex'),
+    scope: VPN_SCOPE,
+    createdAt: new Date(1000),
+    ...overrides,
+  };
+}
+
+describe('buildServiceConfig', () => {
+  it('builds inverse scope→service map', () => {
+    const cfg = defaultCfg();
+    expect(cfg.scopeToService.get(VPN_SCOPE)).toBe('vpn');
+    expect(cfg.scopeToService.get(SMARTWINDOW_SCOPE)).toBe('smartwindow');
+  });
+
+  it('lowercases clientIds in the allowlist', () => {
+    const cfg = buildServiceConfig(
+      { vpn: VPN_SCOPE },
+      { vpn: ['ABCDEF0011223344'] }
+    );
+    expect(cfg.allowedClients.get('vpn')?.has('abcdef0011223344')).toBe(true);
+  });
+
+  it('omits services with no allowlist entry (unrestricted)', () => {
+    const cfg = defaultCfg();
+    expect(cfg.allowedClients.has('smartwindow')).toBe(false);
+  });
+});
+
+describe('inferServiceForToken', () => {
+  const scopeMap = defaultCfg().scopeToService;
+
+  it('returns "" when no scope matches a configured service URL', () => {
+    expect(inferServiceForToken(['openid', 'profile'], scopeMap)).toBe('');
+  });
+
+  it('returns the service when exactly one scope matches a service URL', () => {
+    expect(inferServiceForToken([VPN_SCOPE, 'profile'], scopeMap)).toBe('vpn');
+  });
+
+  it('returns "" when two scopes match service URLs (ambiguous)', () => {
+    expect(inferServiceForToken([VPN_SCOPE, SMARTWINDOW_SCOPE], scopeMap)).toBe(
+      ''
+    );
+  });
+
+  it('returns "" for an empty scope list', () => {
+    expect(inferServiceForToken([], scopeMap)).toBe('');
+  });
+});
+
+describe('resolveTargetRows', () => {
+  it('returns a single row for a token with one service scope and allowlisted clientId', () => {
+    const result = resolveTargetRows(makeToken(), defaultCfg());
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      service: 'vpn',
+      scope: VPN_SCOPE,
+    });
+    expect(result.allowlistDenied).toEqual([]);
+  });
+
+  it('emits rows with service="" for a token whose scopes match two service URLs (ambiguous)', () => {
+    // Two service-scope URLs is the runtime's "inferred.length !== 1" branch:
+    // serviceValue stays '' and every row inherits service=''. Skipping --service
+    // (no filter) ensures the rows are still emitted, just with service=''.
+    const result = resolveTargetRows(
+      makeToken({
+        scope: `${VPN_SCOPE} ${SMARTWINDOW_SCOPE}`,
+        clientId: Buffer.from(VPN_ALLOWED_CLIENT_ID, 'hex'),
+      }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows.every((r) => r.service === '')).toBe(true);
+  });
+
+  it('records all scopes with service="" for a token whose scopes match no service URL', () => {
+    const result = resolveTargetRows(
+      makeToken({ scope: 'profile openid' }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows.every((r) => r.service === '')).toBe(true);
+    expect(result.allowlistDenied).toEqual([]);
+  });
+
+  it('attributes every scope on the token to the single inferred service', () => {
+    // Runtime semantics: a request with scope='profile <vpn-scope-url> openid'
+    // infers serviceValue='vpn' (one scope matches the vpn URL) and writes
+    // every row with service='vpn' — profile and openid inherit the request's
+    // service.
+    const result = resolveTargetRows(
+      makeToken({ scope: `profile ${VPN_SCOPE} openid` }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(3);
+    expect(result.rows.every((r) => r.service === 'vpn')).toBe(true);
+    expect(result.rows.map((r) => r.scope).sort()).toEqual(
+      [VPN_SCOPE, 'openid', 'profile'].sort()
+    );
+  });
+
+  it('rejects a token whose clientId is not in allowedClientsForService', () => {
+    const result = resolveTargetRows(
+      makeToken({ clientId: Buffer.from(VPN_OTHER_CLIENT_ID, 'hex') }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(0);
+    expect(result.allowlistDenied).toEqual(['vpn']);
+  });
+
+  it('allows any clientId for services with no allowlist entry', () => {
+    const result = resolveTargetRows(
+      makeToken({
+        clientId: Buffer.from(SMART_CLIENT_ID, 'hex'),
+        scope: SMARTWINDOW_SCOPE,
+      }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].service).toBe('smartwindow');
+  });
+
+  it('carries the token clientId through to each row', () => {
+    const clientId = Buffer.from(VPN_ALLOWED_CLIENT_ID, 'hex');
+    const result = resolveTargetRows(makeToken({ clientId }), defaultCfg());
+    expect(result.rows[0].clientId).toEqual(clientId);
+  });
+
+  it('sets firstAuthorizedTosAt and lastAuthorizedTosAt to token.createdAt.getTime()', () => {
+    const createdAt = new Date('2024-06-15T12:00:00Z');
+    const result = resolveTargetRows(makeToken({ createdAt }), defaultCfg());
+    expect(result.rows[0].firstAuthorizedTosAt).toBe(createdAt.getTime());
+    expect(result.rows[0].lastAuthorizedTosAt).toBe(createdAt.getTime());
+  });
+
+  it('honors --service filter, dropping tokens whose inferred service does not match', () => {
+    // Smartwindow token + --service vpn → inferred='smartwindow' ≠ 'vpn' →
+    // whole token skipped, no rows emitted.
+    const result = resolveTargetRows(
+      makeToken({
+        scope: SMARTWINDOW_SCOPE,
+        clientId: Buffer.from(SMART_CLIENT_ID, 'hex'),
+      }),
+      defaultCfg(),
+      'vpn'
+    );
+    expect(result.rows).toHaveLength(0);
+    expect(result.allowlistDenied).toEqual([]);
+  });
+
+  it('--service filter keeps all scopes on a matching token (including non-service scopes)', () => {
+    // VPN client signed in with vpn-scope-url + profile + openid →
+    // inferred='vpn' matches filter → all three scopes emitted with
+    // service='vpn'. profile and openid are NOT dropped — they inherit
+    // the request's service like runtime would write them.
+    const result = resolveTargetRows(
+      makeToken({
+        scope: `profile ${VPN_SCOPE} openid`,
+        clientId: Buffer.from(VPN_ALLOWED_CLIENT_ID, 'hex'),
+      }),
+      defaultCfg(),
+      'vpn'
+    );
+    expect(result.rows).toHaveLength(3);
+    expect(result.rows.every((r) => r.service === 'vpn')).toBe(true);
+  });
+
+  it('--service filter drops tokens whose inferred service is ""', () => {
+    // 123done-style token + --service vpn → inferred='' ≠ 'vpn' → skip.
+    const result = resolveTargetRows(
+      makeToken({
+        scope: 'openid profile',
+        clientId: Buffer.from('dcdb5ae7add825d2', 'hex'),
+      }),
+      defaultCfg(),
+      'vpn'
+    );
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it('produces rows for every configured service by default (no default skip)', () => {
+    const allowedClient = Buffer.from(VPN_ALLOWED_CLIENT_ID, 'hex');
+    const relayResult = resolveTargetRows(
+      makeToken({ scope: RELAY_SCOPE, clientId: allowedClient }),
+      defaultCfg()
+    );
+    expect(relayResult.rows.map((r) => r.service)).toEqual(['relay']);
+
+    const syncResult = resolveTargetRows(
+      makeToken({ scope: SYNC_SCOPE, clientId: allowedClient }),
+      defaultCfg()
+    );
+    expect(syncResult.rows.map((r) => r.service)).toEqual(['sync']);
+  });
+
+  it('does not claim service ownership for a scope that is a prefix of a service scope', () => {
+    const result = resolveTargetRows(
+      makeToken({ scope: 'https://identity.mozilla.com/apps/vp' }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].service).toBe('');
+    expect(result.rows[0].scope).toBe('https://identity.mozilla.com/apps/vp');
+  });
+
+  it('does not claim service ownership for a scope that has the service scope as a prefix', () => {
+    const result = resolveTargetRows(
+      makeToken({ scope: `${VPN_SCOPE}-extra` }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].service).toBe('');
+    expect(result.rows[0].scope).toBe(`${VPN_SCOPE}-extra`);
+  });
+
+  it('returns no rows for an empty scope string', () => {
+    const result = resolveTargetRows(makeToken({ scope: '' }), defaultCfg());
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it('123done-style: openid+profile token with no service produces two service="" rows', () => {
+    const result = resolveTargetRows(
+      makeToken({
+        scope: 'openid profile',
+        clientId: Buffer.from('dcdb5ae7add825d2', 'hex'), // arbitrary RP, no allowlist
+      }),
+      defaultCfg()
+    );
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows.every((r) => r.service === '')).toBe(true);
+    expect(result.allowlistDenied).toEqual([]);
+  });
+});
+
+describe('withRetry', () => {
+  function retryCtx(overrides: { attempts?: number } = {}) {
+    return {
+      opName: 'test',
+      attempts: overrides.attempts ?? 3,
+      initialDelayMs: 1,
+      log: makeLog(),
+    };
+  }
+
+  it('returns the value on first success without retrying', async () => {
+    const op = jest.fn().mockResolvedValue('ok');
+    const result = await withRetry(op, retryCtx());
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on a transient error and succeeds on a later attempt', async () => {
+    const transient = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+    const op = jest
+      .fn()
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValue('ok');
+    const ctx = retryCtx();
+    const result = await withRetry(op, ctx);
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      'backfill.retry',
+      expect.objectContaining({ op: 'test', attempt: 1, code: 'ECONNRESET' })
+    );
+  });
+
+  it('throws after exhausting all attempts', async () => {
+    const transient = Object.assign(new Error('timeout'), {
+      code: 'ETIMEDOUT',
+    });
+    const op = jest.fn().mockRejectedValue(transient);
+    await expect(withRetry(op, retryCtx({ attempts: 3 }))).rejects.toThrow(
+      'timeout'
+    );
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry non-transient errors', async () => {
+    const fatal = new Error('syntax error');
+    const op = jest.fn().mockRejectedValue(fatal);
+    await expect(withRetry(op, retryCtx())).rejects.toThrow('syntax error');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry errors whose code is not in the transient set', async () => {
+    const fatal = Object.assign(new Error('access denied'), {
+      code: 'ER_ACCESS_DENIED_ERROR',
+    });
+    const op = jest.fn().mockRejectedValue(fatal);
+    await expect(withRetry(op, retryCtx())).rejects.toThrow('access denied');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('batchUpsert', () => {
+  const uid = Buffer.alloc(16, 0xaa);
+  const clientId = Buffer.from(VPN_ALLOWED_CLIENT_ID, 'hex');
+
+  it('does nothing and does not call query when rows is empty', async () => {
+    const query = makeQuery();
+    await batchUpsert(query, []);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('inserts all six columns in order for a single row', async () => {
+    const query = makeQuery();
+    const row: UpsertRow = {
+      uid,
+      scope: VPN_SCOPE,
+      service: 'vpn',
+      clientId,
+      firstAuthorizedTosAt: 1000,
+      lastAuthorizedTosAt: 1000,
+    };
+    await batchUpsert(query, [row]);
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, values] = query.mock.calls[0];
+    expect(sql).toContain('INSERT INTO accountAuthorizations');
+    expect(sql).toContain(
+      '(uid, scope, service, clientId, firstAuthorizedTosAt, lastAuthorizedTosAt)'
+    );
+    expect(values).toEqual([uid, VPN_SCOPE, 'vpn', clientId, 1000, 1000]);
+  });
+
+  it('builds one 6-placeholder group per row', async () => {
+    const query = makeQuery();
+    const rows: UpsertRow[] = [
+      {
+        uid: Buffer.alloc(16, 0x01),
+        scope: VPN_SCOPE,
+        service: 'vpn',
+        clientId,
+        firstAuthorizedTosAt: 1000,
+        lastAuthorizedTosAt: 1000,
+      },
+      {
+        uid: Buffer.alloc(16, 0x02),
+        scope: SMARTWINDOW_SCOPE,
+        service: 'smartwindow',
+        clientId,
+        firstAuthorizedTosAt: 2000,
+        lastAuthorizedTosAt: 2000,
+      },
+    ];
+    await batchUpsert(query, rows);
+    const [sql, values] = query.mock.calls[0];
+    expect((sql.match(/\(\?, \?, \?, \?, \?, \?\)/g) ?? []).length).toBe(2);
+    expect(values).toHaveLength(12);
+  });
+
+  it('uses LEAST for firstAuthorizedTosAt and GREATEST for lastAuthorizedTosAt', async () => {
+    const query = makeQuery();
+    await batchUpsert(query, [
+      {
+        uid,
+        scope: VPN_SCOPE,
+        service: 'vpn',
+        clientId,
+        firstAuthorizedTosAt: 1000,
+        lastAuthorizedTosAt: 1000,
+      },
+    ]);
+    const [sql] = query.mock.calls[0];
+    expect(sql).toContain('LEAST(firstAuthorizedTosAt');
+    expect(sql).toContain('GREATEST(lastAuthorizedTosAt');
+  });
+});
+
+describe('fetchBatch', () => {
+  const cursor = Buffer.alloc(32, 0x00);
+
+  it('uses an exclusive lower bound (token > cursor)', async () => {
+    const query = makeQuery([]);
+    await fetchBatch(query, cursor, 50);
+    const [sql] = query.mock.calls[0];
+    expect(sql).toContain('token > ?');
+  });
+
+  it('passes batchSize as the LIMIT parameter', async () => {
+    const query = makeQuery([]);
+    await fetchBatch(query, cursor, 250);
+    const values = query.mock.calls[0][1];
+    expect(values[values.length - 1]).toBe(250);
+  });
+});
+
+describe('estimateTotalTokens', () => {
+  it('returns TABLE_ROWS from information_schema', async () => {
+    const query = makeQuery([{ TABLE_ROWS: 42000 }]);
+    const total = await estimateTotalTokens(query);
+    expect(total).toBe(42000);
+  });
+
+  it('returns 0 when the query returns no rows', async () => {
+    const query = makeQuery([]);
+    const total = await estimateTotalTokens(query);
+    expect(total).toBe(0);
+  });
+});
+
+describe('run', () => {
+  const cfg = defaultCfg();
+
+  const baseOpts = {
+    dryRun: false,
+    batchSize: 100,
+    batchDelayMs: 0,
+    retryInitialDelayMs: 1,
+  };
+
+  it('completes cleanly when the table is empty', async () => {
+    const log = makeLog();
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 0 }])
+      .mockResolvedValueOnce([]);
+    await run(query, cfg, log, baseOpts);
+    expect(log.info).toHaveBeenCalledWith(
+      'backfill.complete',
+      expect.objectContaining({ tokensScanned: 0, upsertsAttempted: 0 })
+    );
+  });
+
+  it('does not call INSERT when dryRun is true', async () => {
+    const log = makeLog();
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([makeToken()]);
+    await run(query, cfg, log, { ...baseOpts, dryRun: true });
+    const insertCalls = query.mock.calls.filter(([sql]) =>
+      sql?.includes?.('INSERT INTO')
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('calls INSERT when dryRun is false and a token matches', async () => {
+    const log = makeLog();
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([makeToken()])
+      .mockResolvedValueOnce(undefined);
+    await run(query, cfg, log, baseOpts);
+    const insertCalls = query.mock.calls.filter(([sql]) =>
+      sql?.includes?.('INSERT INTO accountAuthorizations')
+    );
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it('warns when no rows are upserted and dryRun is false', async () => {
+    const log = makeLog();
+    // Empty scope produces no rows; without --service we'd otherwise emit
+    // a row for every scope (including service='') so an "empty scope"
+    // token is what actually exercises the no-rows-upserted warn path.
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([makeToken({ scope: '' })]);
+    await run(query, cfg, log, baseOpts);
+    expect(log.warn).toHaveBeenCalledWith(
+      'backfill.no_rows_upserted',
+      expect.any(Object)
+    );
+  });
+
+  it('does not warn about zero upserts when dryRun is true', async () => {
+    const log = makeLog();
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([makeToken({ scope: '' })]);
+    await run(query, cfg, log, { ...baseOpts, dryRun: true });
+    expect(log.warn).not.toHaveBeenCalledWith(
+      'backfill.no_rows_upserted',
+      expect.any(Object)
+    );
+  });
+
+  it('logs per-service counts in backfill.complete', async () => {
+    const log = makeLog();
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([makeToken()])
+      .mockResolvedValueOnce(undefined);
+    await run(query, cfg, log, baseOpts);
+    expect(log.info).toHaveBeenCalledWith(
+      'backfill.complete',
+      expect.objectContaining({
+        countsByService: expect.objectContaining({ vpn: 1 }),
+        upsertsAttempted: 1,
+      })
+    );
+  });
+
+  it('continues fetching until a partial batch ends the loop', async () => {
+    const log = makeLog();
+    const opts = { ...baseOpts, batchSize: 2 };
+    const fullBatch = [
+      makeToken({ token: Buffer.alloc(32, 0x01) }),
+      makeToken({ token: Buffer.alloc(32, 0x02) }),
+    ];
+    // Second batch returns rows.length < batchSize, which is what stops
+    // the loop — there's no third fetch mocked because the early-break in
+    // run() fires before another fetch is issued.
+    const partialBatch = [makeToken({ token: Buffer.alloc(32, 0x03) })];
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 3 }])
+      .mockResolvedValueOnce(fullBatch)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(partialBatch)
+      .mockResolvedValueOnce(undefined);
+    await run(query, cfg, log, opts);
+
+    const fetchCalls = query.mock.calls.filter(([sql]) =>
+      sql?.includes?.('FROM refreshTokens')
+    );
+    const insertCalls = query.mock.calls.filter(([sql]) =>
+      sql?.includes?.('INSERT INTO accountAuthorizations')
+    );
+    expect(fetchCalls).toHaveLength(2);
+    expect(insertCalls).toHaveLength(2);
+    expect(log.info).toHaveBeenCalledWith(
+      'backfill.complete',
+      expect.objectContaining({ tokensScanned: 3, upsertsAttempted: 3 })
+    );
+  });
+
+  it('advances the cursor between batches using the last token of the previous batch', async () => {
+    const log = makeLog();
+    const opts = { ...baseOpts, batchSize: 1 };
+    const firstToken = Buffer.alloc(32, 0x11);
+    const secondToken = Buffer.alloc(32, 0x22);
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 2 }])
+      .mockResolvedValueOnce([makeToken({ token: firstToken })])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([makeToken({ token: secondToken })])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
+    await run(query, cfg, log, opts);
+
+    const fetchCalls = query.mock.calls.filter(([sql]) =>
+      sql?.includes?.('FROM refreshTokens')
+    );
+    expect(fetchCalls.length).toBeGreaterThanOrEqual(2);
+    const secondFetchCursor = fetchCalls[1][1][0];
+    expect(secondFetchCursor).toEqual(firstToken);
+  });
+
+  it('propagates batchUpsert errors and logs upsert_batch_failed', async () => {
+    const log = makeLog();
+    const upsertError = new Error('connection lost');
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([makeToken()])
+      .mockRejectedValueOnce(upsertError);
+
+    await expect(run(query, cfg, log, baseOpts)).rejects.toThrow(
+      'connection lost'
+    );
+    expect(log.error).toHaveBeenCalledWith(
+      'backfill.upsert_batch_failed',
+      expect.objectContaining({ err: 'connection lost' })
+    );
+  });
+
+  it('retries batchUpsert on a transient error and succeeds', async () => {
+    const log = makeLog();
+    const transient = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([makeToken()])
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValueOnce(undefined);
+
+    await run(query, cfg, log, {
+      ...baseOpts,
+      retryAttempts: 3,
+      retryInitialDelayMs: 1,
+    });
+
+    const insertCalls = query.mock.calls.filter(([sql]) =>
+      sql?.includes?.('INSERT INTO accountAuthorizations')
+    );
+    expect(insertCalls).toHaveLength(2);
+    expect(log.warn).toHaveBeenCalledWith(
+      'backfill.retry',
+      expect.objectContaining({ op: 'batchUpsert', code: 'ECONNRESET' })
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      'backfill.complete',
+      expect.objectContaining({ upsertsAttempted: 1 })
+    );
+  });
+
+  it('counts and emits a stat when a token is denied by the allowlist gate', async () => {
+    const log = makeLog();
+    const statsd: Pick<StatsD, 'increment' | 'timing'> = {
+      increment: jest.fn() as unknown as StatsD['increment'],
+      timing: jest.fn() as unknown as StatsD['timing'],
+    };
+    const deniedToken = makeToken({
+      clientId: Buffer.from(VPN_OTHER_CLIENT_ID, 'hex'),
+    });
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([{ TABLE_ROWS: 1 }])
+      .mockResolvedValueOnce([deniedToken]);
+    await run(query, cfg, log, {
+      ...baseOpts,
+      statsd: statsd as unknown as StatsD,
+    });
+    // statsd increments are aggregated per batch — one call carrying the
+    // count rather than one call per skipped token.
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'account_authz.backfill.tokens_skipped',
+      1,
+      { reason: 'client_not_allowed' }
+    );
+  });
+});

--- a/packages/fxa-auth-server/scripts/backfill-account-authorizations/backfill-account-authorizations.ts
+++ b/packages/fxa-auth-server/scripts/backfill-account-authorizations/backfill-account-authorizations.ts
@@ -1,0 +1,721 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Backfill script for the accountAuthorizations consent ledger.
+ *
+ * Walks the refreshTokens table in cursor order and writes one consent row
+ * per (uid, scope, service, clientId) tuple for every scope on every token.
+ * Each token's `service` column is inferred ONCE from its scopes (mirroring
+ * lib/routes/oauth/authorization.js:recordAuthorizationRows): if exactly one
+ * of the token's scopes is a configured service's scope URL, that's the
+ * service; otherwise service=''. Every row written for that token then
+ * carries that same service value — a VPN sign-in with
+ * scope='<vpn-scope-url> profile' lands as two rows both with service='vpn',
+ * and a 123done sign-in with scope='openid profile' lands as two rows both
+ * with service=''. Backfilled rows look identical to organic ones, including
+ * the service='' rows that future ToS-rejection logic on /authorization will
+ * read for non-browser RPs.
+ *
+ * Per service notes:
+ *   - relay rows are written even though token-exchange currently bypasses
+ *     the consent check. Two reasons: (a) the firstAuthorizedTosAt /
+ *     lastAuthorizedTosAt columns are a per-user ToS-acceptance ledger
+ *     independent of how exchange decides today, and (b) the bypass is
+ *     explicitly transitional — see EXCHANGE_DECISION.BYPASS in
+ *     lib/oauth/db/index.js and the "Remove this path once application-
+ *     services ships a 4xx handler" comment in lib/routes/oauth/token.js.
+ *     Backfilled rows prevent existing users from being re-prompted when
+ *     that bypass is eventually removed.
+ *   - sync rows materialize from mobile only — Firefox Desktop calls /destroy
+ *     on its sync refresh token immediately after sign-in, so Desktop sync
+ *     tokens aren't present in the scan source.
+ *
+ * Prerequisites:
+ *   - accountAuthorizations table at the new (clientId, firstAuthorizedTosAt,
+ *     lastAuthorizedTosAt) shape.
+ *   - oauthServer.exchange.serviceScopes + allowedClientsForService populated
+ *     in config.
+ *
+ * Usage (from packages/fxa-auth-server):
+ *
+ *   # Default — every refreshToken, including 123done-style tokens whose
+ *   # scopes don't map to a browser service (recorded with service='')
+ *   node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/backfill-account-authorizations/backfill-account-authorizations.ts --dry-run
+ *   node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/backfill-account-authorizations/backfill-account-authorizations.ts
+ *
+ *   # Just one service — only tokens whose inferred service matches are
+ *   # touched; tokens that infer to other services or to '' are skipped.
+ *   node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/backfill-account-authorizations/backfill-account-authorizations.ts --service vpn
+ *
+ * The script always scans the full refreshTokens table from the start.
+ * On failure: restart the script — `INSERT … ON DUPLICATE KEY UPDATE
+ * LEAST(first…)/GREATEST(last…)` is idempotent, so re-running converges.
+ *
+ * Execution plan:
+ *   1. --dry-run on stage           → verify per-service counts
+ *   2. Live run on stage            → spot-check accountAuthorizations rows
+ *   3. --dry-run on prod            → validate expected counts
+ *   4. Live run on prod (off-peak)  → tune --batch-size and --batch-delay-ms
+ *                                     to balance throughput against DB load.
+ */
+
+import { promisify } from 'util';
+import * as mysql from 'mysql';
+import program from 'commander';
+import { StatsD } from 'hot-shots';
+import pckg from '../../package.json';
+
+export interface ServiceConfig {
+  // Inverse map: service scope URL → service name. Drives scope matching.
+  scopeToService: Map<string, string>;
+  // service → Set<lowercased clientId hex>. Services absent from the map are
+  // unrestricted (any clientId may produce a row); services present with
+  // a non-empty set require clientId membership. Mirrors the runtime
+  // isClientAllowedForService gate.
+  allowedClients: Map<string, Set<string>>;
+}
+
+export interface UpsertRow {
+  uid: Buffer;
+  scope: string;
+  service: string;
+  clientId: Buffer;
+  firstAuthorizedTosAt: number; // ms epoch
+  lastAuthorizedTosAt: number; // ms epoch
+}
+
+export interface ResolveResult {
+  rows: UpsertRow[];
+  // The inferred service for this token if its allowlist gate rejected the
+  // clientId, otherwise empty. Length is 0 or 1 — a token has exactly one
+  // inferred service. Used by the caller to emit a security-relevant skip
+  // metric distinct from "no rows produced".
+  allowlistDenied: string[];
+}
+
+export interface Logger {
+  info: (op: string, data?: unknown) => void;
+  warn: (op: string, data?: unknown) => void;
+  error: (op: string, data?: unknown) => void;
+  debug?: (op: string, data?: unknown) => void;
+}
+
+export type Query = <T = unknown>(
+  sql: string,
+  values?: unknown[]
+) => Promise<T>;
+
+function makeQuery(pool: mysql.Pool): Query {
+  return <T = unknown>(sql: string, values?: unknown[]): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      pool.query(sql, values, (err, results) => {
+        if (err) reject(err);
+        else resolve(results as T);
+      });
+    });
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function humanDuration(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h${m}m${s}s`;
+  if (m > 0) return `${m}m${s}s`;
+  return `${s}s`;
+}
+
+function buildServiceConfig(
+  serviceScopes: Record<string, string>,
+  allowedClientsForService: Record<string, string[]>
+): ServiceConfig {
+  const scopeToService = new Map<string, string>();
+  for (const [service, scope] of Object.entries(serviceScopes)) {
+    scopeToService.set(scope, service);
+  }
+
+  const allowedClients = new Map<string, Set<string>>();
+  for (const [service, clientIds] of Object.entries(
+    allowedClientsForService || {}
+  )) {
+    if (Array.isArray(clientIds) && clientIds.length > 0) {
+      allowedClients.set(
+        service,
+        new Set(clientIds.map((c) => c.toLowerCase()))
+      );
+    }
+  }
+
+  return { scopeToService, allowedClients };
+}
+
+// Per-token service inference. Mirrors the runtime path
+// (lib/routes/oauth/authorization.js:recordAuthorizationRows): the URL
+// ?service= param is the source of truth in runtime but isn't preserved on
+// the refreshToken, so we fall back to runtime's inference branch — if
+// exactly one of the token's scopes is a configured service's scope URL,
+// that's the service; otherwise service=''. Two or more service-scope URLs
+// are ambiguous and resolve to '' (matches runtime's `inferred.length === 1`
+// guard).
+function inferServiceForToken(
+  scopes: string[],
+  scopeToService: Map<string, string>
+): string {
+  const matchedServices = scopes
+    .map((s) => scopeToService.get(s))
+    .filter((s): s is string => Boolean(s));
+  return matchedServices.length === 1 ? matchedServices[0] : '';
+}
+
+// Mirrors lib/routes/oauth/authorization.js:recordAuthorizationRows semantics
+// for the backfill side:
+//   - One inferred service per token (see inferServiceForToken), applied as
+//     the `service` column on every row written for that token. This matches
+//     runtime, which derives serviceValue once from URL/scope inference and
+//     then writes each scope with that same serviceValue. A 123done token
+//     with scope='openid profile' lands as two rows with service=''; a VPN
+//     token with scope='<vpn-scope-url> profile' lands as two rows both with
+//     service='vpn'.
+//   - Allowlist gate is per-token, not per-scope: if the inferred service
+//     has an allowlist and the token's clientId isn't on it, the whole
+//     token is skipped (matches runtime's early-return on
+//     isClientAllowedForService failure). service='' is always unrestricted.
+//   - --service filter is also per-token: tokens whose inferred service !=
+//     filter are dropped wholesale. Under correct runtime mirroring, every
+//     row from a single token carries the same service, so a filter naturally
+//     excludes whole tokens — service='' rows can't appear under --service.
+//   - Each row carries the token's own clientId (the new PK includes it,
+//     so different RP clients for the same user/scope produce distinct rows).
+//   - lastAuthorizedTosAt is set to the token's createdAt, NOT to a real ToS
+//     view. For refreshTokens minted via prompt=none the user never saw a
+//     ToS, but we have no separate "last consent" signal to draw from.
+//     Backfilled values are upper bounds on "could have seen ToS by";
+//     organic /authorization writes converge the value forward over time.
+function resolveTargetRows(
+  token: {
+    userId: Buffer;
+    clientId: Buffer;
+    scope: string;
+    createdAt: Date;
+  },
+  cfg: ServiceConfig,
+  serviceFilter?: string
+): ResolveResult {
+  const scopes = token.scope.split(/\s+/).filter(Boolean);
+  if (scopes.length === 0) {
+    return { rows: [], allowlistDenied: [] };
+  }
+
+  const serviceValue = inferServiceForToken(scopes, cfg.scopeToService);
+
+  if (serviceFilter !== undefined && serviceValue !== serviceFilter) {
+    return { rows: [], allowlistDenied: [] };
+  }
+
+  const clientHex = token.clientId.toString('hex').toLowerCase();
+  const allowlist = cfg.allowedClients.get(serviceValue);
+  if (allowlist && !allowlist.has(clientHex)) {
+    return { rows: [], allowlistDenied: [serviceValue] };
+  }
+
+  const tsMs = token.createdAt.getTime();
+  const uniqueScopes = new Set(scopes);
+  const rows: UpsertRow[] = [];
+  for (const scope of uniqueScopes) {
+    rows.push({
+      uid: token.userId,
+      scope,
+      service: serviceValue,
+      clientId: token.clientId,
+      firstAuthorizedTosAt: tsMs,
+      lastAuthorizedTosAt: tsMs,
+    });
+  }
+
+  return { rows, allowlistDenied: [] };
+}
+
+// LEAST(firstAuthorizedTosAt) preserves the earliest discovered grant across
+// arbitrary cursor-scan order. GREATEST(lastAuthorizedTosAt) keeps the latest
+// observed timestamp, matching the runtime ingress's GREATEST clause.
+async function batchUpsert(query: Query, rows: UpsertRow[]): Promise<void> {
+  if (rows.length === 0) return;
+
+  const placeholders = rows.map(() => '(?, ?, ?, ?, ?, ?)').join(', ');
+  const values = rows.flatMap((r) => [
+    r.uid,
+    r.scope,
+    r.service,
+    r.clientId,
+    r.firstAuthorizedTosAt,
+    r.lastAuthorizedTosAt,
+  ]);
+
+  await query(
+    `INSERT INTO accountAuthorizations
+       (uid, scope, service, clientId, firstAuthorizedTosAt, lastAuthorizedTosAt)
+     VALUES ${placeholders}
+     ON DUPLICATE KEY UPDATE
+       firstAuthorizedTosAt = LEAST(firstAuthorizedTosAt, VALUES(firstAuthorizedTosAt)),
+       lastAuthorizedTosAt  = GREATEST(lastAuthorizedTosAt, VALUES(lastAuthorizedTosAt))`,
+    values
+  );
+}
+
+async function estimateTotalTokens(query: Query): Promise<number> {
+  // InnoDB TABLE_ROWS is an approximation but fine for progress display.
+  const rows = await query<Array<{ TABLE_ROWS: number }>>(
+    `SELECT TABLE_ROWS FROM information_schema.TABLES
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'refreshTokens'`
+  );
+  return rows[0]?.TABLE_ROWS ?? 0;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Codes the mysql driver / Node net stack surface for transient blips. A
+// single packet hiccup or short lock contention shouldn't kill a multi-hour
+// backfill — we retry, and only propagate the error when the same op fails
+// repeatedly. Anything not in this set (schema errors, syntax errors, etc.)
+// fails fast.
+const TRANSIENT_DB_ERROR_CODES: ReadonlySet<string> = new Set([
+  'PROTOCOL_CONNECTION_LOST',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ER_LOCK_WAIT_TIMEOUT',
+  'ER_LOCK_DEADLOCK',
+]);
+
+/**
+ * Clamp statsd `code` tags to a bounded allowlist. Anything outside the
+ * known set lands in 'other' so a novel driver-surfaced code can't blow
+ * up tag cardinality on the metrics backend.
+ */
+function safeStatsdCode(code: string | undefined): string {
+  return code && TRANSIENT_DB_ERROR_CODES.has(code) ? code : 'other';
+}
+
+async function withRetry<T>(
+  operation: () => Promise<T>,
+  context: {
+    opName: string;
+    attempts: number;
+    initialDelayMs: number;
+    log: Logger;
+    statsd?: StatsD;
+  }
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= context.attempts; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      lastErr = err;
+      const code = (err as { code?: string }).code;
+      const isTransient = !!code && TRANSIENT_DB_ERROR_CODES.has(code);
+      if (!isTransient || attempt === context.attempts) {
+        throw err;
+      }
+      const delayMs = context.initialDelayMs * Math.pow(2, attempt - 1);
+      context.log.warn('backfill.retry', {
+        op: context.opName,
+        attempt,
+        nextDelayMs: delayMs,
+        code,
+        err: errMessage(err),
+      });
+      context.statsd?.increment('account_authz.backfill.retry', {
+        op: context.opName,
+        code: safeStatsdCode(code),
+      });
+      await sleep(delayMs);
+    }
+  }
+  throw lastErr;
+}
+
+type TokenRow = {
+  token: Buffer;
+  userId: Buffer;
+  clientId: Buffer;
+  scope: string;
+  createdAt: Date;
+};
+
+async function fetchBatch(
+  query: Query,
+  cursor: Buffer,
+  batchSize: number
+): Promise<TokenRow[]> {
+  return query<TokenRow[]>(
+    'SELECT token, userId, clientId, scope, createdAt ' +
+      'FROM refreshTokens WHERE token > ? ORDER BY token LIMIT ?',
+    [cursor, batchSize]
+  );
+}
+
+async function run(
+  query: Query,
+  cfg: ServiceConfig,
+  log: Logger,
+  opts: {
+    dryRun: boolean;
+    batchSize: number;
+    batchDelayMs: number;
+    serviceFilter?: string;
+    statsd?: StatsD;
+    retryAttempts?: number;
+    retryInitialDelayMs?: number;
+  }
+): Promise<void> {
+  const { dryRun, batchSize, batchDelayMs, serviceFilter, statsd } = opts;
+  const retryAttempts = opts.retryAttempts ?? 3;
+  const retryInitialDelayMs = opts.retryInitialDelayMs ?? 500;
+  const withDbRetry = <T>(opName: string, op: () => Promise<T>): Promise<T> =>
+    withRetry(op, {
+      opName,
+      attempts: retryAttempts,
+      initialDelayMs: retryInitialDelayMs,
+      log,
+      statsd,
+    });
+
+  const runStartedMs = Date.now();
+  // Estimate is a progress-display nicety, not load-bearing. If
+  // information_schema is unavailable or the DB role can't read it, log
+  // the failure and continue with -1 so logs make the failed state
+  // visible. Downstream percent calculation already guards against negatives.
+  let estimated = -1;
+  try {
+    estimated = await estimateTotalTokens(query);
+  } catch (err) {
+    log.warn('backfill.estimate_failed', { err: errMessage(err) });
+  }
+  const allServiceNames = [...cfg.scopeToService.values()];
+  log.info('backfill.start', {
+    estimatedTokens: estimated,
+    services: allServiceNames,
+    serviceFilter: serviceFilter ?? null,
+    batchSize,
+    batchDelayMs,
+    dryRun,
+  });
+
+  // Internal pagination cursor. Starts at all-zeros (before any token in
+  // sort order) and advances to the last token of each batch.
+  let cursor = Buffer.alloc(32);
+  let batchNum = 0;
+  let totalTokensProcessed = 0;
+  let totalUpsertsAttempted = 0;
+  let totalSkippedNoMatch = 0;
+  let totalSkippedAllowlist = 0;
+  const countsByService: Record<string, number> = {};
+  for (const name of allServiceNames) countsByService[name] = 0;
+
+  let rows = await withDbRetry('fetchBatch', () =>
+    fetchBatch(query, cursor, batchSize)
+  );
+
+  while (rows.length > 0) {
+    batchNum++;
+    totalTokensProcessed += rows.length;
+    const batchStartedMs = Date.now();
+
+    const upserts: UpsertRow[] = [];
+    // Per-batch aggregates flushed to statsd at batch boundary. Emitting a
+    // packet per token would mean 50M+ UDP packets on a real backfill —
+    // counts collapse here and ship once per batch.
+    let batchSkippedNoMatch = 0;
+    let batchSkippedAllowlist = 0;
+    const batchUpsertsByService: Record<string, number> = {};
+
+    for (const row of rows) {
+      const { rows: resolved, allowlistDenied } = resolveTargetRows(
+        row,
+        cfg,
+        serviceFilter
+      );
+
+      if (allowlistDenied.length > 0) {
+        totalSkippedAllowlist += allowlistDenied.length;
+        batchSkippedAllowlist += allowlistDenied.length;
+      }
+
+      if (resolved.length === 0) {
+        if (allowlistDenied.length === 0) {
+          totalSkippedNoMatch++;
+          batchSkippedNoMatch++;
+        }
+        continue;
+      }
+
+      for (const upsert of resolved) {
+        upserts.push(upsert);
+        countsByService[upsert.service] =
+          (countsByService[upsert.service] ?? 0) + 1;
+        batchUpsertsByService[upsert.service] =
+          (batchUpsertsByService[upsert.service] ?? 0) + 1;
+      }
+    }
+
+    if (batchSkippedAllowlist > 0) {
+      statsd?.increment(
+        'account_authz.backfill.tokens_skipped',
+        batchSkippedAllowlist,
+        { reason: 'client_not_allowed' }
+      );
+    }
+    if (batchSkippedNoMatch > 0) {
+      statsd?.increment(
+        'account_authz.backfill.tokens_skipped',
+        batchSkippedNoMatch,
+        { reason: 'no_match' }
+      );
+    }
+    for (const [service, count] of Object.entries(batchUpsertsByService)) {
+      statsd?.increment('account_authz.backfill.upserts_attempted', count, {
+        service,
+      });
+    }
+
+    if (!dryRun && upserts.length > 0) {
+      try {
+        await withDbRetry('batchUpsert', () => batchUpsert(query, upserts));
+      } catch (err) {
+        statsd?.increment('account_authz.backfill.upsert_batch_failed');
+        log.error('backfill.upsert_batch_failed', {
+          batchNum,
+          rowCount: upserts.length,
+          err: errMessage(err),
+        });
+        throw err;
+      }
+    }
+
+    totalUpsertsAttempted += upserts.length;
+    cursor = rows[rows.length - 1].token;
+
+    const batchDurationMs = Date.now() - batchStartedMs;
+    statsd?.timing('account_authz.backfill.batch_duration_ms', batchDurationMs);
+    statsd?.increment('account_authz.backfill.tokens_scanned', rows.length);
+    statsd?.increment('account_authz.backfill.batches_completed', {
+      dry_run: String(dryRun),
+    });
+
+    const percent =
+      estimated > 0
+        ? Math.round((totalTokensProcessed / estimated) * 100)
+        : null;
+    log.info('backfill.batch', {
+      batchNum,
+      tokensProcessed: totalTokensProcessed,
+      percent,
+      upsertsAttempted: totalUpsertsAttempted,
+      skippedNoMatch: totalSkippedNoMatch,
+      skippedAllowlist: totalSkippedAllowlist,
+      durationMs: batchDurationMs,
+    });
+
+    if (rows.length < batchSize) break;
+
+    if (batchDelayMs > 0) await sleep(batchDelayMs);
+
+    rows = await withDbRetry('fetchBatch', () =>
+      fetchBatch(query, cursor, batchSize)
+    );
+  }
+
+  const totalDurationMs = Date.now() - runStartedMs;
+  statsd?.timing('account_authz.backfill.run_duration_ms', totalDurationMs);
+  log.info('backfill.complete', {
+    tokensScanned: totalTokensProcessed,
+    upsertsAttempted: totalUpsertsAttempted,
+    skippedNoMatch: totalSkippedNoMatch,
+    skippedAllowlist: totalSkippedAllowlist,
+    totalDurationMs,
+    totalDurationHuman: humanDuration(totalDurationMs),
+    dryRun,
+    countsByService,
+  });
+
+  if (totalUpsertsAttempted === 0 && !dryRun) {
+    log.warn('backfill.no_rows_upserted', {
+      op: 'backfill.complete',
+      msg: 'No rows were upserted — verify oauthServer.exchange.serviceScopes and allowedClientsForService are configured correctly.',
+    });
+  }
+}
+
+export {
+  buildServiceConfig,
+  inferServiceForToken,
+  resolveTargetRows,
+  batchUpsert,
+  fetchBatch,
+  estimateTotalTokens,
+  withRetry,
+  run,
+};
+
+export async function init() {
+  // require() (not import) so the module's env-driven config validation
+  // doesn't fire when this file is imported by the spec.
+  const config = require('../../config').default.getProperties();
+  const statsd = new StatsD({ ...config.statsd, maxBufferSize: 0 });
+  const log = require('../../lib/log')(
+    config.log.level,
+    'backfill-account-authorizations',
+    statsd
+  );
+
+  program
+    .version(pckg.version)
+    .option(
+      '--dry-run',
+      'Log what would be written without writing (recommended first pass)',
+      false
+    )
+    .option('--batch-size <number>', 'Rows read per iteration', '1000')
+    .option(
+      '--batch-delay-ms <number>',
+      'Sleep between batches in ms (controls DB load)',
+      '100'
+    )
+    .option(
+      '--service <name>',
+      'Only backfill a single service (e.g. vpn). Omit to backfill all configured services.'
+    )
+    .option(
+      '--retry-attempts <number>',
+      'Total attempts (incl. first) for transient DB errors before giving up',
+      '3'
+    )
+    .option(
+      '--retry-initial-delay-ms <number>',
+      'Initial backoff delay in ms; doubles on each retry (500 → 1000 → 2000)',
+      '500'
+    )
+    .parse(process.argv);
+
+  const dryRun: boolean = program.dryRun;
+  const batchSize = parseInt(program.batchSize, 10) || 1000;
+  const batchDelayMs = parseInt(program.batchDelayMs, 10) || 100;
+  const retryAttempts = parseInt(program.retryAttempts, 10) || 3;
+  const retryInitialDelayMs = parseInt(program.retryInitialDelayMs, 10) || 500;
+  const serviceFilter: string | undefined = program.service;
+
+  const dbConfig = config.oauthServer.mysql;
+  const exchangeCfg = config.oauthServer.exchange ?? {};
+  const serviceScopes: Record<string, string> = exchangeCfg.serviceScopes ?? {};
+  const allowedClientsForService: Record<string, string[]> =
+    exchangeCfg.allowedClientsForService ?? {};
+
+  let cfg: ServiceConfig;
+  try {
+    if (Object.keys(serviceScopes).length === 0) {
+      throw new Error(
+        'oauthServer.exchange.serviceScopes is empty. Add at least one ' +
+          'service entry (vpn, smartwindow, etc.) to config or config/secrets.json.'
+      );
+    }
+    if (serviceFilter !== undefined && !(serviceFilter in serviceScopes)) {
+      throw new Error(
+        `No service '${serviceFilter}' found in oauthServer.exchange.serviceScopes. ` +
+          `Available: ${Object.keys(serviceScopes).join(', ')}`
+      );
+    }
+    cfg = buildServiceConfig(serviceScopes, allowedClientsForService);
+  } catch (err) {
+    log.error('backfill.config_error', { err: errMessage(err) });
+    return 1;
+  }
+
+  // connectionLimit: 1 keeps load on the OAuth DB single-threaded (this script
+  // is sequential by design — see --batch-delay-ms). The pool auto-replaces a
+  // connection that dies from wait_timeout / network drops; paired with
+  // withRetry, the script rides through transient blips.
+  const pool = mysql.createPool({
+    connectionLimit: 1,
+    host: dbConfig.host || 'localhost',
+    port: parseInt(dbConfig.port || '3306', 10),
+    user: dbConfig.user || 'root',
+    password: dbConfig.password || '',
+    database: dbConfig.database || 'fxa_oauth',
+    timezone: '+00:00',
+    charset: 'UTF8MB4_UNICODE_CI',
+  });
+
+  pool.on('connection', (conn: mysql.PoolConnection) => {
+    conn.on('error', (err) => {
+      // Log only the bounded `code` field. The mysql driver decorates errors
+      // with internal state that has historically included connection options
+      // (host, user, even password in older versions); logging the raw `err`
+      // or `String(err)` risks leaking those into structured logs. Clamp
+      // the metric tag to a known allowlist; let the log carry the raw code
+      // for ops triage.
+      const rawCode = (err as { code?: string }).code ?? 'unknown';
+      statsd?.increment('account_authz.backfill.connection_error', {
+        code: safeStatsdCode(rawCode),
+      });
+      log.error('backfill.connection_error', {
+        code: rawCode,
+        msg: 'Connection lost mid-run; pool will acquire a fresh one for the next query.',
+      });
+    });
+  });
+
+  const query = makeQuery(pool);
+
+  try {
+    await run(query, cfg, log, {
+      dryRun,
+      batchSize,
+      batchDelayMs,
+      serviceFilter,
+      statsd,
+      retryAttempts,
+      retryInitialDelayMs,
+    });
+  } catch (err) {
+    log.error('backfill.run_failed', {
+      code: (err as { code?: string }).code,
+      err: errMessage(err),
+      msg: 'Run aborted; re-run the script (upsert is idempotent).',
+    });
+    return 1;
+  } finally {
+    await new Promise<void>((resolve) => pool.end(() => resolve()));
+    // Flush pending UDP metrics. Without this the final run_duration_ms
+    // timing and any retry packets emitted in the last few ms can be lost
+    // to socket teardown at process.exit.
+    await promisify(statsd.close).bind(statsd)();
+  }
+
+  return 0;
+}
+
+if (require.main === module) {
+  let exitStatus = 1;
+  init()
+    .then((code) => {
+      exitStatus = code;
+    })
+    .catch((err) => {
+      // Fallback to console.error here: init() constructs the structured log
+      // via require('../../lib/log'), so a crash during config or log
+      // construction itself leaves us with no log instance to use.
+      console.error(err);
+    })
+    .finally(() => {
+      process.exit(exitStatus);
+    });
+}

--- a/packages/fxa-auth-server/test/scripts/backfill-account-authorizations.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/backfill-account-authorizations.in.spec.ts
@@ -1,0 +1,311 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as crypto from 'crypto';
+import * as mysql from 'mysql';
+
+import {
+  buildServiceConfig,
+  Query,
+  run as runBackfill,
+} from '../../scripts/backfill-account-authorizations/backfill-account-authorizations';
+
+const config = require('../../config').default.getProperties();
+
+const VPN_SCOPE = 'https://identity.mozilla.com/apps/vpn';
+const SMARTWINDOW_SCOPE = 'https://identity.mozilla.com/apps/smartwindow';
+
+// Pull a real VPN-allowlisted clientId from config so the allowlist gate
+// passes in the same way it would in production.
+const exchangeCfg = config.oauthServer.exchange;
+const VPN_ALLOWED_CLIENT_ID: string =
+  exchangeCfg.allowedClientsForService?.vpn?.[0];
+// Synthetic clientId that is NOT on any allowlist, for the negative test.
+const UNRELATED_CLIENT_ID = 'aa01000000000009';
+// Smartwindow has no allowlist; any clientId works.
+const SMART_CLIENT_ID = UNRELATED_CLIENT_ID;
+
+// Test fixture UIDs use the 0xCC prefix so they don't collide with
+// seed-test-data.ts (0xAA deterministic, 0xBB volume noise).
+function uid(suffix: string): Buffer {
+  return Buffer.from('cc' + suffix.padStart(30, '0'), 'hex');
+}
+
+function tokenHash(label: string): Buffer {
+  return crypto.createHash('sha256').update(`int-test-${label}`).digest();
+}
+
+function toMysqlTs(d: Date): string {
+  return d.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function noopLog() {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+describe('#integration - scripts/backfill-account-authorizations', () => {
+  let pool: mysql.Pool;
+  let query: Query;
+
+  const baseRunOpts = {
+    dryRun: false,
+    batchSize: 100,
+    batchDelayMs: 0,
+    retryAttempts: 1,
+    retryInitialDelayMs: 1,
+  };
+
+  function buildCfg() {
+    return buildServiceConfig(
+      exchangeCfg.serviceScopes,
+      exchangeCfg.allowedClientsForService || {}
+    );
+  }
+
+  async function insertRefreshToken(args: {
+    label: string;
+    userId: Buffer;
+    clientId: string;
+    scope: string;
+    createdAt: Date;
+  }) {
+    await query(
+      'INSERT INTO refreshTokens (clientId, userId, scope, token, profileChangedAt, createdAt, lastUsedAt) ' +
+        'VALUES (?, ?, ?, ?, NULL, ?, ?)',
+      [
+        Buffer.from(args.clientId, 'hex'),
+        args.userId,
+        args.scope,
+        tokenHash(args.label),
+        toMysqlTs(args.createdAt),
+        toMysqlTs(args.createdAt),
+      ]
+    );
+  }
+
+  async function clearTestRows() {
+    await query(
+      "DELETE FROM refreshTokens WHERE LEFT(userId, 1) = UNHEX('cc')"
+    );
+    await query(
+      "DELETE FROM accountAuthorizations WHERE LEFT(uid, 1) = UNHEX('cc')"
+    );
+  }
+
+  beforeAll(() => {
+    const c = config.oauthServer.mysql;
+    pool = mysql.createPool({
+      connectionLimit: 2,
+      host: c.host,
+      port: parseInt(c.port, 10),
+      user: c.user,
+      password: c.password,
+      database: c.database,
+      timezone: '+00:00',
+    });
+    query = <T = unknown>(sql: string, values?: unknown[]) =>
+      new Promise<T>((resolve, reject) => {
+        pool.query(sql, values, (err, results) => {
+          if (err) reject(err);
+          else resolve(results as T);
+        });
+      });
+  });
+
+  afterAll(async () => {
+    await clearTestRows();
+    await new Promise<void>((resolve) => pool.end(() => resolve()));
+  });
+
+  beforeEach(async () => {
+    await clearTestRows();
+  });
+
+  it('writes a row populating all new columns for a vpn-scope token from an allowlisted clientId', async () => {
+    const userId = uid('01');
+    const createdAt = new Date('2024-06-15T12:00:00Z');
+    await insertRefreshToken({
+      label: 'one-match',
+      userId,
+      clientId: VPN_ALLOWED_CLIENT_ID,
+      scope: VPN_SCOPE,
+      createdAt,
+    });
+
+    await runBackfill(query, buildCfg(), noopLog(), baseRunOpts);
+
+    const rows = await query<
+      Array<{
+        scope: string;
+        service: string;
+        clientId: Buffer;
+        firstAuthorizedTosAt: number;
+        lastAuthorizedTosAt: number;
+      }>
+    >(
+      'SELECT scope, service, clientId, firstAuthorizedTosAt, lastAuthorizedTosAt ' +
+        'FROM accountAuthorizations WHERE uid = ?',
+      [userId]
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].scope).toBe(VPN_SCOPE);
+    expect(rows[0].service).toBe('vpn');
+    expect(rows[0].clientId.toString('hex')).toBe(VPN_ALLOWED_CLIENT_ID);
+    // TIMESTAMP → BIGINT ms-epoch round-trip end-to-end.
+    expect(Number(rows[0].firstAuthorizedTosAt)).toBe(createdAt.getTime());
+    expect(Number(rows[0].lastAuthorizedTosAt)).toBe(createdAt.getTime());
+  });
+
+  it('writes one row per clientId when the same (uid, scope, service) appears with different clientIds', async () => {
+    // Smartwindow has no allowlist gate, so this exercise focuses on the
+    // PK-includes-clientId property: same scope, same service, two
+    // different clientIds → two distinct rows.
+    const userId = uid('02');
+    const createdAt = new Date('2024-06-15T00:00:00Z');
+    const clientA = SMART_CLIENT_ID;
+    const clientB = 'aa01000000000010';
+
+    await insertRefreshToken({
+      label: 'multi-client-a',
+      userId,
+      clientId: clientA,
+      scope: SMARTWINDOW_SCOPE,
+      createdAt,
+    });
+    await insertRefreshToken({
+      label: 'multi-client-b',
+      userId,
+      clientId: clientB,
+      scope: SMARTWINDOW_SCOPE,
+      createdAt,
+    });
+
+    await runBackfill(query, buildCfg(), noopLog(), baseRunOpts);
+
+    const rows = await query<Array<{ clientId: Buffer }>>(
+      'SELECT clientId FROM accountAuthorizations WHERE uid = ? AND service = ? ' +
+        'ORDER BY clientId',
+      [userId, 'smartwindow']
+    );
+    const hexClientIds = rows.map((r) => r.clientId.toString('hex')).sort();
+    expect(hexClientIds).toEqual([clientA, clientB].sort());
+  });
+
+  it('aggregates LEAST/GREATEST across multiple tokens for the same (uid, scope, service, clientId)', async () => {
+    const userId = uid('03');
+    const earlier = new Date('2023-01-01T00:00:00Z');
+    const later = new Date('2024-06-01T00:00:00Z');
+    // Insert the later token first; cursor scan order shouldn't matter
+    // because the ON DUPLICATE KEY UPDATE clause does LEAST/GREATEST.
+    await insertRefreshToken({
+      label: 'least-late',
+      userId,
+      clientId: VPN_ALLOWED_CLIENT_ID,
+      scope: VPN_SCOPE,
+      createdAt: later,
+    });
+    await insertRefreshToken({
+      label: 'least-early',
+      userId,
+      clientId: VPN_ALLOWED_CLIENT_ID,
+      scope: VPN_SCOPE,
+      createdAt: earlier,
+    });
+
+    await runBackfill(query, buildCfg(), noopLog(), baseRunOpts);
+
+    const rows = await query<
+      Array<{ firstAuthorizedTosAt: number; lastAuthorizedTosAt: number }>
+    >(
+      'SELECT firstAuthorizedTosAt, lastAuthorizedTosAt ' +
+        'FROM accountAuthorizations WHERE uid = ? AND service = ?',
+      [userId, 'vpn']
+    );
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].firstAuthorizedTosAt)).toBe(earlier.getTime());
+    expect(Number(rows[0].lastAuthorizedTosAt)).toBe(later.getTime());
+  });
+
+  it('skips tokens whose clientId is not on the service allowlist', async () => {
+    // Security gate: a refresh token with vpn scope from a clientId
+    // outside allowedClientsForService.vpn must not produce a row.
+    const userId = uid('04');
+    await insertRefreshToken({
+      label: 'allowlist-denied',
+      userId,
+      clientId: UNRELATED_CLIENT_ID,
+      scope: VPN_SCOPE,
+      createdAt: new Date('2024-06-15T00:00:00Z'),
+    });
+
+    await runBackfill(query, buildCfg(), noopLog(), baseRunOpts);
+
+    const rows = await query<Array<{ scope: string }>>(
+      'SELECT scope FROM accountAuthorizations WHERE uid = ?',
+      [userId]
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('writes service="" rows for non-service scopes (123done-style RP)', async () => {
+    // Sign-in to a non-browser RP that grants openid + profile. Runtime writes
+    // one row per scope with service=''; backfill must do the same so
+    // future ToS-rejection on /authorization can find them.
+    const userId = uid('06');
+    const createdAt = new Date('2024-06-15T12:00:00Z');
+    await insertRefreshToken({
+      label: 'non-service-rp',
+      userId,
+      clientId: UNRELATED_CLIENT_ID,
+      scope: 'openid profile',
+      createdAt,
+    });
+
+    await runBackfill(query, buildCfg(), noopLog(), baseRunOpts);
+
+    const rows = await query<Array<{ scope: string; service: string }>>(
+      'SELECT scope, service FROM accountAuthorizations WHERE uid = ? ORDER BY scope',
+      [userId]
+    );
+    expect(rows).toEqual([
+      { scope: 'openid', service: '' },
+      { scope: 'profile', service: '' },
+    ]);
+  });
+
+  it('with serviceFilter only writes rows for the targeted service', async () => {
+    const userId = uid('05');
+    const createdAt = new Date('2024-06-15T00:00:00Z');
+    await insertRefreshToken({
+      label: 'filter-vpn',
+      userId,
+      clientId: VPN_ALLOWED_CLIENT_ID,
+      scope: VPN_SCOPE,
+      createdAt,
+    });
+    await insertRefreshToken({
+      label: 'filter-smart',
+      userId,
+      clientId: SMART_CLIENT_ID,
+      scope: SMARTWINDOW_SCOPE,
+      createdAt,
+    });
+
+    await runBackfill(query, buildCfg(), noopLog(), {
+      ...baseRunOpts,
+      serviceFilter: 'vpn',
+    });
+
+    const rows = await query<Array<{ service: string }>>(
+      'SELECT service FROM accountAuthorizations WHERE uid = ? ORDER BY service',
+      [userId]
+    );
+    expect(rows.map((r) => r.service)).toEqual(['vpn']);
+  });
+});


### PR DESCRIPTION
Because:
 - We want to be able to backfill refreshTokens into the accountAuthorizations table

This commit:
 - Adds a backfill script to walk the refreshTokens table, inserting a new accountAuthoriztions for the most recent token/scope/service combo
 - Adds unit tests for the backfill script

Closes: FXA-12932

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="1304" height="300" alt="Screenshot 2026-05-20 at 09 18 16" src="https://github.com/user-attachments/assets/e4bb799e-e5aa-4dcf-9fb5-838f2b4fbd84" />

## Other information (Optional)

Any other information that is important to this pull request.
