### PR TITLE
fix(settings): allow pairing when TOTP token is unverified

### DIFF
--- a/packages/fxa-settings/src/pages/Pair/AuthAllow/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthAllow/index.test.tsx
@@ -54,16 +54,27 @@ jest.mock('../../../lib/glean', () => ({
   default: { cadApproveDevice: { view: jest.fn(), submit: jest.fn() } },
 }));
 
-// Mock getBasicAccountData to return null so TOTP check is skipped
+// Default to no session token; tests override via mockGetBasicAccountData.
 jest.mock('../../../lib/account-storage', () => ({
   getBasicAccountData: jest.fn().mockReturnValue(null),
 }));
+const { getBasicAccountData: mockGetBasicAccountData } = jest.requireMock(
+  '../../../lib/account-storage'
+);
 
 const MOCK_EMAIL = MOCK_ACCOUNT.primaryEmail.email;
 
 // Helper to render with AppContext (authClient) and LocationProvider (useLocation)
-function renderWithAppContext(ui: React.ReactElement) {
+function renderWithAppContext(
+  ui: React.ReactElement,
+  authClientOverrides: Partial<{
+    accountProfile: jest.Mock;
+  }> = {}
+) {
   const appCtx = mockAppContext();
+  if (appCtx.authClient) {
+    Object.assign(appCtx.authClient as object, authClientOverrides);
+  }
   const history = createHistory(createMemorySource('/pair/auth/allow'));
   return renderWithLocalizationProvider(
     <AppContext.Provider value={appCtx}>
@@ -198,6 +209,59 @@ describe('Pair/AuthAllow page', () => {
       );
       await waitFor(() => {
         expect(screen.getByText('Firefox on macOS')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('TOTP gate', () => {
+    beforeEach(() => {
+      mockNavigateWithQuery.mockClear();
+      mockGetBasicAccountData.mockReturnValue({
+        sessionToken: 'deadbeef',
+        uid: 'uid-123',
+      });
+    });
+
+    afterEach(() => {
+      mockGetBasicAccountData.mockReturnValue(null);
+    });
+
+    it('does not redirect when "otp" is not in authenticationMethods', async () => {
+      const accountProfile = jest
+        .fn()
+        .mockResolvedValue({ authenticationMethods: ['pwd', 'email'] });
+      renderWithAppContext(
+        <AuthAllow
+          email={MOCK_EMAIL}
+          suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
+        />,
+        { accountProfile }
+      );
+
+      await waitFor(() => {
+        expect(accountProfile).toHaveBeenCalledWith('deadbeef');
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Yes, approve device' })
+        ).toBeInTheDocument();
+      });
+      expect(mockNavigateWithQuery).not.toHaveBeenCalledWith('/pair/auth/totp');
+    });
+
+    it('redirects to /pair/auth/totp when "otp" is an available AMR', async () => {
+      const accountProfile = jest
+        .fn()
+        .mockResolvedValue({ authenticationMethods: ['pwd', 'email', 'otp'] });
+      renderWithAppContext(
+        <AuthAllow
+          email={MOCK_EMAIL}
+          suppDeviceInfo={MOCK_METADATA_UNKNOWN_LOCATION}
+        />,
+        { accountProfile }
+      );
+      await waitFor(() => {
+        expect(mockNavigateWithQuery).toHaveBeenCalledWith('/pair/auth/totp');
       });
     });
   });

--- a/packages/fxa-settings/src/pages/Pair/AuthAllow/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthAllow/index.tsx
@@ -19,6 +19,7 @@ import { firefox } from '../../../lib/channels/firefox';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { getBasicAccountData } from '../../../lib/account-storage';
 import { getPairingErrorMessage } from '../../../lib/utilities';
+import AuthenticationMethods from '../../../constants/authentication-methods';
 
 // pair/auth/allow is the authority approval page.
 // When the user clicks "Yes, approve device", it sends the PAIR_AUTHORIZE
@@ -82,13 +83,15 @@ const AuthAllow = ({
 
     (async () => {
       try {
-        const status = await authClient.checkTotpTokenExists(sessionToken);
-        if (status.exists) {
+        // Mirror Backbone: 'otp' is in AMR only when TOTP is verified AND enabled.
+        const { authenticationMethods } =
+          await authClient.accountProfile(sessionToken);
+        if (authenticationMethods?.includes(AuthenticationMethods.OTP)) {
           navigateWithQuery('/pair/auth/totp');
           return;
         }
       } catch {
-        // If the check fails, allow the user to proceed (non-blocking)
+        // Non-blocking: fall through and render the approval page on profile errors.
       }
       setTotpChecked(true);
     })();


### PR DESCRIPTION
  ## Because

  - The React pair flow (`/pair/auth/allow`) redirected to `/pair/auth/totp` whenever a TOTP row existed, even one left behind from abandoned setup (`verified=false`).
  - Users who started but never finished TOTP setup were locked out of pairing — they had no authenticator to produce a code from, and no way past the prompt.

  ## This pull request

  - Replaces the `/totp/exists` check in `AuthAllow/index.tsx` with `authClient.accountProfile()`, gating the redirect on the `'otp'` AMR.
  - This mirrors the legacy Backbone implementation in `pairing-totp-mixin.js#hasTotpEnabledOnAccount` — the auth-server only adds `'otp'` to `authenticationMethods` when TOTP is both `verified` and `enabled`, so the partial-row state no longer trips the gate.

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13737

  ## Checklist

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**
  1. Sign up a fresh account in fxa-settings.
  2. Start TOTP setup (Settings → Two-step authentication → enable) and abandon before entering the verification code — leaves a `verified=false, enabled=true` row in the `totp` table.
  3. Trigger a desktop pairing flow that lands on `/pair/auth/allow?...`.
  4. **Before this PR:** redirects to `/pair/auth/totp` and the user is stuck (no code available).
  5. **With this PR:** stays on `/pair/auth/allow` and the "Yes, approve device" button is visible. Pairing completes normally.
  6. Re-verify the happy path: complete TOTP setup, then start a pair flow — should still redirect to `/pair/auth/totp` as expected.