### PR TITLE
feat(auth): Allow device management for Firefox client_ids

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1199,10 +1199,22 @@ const convictConf = convict({
       env: 'OAUTH_CLIENT_IDS',
     },
     oldSyncClientIds: {
-      doc: 'Client IDs of sync clients that migrated to OAuth.',
+      doc: 'Client IDs of sync clients that migrated to OAuth. Used only by routes/oauth/token.js to label the account.signed metrics event service as "sync" for continuity with the retired BrowserID /certificate/sign flow',
       format: Array,
       default: ['5882386c6d801776', '1b1a3e44c54fbb58'],
       env: 'OAUTH_OLD_SYNC_CLIENT_IDS',
+    },
+    deviceManagementClientIds: {
+      doc: 'OAuth client_ids whose refresh tokens may register, read, destroy, notify, read own commands, and invoke commands for devices. Replaces the legacy oldsync-scope-only gate so Firefox sign-ins without Sync can still manage devices.',
+      format: Array,
+      default: [
+        '5882386c6d801776', // Firefox Desktop
+        '1b1a3e44c54fbb58', // Firefox iOS
+        '3332a18d142636cb', // Firefox Android (Fennec)
+        'a2270f727f45f648', // Firefox Android (Fenix)
+        '3c49430b43dfba77', // Android Components Reference Browser
+      ],
+      env: 'OAUTH_DEVICE_MANAGEMENT_CLIENT_IDS',
     },
     // A safety switch for disabling new signins/signups from particular clients,
     // as a hedge against unexpected client behaviour.

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
@@ -8,20 +8,19 @@ const { AppError } = require('@fxa/accounts/errors');
 const joi = require('joi');
 const validators = require('../validators');
 const { BEARER_AUTH_REGEX } = validators;
-const { OAUTH_SCOPE_OLD_SYNC } = require('fxa-shared/oauth/constants');
 const encrypt = require('fxa-shared/auth/encrypt');
 const oauthDB = require('../../oauth/db');
 const client = require('../../oauth/client');
-const ScopeSet = require('fxa-shared/oauth/scopes').scopeSetHelpers;
-
-// the refresh token scheme is currently used by things connected to sync,
-// and we're at a transitionary stage of its evolution into something more generic,
-// so we limit to the scope below as a safety mechanism
-const ALLOWED_REFRESH_TOKEN_SCHEME_SCOPES = ScopeSet.fromArray([
-  OAUTH_SCOPE_OLD_SYNC,
-]);
 
 module.exports = function schemeRefreshTokenScheme(config, db) {
+  // Gate access to the device API by Firefox client_id. Firefox sign-ins
+  // without Sync can still register a device.
+  const deviceManagementClientIds = new Set(
+    (config?.oauth?.deviceManagementClientIds || []).map((id) =>
+      id.toLowerCase()
+    )
+  );
+
   return function schemeRefreshToken(server, options) {
     return {
       async authenticate(request, h) {
@@ -46,11 +45,9 @@ module.exports = function schemeRefreshTokenScheme(config, db) {
         if (!refreshToken) {
           return h.unauthenticated(AppError.invalidToken());
         }
-        if (
-          !refreshToken.scope.intersects(ALLOWED_REFRESH_TOKEN_SCHEME_SCOPES)
-        ) {
-          // unauthenticated if refreshToken is missing the required scope
-          return h.unauthenticated(AppError.invalidScopes(refreshToken.scope));
+        const clientIdHex = refreshToken.clientId.toString('hex').toLowerCase();
+        if (!deviceManagementClientIds.has(clientIdHex)) {
+          return h.unauthenticated(AppError.invalidToken());
         }
 
         const { ua = {} } = request.app;

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.spec.ts
@@ -44,7 +44,11 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
   };
 
   beforeEach(() => {
-    config = { oauth: {} };
+    config = {
+      oauth: {
+        deviceManagementClientIds: [OAUTH_CLIENT_ID],
+      },
+    };
 
     db = {
       deviceFromRefreshTokenId: jest.fn(() =>
@@ -127,6 +131,7 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
     oauthDB.getRefreshToken.mockResolvedValue({
       scope: ScopeSet.fromString('https://identity.mozilla.com/apps/oldsync'),
       userId: USER_ID,
+      clientId: Buffer.from(OAUTH_CLIENT_ID, 'hex'),
     });
 
     const scheme = schemeRefreshToken(config, db);
@@ -177,10 +182,11 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
     });
   });
 
-  it('requires an approved scope to authenticate', async () => {
+  it('rejects refresh tokens from non-allowlisted client_ids', async () => {
     oauthDB.getRefreshToken.mockResolvedValue({
-      scope: ScopeSet.fromString('profile'),
+      scope: ScopeSet.fromString('https://identity.mozilla.com/apps/oldsync'),
       userId: USER_ID,
+      clientId: Buffer.from('0123456789abcdef', 'hex'),
     });
 
     const scheme = schemeRefreshToken(config, db);
@@ -196,10 +202,33 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
 
     expect(response.unauthenticated).toHaveBeenCalledTimes(1);
     const args = response.unauthenticated.mock.calls[0][0];
-    expect(args.output.statusCode).toBe(400);
-    expect(args.output.payload.errno).toBe(error.ERRNO.INVALID_SCOPES);
+    expect(args.output.statusCode).toBe(401);
+    expect(args.output.payload.errno).toBe(error.ERRNO.INVALID_TOKEN);
 
     expect(response.authenticated).not.toHaveBeenCalled();
+  });
+
+  it('allows non-Sync scope from an allowlisted client_id', async () => {
+    oauthDB.getRefreshToken.mockResolvedValue({
+      scope: ScopeSet.fromString('profile'),
+      userId: USER_ID,
+      clientId: Buffer.from(OAUTH_CLIENT_ID, 'hex'),
+    });
+
+    const scheme = schemeRefreshToken(config, db);
+    await scheme().authenticate(
+      {
+        headers: {
+          authorization:
+            'Bearer B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78',
+        },
+        app,
+      },
+      response
+    );
+
+    expect(response.unauthenticated).not.toHaveBeenCalled();
+    expect(response.authenticated).toHaveBeenCalledTimes(1);
   });
 
   it('requires an known refresh token to authenticate', async () => {

--- a/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.in.spec.ts
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import crypto from 'crypto';
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 
 const Client = require('../client')();
 const encrypt = require('fxa-shared/auth/encrypt');
@@ -62,7 +65,12 @@ describe.each(testVersions)(
     beforeEach(async () => {
       email = server.uniqueEmail();
       password = 'test password';
-      client = await Client.create(server.publicUrl, email, password, testOptions);
+      client = await Client.create(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
     });
 
     it('device registration with unknown refresh token', async () => {
@@ -76,7 +84,10 @@ describe.each(testVersions)(
       };
 
       try {
-        await client.updateDeviceWithRefreshToken(UNKNOWN_REFRESH_TOKEN, deviceInfo);
+        await client.updateDeviceWithRefreshToken(
+          UNKNOWN_REFRESH_TOKEN,
+          deviceInfo
+        );
         throw new Error('should have failed');
       } catch (err: any) {
         expect(err.code).toBe(401);
@@ -106,7 +117,11 @@ describe.each(testVersions)(
 
     it('deviceCommandsWithRefreshToken fails with unknown refresh token', async () => {
       try {
-        await client.deviceCommandsWithRefreshToken(UNKNOWN_REFRESH_TOKEN, 0, 50);
+        await client.deviceCommandsWithRefreshToken(
+          UNKNOWN_REFRESH_TOKEN,
+          0,
+          50
+        );
         throw new Error('should have failed');
       } catch (err: any) {
         expect(err.code).toBe(401);
@@ -117,7 +132,11 @@ describe.each(testVersions)(
     it('devicesInvokeCommandWithRefreshToken fails with unknown refresh token', async () => {
       try {
         await client.devicesInvokeCommandWithRefreshToken(
-          UNKNOWN_REFRESH_TOKEN, 'target', 'command', {}, 5
+          UNKNOWN_REFRESH_TOKEN,
+          'target',
+          'command',
+          {},
+          5
         );
         throw new Error('should have failed');
       } catch (err: any) {
@@ -128,7 +147,10 @@ describe.each(testVersions)(
 
     it('devicesNotifyWithRefreshToken fails with unknown refresh token', async () => {
       try {
-        await client.devicesNotifyWithRefreshToken(UNKNOWN_REFRESH_TOKEN, '123');
+        await client.devicesNotifyWithRefreshToken(
+          UNKNOWN_REFRESH_TOKEN,
+          '123'
+        );
         throw new Error('should have failed');
       } catch (err: any) {
         expect(err.code).toBe(401);
@@ -157,7 +179,10 @@ describe.each(testVersions)(
       let devices = await client.devicesWithRefreshToken(refreshToken);
       expect(devices.length).toBe(0);
 
-      const device = await client.updateDeviceWithRefreshToken(refreshToken, deviceInfo);
+      const device = await client.updateDeviceWithRefreshToken(
+        refreshToken,
+        deviceInfo
+      );
       expect(device.id).toBeTruthy();
       expect(device.createdAt).toBeGreaterThan(0);
       expect(device.name).toBe(deviceInfo.name);
@@ -172,11 +197,42 @@ describe.each(testVersions)(
       expect(devices.length).toBe(1);
       expect(devices[0].name).toBe(deviceInfo.name);
       expect(devices[0].type).toBe(deviceInfo.type);
-      expect(devices[0].availableCommands).toEqual(deviceInfo.availableCommands);
+      expect(devices[0].availableCommands).toEqual(
+        deviceInfo.availableCommands
+      );
       expect(devices[0].pushCallback).toBe(deviceInfo.pushCallback);
       expect(devices[0].pushPublicKey).toBe(deviceInfo.pushPublicKey);
       expect(devices[0].pushAuthKey).toBe(deviceInfo.pushAuthKey);
       expect(devices[0].pushEndpointExpired).toBeFalsy();
+
+      await client.destroyDeviceWithRefreshToken(refreshToken, devices[0].id);
+    });
+
+    it('device registration succeeds without the oldsync scope', async () => {
+      const refresh = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile',
+      });
+      refreshToken = refresh.token.toString('hex');
+
+      const deviceInfo = {
+        name: 'firefox sign-in without sync',
+        type: 'desktop',
+      };
+
+      const device = await client.updateDeviceWithRefreshToken(
+        refreshToken,
+        deviceInfo
+      );
+      expect(device.id).toBeTruthy();
+      expect(device.name).toBe(deviceInfo.name);
+      expect(device.type).toBe(deviceInfo.type);
+
+      const devices = await client.devicesWithRefreshToken(refreshToken);
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(deviceInfo.name);
 
       await client.destroyDeviceWithRefreshToken(refreshToken, devices[0].id);
     });
@@ -198,7 +254,10 @@ describe.each(testVersions)(
       let devices = await client.devicesWithRefreshToken(refreshToken);
       expect(devices.length).toBe(0);
 
-      const device = await client.updateDeviceWithRefreshToken(refreshToken, deviceInfo);
+      const device = await client.updateDeviceWithRefreshToken(
+        refreshToken,
+        deviceInfo
+      );
       expect(device.id).toBeTruthy();
       expect(device.createdAt).toBeGreaterThan(0);
       expect(device.name).toBe(deviceInfo.name);
@@ -218,12 +277,16 @@ describe.each(testVersions)(
       expect(devices[0].pushAuthKey == null).toBe(true);
       expect(devices[0].pushEndpointExpired).toBe(false);
 
-      const tokenObj = await oauthServerDb.getRefreshToken(encrypt.hash(refreshToken));
+      const tokenObj = await oauthServerDb.getRefreshToken(
+        encrypt.hash(refreshToken)
+      );
       expect(tokenObj).toBeTruthy();
 
       await client.destroyDeviceWithRefreshToken(refreshToken, deviceId);
 
-      const tokenObjAfter = await oauthServerDb.getRefreshToken(encrypt.hash(refreshToken));
+      const tokenObjAfter = await oauthServerDb.getRefreshToken(
+        encrypt.hash(refreshToken)
+      );
       expect(tokenObjAfter).toBeFalsy();
     });
 
@@ -247,7 +310,10 @@ describe.each(testVersions)(
       let devices = await client.devicesWithRefreshToken(refreshToken);
       expect(devices.length).toBe(0);
 
-      const device = await client.updateDeviceWithRefreshToken(refreshToken, {});
+      const device = await client.updateDeviceWithRefreshToken(
+        refreshToken,
+        {}
+      );
       expect(device.id).toBeTruthy();
       expect(device.createdAt).toBeGreaterThan(0);
       expect(device.name).toBe(OAUTH_CLIENT_NAME);
@@ -299,7 +365,9 @@ describe.each(testVersions)(
         name: 'second device',
       });
 
-      const devices = await client.devicesWithRefreshToken(rt1.token.toString('hex'));
+      const devices = await client.devicesWithRefreshToken(
+        rt1.token.toString('hex')
+      );
       expect(devices.length).toBe(2);
 
       if (devices[0].name === 'first device') {
@@ -317,7 +385,11 @@ describe.each(testVersions)(
       expect(devices[1].name).toBe('first device');
     });
 
-    it('does not allow non-public clients', async () => {
+    it('does not allow non-allowlisted clients', async () => {
+      // After FXA-13704 the refresh-token scheme rejects any client_id not in
+      // the deviceManagementClientIds allowlist before reaching the
+      // publicClient check, so this also covers the prior "non-public client"
+      // case using NON_PUBLIC_CLIENT_ID (not in the allowlist either).
       const refresh = await oauthServerDb.generateRefreshToken({
         clientId: buf(NON_PUBLIC_CLIENT_ID),
         userId: buf(client.uid),
@@ -327,11 +399,13 @@ describe.each(testVersions)(
       refreshToken = refresh.token.toString('hex');
 
       try {
-        await client.updateDeviceWithRefreshToken(refreshToken, { type: 'mobile' });
+        await client.updateDeviceWithRefreshToken(refreshToken, {
+          type: 'mobile',
+        });
         throw new Error('must fail');
       } catch (err: any) {
-        expect(err.message).toBe('Not a public client');
-        expect(err.errno).toBe(166);
+        expect(err.code).toBe(401);
+        expect(err.errno).toBe(110);
       }
     });
 
@@ -357,7 +431,9 @@ describe.each(testVersions)(
         await db.createDevice(client.uid, conflictingDeviceInfo);
         throw new Error('must fail');
       } catch (err: any) {
-        expect(err.message).toBe('Session already registered by another device');
+        expect(err.message).toBe(
+          'Session already registered by another device'
+        );
       }
     });
   }


### PR DESCRIPTION
Because:
* Currently, the only OAuth scope allowed to register/manage a device via refresh token is the Sync scope and other scopes are explicitly rejected by the refreshToken auth scheme's scope allowlist. When Firefox logins occur without Sync but with a refresh token, we still want the device registered.

This commit:
* Changes the gate for device management from a refresh token with the Sync scope, to a refresh token tied to a Firefox client ID

closes FXA-13704
