### PR TITLE
test(functional): add passkey signin + AMO AAL2 functional coverage

### DIFF
--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -88,6 +88,10 @@ function setupOAuthFlow(req, action, options = {}, cb) {
       req.session.state = params.state;
       oauthFlows[params.state] = { params: params, config: config };
 
+      // Clear stale profile-AAL2 enforcement so an abandoned flow can't leak.
+      req.session.profileAal2Required = null;
+      req.session.profileAal2Bounced = null;
+
       return cb(
         null,
         {
@@ -160,6 +164,29 @@ module.exports = function (app, db) {
         return res.redirect(redirectUrl(params, oauthConfig));
       }
     );
+  });
+
+  // AMO-style enforcement: session AAL2 plus a post-grant
+  // profile.twoFactorAuthentication check. Passkey-only accounts satisfy
+  // session AAL2 but not profile AAL2, so the RP bounces back unless the
+  // FxA-side divert to /inline_totp_setup runs.
+  app.get('/api/profile_aal2', function (req, res) {
+    const wasBounced = !!req.session.profileAal2Bounced;
+    const opts = { acrValues: 'AAL2' };
+    if (wasBounced) {
+      // Skip the cached-session short-circuit so the divert can re-run.
+      opts.prompt = 'login';
+      opts.max_age = 0;
+    }
+    setupOAuthFlow(req, 'email', opts, function (err, params, oauthConfig) {
+      if (err) {
+        return res.send(400, err);
+      }
+      req.session.profileAal2Required = true;
+      // Restore the bounce flag that setupOAuthFlow cleared, to cap at one pass.
+      req.session.profileAal2Bounced = wasBounced;
+      return res.redirect(redirectUrl(params, oauthConfig));
+    });
   });
 
   // begin a force auth flow
@@ -282,8 +309,26 @@ module.exports = function (app, db) {
                     return res.send(r ? r.status : 400, err || body);
                   }
                   var profile = JSON.parse(body);
+                  var accountAal2 = !!profile.twoFactorAuthentication;
+
+                  // Passkey-only account with required profile AAL2: bounce
+                  // once to FxA to force TOTP enrolment. The bounced flag
+                  // caps it at one pass if the FxA divert is broken.
+                  if (
+                    req.session.profileAal2Required &&
+                    !accountAal2 &&
+                    !req.session.profileAal2Bounced
+                  ) {
+                    req.session.profileAal2Bounced = true;
+                    return res.redirect('/api/profile_aal2');
+                  }
+
                   req.session.email = profile.email;
                   req.session.subscriptions = profile.subscriptions;
+                  req.session.account_aal2 = accountAal2;
+                  req.session.profileAal2Required = null;
+                  req.session.profileAal2Bounced = null;
+
                   // ensure the redirect goes to the correct place for either
                   // the redirect or iframe OAuth flows.
                   var referrer = req.get('referrer') || '';

--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -72,6 +72,7 @@ app.get('/api/auth_status', function (req, res) {
       subscriptions: req.session.subscriptions || [],
       amr: req.session.amr || null,
       acr: req.session.acr || '0',
+      account_aal2: req.session.account_aal2 || false,
       keys_jwe: req.session.keys_jwe || null,
     })
   );

--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -40,7 +40,13 @@
         class="btn btn-large btn-info btn-persona two-step-authentication"
         type="submit"
       >
