### PR TITLE
feat(settings): show terms and privacy on email OTP screens

### DIFF
--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -50,6 +50,7 @@ export type FormVerifyCodeProps = {
   cmsButton?: CmsButtonType;
   onEngageCb?: () => void;
   onChangeCb?: () => void;
+  className?: string;
 };
 
 type FormData = {
@@ -69,6 +70,7 @@ const FormVerifyCode = ({
   cmsButton,
   onEngageCb,
   onChangeCb,
+  className = 'flex flex-col gap-4 my-6',
 }: FormVerifyCodeProps) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -142,11 +144,7 @@ const FormVerifyCode = ({
   }, [codeValue, formAttributes.pattern]);
 
   return (
-    <form
-      noValidate
-      className="flex flex-col gap-4 my-6"
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <form noValidate {...{ className }} onSubmit={handleSubmit(onSubmit)}>
       {/* Using `type="text" inputmode="numeric"` shows the numeric keyboard on mobile
       and strips out whitespace on desktop, but does not add an incrementer. */}
       <InputText

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.stories.tsx
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import TermsPrivacyAgreement, { LegalTerms } from '.';
+import TermsPrivacyAgreement from '.';
 import AppLayout from '../../components/AppLayout';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { RelierLegalTerms } from '../../models/integrations/relier-interfaces';
 
 export default {
   title: 'Components/TermsPrivacyAgreement',
@@ -13,7 +14,7 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const mockCustomLegalTerms: LegalTerms = {
+const mockCustomLegalTerms: RelierLegalTerms = {
   label: 'Custom Service Label',
   termsOfServiceLink:
     'https://www.mozilla.org/about/legal/terms/subscription-services/',

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.test.tsx
@@ -4,9 +4,10 @@
 
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import TermsPrivacyAgreement, { LegalTerms } from '.';
+import TermsPrivacyAgreement from '.';
+import { RelierLegalTerms } from '../../models/integrations/relier-interfaces';
 
-const mockLegalTerms: LegalTerms = {
+const mockLegalTerms: RelierLegalTerms = {
   label: 'Mozilla Subscription Services',
   termsOfServiceLink:
     'https://www.mozilla.org/about/legal/terms/subscription-services/',
@@ -81,7 +82,7 @@ describe('TermsPrivacyAgreement', () => {
     });
 
     it('renders custom label correctly', () => {
-      const customTerms: LegalTerms = {
+      const customTerms: RelierLegalTerms = {
         label: 'Custom Service Name',
         termsOfServiceLink: 'https://example.com/terms',
         privacyNoticeLink: 'https://example.com/privacy',

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
@@ -5,16 +5,10 @@
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { Link } from '@reach/router';
 import LinkExternal from 'fxa-react/components/LinkExternal';
-
-export interface LegalTerms {
-  label: string;
-  termsOfServiceLink: string;
-  privacyNoticeLink: string;
-  fontSize: 'default' | 'medium' | 'large';
-}
+import { RelierLegalTerms } from '../../models/integrations/relier-interfaces';
 
 export type TermsPrivacyAgreementProps = {
-  legalTerms?: LegalTerms | null;
+  legalTerms?: RelierLegalTerms | null;
 };
 
 const TermsPrivacyAgreement = ({ legalTerms }: TermsPrivacyAgreementProps) => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -208,6 +208,16 @@ describe('SigninPasswordlessCode page', () => {
       screen.getByLabelText('Enter 6-digit code');
       screen.getByRole('button', { name: 'Confirm' });
       screen.getByText('Code expired?');
+
+      expect(
+        screen.getByTestId('terms-privacy-agreement-default')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Terms of Service' })
+      ).toHaveAttribute('href', '/legal/terms');
+      expect(
+        screen.getByRole('link', { name: 'Privacy Notice' })
+      ).toHaveAttribute('href', '/legal/privacy');
     });
 
     it('renders signup flow with correct heading and instructions', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -28,6 +28,7 @@ import { SigninPasswordlessCodeProps } from './interfaces';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import Banner, { ResendCodeSuccessBanner } from '../../../components/Banner';
+import TermsPrivacyAgreement from '../../../components/TermsPrivacyAgreement';
 import { currentAccount } from '../../../lib/cache';
 import {
   setCurrentAccount,
@@ -577,10 +578,26 @@ const SigninPasswordlessCode = ({
               gleanOtp.engage();
             }
           },
+          className: `flex flex-col gap-4 mt-6 ${showPasskeySignin ? 'mb-2' : 'mb-6'}`,
         }}
       />
 
-      <div className="text-grey-500 text-sm inline-flex gap-1">
+      {showPasskeySignin && (
+        <AlternativeAuthOptions
+          showThirdPartyAuth={false}
+          showPasskeySignin={showPasskeySignin}
+          passkeySignIn={{
+            isLoading: passkey.isLoading,
+            onClick: passkey.onClick,
+          }}
+          errorBanner={passkey.errorBanner}
+          {...{ viewName, flowQueryParams }}
+        />
+      )}
+
+      <TermsPrivacyAgreement legalTerms={integration.getLegalTerms()} />
+
+      <div className="mt-6 text-grey-500 text-sm inline-flex gap-1">
         <FtlMsg id="signin-passwordless-code-expired">
           <p>Code expired?</p>
         </FtlMsg>
@@ -612,19 +629,6 @@ const SigninPasswordlessCode = ({
           </FtlMsg>
         )}
       </div>
-
-      {showPasskeySignin && (
-        <AlternativeAuthOptions
-          showThirdPartyAuth={false}
-          showPasskeySignin={showPasskeySignin}
-          passkeySignIn={{
-            isLoading: passkey.isLoading,
-            onClick: passkey.onClick,
-          }}
-          errorBanner={passkey.errorBanner}
-          {...{ viewName, flowQueryParams }}
-        />
-      )}
     </AppLayout>
   );
 };


### PR DESCRIPTION
## Because

- Email OTP entry screens had no Terms of Service or Privacy Notice disclosure before users submitted their code.
- CMS-customized terms from Strapi (VPN, Smart Window, etc.) should be surfaced on these flows alongside the default Mozilla links.

## This pull request

- Renders `TermsPrivacyAgreement` on `SigninPasswordlessCode`, sourcing terms from `integration.getLegalTerms()`.
- Unifies the `TermsPrivacyAgreement` prop type with the existing `RelierLegalTerms` shape so the component contract follows the relier source of truth.
- Updates mocks and tests in the three OTP page suites and the shared component suite to cover the new render path.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13783

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:**
1. Start the FxA stack and open the signup flow at `/signup`.
2. Submit an email, reach `ConfirmSignupCode` — verify the Terms of Service / Privacy Notice links appear below the code form.
3. Trigger the email-token signin flow and reach `SigninTokenCode` — verify the same.
4. Trigger the passwordless flow and reach `SigninPasswordlessCode` — verify the same.
5. With a relier that sets `legalTerms` in CMS (e.g., VPN), confirm the customized two-line variant renders (custom ToS/PN plus Mozilla Accounts ToS/PN).
6. 
<img width="509" height="760" alt="Screenshot 2026-05-26 at 10 21 14 PM" src="https://github.com/user-attachments/assets/e8a0e71e-9f6f-4900-b2af-826ccb4037d8" />
