### PR TITLE
fix(passkeys): point "Learn more" links at real SUMO articles

### DIFF
--- a/libs/accounts/email-renderer/src/templates/postAddPasskey/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddPasskey/index.stories.ts
@@ -17,7 +17,8 @@ const baseData = {
   securitySettingsLink: 'http://localhost:3030/settings#security',
   reviewActivitySupportUrl:
     'https://support.mozilla.org/kb/review-mozilla-account-activity-and-protect-data',
-  passkeySupportUrl: 'https://support.mozilla.org',
+  passkeySupportUrl:
+    'https://support.mozilla.org/kb/use-passkey-mozilla-account',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -730,12 +730,11 @@ const conf = convict({
       default:
         'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
     },
-    // TODO: Replace with dedicated passkeys support article URL when available
     passkeySupportUrl: {
       doc: 'url to support article about passkeys and Firefox Sync',
       format: String,
       env: 'PASSKEY_SUPPORT_URL',
-      default: 'https://support.mozilla.org',
+      default: 'https://support.mozilla.org/kb/use-passkey-mozilla-account',
     },
     reviewActivitySupportUrl: {
       doc: 'url to support article about reviewing Mozilla account activity',

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -546,11 +546,10 @@ const convictConf = convict({
       default:
         'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
     },
-    // TODO: Replace with dedicated passkeys support article URL when available
     passkeySupportUrl: {
       doc: 'url to support article about passkeys and Firefox Sync',
       format: String,
-      default: 'https://support.mozilla.org',
+      default: 'https://support.mozilla.org/kb/use-passkey-mozilla-account',
       env: 'PASSKEY_SUPPORT_URL',
     },
     reviewActivitySupportUrl: {

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
@@ -113,7 +113,7 @@ describe('UnitRowPasskey', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Learn more/ })).toHaveAttribute(
       'href',
-      'https://support.mozilla.org/kb/placeholder-article'
+      'https://support.mozilla.org/kb/use-passkey-mozilla-account'
     );
   });
 
@@ -178,7 +178,7 @@ describe('UnitRowPasskey', () => {
       within(container).getByRole('link', { name: /Learn more/ })
     ).toHaveAttribute(
       'href',
-      'https://support.mozilla.org/kb/placeholder-article'
+      'https://support.mozilla.org/kb/troubleshoot-passkey-mozilla-account'
     );
   });
 

--- a/packages/fxa-settings/src/lib/passkeys/constants.ts
+++ b/packages/fxa-settings/src/lib/passkeys/constants.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// TODO: Update with the actual SUMO support article link once published.
 export const PASSKEY_SUPPORT_URL =
-  'https://support.mozilla.org/kb/placeholder-article';
+  'https://support.mozilla.org/kb/use-passkey-mozilla-account';
+
+export const PASSKEY_TROUBLESHOOT_URL =
+  'https://support.mozilla.org/kb/troubleshoot-passkey-mozilla-account';

--- a/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
@@ -5,7 +5,7 @@
 import React, { ReactNode } from 'react';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { PASSKEY_SUPPORT_URL } from './constants';
+import { PASSKEY_TROUBLESHOOT_URL } from './constants';
 
 export const unsupportedPasskeyMessage = (): ReactNode => (
   <>
@@ -13,7 +13,7 @@ export const unsupportedPasskeyMessage = (): ReactNode => (
       <span>Your browser or device doesn’t support passkeys.</span>
     </FtlMsg>{' '}
     <FtlMsg id="passkey-registration-error-not-supported-link">
-      <LinkExternal href={PASSKEY_SUPPORT_URL} className="link-blue">
+      <LinkExternal href={PASSKEY_TROUBLESHOOT_URL} className="link-blue">
         Learn more
       </LinkExternal>
     </FtlMsg>


### PR DESCRIPTION
## Because

- The settings passkey row, the postAddPasskey email, and the "browser/device doesn't support passkeys" error all link to placeholder SUMO URLs (`kb/placeholder-article` in `fxa-settings`, the SUMO root in the email config).
- The dedicated support articles now have final slugs, so the placeholders can be replaced. Per the ticket comment: settings row + emails point at the general article; error messages point at the troubleshooting article.

## This pull request

- Splits `PASSKEY_SUPPORT_URL` in `packages/fxa-settings/src/lib/passkeys/constants.ts` into `PASSKEY_SUPPORT_URL` (general: `/kb/use-passkey-mozilla-account`) and `PASSKEY_TROUBLESHOOT_URL` (`/kb/troubleshoot-passkey-mozilla-account`) so the settings row and the unsupported-error message can point at different articles.
- Switches the unsupported-passkey alert in `packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx` to the troubleshooting URL.
- Updates the `passkeySupportUrl` convict default in `packages/fxa-auth-server/config/index.ts` and `packages/fxa-admin-server/src/config/index.ts` to the general article URL. Env var override (`PASSKEY_SUPPORT_URL`) is unchanged.
- Updates the `UnitRowPasskey` unit-test URL assertions and the `postAddPasskey` Storybook fixture to match the new URLs.
- Drops the now-resolved TODO comments on the constant and both convict defaults.

## Issue that this pull request solves

Closes: FXA-13765

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- The SUMO articles (`use-passkey-mozilla-account` and `troubleshoot-passkey-mozilla-account`) are not yet live; links will 404 until SUMO publishes them. The slugs themselves are final (per [bugzilla 2037218](https://bugzilla.mozilla.org/show_bug.cgi?id=2037218)).
- `PASSKEY_SUPPORT_URL` is not pinned in `webservices-infra`, so the new convict default takes effect on the next auth-server / admin-server deploy with no infra change required.
- Review tier: skipping `/fxa-review-quick` — this is a URL/config update with no logic change, and the `UnitRowPasskey` unit tests cover the new URL assertions.