-        Sign In (Require 2FA)
+        Sign In (Require AAL2 Session)
+      </button>
+      <button
+        class="btn btn-large btn-info btn-persona profile-aal2"
+        type="submit"
+      >
+        Sign In (Require Profile AAL2)
       </button>
       <button
         class="btn btn-large btn-info btn-persona third-party"

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -129,6 +129,10 @@ $(document).ready(function () {
     if (loggedInState.acr === 'AAL2') {
       loggedInEmail += ' ' + String.fromCodePoint(0x1f512);
     }
+    // Account-level AAL2 marker, distinct from the session AAL2 lock icon.
+    if (loggedInState.account_aal2) {
+      loggedInEmail += ' ' + String.fromCodePoint(0x1f6e1);
+    }
 
     function updateUI(email) {
       $('ul.loginarea li').css('display', 'none');
@@ -237,6 +241,10 @@ $(document).ready(function () {
 
     $('button.two-step-authentication').click(function (ev) {
       authenticate('two_step_authentication');
+    });
+
+    $('button.profile-aal2').click(function (ev) {
+      authenticate('profile_aal2');
     });
 
     $('button.third-party').click(function (ev) {

--- a/packages/functional-tests/lib/passkeyPolyfill.ts
+++ b/packages/functional-tests/lib/passkeyPolyfill.ts
@@ -44,7 +44,7 @@ const WEBAUTHN_DOM_EXCEPTION_NAMES = [
   'UnknownError',
 ];
 
-type Mode = 'pending' | 'success' | 'cancel';
+type Mode = 'pending' | 'success' | 'cancel' | 'corrupt';
 type Trigger = () => Promise<void>;
 type PostCheck = () => Promise<void>;
 
@@ -173,6 +173,18 @@ export class PasskeyPolyfill {
     }
   }
 
+  /** Return an assertion with a tampered signature so the server rejects it. */
+  async corrupt(trigger: Trigger, postCheck: PostCheck) {
+    const previous = this.mode;
+    this.mode = 'corrupt';
+    try {
+      await trigger();
+      await postCheck();
+    } finally {
+      this.mode = previous;
+    }
+  }
+
   /**
    * Number of credentials the VirtualAuthenticator has minted during the
    * lifetime of this polyfill. Tests use this to assert registration happened
@@ -233,11 +245,18 @@ export class PasskeyPolyfill {
     }
 
     const rpId = options.rpId ?? new URL(origin).hostname;
-    return VirtualAuthenticator.createAssertionResponse(cred, {
+    const assertion = VirtualAuthenticator.createAssertionResponse(cred, {
       challenge: options.challenge,
       origin,
       rpId,
     });
+
+    if (this.mode === 'corrupt') {
+      assertion.response.signature = tamperBase64UrlByte(
+        assertion.response.signature
+      );
+    }
+    return assertion;
   }
 
   private pickCredential(allow?: Array<{ id: string }>) {
@@ -273,6 +292,13 @@ function makeDomExceptionLike(name: string, message: string) {
   const err = new Error(message);
   err.name = name;
   return err;
+}
+
+/** Flip a byte of a base64url-encoded buffer to produce an invalid signature. */
+function tamperBase64UrlByte(b64url: string): string {
+  const buf = Buffer.from(b64url, 'base64url');
+  buf[0] ^= 0xff;
+  return buf.toString('base64url');
 }
 
 /**

--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -247,15 +247,15 @@ export class TestAccountTracker {
 
   /**
    * Creates a passwordless account via API (verifierSetAt: 0, no password).
-   * Used for testing signin to existing passwordless accounts.
-   * Note: The account is created WITHOUT a password to remain passwordless-eligible.
-   * Cleanup will set a password before destroying the account.
-   * @returns Partial credentials with email, uid, and sessionToken
+   * The returned `password` is generated for tests that subsequently drive
+   * the set-password flow, and is also used by cleanup to plant a password
+   * before destroying the account.
    */
   async signUpPasswordless(): Promise<{
     email: string;
     uid: string;
     sessionToken: string;
+    password: string;
   }> {
     const email = this.generateEmail(EmailPrefix.PASSWORDLESS);
     const password = this.generatePassword();
@@ -291,6 +291,7 @@ export class TestAccountTracker {
       email,
       uid: result.uid,
       sessionToken: result.sessionToken,
+      password,
     };
   }
 

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -112,7 +112,22 @@ export class RelierPage extends BaseLayout {
   }
 
   async clickRequire2FA() {
-    await this.page.getByText('Sign In (Require 2FA)').click();
+    await this.page.getByText('Sign In (Require AAL2 Session)').click();
     return this.page.waitForURL(`${this.target.contentServerUrl}/**`);
+  }
+
+  async clickRequireProfileAAL2() {
+    await this.page.getByText('Sign In (Require Profile AAL2)').click();
+    return this.page.waitForURL(`${this.target.contentServerUrl}/**`);
+  }
+
+  async hasAccountAAL2Badge() {
+    const text = await this.page.locator('#loggedin span').innerText();
+    return text.includes(String.fromCodePoint(0x1f6e1));
+  }
+
+  async hasSessionAAL2Badge() {
+    const text = await this.page.locator('#loggedin span').innerText();
+    return text.includes(String.fromCodePoint(0x1f512));
   }
 }

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -9,6 +9,7 @@ import { SettingsLayout } from './layout';
 import { getTotpCode } from '../../lib/totp';
 import { DataTrioComponent } from './components/dataTrio';
 import { Credentials } from '../../lib/targets/base';
+import { InlineTotpSetupPage } from '../inlineTotpSetup';
 
 export type TotpCredentials = {
   secret: string;
@@ -219,5 +220,33 @@ export class TotpPage extends SettingsLayout {
     const secret = await this.setUp2faAppWithManualCode(credentials);
     await this.chooseRecoveryPhoneOption();
     return { secret };
+  }
+
+  // Walks the inline TOTP setup an AAL2-requiring RP triggers after a divert to
+  // /inline_totp_setup: confirm intro, enrol via manual code, then backup codes.
+  // Stores the secret on `credentials` (via setUp2faAppWithManualCode) so the
+  // account tracker can elevate AAL during teardown.
+  //
+  // `recoveryPhoneAvailable` is the auth-server-determined availability
+  // (recoveryPhone.enabled + an allowed region) the caller reads from
+  // authClient.recoveryPhoneAvailable; the recovery-method chooser only renders
+  // when it is true, otherwise the flow goes straight to backup codes.
+  async completeInlineSetupWithBackupCodes(
+    inlineTotpSetup: InlineTotpSetupPage,
+    credentials: Credentials,
+    recoveryPhoneAvailable: boolean
+  ): Promise<string> {
+    await this.page.waitForURL(/inline_totp_setup/);
+    await expect(inlineTotpSetup.introHeading).toBeVisible();
+    await inlineTotpSetup.continueButton.click();
+    const secret = await this.setUp2faAppWithManualCode(credentials);
+    await this.page.waitForURL(/inline_recovery_setup/);
+    if (recoveryPhoneAvailable) {
+      await this.chooseBackupCodesOption();
+    }
+    const recoveryCodes = await this.backupCodesDownloadStep();
+    await this.confirmBackupCodeStep(recoveryCodes[0]);
+    await this.page.getByRole('button', { name: /Continue/ }).click();
+    return secret;
   }
 }

--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -16,6 +16,7 @@ import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SettingsPasskeyAddPage } from '../../pages/settings/passkey';
 import { SigninPage } from '../../pages/signin';
+import { enableTotpOnAccount } from '../../lib/pairing-helpers';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('passkey sign-in', () => {
@@ -69,8 +70,7 @@ test.describe('severity-1 #smoke', () => {
       await clearSession(page);
       await page.goto(target.contentServerUrl);
 
-      // Submit the email on email-first to land on /signin's password form,
-      // then choose passkey from there instead of typing the password.
+      // Land on /signin's password form, then pick passkey instead of typing.
       await signin.fillOutEmailFirstForm(email);
       await expect(signin.passwordFormHeading).toBeVisible();
 
@@ -105,18 +105,316 @@ test.describe('severity-1 #smoke', () => {
           await signin.passkeySigninButton.click();
         },
         async () => {
-          // Banner renders with role="alert" for error type. Match by role
-          // and assert it contains *some* mention of the failed sign-in to
-          // avoid coupling to the exact localized string.
+          // Match by role to avoid coupling to the exact localized string.
           await expect(page.getByRole('alert')).toContainText(
             /Sign-in with passkey failed/i
           );
         }
       );
 
-      // The hook keeps the user on the email-first page after a cancelled
-      // ceremony so they can retry or choose another method.
+      // Cancelled ceremony keeps the user on email-first so they can retry.
       expect(page.url()).toBe(signinUrl);
+    });
+
+    test('signs in via passkey into a non-AAL2 OAuth RP for an account without TOTP', async ({
+      target,
+      pages: { page, relier, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickEmailFirst();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
+      });
+
+      expect(page.url()).not.toContain('/signin_token_code');
+      expect(page.url()).not.toContain('/signin_totp_code');
+      expect(page.url()).not.toContain('/inline_totp_setup');
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    test('skips /signin_totp_code when an OAuth RP without AAL2 signs the user in via passkey on a TOTP account', async ({
+      target,
+      pages: { page, settings, settingsPasskeyAdd, signin, relier },
+      testAccountTracker,
+    }) => {
+      // Passkey session is verified with no verificationMethod, so
+      // handleNavigation must skip /signin_totp_code and grant directly.
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      credentials.secret = await enableTotpOnAccount(
+        target.authClient,
+        credentials.sessionToken
+      );
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickEmailFirst();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
+      });
+
+      expect(page.url()).not.toContain('/signin_totp_code');
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    test('completes sign-in on an AAL2-requiring RP when the passkey account already has TOTP', async ({
+      target,
+      pages: { page, settings, settingsPasskeyAdd, signin, relier },
+      testAccountTracker,
+    }) => {
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      credentials.secret = await enableTotpOnAccount(
+        target.authClient,
+        credentials.sessionToken
+      );
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickRequire2FA();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
+      });
+
+      expect(page.url()).not.toContain('/signin_totp_code');
+      expect(page.url()).not.toContain('/inline_totp_setup');
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    test('forces /inline_totp_setup when an AAL2-requiring RP signs in a passkey user without TOTP', async ({
+      target,
+      pages: {
+        page,
+        inlineTotpSetup,
+        relier,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        totp,
+      },
+      testAccountTracker,
+    }) => {
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickRequire2FA();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/inline_totp_setup/);
+      });
+
+      // Force TOTP enrollment so non-passkey sign-ins also satisfy AMR.
+      const { available: recoveryPhoneAvailable } =
+        await target.authClient.recoveryPhoneAvailable(
+          credentials.sessionToken
+        );
+      await totp.completeInlineSetupWithBackupCodes(
+        inlineTotpSetup,
+        credentials,
+        recoveryPhoneAvailable
+      );
+
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    test('AMO-style profile AAL2: passkey-only user is diverted to TOTP setup before the RP grant', async ({
+      target,
+      pages: {
+        page,
+        inlineTotpSetup,
+        relier,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        totp,
+      },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'requires the local 123done /api/profile_aal2 toggle'
+      );
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickRequireProfileAAL2();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/inline_totp_setup/);
+      });
+
+      const { available: recoveryPhoneAvailable } =
+        await target.authClient.recoveryPhoneAvailable(
+          credentials.sessionToken
+        );
+      await totp.completeInlineSetupWithBackupCodes(
+        inlineTotpSetup,
+        credentials,
+        recoveryPhoneAvailable
+      );
+
+      expect(await relier.isLoggedIn()).toBe(true);
+      // Session AAL2 from the passkey signin; account AAL2 from the
+      // divert-triggered TOTP enrolment. A divert regression would leave
+      // account_aal2 false and trip 123done's bounce loop.
+      expect(await relier.hasSessionAAL2Badge()).toBe(true);
+      expect(await relier.hasAccountAAL2Badge()).toBe(true);
+    });
+
+    test('AMO-style profile AAL2: account already has TOTP completes without the divert', async ({
+      target,
+      pages: { page, relier, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'requires the local 123done /api/profile_aal2 toggle'
+      );
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      credentials.secret = await enableTotpOnAccount(
+        target.authClient,
+        credentials.sessionToken
+      );
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickRequireProfileAAL2();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
+      });
+
+      expect(page.url()).not.toContain('/inline_totp_setup');
+      expect(await relier.isLoggedIn()).toBe(true);
+      expect(await relier.hasSessionAAL2Badge()).toBe(true);
+      expect(await relier.hasAccountAAL2Badge()).toBe(true);
+    });
+
+    test('AMO-style profile AAL2: passwordless account using passkey signin without TOTP is diverted to inline TOTP setup', async ({
+      target,
+      pages: {
+        page,
+        signin,
+        signinPasswordlessCode,
+        settings,
+        settingsPasskeyAdd,
+        totp,
+        inlineTotpSetup,
+        relier,
+      },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'requires the local 123done /api/profile_aal2 toggle'
+      );
+
+      // A passwordless account that signs in with a passkey provides session
+      // AAL2, but an AMO-style RP also requires profile AAL2 (account-level
+      // 2FA). With no TOTP, the user must be diverted to inline TOTP setup
+      // rather than bounced back to the passwordless code screen in a loop.
+
+      // Create a passwordless account and register a passkey on it.
+      const { email, sessionToken } =
+        await testAccountTracker.signUpPasswordless();
+      const account: any = testAccountTracker.accounts.find(
+        (a) => a.email === email
+      );
+      if (!account) {
+        throw new Error(
+          `Account for email ${email} not found in testAccountTracker.accounts`
+        );
+      }
+
+      // Recovery phone availability (auth-server config + region) decides
+      // whether the inline flow shows the recovery-method chooser.
+      const { available: recoveryPhoneAvailable } =
+        await target.authClient.recoveryPhoneAvailable(sessionToken);
+
+      await page.goto(
+        `${target.contentServerUrl}/signin?email=${encodeURIComponent(email)}`
+      );
+      await page.waitForURL(/signin_passwordless_code/);
+      const otp = await target.emailClient.getPasswordlessSigninCode(email);
+      await signinPasswordlessCode.fillOutCodeForm(otp);
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settingsPasskeyAdd.registerNewPasskey(settings, email);
+      await expect(settings.passkey.status).toHaveText('Enabled');
+      await settings.signOut();
+
+      // Sign in to the profile-AAL2 RP using the passkey button on the
+      // passwordless code screen. No TOTP yet, so the divert must fire.
+      await relier.goto();
+      await relier.clickRequireProfileAAL2();
+      await signin.fillOutEmailFirstForm(email);
+      await page.waitForURL(/signin_passwordless_code/);
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/inline_totp_setup/);
+      });
+
+      await totp.completeInlineSetupWithBackupCodes(
+        inlineTotpSetup,
+        account,
+        recoveryPhoneAvailable
+      );
+
+      // Session AAL2 from the passkey; account AAL2 from the divert-triggered
+      // enrolment. A divert regression leaves account_aal2 false and trips
+      // 123done's bounce loop.
+      expect(await relier.isLoggedIn()).toBe(true);
+      expect(await relier.hasSessionAAL2Badge()).toBe(true);
+      expect(await relier.hasAccountAAL2Badge()).toBe(true);
     });
 
     test('shows the "passkey not recognized" banner when the server no longer knows the credential', async ({
@@ -133,10 +431,8 @@ test.describe('severity-1 #smoke', () => {
         testAccountTracker,
       });
 
-      // Delete the passkey server-side; the polyfill keeps the credential in
-      // memory so a sign-in attempt still produces an assertion for the now
-      // unknown credentialId — exactly the divergence PASSKEY_NOT_FOUND covers
-      // (e.g. user deleted from another device, authenticator retained it).
+      // Server-side delete only; the polyfill still produces an assertion
+      // for the now-unknown credentialId, mirroring PASSKEY_NOT_FOUND.
       await settings.deletePasskey(email);
       await expect(settings.passkey.status).toHaveText('Not set');
 
@@ -149,6 +445,87 @@ test.describe('severity-1 #smoke', () => {
           /Passkey not recognized/i
         );
       });
+    });
+
+    test('shows an error banner when the assertion response has an invalid signature', async ({
+      target,
+      pages: { page, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await clearSession(page);
+      await page.goto(target.contentServerUrl);
+
+      await settingsPasskeyAdd.passkeyAuth.corrupt(
+        async () => {
+          await signin.passkeySigninButton.click();
+        },
+        async () => {
+          // Tampered assertion → passkeyAuthenticationFailed → generic banner.
+          await expect(page.getByRole('alert')).toContainText(
+            /Something went wrong/i
+          );
+        }
+      );
+    });
+
+    test('forces /inline_totp_setup when password sign-in on a passkey-only account hits an AAL2 RP', async ({
+      target,
+      pages: { page, relier, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      // Passkey enrolment alone doesn't satisfy AAL2 for a password session,
+      // so an AAL2 RP must still divert to /inline_totp_setup.
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickRequire2FA();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/inline_totp_setup/);
+    });
+
+    test('shows the passkey button on prompt=login re-auth and completes sign-in via passkey', async ({
+      target,
+      pages: { page, relier, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      // prompt=login forces a fresh auth; the passkey button should still
+      // appear so the user can re-authenticate without typing the password.
+      const { email } = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await settings.signOut();
+
+      await page.goto(`${target.relierUrl}/api/prompt_login`);
+      await signin.fillOutEmailFirstForm(email);
+      await expect(signin.passwordFormHeading).toBeVisible();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
+      });
+      expect(await relier.isLoggedIn()).toBe(true);
     });
   });
 });
