### PR TITLE
feat(release): add SubPlat tag schema and release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1202,7 +1202,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v\d+\.\d+\.\d+(-rc\d+)?$/
           nx_run: run-many --no-cloud
           requires:
             - Build
@@ -1216,7 +1216,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v\d+\.\d+\.\d+(-rc\d+)?$/
           nx_run: run-many --no-cloud
           requires:
             - Build
@@ -1229,7 +1229,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v\d+\.\d+\.\d+(-rc\d+)?$/
           nx_run: run-many --no-cloud
           requires:
             - Build
@@ -1244,7 +1244,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v\d+\.\d+\.\d+(-rc\d+)?$/
           nx_run: run-many --no-cloud
           requires:
             - Build
@@ -1258,7 +1258,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v\d+\.\d+\.\d+(-rc\d+)?$/
           nx_run: run-many --no-cloud
           requires:
             - Build
@@ -1271,7 +1271,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v\d+\.\d+\.\d+(-rc\d+)?$/
           nx_run: run-many --no-cloud
           requires:
             - Build
@@ -1282,7 +1282,17 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v\d+\.\d+\.\d+(-rc\d+)?$/
+          requires:
+            - Build
+      - playwright-payments-tests:
+          name: Payments Functional Tests - Playwright
+          workflow: test_and_deploy_tag
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^subplat-v\d+\.\d+\.\d+(-rc\d+)?$/
           requires:
             - Build
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: determine
         run: |
