### PR TITLE
feat(settings): add labels for 22 unmapped security event types

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/SecurityEvent.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/SecurityEvent.tsx
@@ -4,7 +4,7 @@
 
 import { FtlMsg } from 'fxa-react/lib/utils';
 
-enum SecurityEventName {
+export enum SecurityEventName {
   Create = 'account.create',
   Disable = 'account.disable',
   Enable = 'account.enable',
@@ -42,7 +42,40 @@ enum SecurityEventName {
   MustReset = 'account.must_reset',
   RecoveryPhoneResetPasswordComplete = 'account.recovery_phone_reset_password_complete',
   RecoveryPhoneResetPasswordFailed = 'account.recovery_phone_reset_password_failed',
+  RecoveryPhoneReplaceComplete = 'account.recovery_phone_replace_complete',
+  RecoveryPhoneReplaceFailure = 'account.recovery_phone_replace_failure',
+  TwoFactorReplaceSuccess = 'account.two_factor_replace_success',
+  TwoFactorReplaceFailure = 'account.two_factor_replace_failure',
+  PasswordUpgradeSuccess = 'account.password_upgrade_success',
+  RecoveryPhoneSetupFailed = 'account.recovery_phone_setup_failed',
+  MfaOtpSent = 'account.mfa_send_otp_code',
+  MfaOtpVerifySuccess = 'account.mfa_verify_otp_code_success',
+  MfaOtpVerifyFailed = 'account.mfa_verify_otp_code_failed',
+  SigninConfirmBypassKnownIp = 'account.signin_confirm_bypass_known_ip',
+  SigninConfirmBypassNewAccount = 'account.signin_confirm_bypass_new_account',
+  SigninConfirmBypassKnownDevice = 'account.signin_confirm_bypass_known_device',
+  PasskeyRegistrationSuccess = 'account.passkey.registration_success',
+  PasskeyRegistrationFailure = 'account.passkey.registration_failure',
+  PasskeyRemoved = 'account.passkey.removed',
+  PasskeyAuthenticationSuccess = 'account.passkey.authentication_success',
+  PasskeyAuthenticationFailure = 'account.passkey.authentication_failure',
+  PasswordlessLoginOtpSent = 'account.passwordless_login_otp_sent',
+  PasswordlessLoginOtpFailed = 'account.passwordless_login_otp_failed',
+  PasswordlessLoginOtpVerified = 'account.passwordless_login_otp_verified',
+  PasswordlessRegistrationComplete = 'account.passwordless_registration_complete',
+  RecoveryCodesSet = 'account.recovery_codes_set',
 }
+
+// Internal server decisions, not user-triggered actions. Filtered before
+// rendering so they don't clutter the security audit log or duplicate
+// account.login (the signin_confirm_bypass_* trio fires on every login
+// where confirmation was skipped).
+export const HIDDEN_SECURITY_EVENT_NAMES: ReadonlySet<string> = new Set([
+  SecurityEventName.PasswordUpgradeSuccess,
+  SecurityEventName.SigninConfirmBypassKnownIp,
+  SecurityEventName.SigninConfirmBypassNewAccount,
+  SecurityEventName.SigninConfirmBypassKnownDevice,
+]);
 
 const getSecurityEventNameL10n = (name: string) => {
   switch (name) {
@@ -138,13 +171,13 @@ const getSecurityEventNameL10n = (name: string) => {
     }
     case SecurityEventName.RecoveryKeyChallengeFailure: {
       return {
-        ftlId: 'recent-activity-account-recovery-key-challenge-failure',
+        ftlId: 'recent-activity-account-recovery-key-verification-failure',
         fallbackText: 'Account recovery key verification failed',
       };
     }
     case SecurityEventName.RecoveryKeyChallengeSuccess: {
       return {
-        ftlId: 'recent-activity-account-recovery-key-challenge-success',
+        ftlId: 'recent-activity-account-recovery-key-verification-success',
         fallbackText: 'Account recovery key verification successful',
       };
     }
@@ -258,14 +291,122 @@ const getSecurityEventNameL10n = (name: string) => {
     }
     case SecurityEventName.RecoveryPhoneResetPasswordComplete: {
       return {
-        ftlId: 'recent-activity-recovery-phone-reset-password-complete',
+        ftlId: 'recent-activity-account-recovery-phone-reset-password-complete',
         fallbackText: 'Password reset with recovery phone completed',
       };
     }
     case SecurityEventName.RecoveryPhoneResetPasswordFailed: {
       return {
-        ftlId: 'recent-activity-recovery-phone-reset-password-failed',
+        ftlId: 'recent-activity-account-recovery-phone-reset-password-failed',
         fallbackText: 'Password reset with recovery phone failed',
+      };
+    }
+    case SecurityEventName.RecoveryPhoneReplaceComplete: {
+      return {
+        ftlId: 'recent-activity-account-recovery-phone-replace-complete',
+        fallbackText: 'Recovery phone replaced',
+      };
+    }
+    case SecurityEventName.RecoveryPhoneReplaceFailure: {
+      return {
+        ftlId: 'recent-activity-account-recovery-phone-replace-failure',
+        fallbackText: 'Recovery phone replacement failed',
+      };
+    }
+    case SecurityEventName.TwoFactorReplaceSuccess: {
+      return {
+        ftlId: 'recent-activity-account-two-factor-replace-success',
+        fallbackText: 'Two-step authentication replaced',
+      };
+    }
+    case SecurityEventName.TwoFactorReplaceFailure: {
+      return {
+        ftlId: 'recent-activity-account-two-factor-replace-failure',
+        fallbackText: 'Two-step authentication replacement failed',
+      };
+    }
+    case SecurityEventName.RecoveryPhoneSetupFailed: {
+      return {
+        ftlId: 'recent-activity-account-recovery-phone-setup-failed',
+        fallbackText: 'Recovery phone setup failed',
+      };
+    }
+    case SecurityEventName.MfaOtpSent: {
+      return {
+        ftlId: 'recent-activity-account-mfa-otp-sent',
+        fallbackText: 'Account change authorization requested',
+      };
+    }
+    case SecurityEventName.MfaOtpVerifySuccess: {
+      return {
+        ftlId: 'recent-activity-account-mfa-otp-verified',
+        fallbackText: 'Account change authorized',
+      };
+    }
+    case SecurityEventName.MfaOtpVerifyFailed: {
+      return {
+        ftlId: 'recent-activity-account-mfa-otp-failed',
+        fallbackText: 'Account change authorization failed',
+      };
+    }
+    case SecurityEventName.PasskeyRegistrationSuccess: {
+      return {
+        ftlId: 'recent-activity-account-passkey-registration-success',
+        fallbackText: 'Passkey added',
+      };
+    }
+    case SecurityEventName.PasskeyRegistrationFailure: {
+      return {
+        ftlId: 'recent-activity-account-passkey-registration-failure',
+        fallbackText: 'Passkey registration failed',
+      };
+    }
+    case SecurityEventName.PasskeyRemoved: {
+      return {
+        ftlId: 'recent-activity-account-passkey-removed',
+        fallbackText: 'Passkey removed',
+      };
+    }
+    case SecurityEventName.PasskeyAuthenticationSuccess: {
+      return {
+        ftlId: 'recent-activity-account-passkey-authentication-success',
+        fallbackText: 'Sign-in with passkey completed',
+      };
+    }
+    case SecurityEventName.PasskeyAuthenticationFailure: {
+      return {
+        ftlId: 'recent-activity-account-passkey-authentication-failure',
+        fallbackText: 'Sign-in with passkey failed',
+      };
+    }
+    case SecurityEventName.PasswordlessLoginOtpSent: {
+      return {
+        ftlId: 'recent-activity-account-passwordless-login-otp-sent',
+        fallbackText: 'Passwordless sign-in code sent',
+      };
+    }
+    case SecurityEventName.PasswordlessLoginOtpFailed: {
+      return {
+        ftlId: 'recent-activity-account-passwordless-login-otp-failed',
+        fallbackText: 'Passwordless sign-in code failed',
+      };
+    }
+    case SecurityEventName.PasswordlessLoginOtpVerified: {
+      return {
+        ftlId: 'recent-activity-account-passwordless-login-otp-verified',
+        fallbackText: 'Passwordless sign-in code verified',
+      };
+    }
+    case SecurityEventName.PasswordlessRegistrationComplete: {
+      return {
+        ftlId: 'recent-activity-account-passwordless-registration-complete',
+        fallbackText: 'Passwordless account registration completed',
+      };
+    }
+    case SecurityEventName.RecoveryCodesSet: {
+      return {
+        ftlId: 'recent-activity-account-recovery-codes-set',
+        fallbackText: 'Recovery codes set',
       };
     }
     default: {

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/en.ftl
@@ -41,6 +41,29 @@ recent-activity-account-recovery-codes-signin-complete = Sign-in with recovery c
 recent-activity-password-reset-otp-sent = Reset password confirmation code sent
 recent-activity-password-reset-otp-verified = Reset password confirmation code verified
 recent-activity-must-reset-password = Password reset required
+recent-activity-account-recovery-phone-replace-complete = Recovery phone replaced
+recent-activity-account-recovery-phone-replace-failure = Recovery phone replacement failed
+recent-activity-account-two-factor-replace-success = Two-step authentication replaced
+recent-activity-account-two-factor-replace-failure = Two-step authentication replacement failed
+recent-activity-account-recovery-phone-setup-failed = Recovery phone setup failed
+recent-activity-account-recovery-phone-reset-password-complete = Password reset with recovery phone completed
+recent-activity-account-recovery-phone-reset-password-failed = Password reset with recovery phone failed
+# A code was emailed to the user to authorize a sensitive account change (e.g. removing 2FA, deleting the account).
+recent-activity-account-mfa-otp-sent = Account change authorization requested
+# The user successfully entered the code emailed to authorize a sensitive account change.
+recent-activity-account-mfa-otp-verified = Account change authorized
+# The user entered an incorrect or expired code when trying to authorize a sensitive account change.
+recent-activity-account-mfa-otp-failed = Account change authorization failed
+recent-activity-account-passkey-registration-success = Passkey added
+recent-activity-account-passkey-registration-failure = Passkey registration failed
+recent-activity-account-passkey-removed = Passkey removed
+recent-activity-account-passkey-authentication-success = Sign-in with passkey completed
+recent-activity-account-passkey-authentication-failure = Sign-in with passkey failed
+recent-activity-account-passwordless-login-otp-sent = Passwordless sign-in code sent
+recent-activity-account-passwordless-login-otp-failed = Passwordless sign-in code failed
+recent-activity-account-passwordless-login-otp-verified = Passwordless sign-in code verified
+recent-activity-account-passwordless-registration-complete = Passwordless account registration completed
+recent-activity-account-recovery-codes-set = Recovery codes set
 
 # Security event was recorded, but the activity details are unknown or not shown to user
 recent-activity-unknown = Other account activity

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
@@ -3,11 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import 'mutationobserver-shim';
-import { act, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { renderWithRouter, mockAppContext } from '../../../models/mocks';
 import PageRecentActivity from '.';
 import { Account, AppContext } from '../../../models';
 import { MOCK_SECURITY_EVENTS } from './mocks';
+import { HIDDEN_SECURITY_EVENT_NAMES } from './SecurityEvent';
 
 const account = {
   primaryEmail: {
@@ -25,24 +26,119 @@ const render = (acct: Account = account) =>
 
 describe('Recent Account Activity', () => {
   it('renders', async () => {
-    await act(async () => {
-      await render();
-    });
+    // One label per mapped event name in SecurityEventName, excluding the
+    // events listed in HIDDEN_SECURITY_EVENT_NAMES.
+    const expectedLabels = [
+      'Account created',
+      'Account disabled',
+      'Account enabled',
+      'Account login initiated',
+      'Password reset initiated',
+      'Email bounces cleared',
+      'Account login attempt failed',
+      'Two-step authentication enabled',
+      'Two-step authentication requested',
+      'Two-step authentication failed',
+      'Two-step authentication successful',
+      'Two-step authentication removed',
+      'Password reset requested',
+      'Password reset successful',
+      'Account recovery key enabled',
+      'Account recovery key verification failed',
+      'Account recovery key verification successful',
+      'Account recovery key removed',
+      'New password added',
+      'Password changed',
+      'Secondary email address added',
+      'Secondary email address removed',
+      'Primary and secondary emails swapped',
+      'Logged out of session',
+      'Recovery phone code sent',
+      'Recovery phone setup completed',
+      'Sign-in with recovery phone completed',
+      'Sign-in with recovery phone failed',
+      'Recovery phone removed',
+      'Recovery codes replaced',
+      'Recovery codes created',
+      'Sign-in with recovery codes completed',
+      'Reset password confirmation code sent',
+      'Reset password confirmation code verified',
+      'Password reset required',
+      'Password reset with recovery phone completed',
+      'Password reset with recovery phone failed',
+      'Recovery phone replaced',
+      'Recovery phone replacement failed',
+      'Two-step authentication replaced',
+      'Two-step authentication replacement failed',
+      'Recovery phone setup failed',
+      'Account change authorization requested',
+      'Account change authorized',
+      'Account change authorization failed',
+      'Passkey added',
+      'Passkey registration failed',
+      'Passkey removed',
+      'Sign-in with passkey completed',
+      'Sign-in with passkey failed',
+      'Passwordless sign-in code sent',
+      'Passwordless sign-in code failed',
+      'Passwordless sign-in code verified',
+      'Passwordless account registration completed',
+      'Recovery codes set',
+    ];
+
+    render();
+
     expect(screen.getByTestId('flow-container')).toBeInTheDocument();
     expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Recent account activity' })
+    ).toBeInTheDocument();
 
+    expect(await screen.findByText(expectedLabels[0])).toBeInTheDocument();
     expect(account.getSecurityEvents).toHaveBeenCalled();
+    for (const label of expectedLabels.slice(1)) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('filters HIDDEN_SECURITY_EVENT_NAMES before rendering', async () => {
+    const accountWithHiddenAndVisible = {
+      primaryEmail: { email: 'foxy@mozilla.com' },
+      getSecurityEvents: jest.fn().mockResolvedValue([
+        { name: 'account.create', createdAt: Date.now(), verified: true },
+        ...Array.from(HIDDEN_SECURITY_EVENT_NAMES, (name) => ({
+          name,
+          createdAt: Date.now(),
+          verified: true,
+        })),
+      ]),
+    } as unknown as Account;
+
+    render(accountWithHiddenAndVisible);
+
+    // findByText gates on the post-fetch render. If the filter regressed,
+    // each hidden event would render an additional <li> and the count
+    // assertion below would fail.
+    expect(await screen.findByText('Account created')).toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('falls back to "Other account activity" for unrecognized event names', async () => {
+    const unknownAccount = {
+      primaryEmail: { email: 'foxy@mozilla.com' },
+      getSecurityEvents: jest.fn().mockResolvedValue([
+        {
+          name: 'account.some_future_event',
+          createdAt: Date.now(),
+          verified: true,
+        },
+      ]),
+    } as unknown as Account;
+
+    render(unknownAccount);
 
     expect(
-      screen.getByRole('heading', {
-        name: 'Recent account activity',
-      })
+      await screen.findByText('Other account activity')
     ).toBeInTheDocument();
-    screen.getByText('Account created');
-    screen.getByText('Account disabled');
-    screen.getByText('Account enabled');
-    screen.getByText('Account login initiated');
-    screen.getByText('Password reset initiated');
-    screen.getByText('Email bounces cleared');
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
@@ -6,7 +6,10 @@ import { RouteComponentProps } from '@reach/router';
 
 import FlowContainer from '../FlowContainer';
 import { useAccount, useFtlMsgResolver } from '../../../models';
-import { SecurityEvent as SecurityEventSection } from './SecurityEvent';
+import {
+  HIDDEN_SECURITY_EVENT_NAMES,
+  SecurityEvent as SecurityEventSection,
+} from './SecurityEvent';
 import React, { useState, useEffect } from 'react';
 
 export const PageRecentActivity = (_: RouteComponentProps) => {
@@ -31,15 +34,20 @@ export const PageRecentActivity = (_: RouteComponentProps) => {
     >
       <ol className="mt-5 relative border-s border-gray-100">
         {!!securityEvents &&
-          securityEvents.map((securityEvent) => (
-            <SecurityEventSection
-              key={securityEvent.name + securityEvent.createdAt}
-              {...{
-                name: securityEvent.name,
-                createdAt: securityEvent.createdAt,
-              }}
-            />
-          ))}
+          securityEvents
+            .filter(
+              (securityEvent) =>
+                !HIDDEN_SECURITY_EVENT_NAMES.has(securityEvent.name)
+            )
+            .map((securityEvent) => (
+              <SecurityEventSection
+                key={securityEvent.name + securityEvent.createdAt}
+                {...{
+                  name: securityEvent.name,
+                  createdAt: securityEvent.createdAt,
+                }}
+              />
+            ))}
       </ol>
     </FlowContainer>
   );

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/mocks.ts
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/mocks.ts
@@ -2,35 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const MOCK_SECURITY_EVENTS = [
-  {
-    name: 'account.create',
+import { SecurityEventName } from './SecurityEvent';
+
+// One mock event per mapped event name so coverage stays in sync with the
+// SecurityEventName enum when new events are added.
+export const MOCK_SECURITY_EVENTS = Object.values(SecurityEventName).map(
+  (name) => ({
+    name,
     createdAt: Date.now(),
     verified: true,
-  },
-  {
-    name: 'account.disable',
-    createdAt: Date.now(),
-    verified: true,
-  },
-  {
-    name: 'account.enable',
-    createdAt: Date.now(),
-    verified: true,
-  },
-  {
-    name: 'account.login',
-    createdAt: Date.now(),
-    verified: true,
-  },
-  {
-    name: 'account.reset',
-    createdAt: Date.now(),
-    verified: true,
-  },
-  {
-    name: 'emails.clearBounces',
-    createdAt: Date.now(),
-    verified: true,
-  },
-];
+  })
+);


### PR DESCRIPTION
## Because

- Most rows on Recent Account Activity rendered as "Other account activity" — the UI's event-name switch covered only 37 of the 59 distinct security events emitted by the auth server.

## This pull request

- Adds switch cases, enum entries, and FTL strings for the 18 newly user-facing event types (passkey, MFA OTP, 2FA/phone replace, passwordless, recovery codes set, recovery phone setup failure).
- Hides 4 internal events that describe server decisions rather than user actions: `account.password_upgrade_success` (key-stretching) and the three `account.signin_confirm_bypass_*` variants (each pairs with `account.login` on every no-prompt login).
- Realigns 4 mismatched FTL IDs and adds 2 missing strings so localized builds resolve labels for recovery-key challenge and recovery-phone reset-password (previously fell back to English).
- Derives `MOCK_SECURITY_EVENTS` from the `SecurityEventName` enum so mock coverage stays in sync with future additions.
- Rewrites the test suite to cover every mapped event in one place, verifies hidden events don't surface, and drops the deprecated `act()` wrapper.

Net: 59 mapped events, 4 hidden, 55 visible labels.

## Issue that this pull request solves

Closes: FXA-13762

## Checklist

_Put an \`x\` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.