@@ -185,13 +562,12 @@ async function setUpAccountWithPasskey({
   return credentials;
 }
 
-/**
- * Drops cookies and localStorage so the next visit to the content server is
- * treated as fully signed-out. The page-level passkey polyfill (installed via
- * `page.addInitScript`) survives the clear, so previously minted credentials
- * remain discoverable in the next ceremony.
- */
+// Signs out without clearing the polyfill installed via `addInitScript`,
+// so previously minted credentials stay discoverable.
 async function clearSession(page: Page) {
   await page.context().clearCookies();
-  await page.evaluate(() => localStorage.clear());
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
 }

--- a/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
@@ -2,56 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Browser-driven Sync passkey signin + password-fallback flow: enroll a
-// passkey, simulate a new-device passkey ceremony via auth-client, seed the
-// resulting session, then drive /signin_passkey_fallback from a fresh browser.
+// Sync passkey signin + password-fallback flow, driven through the UI via the
+// Sync OAuth URL (context=oauth_webchannel_v1, service=sync) so the auth-server
+// sets requiresPasswordForSync=true and the SPA routes to
+// /signin_passkey_fallback (the production trigger).
 
-import { Page } from '@playwright/test';
-import { PublicKeyCredentialJSON } from '../../../fxa-auth-client/lib/client';
-import { FirefoxCommand } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
+import { FirefoxCommand } from '../../lib/channels';
 import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
-import {
-  VirtualAuthenticator,
-  VirtualCredential,
-} from '../../../../libs/accounts/passkey/src/lib/virtual-authenticator';
-import { BaseTarget } from '../../lib/targets/base';
-
-async function seedAccountInLocalStorage(
-  page: Page,
-  args: { uid: string; sessionToken: string; email: string }
-) {
-  await page.evaluate(({ uid, sessionToken, email }) => {
-    const account = { uid, sessionToken, email, verified: true };
-    window.localStorage.setItem(
-      '__fxa_storage.accounts',
-      JSON.stringify({ [uid]: account })
-    );
-    window.localStorage.setItem(
-      '__fxa_storage.currentAccountUid',
-      JSON.stringify(uid)
-    );
-  }, args);
-}
-
-async function simulateNewDevicePasskeyAuth(
-  target: BaseTarget,
-  credential: VirtualCredential
-) {
-  const origin = target.contentServerUrl;
-  const rpId = new URL(target.contentServerUrl).hostname;
-  const authStart = await target.authClient.beginPasskeyAuthentication();
-  const assertion = VirtualAuthenticator.createAssertionResponse(credential, {
-    challenge: authStart.challenge,
-    origin,
-    rpId,
-  });
-  return target.authClient.completePasskeyAuthentication(
-    assertion as PublicKeyCredentialJSON,
-    authStart.challenge,
-    { service: 'sync' }
-  );
-}
+import { enableTotpOnAccount } from '../../lib/pairing-helpers';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Sync passkey signin with password fallback', () => {
@@ -59,12 +18,13 @@ test.describe('severity-1 #smoke', () => {
       const config = await configPage.getConfig();
       test.skip(
         !config.featureFlags?.passkeysEnabled ||
-          !config.featureFlags?.passkeyRegistrationEnabled,
+          !config.featureFlags?.passkeyRegistrationEnabled ||
+          !config.featureFlags?.passkeyAuthenticationEnabled,
         'Passkey feature flags are not enabled'
       );
     });
 
-    test('full flow: enable passkey → fallback page submit signs into Sync', async ({
+    test('full flow: passkey sign-in into Sync routes through /signin_passkey_fallback', async ({
       target,
       syncOAuthBrowserPages: {
         page,
@@ -78,6 +38,7 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       const { email, password } = await testAccountTracker.signUpSync();
 
+      // Initial Sync OAuth password sign-in so we can register a passkey.
       await signin.goto('/authorization', syncDesktopOAuthQueryParams);
       await signin.fillOutEmailFirstForm(email);
       await signin.fillOutPasswordForm(password);
@@ -87,42 +48,26 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
       await settings.goto();
-      await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.passkey.status).toHaveText('Not set');
-
-      await settingsPasskeyAdd.initPasskeys(page);
-      await settingsPasskeyAdd.passkeyAuth.success(async () => {
-        await settings.passkey.createButton.click();
-        await settings.confirmMfaGuard(email);
-      });
+      await settingsPasskeyAdd.registerNewPasskey(settings, email);
       await expect(settings.passkey.status).toHaveText('Enabled');
 
-      const [credential] =
-        settingsPasskeyAdd.passkeyAuth.getCredentialObjects();
-      const authFinish = await simulateNewDevicePasskeyAuth(target, credential);
-      expect(authFinish.requiresPasswordForSync).toBe(true);
+      // The polyfill credential survives signOut via page.addInitScript.
+      await settings.signOut();
 
-      // Simulate a fresh device so the fallback page hydrates from the seeded
-      // passkey session, not leftover state from the initial Sync OAuth flow.
-      await page.context().clearCookies();
-      await page.evaluate(() => {
-        localStorage.clear();
-        sessionStorage.clear();
+      // Returning user picks passkey; service=sync routes to the fallback.
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(email);
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/signin_passkey_fallback/);
       });
-      await seedAccountInLocalStorage(page, {
-        uid: authFinish.uid,
-        sessionToken: authFinish.sessionToken,
-        email,
-      });
-
-      await page.goto(
-        `${target.contentServerUrl}/signin_passkey_fallback?${syncDesktopOAuthQueryParams}`
-      );
 
       await expect(page.getByTestId('passkey-fallback-email')).toHaveText(
         email
       );
 
+      // Password gate derives the Sync keys and emits fxaccounts:oauth_login.
       await page.getByTestId('password-input-field').fill(password);
       await page.getByTestId('continue-button').click();
 
@@ -155,37 +100,76 @@ test.describe('severity-1 #smoke', () => {
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
       await settings.goto();
-      await settingsPasskeyAdd.initPasskeys(page);
-      await settingsPasskeyAdd.passkeyAuth.success(async () => {
-        await settings.passkey.createButton.click();
-        await settings.confirmMfaGuard(email);
-      });
+      await settingsPasskeyAdd.registerNewPasskey(settings, email);
       await expect(settings.passkey.status).toHaveText('Enabled');
 
-      const [credential] =
-        settingsPasskeyAdd.passkeyAuth.getCredentialObjects();
-      const authFinish = await simulateNewDevicePasskeyAuth(target, credential);
+      await settings.signOut();
 
-      await page.context().clearCookies();
-      await page.evaluate(() => {
-        localStorage.clear();
-        sessionStorage.clear();
-      });
-      await seedAccountInLocalStorage(page, {
-        uid: authFinish.uid,
-        sessionToken: authFinish.sessionToken,
-        email,
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(email);
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/signin_passkey_fallback/);
       });
 
-      await page.goto(
-        `${target.contentServerUrl}/signin_passkey_fallback?${syncDesktopOAuthQueryParams}`
-      );
       await page
         .getByTestId('password-input-field')
         .fill('definitely-the-wrong-password');
       await page.getByTestId('continue-button').click();
 
       await expect(page.getByText(/password/i).first()).toBeVisible();
+    });
+
+    test('skips /signin_totp_code through the passkey fallback for a TOTP-enrolled Sync account', async ({
+      target,
+      syncOAuthBrowserPages: {
+        page,
+        signin,
+        signinTokenCode,
+        settings,
+        settingsPasskeyAdd,
+        connectAnotherDevice,
+      },
+      testAccountTracker,
+    }) => {
+      // Passkey assertion is AAL2; the fallback only derives the Sync keys.
+      const credentials = await testAccountTracker.signUpSync();
+      const { email, password } = credentials;
+
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(email);
+      await signin.fillOutPasswordForm(password);
+      await page.waitForURL(/signin_token_code/);
+      const tokenCode = await target.emailClient.getVerifyLoginCode(email);
+      await signinTokenCode.fillOutCodeForm(tokenCode);
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+
+      await settings.goto();
+      await settingsPasskeyAdd.registerNewPasskey(settings, email);
+      await expect(settings.passkey.status).toHaveText('Enabled');
+      credentials.secret = await enableTotpOnAccount(
+        target.authClient,
+        credentials.sessionToken
+      );
+
+      await settings.signOut();
+
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(email);
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/signin_passkey_fallback/);
+      });
+
+      await page.getByTestId('password-input-field').fill(password);
+      await page.getByTestId('continue-button').click();
+
+      await signin.checkWebChannelMessageScopes(
+        FirefoxCommand.OAuthLogin,
+        'https://identity.mozilla.com/apps/oldsync'
+      );
+      expect(page.url()).not.toContain('/signin_totp_code');
+      expect(page.url()).not.toContain('/inline_totp_setup');
     });
   });
 });

