### PR TITLE
feat(settings): Display refresh token OAuthNative client IDs VPN scope in connected services

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
@@ -24,10 +24,12 @@ import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 
 const SCOPE_RELAY = 'https://identity.mozilla.com/apps/relay';
+const SCOPE_VPN = 'https://identity.mozilla.com/apps/vpn';
 
 interface ScopeService {
   name: string;
   icon: React.ReactNode;
+  ftlId?: string;
 }
 
 function getScopeServices(scope: string[] | null): ScopeService[] {
@@ -36,12 +38,19 @@ function getScopeServices(scope: string[] | null): ScopeService[] {
   for (const individualScope of scope) {
     // TODO: We will add other `service=` flows here when they have
     // switched to refresh tokens and we will allow revoking
-    // scope later. For now, just display Relay read-only.
+    // scope later. For now, just display Relay and VPN read-only.
     switch (individualScope) {
       case SCOPE_RELAY:
         services.push({
           name: 'Firefox Relay',
           icon: <RelayIcon data-testid="scope-relay-icon" />,
+        });
+        break;
+      case SCOPE_VPN:
+        services.push({
+          name: 'Firefox’s built-in VPN',
+          icon: <FPNIcon data-testid="scope-vpn-icon" />,
+          ftlId: 'cs-scope-firefox-vpn',
         });
         break;
     }
@@ -188,18 +197,29 @@ export function Service({
             </Localized>
           </div>
         </div>
-        {scopeServices.map((scopeService) => (
+        {scopeServices.map((scopeService, index) => (
           <div
             key={scopeService.name}
-            className="px-4 py-2 bg-grey-50 dark:bg-grey-600 flex items-center"
+            className={classNames(
+              'px-4 py-2 bg-grey-50 dark:bg-grey-600 flex items-center',
+              index > 0 && 'border-t border-grey-100 dark:border-grey-500'
+            )}
             data-testid="scope-service"
           >
             <span className={classNames(iconClasses, 'px-3')}>
               {scopeService.icon}
             </span>
-            <p className="text-sm text-grey-600 dark:text-grey-200">
-              {scopeService.name}
-            </p>
+            {scopeService.ftlId ? (
+              <Localized id={scopeService.ftlId}>
+                <p className="text-sm text-grey-600 dark:text-grey-200">
+                  {scopeService.name}
+                </p>
+              </Localized>
+            ) : (
+              <p className="text-sm text-grey-600 dark:text-grey-200">
+                {scopeService.name}
+              </p>
+            )}
           </div>
         ))}
       </div>

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
@@ -50,3 +50,12 @@ cs-disconnect-suspicious-advice-content-2 = If the disconnected device is indeed
 cs-sign-out-button = Sign out
 
 ##
+
+## Sub-rows shown beneath a connected browser entry to indicate which Mozilla
+## services that browser is currently authorized to access via its refresh token.
+
+# Shown as a read-only sub-row under a browser device entry to indicate that
+# the device's refresh token is authorized for Firefox’s built-in VPN.
+# In this context, "VPN" is a VPN service built into the Firefox browser, and
+# generally isn’t localized differently than "VPN".
+cs-scope-firefox-vpn = { -brand-firefox }’s built-in VPN

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
@@ -7,7 +7,11 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';
 import { ConnectedServices } from '.';
 
-import { MOCK_SERVICES, MOCK_SERVICES_WITHOUT_MOBILE } from './mocks';
+import {
+  MOCK_BROWSER_SERVICES,
+  MOCK_SERVICES,
+  MOCK_SERVICES_WITHOUT_MOBILE,
+} from './mocks';
 import { Account, AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/mocks';
 
@@ -23,6 +27,10 @@ const accountWithManyServices = {
 
 const accountWithoutMobileDevice = {
   attachedClients: MOCK_SERVICES_WITHOUT_MOBILE,
+} as unknown as Account;
+
+const accountWithBrowserServices = {
+  attachedClients: MOCK_BROWSER_SERVICES,
 } as unknown as Account;
 
 const storyWithContext = (account: Partial<Account>) => {
@@ -42,5 +50,9 @@ export const Default = storyWithContext(accountWithManyServices);
 
 // Shows ConnectAnotherDevicePromo if no mobile devices in the list
 export const NoMobileServices = storyWithContext(accountWithoutMobileDevice);
+
+// Demonstrates the read-only scope sub-entries shown under a refresh-token
+// browser entry when the token's scope includes Relay and/or VPN.
+export const BrowserServices = storyWithContext(accountWithBrowserServices);
 
 // TODO: Add story with advice modal for lost/suspicious devices

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -683,5 +683,42 @@ describe('Connected Services', () => {
       await screen.findByTestId('settings-connected-service');
       expect(screen.queryByTestId('scope-service')).not.toBeInTheDocument();
     });
+
+    it('renders VPN scope sub-entry when scope includes vpn and client ID is OAuthNative', async () => {
+      renderWithClient({
+        ...baseMockClient,
+        clientId: OAuthNativeClients.Fenix,
+        name: 'Firefox for Android',
+        scope: [
+          'https://identity.mozilla.com/apps/oldsync',
+          'profile',
+          'https://identity.mozilla.com/apps/vpn',
+        ],
+      });
+      await screen.findByTestId('settings-connected-service');
+      const scopeEntry = screen.getByTestId('scope-service');
+      expect(scopeEntry).toBeInTheDocument();
+      expect(scopeEntry).toHaveTextContent('Firefox’s built-in VPN');
+    });
+
+    it('renders both Relay and VPN scope sub-entries when scope includes both and client ID is OAuthNative', async () => {
+      renderWithClient({
+        ...baseMockClient,
+        clientId: OAuthNativeClients.FirefoxIOS,
+        name: 'Firefox for iOS',
+        // Scopes are alphabetized to mirror the order returned by
+        // fxa-auth-server (authorized_clients.js#serialize).
+        scope: [
+          'https://identity.mozilla.com/apps/oldsync',
+          'https://identity.mozilla.com/apps/relay',
+          'https://identity.mozilla.com/apps/vpn',
+          'profile',
+        ],
+      });
+      await screen.findByTestId('settings-connected-service');
+      expect(screen.getAllByTestId('scope-service')).toHaveLength(2);
+      expect(screen.getByText('Firefox Relay')).toBeInTheDocument();
+      expect(screen.getByText('Firefox’s built-in VPN')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/mocks.ts
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/mocks.ts
@@ -403,3 +403,63 @@ export const MOCK_SERVICES_WITHOUT_MOBILE = [
   ...DESKTOP_SYNC_MOCKS,
   ...OAUTH_SERVICE_MOCKS,
 ];
+
+const BROWSER_SERVICE_BASE = {
+  sessionTokenId: null,
+  isCurrentSession: false,
+  deviceType: 'mobile',
+  createdTime: 1570100000000,
+  lastAccessTime: 1570100000000,
+  location: { city: null, country: null, state: null, stateCode: null },
+  userAgent: '',
+  os: null,
+  createdTimeFormatted: 'a month ago',
+  lastAccessTimeFormatted: 'a month ago',
+  approximateLastAccessTime: null,
+  approximateLastAccessTimeFormatted: null,
+};
+
+// Scopes are sorted alphabetically to match how fxa-auth-server returns them
+// (see authorized_clients.js#serialize).
+export const MOCK_BROWSER_SERVICES = [
+  {
+    ...BROWSER_SERVICE_BASE,
+    clientId: '1b1a3e44c54fbb58',
+    deviceId: 'a91cc4d7b8e4495fa3c6e2edf8c5132b',
+    refreshTokenId:
+      'c4a8f3b2d1e6a9507f2c4e8b3d1a6f9072e5c8b4a3d7f1e6920b5c8a4d3f7e1',
+    name: 'Firefox for iOS',
+    scope: [
+      'https://identity.mozilla.com/apps/oldsync',
+      'https://identity.mozilla.com/apps/relay',
+      'profile',
+    ],
+  },
+  {
+    ...BROWSER_SERVICE_BASE,
+    clientId: 'a2270f727f45f648',
+    deviceId: 'b14e9f8d2a3b4c5d6e7f8a9b0c1d2e3f',
+    refreshTokenId:
+      'd5b9f4c3e2f7a0617f3d5e9c4e2b7f0183f6d9c5b4e8f2f7031c6d9b5e4f8f2',
+    name: 'Firefox for Android',
+    scope: [
+      'https://identity.mozilla.com/apps/oldsync',
+      'https://identity.mozilla.com/apps/vpn',
+      'profile',
+    ],
+  },
+  {
+    ...BROWSER_SERVICE_BASE,
+    clientId: '1b1a3e44c54fbb58',
+    deviceId: 'c25f0e9d3b4c5d6e7f8a9b0c1d2e3f40',
+    refreshTokenId:
+      'e6c0f5d4f3a8b1728f4e6f0d5f3c8a1294a7e0d6c5f9a3f8142d7e0c6f5a9a3',
+    name: 'Firefox on Foxxy’s iPad',
+    scope: [
+      'https://identity.mozilla.com/apps/oldsync',
+      'https://identity.mozilla.com/apps/relay',
+      'https://identity.mozilla.com/apps/vpn',
+      'profile',
+    ],
+  },
+];


### PR DESCRIPTION
Because:
* FxA should display refresh token scopes underneath the login for transparency

This commit:
* Displays only refresh tokens that match the OAuthNative client IDs that have a VPN scope in connected services. Revoking and displaying other services will come in follow ups

closes FXA-13764
