### PR TITLE
fix(paypal): handle octet-stream NVP responses

### DIFF
--- a/libs/payments/paypal/src/lib/paypal.client.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.spec.ts
@@ -32,6 +32,7 @@ import {
   DoReferenceTransactionOptions,
   NVPErrorSeverity,
   PaypalMethods,
+  PaypalNVPAckOptions,
   RefundTransactionOptions,
   RefundType,
   TransactionSearchOptions,
@@ -375,6 +376,112 @@ describe('PayPalClient', () => {
       const result = await paypalClient.transactionSearch(options);
 
       expect(result).toMatchObject(response);
+    });
+  });
+
+  describe('doRequest response handling', () => {
+    // createBillingAgreement is used here purely as the simplest public entry
+    // point into doRequest. These tests cover transport-layer behavior shared
+    // by every NVP call: Content-Type handling, ACK dispatch, and response
+    // event emission.
+    const token = 'test-token-doreq-001';
+    const expectedPayload = {
+      ...commonPayloadArgs,
+      METHOD: PaypalMethods.CreateBillingAgreement,
+      token,
+    };
+
+    it('parses the NVP body when PayPal returns application/octet-stream', async () => {
+      const response = NVPResponseFactory();
+
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
+        .reply(200, objectToNVP(response), {
+          'Content-Type': 'application/octet-stream',
+        });
+
+      const result = await paypalClient.createBillingAgreement({ token });
+
+      expect(result).toMatchObject(response);
+    });
+
+    it('throws PayPalClientError with the raw body populated when an application/octet-stream response has a Failure ACK', async () => {
+      const errorResponse = NVPErrorResponseFactory();
+      const rawBody = objectToNVP(errorResponse);
+
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
+        .reply(200, rawBody, {
+          'Content-Type': 'application/octet-stream',
+        });
+
+      await expect(
+        paypalClient.createBillingAgreement({ token })
+      ).rejects.toMatchObject({
+        name: 'PayPalClientError',
+        raw: rawBody,
+        data: { ACK: PaypalNVPAckOptions.Failure },
+      });
+    });
+
+    it('treats a SuccessWithWarning ACK as a successful response', async () => {
+      const response = NVPResponseFactory({
+        ACK: PaypalNVPAckOptions.SuccessWithWarning,
+      });
+
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
+        .reply(200, objectToNVP(response));
+
+      const result = await paypalClient.createBillingAgreement({ token });
+
+      expect(result.ACK).toBe(PaypalNVPAckOptions.SuccessWithWarning);
+      expect(result).toMatchObject(response);
+    });
+
+    it('emits a response event with method, version, and timing on success', async () => {
+      const response = NVPResponseFactory();
+      const listener = jest.fn();
+      paypalClient.on('response', listener);
+
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
+        .reply(200, objectToNVP(response));
+
+      await paypalClient.createBillingAgreement({ token });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event = listener.mock.calls[0][0];
+      expect(event).toMatchObject({
+        method: PaypalMethods.CreateBillingAgreement,
+        version: PAYPAL_VERSION,
+      });
+      expect(typeof event.request_start_time).toBe('number');
+      expect(typeof event.request_end_time).toBe('number');
+      expect(typeof event.elapsed).toBe('number');
+      expect(event.request_end_time).toBeGreaterThanOrEqual(
+        event.request_start_time
+      );
+      expect(event.error).toBeUndefined();
+    });
+
+    it('emits a response event without error when the body has a Failure ACK', async () => {
+      const errorResponse = NVPErrorResponseFactory();
+      const listener = jest.fn();
+      paypalClient.on('response', listener);
+
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, objectToNVP(expectedPayload))
+        .reply(200, objectToNVP(errorResponse));
+
+      await expect(
+        paypalClient.createBillingAgreement({ token })
+      ).rejects.toBeInstanceOf(PayPalClientError);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event = listener.mock.calls[0][0];
+      expect(event.method).toBe(PaypalMethods.CreateBillingAgreement);
+      expect(event.error).toBeUndefined();
     });
   });
 

--- a/libs/payments/paypal/src/lib/paypal.client.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.ts
@@ -106,6 +106,11 @@ export class PayPalClient {
           superagent
             .post(this.url)
             .set('content-type', 'application/x-www-form-urlencoded')
+            // PayPal's NVP endpoint sometimes returns application/octet-stream
+            // instead of text/plain. .buffer(true) ensures superagent reads
+            // the body regardless of Content-Type (as a Buffer on result.body
+            // for non-text types).
+            .buffer(true)
             .send(payload),
         this.retryOptions
       );
@@ -120,7 +125,10 @@ export class PayPalClient {
       throw err;
     }
     const request_end_time = Date.now();
-    const resultObj = nvpToObject(result.text) as T | NVPErrorResponse;
+    const raw =
+      result.text ??
+      (Buffer.isBuffer(result.body) ? result.body.toString('utf8') : '');
+    const resultObj = nvpToObject(raw) as T | NVPErrorResponse;
     this.emitter.emit('response', {
       ...response,
       elapsed: request_end_time - response.request_start_time,
@@ -135,10 +143,10 @@ export class PayPalClient {
       // TypeScript doesn't narrow ACK, necessitating a cast
       throw new PayPalClientError(
         PayPalClient.getListOfPayPalNVPErrors(
-          result.text,
+          raw,
           resultObj as NVPErrorResponse
         ),
-        result.text,
+        raw,
         resultObj as NVPErrorResponse
       );
     }


### PR DESCRIPTION
## Because

* PayPal's NVP endpoint intermittently returns application/octet-stream instead of text/plain. Superagent does not buffer unknown content types by default, leaving result.text and result.body empty and silently breaking every downstream NVP parse.

## This pull request

* Adds .buffer(true) so superagent always reads the response body.
* Reads from result.text when populated, falling back to decoding result.body as utf-8 when it arrives as a Buffer.

## Issue that this pull request solves

Closes: PAY-3709

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