--- a/packages/functional-tests/tests/passkeyAuth/passkeySetPassword.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkeySetPassword.spec.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Sync needs a password to derive its keys, even when the account has a passkey.
+
+import { expect, test } from '../../lib/fixtures/standard';
+import { FirefoxCommand } from '../../lib/channels';
+import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
+import { enableTotpOnAccount } from '../../lib/pairing-helpers';
+import { getTotpCode } from '../../lib/totp';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+
+test.describe('severity-1 #smoke', () => {
+  test.describe('Sync passkey signin with set-password', () => {
+    test.beforeEach(async ({ pages: { configPage } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        !config.featureFlags?.passkeysEnabled ||
+          !config.featureFlags?.passkeyRegistrationEnabled ||
+          !config.featureFlags?.passkeyAuthenticationEnabled,
+        'Passkey feature flags are not enabled'
+      );
+    });
+
+    test('passwordless+passkey signin into Sync routes through /post_verify/set_password', async ({
+      target,
+      syncOAuthBrowserPages: {
+        page,
+        signin,
+        signinPasswordlessCode,
+        settings,
+        settingsPasskeyAdd,
+      },
+      testAccountTracker,
+    }) => {
+      const { email, password } = await testAccountTracker.signUpPasswordless();
+
+      await page.goto(
+        `${target.contentServerUrl}/signin?email=${encodeURIComponent(email)}`
+      );
+      await page.waitForURL(/signin_passwordless_code/);
+      const otp = await target.emailClient.getPasswordlessSigninCode(email);
+      await signinPasswordlessCode.fillOutCodeForm(otp);
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settingsPasskeyAdd.registerNewPasskey(settings, email);
+      await expect(settings.passkey.status).toHaveText('Enabled');
+
+      await settings.signOut();
+
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(email);
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/post_verify\/set_password/);
+      });
+
+      await expect(
+        page.getByRole('heading', { name: 'Create password to sync' })
+      ).toBeVisible();
+      await page.getByLabel('Password', { exact: true }).fill(password);
+      await page.getByLabel('Repeat password').fill(password);
+      await page.getByRole('button', { name: 'Start syncing' }).click();
+
+      await signin.checkWebChannelMessageScopes(
+        FirefoxCommand.OAuthLogin,
+        'https://identity.mozilla.com/apps/oldsync'
+      );
+    });
+
+    test('passwordless+passkey+TOTP into Sync routes through set_password without re-prompting TOTP', async ({
+      target,
+      syncOAuthBrowserPages: {
+        page,
+        signin,
+        signinPasswordlessCode,
+        signinTotpCode,
+        settings,
+        settingsPasskeyAdd,
+      },
+      testAccountTracker,
+    }) => {
+      // Passkey assertion is AAL2; TOTP must not re-prompt before Sync OAuth.
+      const { email, sessionToken, password } =
+        await testAccountTracker.signUpPasswordless();
+
+      // Enrol TOTP and mirror onto the tracker so cleanup can elevate AAL.
+      const secret = await enableTotpOnAccount(target.authClient, sessionToken);
+      const account = findPasswordlessAccount(testAccountTracker, email);
+      account.secret = secret;
+      account.sessionToken = sessionToken;
+
+      await page.goto(
+        `${target.contentServerUrl}/signin?email=${encodeURIComponent(email)}`
+      );
+      await page.waitForURL(/signin_passwordless_code/);
+      const otp = await target.emailClient.getPasswordlessSigninCode(email);
+      await signinPasswordlessCode.fillOutCodeForm(otp);
+      await page.waitForURL(/signin_totp_code/);
+      const totpCode = await getTotpCode(secret);
+      await signinTotpCode.fillOutCodeForm(totpCode);
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settingsPasskeyAdd.registerNewPasskey(settings, email);
+      await expect(settings.passkey.status).toHaveText('Enabled');
+      await settings.signOut();
+
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(email);
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL(/post_verify\/set_password/);
+      });
+
+      await expect(
+        page.getByRole('heading', { name: 'Create password to sync' })
+      ).toBeVisible();
+      await page.getByLabel('Password', { exact: true }).fill(password);
+      await page.getByLabel('Repeat password').fill(password);
+      await page.getByRole('button', { name: 'Start syncing' }).click();
+
+      await signin.checkWebChannelMessageScopes(
+        FirefoxCommand.OAuthLogin,
+        'https://identity.mozilla.com/apps/oldsync'
+      );
+      expect(page.url()).not.toContain('/signin_totp_code');
+      expect(page.url()).not.toContain('/inline_totp_setup');
+    });
+  });
+});
+
+function findPasswordlessAccount(tracker: TestAccountTracker, email: string) {
+  const account = tracker.accounts.find((a) => a.email === email);
+  if (!account) {
+    throw new Error(
+      `signUpPasswordless did not record an account for ${email}`
+    );
+  }
+  return account;
+}

