### PR TITLE
add optional passkey signin and AMO AAL2 enforcement

### DIFF
--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -69,6 +69,7 @@ const buildArgs = (
   });
   const account = jest.fn().mockResolvedValue({
     emails: [{ email: EMAIL, isPrimary: true, verified: true }],
+    totp: { exists: false, verified: false },
   });
 
   const authClient = {
@@ -82,6 +83,7 @@ const buildArgs = (
     getService: () => 'service-id',
     type: IntegrationType.OAuthWeb,
     data: {},
+    wantsTwoStepAuthentication: () => false,
   } as unknown as PasskeySignInIntegration;
   const finishOAuthFlowHandler = jest.fn();
   const ftlMsgResolver = {
@@ -169,6 +171,8 @@ describe('usePasskeySignIn', () => {
       handleFxaLogin: true,
       handleFxaOAuthLogin: true,
       performNavigation: true,
+      isPasskeySession: true,
+      accountHasTotp: false,
     });
     expect(storeAccountData).toHaveBeenCalledWith({
       email: EMAIL,
@@ -217,6 +221,8 @@ describe('usePasskeySignIn', () => {
       handleFxaLogin: true,
       handleFxaOAuthLogin: true,
       performNavigation: true,
+      isPasskeySession: true,
+      accountHasTotp: false,
     });
   });
 
@@ -527,5 +533,121 @@ describe('usePasskeySignIn', () => {
     // to end, not just at the entry point.
     expect(storeAccountData).toHaveBeenCalledTimes(1);
     expect(handleNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  describe('AAL2 RP TOTP status', () => {
+    const buildAAL2Args = (
+      totp: { exists: boolean; verified: boolean } | undefined,
+      overrides: Record<string, unknown> = {}
+    ) => {
+      const integration = {
+        isSync: () => false,
+        isFirefoxNonSync: () => false,
+        getService: () => 'service-id',
+        type: IntegrationType.OAuthWeb,
+        data: {},
+        wantsTwoStepAuthentication: () => true,
+      } as unknown as PasskeySignInIntegration;
+      const { args, spies } = buildArgs({ integration, ...overrides });
+      (args.authClient.account as jest.Mock).mockResolvedValue({
+        emails: [{ email: EMAIL, isPrimary: true, verified: true }],
+        ...(totp !== undefined && { totp }),
+      });
+      return { args, spies };
+    };
+
+    it('passes accountHasTotp=false when the account has no TOTP enrolled', async () => {
+      const { args } = buildAAL2Args({ exists: false, verified: false });
+
+      const { result } = renderHook(() => usePasskeySignIn(args));
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPasskeySession: true,
+          accountHasTotp: false,
+        })
+      );
+    });
+
+    it('passes accountHasTotp=true when the account has TOTP enrolled', async () => {
+      const { args } = buildAAL2Args({ exists: true, verified: true });
+
+      const { result } = renderHook(() => usePasskeySignIn(args));
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPasskeySession: true,
+          accountHasTotp: true,
+        })
+      );
+    });
+
+    it('passes accountHasTotp=false when TOTP record exists but is unverified', async () => {
+      // Must read `verified`, not `exists`, to gate on completed enrolment.
+      const { args } = buildAAL2Args({ exists: true, verified: false });
+
+      const { result } = renderHook(() => usePasskeySignIn(args));
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPasskeySession: true,
+          accountHasTotp: false,
+        })
+      );
+    });
+
+    it('treats a missing totp field as not-enrolled', async () => {
+      const { args } = buildAAL2Args(undefined);
+
+      const { result } = renderHook(() => usePasskeySignIn(args));
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPasskeySession: true,
+          accountHasTotp: false,
+        })
+      );
+    });
+
+    it('still passes accountHasTotp even when the RP does not require AAL2', async () => {
+      // utils.ts gates on wantsTwoStepAuthentication() before reading it.
+      const { args } = buildAAL2Args(
+        { exists: true, verified: true },
+        {
+          integration: {
+            isSync: () => false,
+            isFirefoxNonSync: () => false,
+            getService: () => 'service-id',
+            type: IntegrationType.OAuthWeb,
+            data: {},
+            wantsTwoStepAuthentication: () => false,
+          } as unknown as PasskeySignInIntegration,
+        }
+      );
+
+      const { result } = renderHook(() => usePasskeySignIn(args));
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isPasskeySession: true,
+          accountHasTotp: true,
+        })
+      );
+    });
   });
 });

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -210,15 +210,15 @@ export function usePasskeySignIn({
         return;
       }
 
+      const accountHasTotp = !!account?.totp?.verified;
+
       // Delegate to handleNavigation (same path as password sign-in).
-      // hardNavigate here would briefly render the cached-signin view
-      // between storeAccountData and the deferred window.location assignment.
       const { error: navError } = await handleNavigation({
         email,
         signinData: {
           uid: completion.uid,
           sessionToken: completion.sessionToken,
-          // AAL2 by definition; email had to be verified to register a passkey.
+          // Passkey assertion is AAL2; email was verified at registration.
           emailVerified: true,
           sessionVerified: completion.verified,
           verificationMethod: undefined,
@@ -230,6 +230,8 @@ export function usePasskeySignIn({
         handleFxaLogin: true,
         handleFxaOAuthLogin: true,
         performNavigation: true,
+        isPasskeySession: true,
+        accountHasTotp,
       });
 
       if (navError) {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.test.tsx
@@ -18,7 +18,9 @@ import { createMockPasswordlessLocationState } from './mocks';
 let integration: Integration;
 
 function mockWebIntegration() {
-  integration = createMockWebIntegration({ clientIdFallback: MOCK_CLIENT_ID }) as Integration;
+  integration = createMockWebIntegration({
+    clientIdFallback: MOCK_CLIENT_ID,
+  }) as Integration;
 }
 
 function applyDefaultMocks() {
@@ -68,7 +70,7 @@ function mockSigninPasswordlessCodeModule() {
 }
 
 function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => { });
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
 function resetMockAuthClient() {
@@ -84,7 +86,7 @@ async function render() {
         {...{
           integration,
           serviceName: 'sync',
-          flowQueryParams: {}
+          flowQueryParams: {},
         }}
       />
     </LocationProvider>
@@ -104,11 +106,15 @@ describe('SigninPasswordlessCode container', () => {
         await render();
 
         await waitFor(() =>
-          expect(screen.getByText('signin passwordless code mock')).toBeInTheDocument()
+          expect(
+            screen.getByText('signin passwordless code mock')
+          ).toBeInTheDocument()
         );
 
         expect(currentSigninPasswordlessCodeProps?.email).toBe(MOCK_EMAIL);
-        expect(currentSigninPasswordlessCodeProps?.integration).toBe(integration);
+        expect(currentSigninPasswordlessCodeProps?.integration).toBe(
+          integration
+        );
         expect(SigninPasswordlessCodeModule.default).toHaveBeenCalled();
       });
 
@@ -127,14 +133,18 @@ describe('SigninPasswordlessCode container', () => {
         mockLocationState = createMockPasswordlessLocationState();
 
         // Make passwordlessSendCode slow to simulate loading
-        mockAuthClient.passwordlessSendCode = jest.fn().mockImplementation(
-          () => new Promise((resolve) => setTimeout(resolve, 100))
-        );
+        mockAuthClient.passwordlessSendCode = jest
+          .fn()
+          .mockImplementation(
+            () => new Promise((resolve) => setTimeout(resolve, 100))
+          );
 
         await render();
 
         // Should show loading initially
-        expect(screen.queryByText('signin passwordless code mock')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('signin passwordless code mock')
+        ).not.toBeInTheDocument();
       });
     });
 
@@ -149,7 +159,11 @@ describe('SigninPasswordlessCode container', () => {
         await waitFor(() => {
           expect(mockAuthClient.passwordlessSendCode).toHaveBeenCalledWith(
             MOCK_EMAIL,
-            { clientId: MOCK_CLIENT_ID, service: 'sync', metricsContext: { clientId: MOCK_CLIENT_ID } }
+            {
+              clientId: MOCK_CLIENT_ID,
+              service: 'sync',
+              metricsContext: { clientId: MOCK_CLIENT_ID },
+            }
           );
         });
       });
@@ -175,7 +189,9 @@ describe('SigninPasswordlessCode container', () => {
         await render();
 
         await waitFor(() => {
-          expect(screen.getByText('signin passwordless code mock')).toBeInTheDocument();
+          expect(
+            screen.getByText('signin passwordless code mock')
+          ).toBeInTheDocument();
         });
 
         // Should NOT send code because location state has codeSent: true
@@ -233,7 +249,9 @@ describe('SigninPasswordlessCode container', () => {
       await render();
 
       await waitFor(() => {
-        expect(screen.getByText('signin passwordless code mock')).toBeInTheDocument();
+        expect(
+          screen.getByText('signin passwordless code mock')
+        ).toBeInTheDocument();
       });
 
       expect(currentSigninPasswordlessCodeProps?.sendError).toBeNull();
@@ -242,12 +260,16 @@ describe('SigninPasswordlessCode container', () => {
     it('passes sendError when code send fails', async () => {
       const mockError = new Error('Network error');
       (mockError as any).errno = 999;
-      mockAuthClient.passwordlessSendCode = jest.fn().mockRejectedValue(mockError);
+      mockAuthClient.passwordlessSendCode = jest
+        .fn()
+        .mockRejectedValue(mockError);
 
       await render();
 
       await waitFor(() => {
-        expect(screen.getByText('signin passwordless code mock')).toBeInTheDocument();
+        expect(
+          screen.getByText('signin passwordless code mock')
+        ).toBeInTheDocument();
       });
 
       expect(currentSigninPasswordlessCodeProps?.sendError).toBeDefined();
@@ -255,26 +277,34 @@ describe('SigninPasswordlessCode container', () => {
     });
 
     it('does not render SigninPasswordlessCode component while code is sending', async () => {
-      mockAuthClient.passwordlessSendCode = jest.fn().mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
-      );
+      mockAuthClient.passwordlessSendCode = jest
+        .fn()
+        .mockImplementation(
+          () => new Promise((resolve) => setTimeout(resolve, 100))
+        );
 
       await render();
 
       // Should not render the component while loading
-      expect(screen.queryByText('signin passwordless code mock')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('signin passwordless code mock')
+      ).not.toBeInTheDocument();
       expect(SigninPasswordlessCodeModule.default).not.toHaveBeenCalled();
     });
 
     it('renders SigninPasswordlessCode component after sendError is set', async () => {
       const mockError = new Error('Throttled');
       (mockError as any).errno = 114;
-      mockAuthClient.passwordlessSendCode = jest.fn().mockRejectedValue(mockError);
+      mockAuthClient.passwordlessSendCode = jest
+        .fn()
+        .mockRejectedValue(mockError);
 
       await render();
 
       await waitFor(() => {
-        expect(screen.getByText('signin passwordless code mock')).toBeInTheDocument();
+        expect(
+          screen.getByText('signin passwordless code mock')
+        ).toBeInTheDocument();
       });
 
       expect(SigninPasswordlessCodeModule.default).toHaveBeenCalled();

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
@@ -10,8 +10,7 @@ import { AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
 import { createMockSigninOAuthNativeIntegration } from '../mocks';
 
-// Override mockAppContext's config to flip the passkey signin feature flags
-// on. Used by the stories that document the passkey-enabled states.
+// Flips passkey feature flags on for the passkey-enabled story variants.
 const passkeyEnabledContext = () => {
   const ctx = mockAppContext();
   if (ctx.config) {
@@ -105,12 +104,47 @@ export const WithSendError = () => (
   </AppContext.Provider>
 );
 
-// Passkey signin enabled: the alternative-auth block renders an "or"
-// separator and the passkey button beneath the OTP form. Click the button
-// to drive the WebAuthn ceremony — in Storybook this surfaces the natural
-// "unexpected error" banner (no authenticator wired up).
+// Passkey button stacks beneath the OTP form with an "or" separator.
 export const DefaultSigninWithPasskey = () => (
   <AppContext.Provider value={passkeyEnabledContext()}>
     <Subject email="user@example.com" expirationMinutes={5} isSignup={false} />
+  </AppContext.Provider>
+);
+
+// Signup flow: passkey button hidden (brand-new account has no passkey).
+export const DefaultSignupWithPasskey = () => (
+  <AppContext.Provider value={passkeyEnabledContext()}>
+    <Subject
+      email="newuser@example.com"
+      expirationMinutes={5}
+      isSignup={true}
+    />
+  </AppContext.Provider>
+);
+
+// Passkey + CMS info: branded layout variant.
+export const WithCmsInfoAndPasskey = () => (
+  <AppContext.Provider value={passkeyEnabledContext()}>
+    <Subject
+      email="user@example.com"
+      expirationMinutes={5}
+      integration={createMockWebIntegration(MOCK_CMS_INFO)}
+      isSignup={false}
+    />
+  </AppContext.Provider>
+);
+
+// Passkey + send error: OTP error banner coexists with the passkey block.
+export const WithSendErrorAndPasskey = () => (
+  <AppContext.Provider value={passkeyEnabledContext()}>
+    <Subject
+      email="user@example.com"
+      expirationMinutes={5}
+      isSignup={false}
+      sendError={{
+        errno: 999,
+        message: 'Something went wrong sending the code',
+      }}
+    />
   </AppContext.Provider>
 );

--- a/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.stories.tsx
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+
+import SigninAlternativeAuthOptions from '.';
+import { AppContext } from '../../../../models';
+import { mockAppContext } from '../../../../models/mocks';
+import {
+  createMockSigninOAuthNativeSyncIntegration,
+  createMockSigninWebIntegration,
+} from '../../mocks';
+import {
+  MOCK_AVATAR_NON_DEFAULT,
+  MOCK_EMAIL,
+  mockFinishOAuthFlowHandler,
+} from '../../../mocks';
+import { MozServices } from '../../../../lib/types';
+
+// Renders for linked-passwordless users: only path forward is alt auth.
+
+const passkeyEnabledContext = () => {
+  const ctx = mockAppContext();
+  if (ctx.config) {
+    ctx.config.featureFlags = {
+      ...ctx.config.featureFlags,
+      passkeysEnabled: true,
+      passkeyAuthenticationEnabled: true,
+    };
+  }
+  return ctx;
+};
+
+type SubjectProps = Partial<
+  React.ComponentProps<typeof SigninAlternativeAuthOptions>
+> & {
+  passkeyEnabled?: boolean;
+};
+
+const Subject = ({
+  integration = createMockSigninWebIntegration(),
+  email = MOCK_EMAIL,
+  serviceName = MozServices.Default,
+  hasLinkedAccount = true,
+  hasPassword = false,
+  avatarData = { account: { avatar: MOCK_AVATAR_NON_DEFAULT } },
+  avatarLoading = false,
+  finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
+  passkeyEnabled = false,
+  ...props
+}: SubjectProps) => (
+  <LocationProvider>
+    <AppContext.Provider
+      value={passkeyEnabled ? passkeyEnabledContext() : mockAppContext()}
+    >
+      <SigninAlternativeAuthOptions
+        {...{
+          integration,
+          email,
+          serviceName,
+          hasLinkedAccount,
+          hasPassword,
+          avatarData,
+          avatarLoading,
+          finishOAuthFlowHandler,
+          ...props,
+        }}
+      />
+    </AppContext.Provider>
+  </LocationProvider>
+);
+
+export default {
+  title: 'Pages/Signin/SigninAlternativeAuthOptions',
+  component: SigninAlternativeAuthOptions,
+  decorators: [withLocalization],
+} as Meta;
+
+// Passkey flags off: only third-party providers render.
+export const Default = () => <Subject />;
+
+// Sync variant: merge gate runs after third-party / passkey signin.
+export const Sync = () => (
+  <Subject
+    serviceName={MozServices.FirefoxSync}
+    integration={createMockSigninOAuthNativeSyncIntegration()}
+  />
+);
+
+// Firefox Desktop hides the "Use a different account" link (no merge support).
+export const SignedIntoFirefoxDesktop = () => (
+  <Subject
+    integration={createMockSigninOAuthNativeSyncIntegration()}
+    isSignedIntoFirefox={true}
+  />
+);
+
+// Success banner carried over from a previous page (e.g. password reset).
+export const WithSuccessBanner = () => (
+  <Subject
+    localizedSuccessBannerHeading="Password updated"
+    localizedSuccessBannerDescription="You can now sign in with your new password."
+  />
+);
+
+// Error carried over from a previous page (e.g. session expired).
+export const WithErrorBanner = () => (
+  <Subject localizedErrorFromLocationState="Your sign-in session has expired." />
+);
+
+// Passkey enabled: third-party providers + passkey button stack together.
+export const WithPasskeyEnabled = () => <Subject passkeyEnabled={true} />;
+
+// Passkey + Sync: ceremony routes to /signin_passkey_fallback for the password gate.
+export const WithPasskeyEnabledSync = () => (
+  <Subject
+    passkeyEnabled={true}
+    serviceName={MozServices.FirefoxSync}
+    integration={createMockSigninOAuthNativeSyncIntegration()}
+  />
+);
+
+// Passkey + carried-over error: error banner coexists with the alt-auth block.
+export const WithPasskeyEnabledAndErrorBanner = () => (
+  <Subject
+    passkeyEnabled={true}
+    localizedErrorFromLocationState="Your sign-in session has expired."
+  />
+);

--- a/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
@@ -15,7 +15,11 @@ import Banner from '../../../../components/Banner';
 import { SigninAlternativeAuthOptionsProps } from '../../interfaces';
 import SigninUserLockup from '../SigninUserLockup';
 import { useCachedSigninLockup } from '../../useCachedSigninLockup';
-import { useAuthClient, useConfig, useFtlMsgResolver } from '../../../../models';
+import {
+  useAuthClient,
+  useConfig,
+  useFtlMsgResolver,
+} from '../../../../models';
 import { usePasskeySignIn } from '../../../../lib/passkeys/signin-flow';
 
 export const viewName = 'signin';

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -272,24 +272,39 @@ export const CmsCachedNoCachedPageConfig: Story = {
   name: 'CMS > Regular layout > Cached > No SigninCachedPage config',
 };
 
-// Passkey button is offered as an alternative to entering a password, in
-// addition to the third-party providers. Click the button to drive the
-// WebAuthn ceremony — in Storybook this surfaces the natural "unexpected
-// error" banner (no authenticator wired up).
+// Passkey button alongside third-party providers, alternative to password entry.
 export const NonCachedAccountHasPasswordWithPasskey: Story = {
   ...story({ passkeyEnabled: true }),
   name: 'Passkey enabled > Non-Cached > Account has password',
 };
 
-// Linked-passwordless account routes through SigninAlternativeAuthOptions —
-// passkey button renders alongside the third-party providers (no password
-// input). Click drives the WebAuthn ceremony; surfaces the natural
-// "unexpected error" banner in Storybook (no authenticator wired up).
-export const NonCachedPasswordlessAccountWithPasskey: Story = {
+// Sync passkey signin routes to /signin_passkey_fallback for key derivation.
+export const NonCachedSyncWithPasskey: Story = {
   ...story({
+    passkeyEnabled: true,
+    serviceName: MozServices.FirefoxSync,
+    hasLinkedAccount: true,
+    hasPassword: true,
+    integration: createMockSigninOAuthNativeSyncIntegration(),
+  }),
+  name: 'Passkey enabled > Non-Cached > Sync browser service > Account has password',
+};
+
+// SigninDecider routes linked-passwordless users to SigninAlternativeAuthOptions.
+export const NonCachedPasswordlessWithPasskey: Story = {
+  ...story({
+    passkeyEnabled: true,
     hasLinkedAccount: true,
     hasPassword: false,
-    passkeyEnabled: true,
   }),
-  name: 'Passkey enabled > Non-Cached > Passwordless account',
+  name: 'Passkey enabled > Non-Cached > Passwordless account (routes through SigninAlternativeAuthOptions)',
+};
+
+// Cached re-auth (SigninCached) hides the passkey button regardless of flags.
+export const CachedWithPasskeyFlagOn: Story = {
+  ...story({
+    passkeyEnabled: true,
+    sessionToken: MOCK_SESSION_TOKEN,
+  }),
+  name: 'Passkey enabled > Cached > passkey button correctly hidden (SigninCached path)',
 };

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -110,6 +110,10 @@ jest.mock('../../models', () => {
     }),
     useConfig: () => ({
       servicesWithEmailVerification: ['123456'],
+      featureFlags: {
+        passkeysEnabled: true,
+        passkeyAuthenticationEnabled: true,
+      },
     }),
   };
 });
@@ -978,7 +982,6 @@ describe('Signin component', () => {
       expect(
         screen.queryByRole('link', { name: 'Forgot password?' })
       ).not.toBeInTheDocument();
-      expect(screen.queryByText('or')).not.toBeInTheDocument();
       passwordInputNotRendered();
     });
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -100,9 +100,7 @@ const Signin = ({
   const isServiceWithEmailVerification =
     !!clientId && config.servicesWithEmailVerification.includes(clientId);
 
-  // Passkey signin is an alternative to password entry. The decider only
-  // routes to this component when a password is needed, so we don't need to
-  // gate on `!hasCachedAccount` like the original monolithic Signin did.
+  // Button stays visible without WebAuthn support; the hook surfaces an error.
   const showPasskeySignin = !!(
     config.featureFlags?.passkeysEnabled &&
     config.featureFlags?.passkeyAuthenticationEnabled

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -271,6 +271,10 @@ export interface NavigationOptions {
   performNavigation?: boolean;
   isServiceWithEmailVerification?: boolean;
   isPasswordlessFlow?: boolean;
+  // True when the session was established by a passkey assertion; pairs
+  // with accountHasTotp to drive the AAL2-RP TOTP redirect in utils.ts.
+  isPasskeySession?: boolean;
+  accountHasTotp?: boolean;
 }
 
 export interface OAuthSigninResult {

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -362,6 +362,82 @@ describe('Signin utils', () => {
       });
     });
 
+    describe('passkey-session AAL2 gate', () => {
+      const buildPasskeyOAuthOptions = (
+        overrides: Partial<NavigationOptions> = {}
+      ) => {
+        const integration = createMockSigninOAuthIntegration();
+        integration.wantsTwoStepAuthentication = jest
+          .fn()
+          .mockReturnValue(true);
+        return createBaseNavigationOptions({
+          integration,
+          isPasskeySession: true,
+          queryParams: '?client_id=abc',
+          ...overrides,
+        });
+      };
+
+      it('diverts to /inline_totp_setup when the account has no TOTP', async () => {
+        const finishOAuthFlowHandler = jest.fn();
+        const navigationOptions = buildPasskeyOAuthOptions({
+          accountHasTotp: false,
+          finishOAuthFlowHandler,
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(finishOAuthFlowHandler).not.toHaveBeenCalled();
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/inline_totp_setup?client_id=abc',
+          expect.objectContaining({ replace: true })
+        );
+      });
+
+      it('continues to OAuth redirect when the account already has TOTP', async () => {
+        const finishOAuthFlowHandler = jest
+          .fn()
+          .mockResolvedValue(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
+        const navigationOptions = buildPasskeyOAuthOptions({
+          accountHasTotp: true,
+          finishOAuthFlowHandler,
+        });
+
+        await handleNavigation(navigationOptions);
+
+        expect(finishOAuthFlowHandler).toHaveBeenCalledTimes(1);
+        expect(hardNavigateSpy).toHaveBeenCalledWith(
+          MOCK_OAUTH_FLOW_HANDLER_RESPONSE.redirect,
+          undefined,
+          undefined,
+          true
+        );
+      });
+
+      it('continues to OAuth redirect when the RP does not require AAL2', async () => {
+        const integration = createMockSigninOAuthIntegration();
+        integration.wantsTwoStepAuthentication = jest
+          .fn()
+          .mockReturnValue(false);
+        const finishOAuthFlowHandler = jest
+          .fn()
+          .mockResolvedValue(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
+
+        const navigationOptions = createBaseNavigationOptions({
+          integration,
+          isPasskeySession: true,
+          accountHasTotp: false,
+          finishOAuthFlowHandler,
+        });
+
+        await handleNavigation(navigationOptions);
+
+        expect(finishOAuthFlowHandler).toHaveBeenCalledTimes(1);
+        expect(hardNavigateSpy).toHaveBeenCalled();
+      });
+    });
+
     describe('handleNavigation with send-tab entrypoints', () => {
       const createSendTabNavigationOptions = (
         overrides: Partial<NavigationOptions> = {}

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -558,6 +558,20 @@ const getOAuthNavigationTarget = async (
     };
   }
 
+  // Profile-level AMR omits webauthn, so AAL2 RPs (AMO) reject passkey-only
+  // grants. Force TOTP enrollment first when no TOTP is set.
+  if (
+    navigationOptions.isPasskeySession &&
+    isOAuthWebIntegration(navigationOptions.integration) &&
+    navigationOptions.integration.wantsTwoStepAuthentication() &&
+    navigationOptions.accountHasTotp === false
+  ) {
+    return {
+      to: `/inline_totp_setup${navigationOptions.queryParams || ''}`,
+      locationState,
+    };
+  }
+
   const { error, redirect, code, state } =
     await navigationOptions.finishOAuthFlowHandler(
       navigationOptions.signinData.uid,


### PR DESCRIPTION
## Because

- Users with an enrolled passkey could not use it from the email-first signin flow without typing their password first, undermining the value of passkeys as a primary authentication method
- AMO and similar RPs perform a profile-level AAL2 check that excludes webauthn from `availableAuthenticationMethods`, so a passkey-only user satisfied session AAL2 yet was bounced back to FxA in a redirect loop instead of being prompted to enrol TOTP

## This pull request

- Adds a "Continue with passkey" button to `Signin/index.tsx` (password-entry page) and `SigninAlternativeAuthOptions` (email-first), gated by the `passkeyAuthenticationEnabled` feature flag
- Shows the button unconditionally to preserve the privacy invariant that `/account/status` does not leak passkey enrolment
- Adds unit coverage in `signin-flow.test.tsx` and `utils.test.ts` (passkey-session AAL2 gate cases) plus stories for the new alternative-auth UI

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13101

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

Companion PR: FXA-13103 adds the Playwright coverage for these flows (passkey signin paths + AMO profile-AAL2 divert) and a 123done toggle that mirrors AMO's profile-based enforcement. It should land after this one.

### How to test

1. Enable feature flags `passkeysEnabled`, `passkeyRegistrationEnabled`, `passkeyAuthenticationEnabled`
2. Register a passkey on a fresh account via Settings
3. Sign out, return to `/`, then click "Continue with passkey" from email-first or after submitting an email
4. From a 123done `acr_values=AAL2` flow on a passkey-only account, sign in with passkey, should land on `/inline_totp_setup`, not the RP