### PR TITLE
fix(payments-next): UpgradeCartFromOfferingConfigIdMissingError: from OfferingConfigId not present for upgrade cart

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
@@ -13,6 +13,7 @@ import {
   TermsAndPrivacy,
   UpgradePurchaseDetails,
 } from '@fxa/payments/ui/server';
+import { CartState } from '@fxa/shared/db/mysql/account';
 import { config } from 'apps/payments/next/config';
 import { auth } from 'apps/payments/next/auth';
 import {
@@ -44,17 +45,20 @@ export default async function UpgradeLayout({
     cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
     cms.defaultPurchase.purchaseDetails;
 
-  if (!cart.fromOfferingConfigId) {
-    throw new UpgradeCartFromOfferingConfigIdMissingError(resolvedParams.cartId);
+  let currentPurchaseDetails;
+  if (cart.state === CartState.START) {
+    if (!cart.fromOfferingConfigId) {
+      throw new UpgradeCartFromOfferingConfigIdMissingError(resolvedParams.cartId);
+    }
+    if (!cart.fromPrice) {
+      throw new UpgradeCartFromPriceMissingError(resolvedParams.cartId);
+    }
+    const currentCmsDataPromise = fetchCMSData(cart.fromOfferingConfigId, locale);
+    const currentCms = await currentCmsDataPromise;
+    currentPurchaseDetails =
+      currentCms.defaultPurchase.purchaseDetails.localizations.at(0) ||
+      currentCms.defaultPurchase.purchaseDetails;
   }
-  if (!cart.fromPrice) {
-    throw new UpgradeCartFromPriceMissingError(resolvedParams.cartId);
-  }
-  const currentCmsDataPromise = fetchCMSData(cart.fromOfferingConfigId, locale);
-  const currentCms = await currentCmsDataPromise;
-  const currentPurchaseDetails =
-    currentCms.defaultPurchase.purchaseDetails.localizations.at(0) ||
-    currentCms.defaultPurchase.purchaseDetails;
 
   return (
     <MetricsWrapper cart={cart}>
@@ -79,16 +83,19 @@ export default async function UpgradeLayout({
           <SubscriptionTitle cart={cart} l10n={l10n} />
 
           <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
-            <UpgradePurchaseDetails
-              l10n={l10n}
-              interval={cart.interval}
-              invoice={cart.upcomingInvoicePreview}
-              fromPrice={cart.fromPrice}
-              fromPurchaseDetails={currentPurchaseDetails}
-              offeringPrice={cart.offeringPrice}
-              purchaseDetails={purchaseDetails}
-              locale={locale}
-            />
+            {cart.fromPrice &&
+              currentPurchaseDetails && (
+              <UpgradePurchaseDetails
+                l10n={l10n}
+                interval={cart.interval}
+                invoice={cart.upcomingInvoicePreview}
+                fromPrice={cart.fromPrice}
+                fromPurchaseDetails={currentPurchaseDetails}
+                offeringPrice={cart.offeringPrice}
+                purchaseDetails={purchaseDetails}
+                locale={locale}
+              />
+            )}
           </div>
 
           <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">


### PR DESCRIPTION
## Because

* If customer goes through the upgrade flow and lands on the success page then navigates back to start, the cart will be missing the fromOfferingConfigId, throwing an error and showing the "something went wrong" page.

## This pull request

* Uses similar cart.state checks as other layout files in (startLayout)/layout.tsx, so a non-START cart redirects from the start page instead of throwing.

## Issue that this pull request solves

Closes #[PAY-3705](https://mozilla-hub.atlassian.net/browse/PAY-3705)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)


STRs:
1. Subscribe to (for example) VPN monthly.
2. Upgrade (successfully) to yearly.
3. Either: press the 'back' arrow from the success page, OR, edit the URL to be start instead of success (both videos attached).

In Stage, pressing the 'back' arrow:

https://github.com/user-attachments/assets/565ec00c-774f-40c6-a46f-cc834f48ee5c

Or, editing the URL:

https://github.com/user-attachments/assets/b1c815ec-69df-45aa-a524-6a0f9c76a501


After fix:


https://github.com/user-attachments/assets/4fb12609-6b66-4117-8f79-8186d57fa4d2



- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional) 

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3705]: https://mozilla-hub.atlassian.net/browse/PAY-3705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