### PR TITLE
chore(auth-client): Improve sentry capture for failed requests

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -429,6 +429,7 @@ export default class AuthClient {
       requestOptions.credentials = 'include';
     }
 
+    let errorCaptured = false;
     try {
       const response = await fetchOrTimeout(
         this.url(path),
@@ -437,9 +438,34 @@ export default class AuthClient {
       );
       const result = JSON.parse(await response.text());
       if (result.errno) {
+        // We want to monitor down spikes in known responses from the auth server.
+        errorCaptured = true;
+        Sentry.captureMessage(
+          `Auth client encoutered known error response during a request`,
+          {
+            tags: {
+              path: path,
+              method: requestOptions.method || '',
+              errno: result.errno,
+              code: result.code,
+            }
+          }
+        );
         throw result;
       }
       if (!response.ok) {
+        errorCaptured = true;
+        // We want to monitor spikes in non-ok responses.
+        Sentry.captureMessage(
+          `Auth client encoutered non-ok response during a request`,
+          {
+            tags: {
+              path: path,
+              method: requestOptions.method || '',
+              status: response.status,
+            }
+          }
+        );
         throw new AuthClientError(
           'Unknown error',
           result,
@@ -447,8 +473,24 @@ export default class AuthClient {
           response.status
         );
       }
+
       return result;
     } catch (e) {
+      if (!errorCaptured) {
+        // One more check for unexpected errors that wouldn't have been caught by the above two check.
+        Sentry.captureMessage(
+          `Auth client encoutered unexpected error during request`,
+          {
+            tags: {
+              path: path,
+              method: requestOptions.method || '',
+            },
+            extra: {
+              message: e instanceof Error ? e.message : 'unknown error',
+            }
+          }
+        );
+      }
       await this.errorHandler(e);
     }
   }

--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -5,6 +5,10 @@
 import * as assert from 'assert';
 import AuthClient from '../server';
 
+// TODO: Use proper mocks when we move to jest. Not going to add sinon dep just for this...
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const SentryModule = require('@sentry/browser') as Record<string, any>;
+
 describe('lib/client', () => {
   let client: AuthClient;
 
@@ -84,6 +88,174 @@ describe('lib/client', () => {
         'ABCD1234'
       );
       assert.notEqual(lastInit?.credentials, 'include');
+    });
+  });
+
+  describe('Sentry error capturing in request()', () => {
+    let httpClient: AuthClient;
+    let originalFetch: typeof globalThis.fetch;
+    let originalCaptureMessage: (...args: any[]) => any;
+    let capturedMessages: Array<{ message: string; context: Record<string, any> }>;
+
+    before(() => {
+      httpClient = new AuthClient('http://localhost:9000');
+    });
+
+    beforeEach(() => {
+      capturedMessages = [];
+      originalFetch = globalThis.fetch;
+      originalCaptureMessage = SentryModule.captureMessage;
+      SentryModule.captureMessage = (
+        message: string,
+        context: Record<string, any>
+      ) => {
+        capturedMessages.push({ message, context });
+        return '';
+      };
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+      SentryModule.captureMessage = originalCaptureMessage;
+    });
+
+    it('does not call captureMessage on a successful response', async () => {
+      globalThis.fetch = async () =>
+        new Response('{"exists":true}', { status: 200 });
+      await httpClient.accountStatus('0123456789abcdef');
+      assert.equal(capturedMessages.length, 0);
+    });
+
+    describe('known errno response', () => {
+      beforeEach(() => {
+        globalThis.fetch = async () =>
+          new Response(
+            JSON.stringify({ errno: 102, code: 400, message: 'Unknown account' }),
+            { status: 400 }
+          );
+      });
+
+      it('calls captureMessage with the known-error message', async () => {
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        assert.equal(capturedMessages.length, 1);
+        assert.ok(
+          capturedMessages[0].message.includes('known error response'),
+          `expected "known error response" in "${capturedMessages[0].message}"`
+        );
+      });
+
+      it('tags the capture with path, method, errno, and code', async () => {
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        const { tags } = capturedMessages[0].context;
+        assert.ok(
+          (tags.path as string).includes('/account/status'),
+          `expected path to include /account/status, got "${tags.path}"`
+        );
+        assert.equal(typeof tags.method, 'string');
+        assert.equal(tags.errno, 102);
+        assert.equal(tags.code, 400);
+      });
+
+      it('does not call captureMessage a second time from the catch block', async () => {
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        assert.equal(capturedMessages.length, 1);
+      });
+    });
+
+    describe('non-ok response without errno', () => {
+      beforeEach(() => {
+        globalThis.fetch = async () =>
+          new Response('{}', { status: 500 });
+      });
+
+      it('calls captureMessage with the non-ok message', async () => {
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        assert.equal(capturedMessages.length, 1);
+        assert.ok(
+          capturedMessages[0].message.includes('non-ok response'),
+          `expected "non-ok response" in "${capturedMessages[0].message}"`
+        );
+      });
+
+      it('tags the capture with path, method, and HTTP status', async () => {
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        const { tags } = capturedMessages[0].context;
+        assert.ok(
+          (tags.path as string).includes('/account/status'),
+          `expected path to include /account/status, got "${tags.path}"`
+        );
+        assert.equal(typeof tags.method, 'string');
+        assert.equal(tags.status, 500);
+      });
+
+      it('does not call captureMessage a second time from the catch block', async () => {
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        assert.equal(capturedMessages.length, 1);
+      });
+    });
+
+    describe('unexpected error (fetch throws)', () => {
+      it('calls captureMessage with the unexpected-error message when fetch throws an Error', async () => {
+        globalThis.fetch = async () => {
+          throw new Error('Network failure');
+        };
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        assert.equal(capturedMessages.length, 1);
+        assert.ok(
+          capturedMessages[0].message.includes('unexpected error'),
+          `expected "unexpected error" in "${capturedMessages[0].message}"`
+        );
+      });
+
+      it('includes the error message in extra when fetch throws an Error', async () => {
+        globalThis.fetch = async () => {
+          throw new Error('Network failure');
+        };
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        assert.equal(capturedMessages[0].context.extra.message, 'Network failure');
+      });
+
+      it('uses "unknown error" in extra when fetch throws a non-Error value', async () => {
+        globalThis.fetch = async () => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw 'plain string error';
+        };
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        assert.equal(capturedMessages[0].context.extra.message, 'unknown error');
+      });
+
+      it('tags the capture with path and method', async () => {
+        globalThis.fetch = async () => {
+          throw new Error('timeout');
+        };
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch {}
+        const { tags } = capturedMessages[0].context;
+        assert.ok(
+          (tags.path as string).includes('/account/status'),
+          `expected path to include /account/status, got "${tags.path}"`
+        );
+        assert.equal(typeof tags.method, 'string');
+      });
     });
   });
 });


### PR DESCRIPTION
## Because

- We recently had an issue that was effecting end users, but escaped error monitoring.

## This pull request

- Ensures unsuccessful requests to `auth-server` from `auth-client`  are monitored.

## Issue that this pull request solves

Closes: FXA-13714 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The actual fix for FXA-13714 was a WAF policy change, but I think with these changes would have caught the issue much sooner, so I'm using this ticket as the actionable code change for FXA-13714. In the future we might restrict the errnos or status codes that we report, but for now let's leave it open and get a base line.
