### PR TITLE
chore(admin): deeplink to RP when creating WAF bypass token

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -762,8 +762,13 @@ const RelyingPartyRow = ({
               ) : canManageWafTokens ? (
                 <span className="result-grey">
                   None —{' '}
-                  <NavLink to="/waf-tokens" className="underline text-blue-700">
-                    manage in WAF Bypass Tokens
+                  <NavLink
+                    to={`/waf-tokens?createForClientId=${encodeURIComponent(
+                      id
+                    )}&name=${encodeURIComponent(name)}`}
+                    className="underline text-blue-700"
+                  >
+                    Add one via WAF Bypass Tokens panel
                   </NavLink>
                 </span>
               ) : (

--- a/packages/fxa-admin-panel/src/components/PageWafTokens/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageWafTokens/index.test.tsx
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { PageWafTokens } from '.';
+import { IClientConfig } from '../../../interfaces';
+import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
+import { mockConfigBuilder } from '../../lib/config';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { adminApi } from '../../lib/api';
+import type {
+  RelyingPartyDto,
+  WafBypassTokenDto,
+} from 'fxa-admin-server/src/types';
+
+const MOCK_RP_A: Partial<RelyingPartyDto> = {
+  id: 'aaaaaaaaaaaaaaaa',
+  name: 'Mozilla VPN',
+};
+const MOCK_RP_B: Partial<RelyingPartyDto> = {
+  id: 'bbbbbbbbbbbbbbbb',
+  name: 'FxA Functional Tests',
+};
+const MOCK_TOKEN_FOR_B: Partial<WafBypassTokenDto> = {
+  id: 'tok-b',
+  name: 'FxA Functional Tests',
+  token: 'TOKEN_VALUE_B',
+  clientId: MOCK_RP_B.id,
+  createdAt: 1700000000,
+};
+
+// Captures the current URL so we can assert on query-string clearing.
+let lastLocationSearch = '';
+const LocationProbe = () => {
+  const loc = useLocation();
+  lastLocationSearch = loc.search;
+  return null;
+};
+
+const renderPage = (initialEntry: string) =>
+  renderWithLocalizationProvider(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="/waf-tokens"
+          element={
+            <>
+              <PageWafTokens />
+              <LocationProbe />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
+const mockConfig: IClientConfig = mockConfigBuilder({
+  user: {
+    email: 'test@mozilla.com',
+    group: mockGuard.getGroup(AdminPanelGroup.AdminProd),
+  },
+});
+
+jest.mock('../../hooks/UserContext.ts', () => ({
+  useUserContext: () => ({
+    guard: mockGuard,
+    user: mockConfig.user,
+    setUser: () => {},
+  }),
+}));
+
+jest.mock('../../hooks/GuardContext.ts', () => ({
+  useGuardContext: () => ({
+    guard: mockGuard,
+    setGuard: () => {},
+  }),
+}));
+
+jest.mock('../../lib/api', () => ({
+  adminApi: {
+    getWafTokens: jest.fn(),
+    getRelyingParties: jest.fn(),
+    createWafToken: jest.fn(),
+    rotateWafToken: jest.fn(),
+    deleteWafToken: jest.fn(),
+  },
+}));
+
+describe('PageWafTokens', () => {
+  beforeEach(() => {
+    lastLocationSearch = '';
+    (adminApi.getWafTokens as jest.Mock).mockResolvedValue([]);
+    (adminApi.getRelyingParties as jest.Mock).mockResolvedValue([
+      MOCK_RP_A,
+      MOCK_RP_B,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the page heading and an empty state when there are no tokens', async () => {
+    renderPage('/waf-tokens');
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'WAF Bypass Tokens' })
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText('No WAF bypass tokens found.')
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('does not auto-open create form when no prefill params are present', async () => {
+    renderPage('/waf-tokens');
+    await waitFor(() =>
+      expect(
+        screen.getByText('No WAF bypass tokens found.')
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('heading', { level: 3, name: 'Generate new token' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('auto-opens create form with RP preselected and name prefilled from query params', async () => {
+    renderPage(
+      `/waf-tokens?createForClientId=${encodeURIComponent(
+        MOCK_RP_A.id!
+      )}&name=${encodeURIComponent(MOCK_RP_A.name!)}`
+    );
+
+    await screen.findByRole('heading', {
+      level: 3,
+      name: 'Generate new token',
+    });
+
+    const nameInput = screen.getByLabelText('Name:') as HTMLInputElement;
+    const rpSelect = screen.getByLabelText(
+      'Linked relying party (optional):'
+    ) as HTMLSelectElement;
+
+    expect(nameInput.value).toBe(MOCK_RP_A.name);
+    expect(rpSelect.value).toBe(MOCK_RP_A.id);
+
+    // Query params should be stripped after consumption so a refresh doesn't
+    // re-open the form on top of itself.
+    await waitFor(() => expect(lastLocationSearch).toBe(''));
+  });
+
+  it('opens create form with name prefilled but RP unselected when the supplied clientId is already linked to a token', async () => {
+    (adminApi.getWafTokens as jest.Mock).mockResolvedValue([MOCK_TOKEN_FOR_B]);
+
+    renderPage(
+      `/waf-tokens?createForClientId=${encodeURIComponent(
+        MOCK_RP_B.id!
+      )}&name=${encodeURIComponent(MOCK_RP_B.name!)}`
+    );
+
+    await screen.findByRole('heading', {
+      level: 3,
+      name: 'Generate new token',
+    });
+
+    const nameInput = screen.getByLabelText('Name:') as HTMLInputElement;
+    const rpSelect = screen.getByLabelText(
+      'Linked relying party (optional):'
+    ) as HTMLSelectElement;
+
+    expect(nameInput.value).toBe(MOCK_RP_B.name);
+    // RP B is already linked to a token, so it's filtered out of availableRps
+    // and the select stays on "None" rather than silently dropping the request.
+    expect(rpSelect.value).toBe('');
+  });
+});

--- a/packages/fxa-admin-panel/src/components/PageWafTokens/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageWafTokens/index.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { adminApi } from '../../lib/api';
 import { AdminPanelFeature } from '@fxa/shared/guards';
 import { Guard } from '../Guard';
@@ -99,14 +100,18 @@ const WafTokenRow = ({
   );
 };
 
+type CreateTokenPrefill = { clientId?: string; name?: string };
+
 const CreateTokenForm = ({
   rps,
   usedClientIds,
+  initial,
   onCreated,
   onCancel,
 }: {
   rps: RelyingPartyDto[];
   usedClientIds: Set<string>;
+  initial?: CreateTokenPrefill;
   onCreated: (token: WafBypassTokenDto) => void;
   onCancel: () => void;
 }) => {
@@ -163,19 +168,32 @@ const CreateTokenForm = ({
     >
       <h3 className="font-bold mb-3">Generate new token</h3>
 
-      <label className="block mb-1">Name:</label>
+      <label className="block mb-1" htmlFor="waf-token-name">
+        Name:
+      </label>
       <input
+        id="waf-token-name"
         className="bg-grey-50 rounded w-full py-2 px-3 mb-3"
         type="text"
         name="name"
         placeholder="e.g. FxA Functional Tests, Mozilla VPN"
+        defaultValue={initial?.name ?? ''}
         required
       />
 
-      <label className="block mb-1">Linked relying party (optional):</label>
+      <label className="block mb-1" htmlFor="waf-token-client-id">
+        Linked relying party (optional):
+      </label>
       <select
+        id="waf-token-client-id"
         className="bg-grey-50 rounded w-full py-2 px-3 mb-3"
         name="clientId"
+        defaultValue={
+          initial?.clientId &&
+          availableRps.some((rp) => rp.id === initial.clientId)
+            ? initial.clientId
+            : ''
+        }
       >
         <option value="">— None (standalone token) —</option>
         {availableRps.map((rp) => (
@@ -204,6 +222,11 @@ export const PageWafTokens = () => {
   const [showCreate, setShowCreate] = useState(false);
   const [exportCopied, setExportCopied] = useState(false);
   const [newTokenId, setNewTokenId] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Snapshot of prefill params at the moment we open the form. Captured into a
+  // ref so clearing the URL afterwards doesn't reset the form's defaultValues.
+  const prefillRef = useRef<CreateTokenPrefill | undefined>(undefined);
+  const prefillConsumedRef = useRef(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -225,6 +248,22 @@ export const PageWafTokens = () => {
   useEffect(() => {
     load();
   }, [load]);
+
+  // Runs once after load completes. setSearchParams below triggers a re-run,
+  // but the consumed-ref + empty-params early returns make it a no-op.
+  useEffect(() => {
+    if (prefillConsumedRef.current || loading) return;
+    const clientId = searchParams.get('createForClientId') ?? undefined;
+    const name = searchParams.get('name') ?? undefined;
+    if (!clientId && !name) return;
+    prefillConsumedRef.current = true;
+    prefillRef.current = { clientId, name };
+    setShowCreate(true);
+    const next = new URLSearchParams(searchParams);
+    next.delete('createForClientId');
+    next.delete('name');
+    setSearchParams(next, { replace: true });
+  }, [loading, searchParams, setSearchParams]);
 
   const rpById = Object.fromEntries(rps.map((rp) => [rp.id, rp.name]));
   const usedClientIds = new Set(
@@ -299,7 +338,14 @@ export const PageWafTokens = () => {
 
       <Guard features={[AdminPanelFeature.ManageWafTokens]}>
         <div className="mt-4 mb-4 flex gap-2">
-          <button className={btnClass} onClick={() => setShowCreate((v) => !v)}>
+          <button
+            className={btnClass}
+            disabled={loading}
+            onClick={() => {
+              if (showCreate) prefillRef.current = undefined;
+              setShowCreate(!showCreate);
+            }}
+          >
             {showCreate ? 'Cancel' : 'Generate new token'}
           </button>
           {tokens.length > 0 && (
@@ -313,10 +359,14 @@ export const PageWafTokens = () => {
           <CreateTokenForm
             rps={rps}
             usedClientIds={usedClientIds}
+            initial={prefillRef.current}
             onCreated={(token) => {
               handleCreated(token);
             }}
-            onCancel={() => setShowCreate(false)}
+            onCancel={() => {
+              prefillRef.current = undefined;
+              setShowCreate(false);
+            }}
           />
         )}
       </Guard>


### PR DESCRIPTION
## Because

- Admins clicking "manage in WAF Bypass Tokens" from a relying party with no token lost all RP context and had to manually find and reselect the RP in the create form.

## This pull request

- Updates the RP panel link to carry `createForClientId` and `name` query params so the WAF bypass form is prefilled with RP context.

## Issue that this pull request solves

Closes: FXA-13769

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## To test
1. visit relying parties page in admin panel
2. choose an RP (or create one) -- notice the last row has a link to attach a WAF Bypass token
3. click the WAF bypass token link

**Expected results with change:** you are navigated to the WAF bypass token panel, and the "generate token" flow is active with the RP details pre-populated.

**Expected results _**without**_ change:** you are navigated to the WAF bypass token panel.
