### PR TITLE
fix(storybook): Fix index/email-first stories not loading

### DIFF
--- a/packages/fxa-settings/src/pages/Index/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Index/mocks.tsx
@@ -164,9 +164,9 @@ export const Subject = ({
         disableAutoSubmit={() => {}}
         authClient={
           {
-            beginPasskeyAuthentication: jest.fn(),
-            completePasskeyAuthentication: jest.fn(),
-            accountProfile: jest.fn(),
+            beginPasskeyAuthentication: async () => {},
+            completePasskeyAuthentication: async () => {},
+            accountProfile: async () => {},
           } as unknown as AuthClient
         }
         finishOAuthFlowHandler={async () => ({


### PR DESCRIPTION
Because:
* These stories were getting a 'jest is not defined' error

This commit:
* Updates the jest.fn() references to functions that return an empty object

---

We can also install `@storybook/test`. Since we're not using this in tests I didn't install it here.