-          if [[ ! "${GIT_TAG}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+          if [[ ! "${GIT_TAG}" =~ ^(subplat-)?v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
             echo "Invalid tag: ${GIT_TAG}"
             echo "Invalid tag format: ${GIT_TAG}" >> "$GITHUB_STEP_SUMMARY"
             exit 1

--- a/.github/workflows/tag-release-subplat.yml
+++ b/.github/workflows/tag-release-subplat.yml
@@ -1,0 +1,83 @@
+name: Tag Release SubPlat
+on:
+  workflow_dispatch: {}
+permissions: {}
+jobs:
+  tagrelease:
+    permissions:
+      contents: write # To create a branch and tags
+    runs-on: ubuntu-latest
+    outputs:
+      TAG: ${{ steps.echo.outputs.tag }}
+    steps:
+      - name: Show GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+        shell: bash
+
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Fetch all git tags
+        run: git fetch --tags origin
+
+      - name: Resolve latest FxA train tag
+        run: |
+          set -euo pipefail
+          latest_fxa_tag=$(git tag -l 'v1.*.0' --sort=version:refname | tail -1)
+          if [[ -z "${latest_fxa_tag}" ]]; then
+            echo "ERROR: no v1.*.0 FxA train tag found in this repo." >&2
+            exit 1
+          fi
+          if [[ ! "${latest_fxa_tag}" =~ ^v1\.([0-9]+)\.0$ ]]; then
+            echo "ERROR: latest FxA train tag '${latest_fxa_tag}' did not parse as v1.<TRAIN>.0." >&2
+            exit 1
+          fi
+          train="${BASH_REMATCH[1]}"
+          sha=$(git rev-list -n 1 "${latest_fxa_tag}")
+          {
+            echo "TRAIN=${train}"
+            echo "SUBPLAT_TAG=subplat-v1.${train}.0"
+            echo "SUBPLAT_BRANCH=subplat-train-${train}"
+            echo "SUBPLAT_SHA=${sha}"
+          } >> "$GITHUB_ENV"
+          echo "Resolved ${latest_fxa_tag} (sha ${sha}); preparing subplat-v1.${train}.0 / subplat-train-${train}"
+
+      - name: Pre-flight - SubPlat tag must not already exist
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${SUBPLAT_TAG}" >/dev/null 2>&1; then
+            echo "Refusing to create ${SUBPLAT_TAG} - tag already exists on origin." >&2
+            exit 1
+          fi
+
+      - name: Pre-flight - SubPlat branch must not already exist
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "refs/heads/${SUBPLAT_BRANCH}" >/dev/null 2>&1; then
+            echo "Refusing to create ${SUBPLAT_BRANCH} - branch already exists on origin." >&2
+            exit 1
+          fi
+
+      - name: Add git tag to output
+        id: echo
+        run: |
+          echo "tag=${SUBPLAT_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch
+        run: git checkout -b "${SUBPLAT_BRANCH}" "${SUBPLAT_SHA}"
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "${GITHUB_TRIGGERING_ACTOR}"
+          git config user.email "noreply@github.com"
+
+      - name: Push branch
+        run: |
+          git push origin "${SUBPLAT_BRANCH}"
+
+      - name: Make a new tag
+        run: |
+          git tag -a "${SUBPLAT_TAG}" -m "SubPlat train release ${SUBPLAT_TAG}"
+          git push origin "${SUBPLAT_TAG}"

--- a/_scripts/trigger-docker-push-subplat.sh
+++ b/_scripts/trigger-docker-push-subplat.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+#
+# Trigger the GitHub Actions docker.yml workflow to build and push the
+# fxa-mono image at a given SubPlat git tag.
+#
+# Usage:
+#   ./_scripts/trigger-docker-push-subplat.sh <tag>
+#
+# Examples:
+#   ./_scripts/trigger-docker-push-subplat.sh subplat-v1.338.0
+#   ./_scripts/trigger-docker-push-subplat.sh subplat-v1.338.1
+#
+# Requires the `gh` CLI authenticated (run `gh auth status` to check).
+
+set -euo pipefail
+
+tag="${1:-}"
+
+if [[ -z "${tag}" ]]; then
+  echo "Usage: ${0} <tag>" >&2
+  exit 1
+fi
+
+if [[ ! "${tag}" =~ ^subplat-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+  echo "ERROR: '${tag}' does not match the expected format (subplat-vMAJOR.MINOR.PATCH[-rcN])." >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: the 'gh' CLI is not installed (https://cli.github.com)." >&2
+  exit 1
+fi
+
+repo="mozilla/fxa"
+
+if ! gh api "repos/${repo}/git/refs/tags/${tag}" --silent >/dev/null 2>&1; then
+  echo "ERROR: tag '${tag}' does not exist on github.com/${repo}." >&2
+  exit 1
+fi
+
+gh workflow run docker.yml --repo "${repo}" -f "git_tag=${tag}"
+
+echo "Triggered docker build for tag ${tag}"
+echo "https://github.com/${repo}/actions/workflows/docker.yml"

--- a/_scripts/trigger-dot-release-subplat.sh
+++ b/_scripts/trigger-dot-release-subplat.sh
@@ -1,0 +1,79 @@
+#! /bin/bash
+#
+# Tag a SubPlat patch release on the current subplat-train branch and push it
+# to a remote. Defaults to 'origin'. Pushing the tag is what kicks off the
+# docker.yml build via `yarn trigger:docker-push-subplat <tag>`.
+#
+# Usage:
+#   ./_scripts/trigger-dot-release-subplat.sh <tag>
+#   FXA_REMOTE=<remote> ./_scripts/trigger-dot-release-subplat.sh <tag>
+#
+# Environment variables:
+#   FXA_REMOTE   Git remote to fetch/push against (default: origin).
+#
+# Examples:
+#   ./_scripts/trigger-dot-release-subplat.sh subplat-v1.338.1
+#   ./_scripts/trigger-dot-release-subplat.sh subplat-v1.338.0-rc1
+#   FXA_REMOTE=upstream ./_scripts/trigger-dot-release-subplat.sh subplat-v1.338.1
+#
+# Pre-flight checklist (run yourself before invoking):
+#   - Patch has been merged into the subplat-train branch locally
+#   - You've run the server and tests to verify the patch behaves correctly
+
+set -euo pipefail
+
+tag="${1:-}"
+
+if [[ -z "${tag}" ]]; then
+  echo "Usage: [FXA_REMOTE=<remote>] ${0} <tag>" >&2
+  echo "  FXA_REMOTE  Git remote to fetch/push against (default: origin)." >&2
+  exit 1
+fi
+
+if [[ ! "${tag}" =~ ^subplat-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+  echo "ERROR: '${tag}' does not match the expected format (subplat-vMAJOR.MINOR.PATCH[-rcN])." >&2
+  exit 1
+fi
+
+minor="${BASH_REMATCH[2]}"
+branch="subplat-train-${minor}"
+remote="${FXA_REMOTE:-origin}"
+
+echo "Fetching latest tags from ${remote}..."
+git fetch "${remote}" --tags
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "${current_branch}" != "${branch}" ]]; then
+  echo "ERROR: current branch is '${current_branch}', expected '${branch}'." >&2
+  echo "Switch to ${branch} before tagging: git checkout ${branch}" >&2
+  exit 1
+fi
+
+if git rev-parse "${tag}" >/dev/null 2>&1; then
+  echo "ERROR: tag '${tag}' already exists locally." >&2
+  exit 1
+fi
+
+if git ls-remote --tags --exit-code "${remote}" "refs/tags/${tag}" >/dev/null 2>&1; then
+  echo "ERROR: tag '${tag}' already exists on ${remote}." >&2
+  exit 1
+fi
+
+echo "About to:"
+echo "  1. push ${branch} to ${remote}"
+echo "  2. create tag ${tag} at HEAD ($(git rev-parse --short HEAD))"
+echo "  3. push tag ${tag} to ${remote}"
+echo
+read -p "Proceed? (y/N): " confirm
+if [[ ! "${confirm}" =~ ^[yY]([eE][sS])?$ ]]; then
+  echo "Aborted."
+  exit 1
+fi
+
+git push "${remote}" "${branch}"
+git tag -a "${tag}" -m "SubPlat train release ${tag}"
+git push "${remote}" "${tag}"
+
+echo
+echo "Tagged ${tag}. Kick off the docker build with:"
+echo "  yarn trigger:docker-push-subplat ${tag}"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "prepare": "husky",
     "check:frozen": "ts-node _scripts/check-frozen.ts",
     "trigger:docker-push": "_scripts/trigger-docker-push.sh",
+    "trigger:docker-push-subplat": "_scripts/trigger-docker-push-subplat.sh",
     "trigger:smoke-tests": "_scripts/trigger-smoke-tests.sh",
-    "trigger:dot-release": "_scripts/trigger-dot-release.sh"
+    "trigger:dot-release": "_scripts/trigger-dot-release.sh",
+    "trigger:dot-release-subplat": "_scripts/trigger-dot-release-subplat.sh"
   },
   "homepage": "https://github.com/mozilla/fxa",
   "bugs": {


### PR DESCRIPTION
## Because

- SubPlat-owned services (`payments-next`, `payments-api`) need to deploy on an independent cadence from FxA so the two teams can ship without dragging the rest of the monorepo's pods along on every release. The parent epic (PAY-3556) describes the goal of alternating-week deploys so QA can focus on one service area at a time.
- This is the fxa-repo half of that split: it introduces the SubPlat tag convention and CI routing. The pod-rolling half (which pods actually update for a given tag) lives in PAY-3702 and is blocked on this work landing.

## This pull request

- Adds `.github/workflows/tag-release-subplat.yml`, a manual `workflow_dispatch` workflow that resolves the latest `v1.TRAIN.0` tag, runs two pre-flight existence checks (refusing if `subplat-v1.TRAIN.0` or `subplat-train-TRAIN` already exists on origin with a clear error message), and otherwise creates the `subplat-train-TRAIN` branch and `subplat-v1.TRAIN.0` tag at the same commit as the latest FxA train.
- Expands the tag-validation regex in `.github/workflows/docker.yml` to accept an optional `subplat-` prefix, so the same Docker image-build pipeline serves either tag scheme (one mono image, two tag strings).
- Adds `_scripts/trigger-docker-push-subplat.sh` and `_scripts/trigger-dot-release-subplat.sh`, mirroring their FxA siblings but strict on `subplat-v1.X.Y[-rcN]` format. The dot-release script enforces that the user is on `subplat-train-TRAIN` and refuses to tag if `subplat-v1.X.Y` already exists locally or on the remote.
- Wires both scripts into root `package.json` as `trigger:docker-push-subplat` and `trigger:dot-release-subplat` yarn aliases.
- Tightens 7 FxA test-job tag filters in `.circleci/config.yml` from `/.*/` to `/^v\d+\.\d+\.\d+(-rc\d+)?$/`, so `v1.*` tags only fan out to FxA test jobs. `Init`, `Build`, and `Lint` stay on `/.*/` and run for both tag schemes.
- Adds a `playwright-payments-tests` invocation to the `test_and_deploy_tag` workflow with tag filter `/^subplat-v\d+\.\d+\.\d+(-rc\d+)?$/`, so SubPlat tags run only payments functional tests. The job definition itself was already parameterized; this is just a new invocation.

## Issue that this pull request solves

Closes: PAY-3701

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
  - `.github/workflows/tag-release-subplat.yml` — pre-flight existence checks for the SubPlat tag and branch
  - `.circleci/config.yml` — the seven `tags: only:` filter changes and the new `playwright-payments-tests` job
  - `.github/workflows/docker.yml` — single-line regex change
- Suggested review order:
  1. `.github/workflows/tag-release-subplat.yml` (the new workflow, biggest net-new file)
  2. `.circleci/config.yml` (filter tightening + new job invocation)
  3. `.github/workflows/docker.yml` (regex)
  4. `_scripts/trigger-{docker-push,dot-release}-subplat.sh` (parallel to existing FxA scripts)
  5. `package.json` (two new yarn aliases)
- Risky or complex parts:
  - Tightening the FxA test-job filters from `/.*/` to `/^v\d+\.\d+\.\d+(-rc\d+)?$/` means any ad-hoc tag that doesn't match either the FxA or SubPlat pattern (e.g. a manually-pushed `staging-1`) will no longer trigger CircleCI test jobs. No such ad-hoc tags appear to be in active use, but worth a sanity check with SREs.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This PR alone does **not** change deploy behavior — it only adds the SubPlat tag convention and routes the right CircleCI jobs. The actual pod-rolling split (teaching ArgoCD that `subplat-*` tags should only update `payments-next` / `payments-api` pods) lives in PAY-3702 (`global-platform-admin` + `webservices-infra` changes), which is blocked on this work landing.