--- a/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
+++ b/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
@@ -812,6 +812,134 @@ test.describe('severity-1 #smoke', () => {
         }
       });
     });
+
+    test.describe('RP requires 2FA setup', () => {
+      test('passwordless signin to an RP requiring 2FA navigates to inline TOTP setup', async ({
+        target,
+        pages: {
+          page,
+          signin,
+          relier,
+          signinPasswordlessCode,
+          totp,
+          inlineTotpSetup,
+        },
+        testAccountTracker,
+      }) => {
+        // A passwordless account without TOTP signing in to an RP that requires
+        // two-step authentication must be diverted to inline TOTP setup after
+        // the OTP step, not looped back onto the confirmation-code screen.
+
+        const { email, sessionToken } =
+          await testAccountTracker.signUpPasswordless();
+        const account: any = testAccountTracker.accounts.find(
+          (a) => a.email === email
+        );
+        if (!account) {
+          throw new Error(
+            `Account for email ${email} not found in testAccountTracker.accounts`
+          );
+        }
+
+        // Recovery phone availability (auth-server config + region) decides
+        // whether the inline flow shows the recovery-method chooser.
+        const { available: recoveryPhoneAvailable } =
+          await target.authClient.recoveryPhoneAvailable(sessionToken);
+
+        await signin.clearCache();
+
+        // 123done "Sign In (Require AAL2 Session)" forces an AAL2 OAuth flow. Existing
+        // passwordless accounts are always redirected to OTP, so no
+        // force_passwordless flag is needed here.
+        await relier.goto();
+        await relier.clickRequire2FA();
+        await signin.fillOutEmailFirstForm(email);
+
+        // Passwordless OTP step.
+        await page.waitForURL(/signin_passwordless_code/);
+        const code = await target.emailClient.getPasswordlessSigninCode(email);
+        await signinPasswordlessCode.fillOutCodeForm(code);
+
+        // The account has no TOTP yet, so the RP's 2FA requirement must divert
+        // to inline TOTP setup rather than re-rendering the code screen. The
+        // tracker tears down the now-TOTP-enabled passwordless account using the
+        // secret completeInlineSetupWithBackupCodes records on `account`.
+        await totp.completeInlineSetupWithBackupCodes(
+          inlineTotpSetup,
+          account,
+          recoveryPhoneAvailable
+        );
+
+        // Should complete the OAuth flow back to the RP.
+        expect(await relier.isLoggedIn()).toBe(true);
+      });
+
+      test('passwordless signin to an RP requiring an AAL2 session (profile AAL2) diverts to inline TOTP setup', async ({
+        target,
+        pages: {
+          page,
+          signin,
+          relier,
+          signinPasswordlessCode,
+          totp,
+          inlineTotpSetup,
+        },
+        testAccountTracker,
+      }) => {
+        test.skip(
+          target.name !== 'local',
+          'requires the local 123done /api/profile_aal2 toggle'
+        );
+
+        // AMO-style enforcement: the RP requires both an AAL2 session and
+        // profile-level 2FA. A passwordless account without TOTP must be
+        // diverted to inline TOTP setup after the OTP step. Without the divert,
+        // 123done's post-grant profile check bounces the flow back and the user
+        // is stuck looping on the confirmation-code screen.
+
+        const { email, sessionToken } =
+          await testAccountTracker.signUpPasswordless();
+        const account: any = testAccountTracker.accounts.find(
+          (a) => a.email === email
+        );
+        if (!account) {
+          throw new Error(
+            `Account for email ${email} not found in testAccountTracker.accounts`
+          );
+        }
+
+        // Recovery phone availability (auth-server config + region) decides
+        // whether the inline flow shows the recovery-method chooser.
+        const { available: recoveryPhoneAvailable } =
+          await target.authClient.recoveryPhoneAvailable(sessionToken);
+
+        await signin.clearCache();
+
+        await relier.goto();
+        await relier.clickRequireProfileAAL2();
+        await signin.fillOutEmailFirstForm(email);
+
+        await page.waitForURL(/signin_passwordless_code/);
+        const code = await target.emailClient.getPasswordlessSigninCode(email);
+        await signinPasswordlessCode.fillOutCodeForm(code);
+
+        // The divert must route to inline TOTP setup rather than bouncing back.
+        // The tracker tears down the now-TOTP-enabled passwordless account using
+        // the secret completeInlineSetupWithBackupCodes records on `account`.
+        await totp.completeInlineSetupWithBackupCodes(
+          inlineTotpSetup,
+          account,
+          recoveryPhoneAvailable
+        );
+
+        // Both badges must be set: session AAL2 from TOTP verification, account
+        // AAL2 from the divert-triggered enrolment. A divert regression leaves
+        // account_aal2 false and trips 123done's bounce loop.
+        expect(await relier.isLoggedIn()).toBe(true);
+        expect(await relier.hasSessionAAL2Badge()).toBe(true);
+        expect(await relier.hasAccountAAL2Badge()).toBe(true);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
  ## Because

  - The passkey signin work in FXA-13101 lacked Playwright coverage for the OAuth flows it touches, including the AAL2 divert that prevents AMO's profile-based bounce loop
  - 123done's existing "Require 2FA" toggle only exercises the session-level AAL2 check; the AMO-style profile-level AMR check (where availableAuthenticationMethods excludes webauthn) had no test fixture

  ## This pull request

  - Adds passkey signin coverage in `passkey-signin.spec.ts`: email-first sign-in, /signin after submitting an email, error banners, non-AAL2 RPs, AAL2 RPs (with and without TOTP), and the `passkeySetPassword.spec.ts` passwordless flow
  - Adds two AMO-style profile-AAL2 tests (gated to the local target): a passkey-only user is diverted to `/inline_totp_setup` before the OAuth grant, and a passkey+TOTP user completes straight to the RP
  - Extends 123done with a `Sign In (Require Profile AAL2)` toggle that mirrors AMO: checks `profile.twoFactorAuthentication` after the grant and bounces back to FxA once if the account lacks TOTP. Surfaces both session-AAL2 (🔒) and account-AAL2 (🛡) on the post-auth page

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13103

  ## Checklist

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **Depends on:** FXA-13101 (PR #20635). The AMO profile-AAL2 tests rely on the FxA-side divert in `packages/fxa-settings/src/pages/Signin/utils.ts`. This PR should land after that one.

  **How to test locally:**
  ```bash
  cd packages/functional-tests
  yarn test-local --grep "passkey sign-in"
  yarn test-local --grep "AMO-style profile AAL2"

  The two AMO tests skip on stage/prod (target.name !== 'local') because the /api/profile_aal2 toggle lives only in local 123done.
  ```