### PR TITLE
chore(functional-tests): Fixme on flaky test and fix another flaky

### DIFF
--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -10,11 +10,9 @@ export class SignupPage extends BaseLayout {
   readonly path = 'signup';
 
   get emailFormHeading() {
-    return this.page.getByRole('heading', {
-      // Fluent inserts directional markers around "Mozilla account" so
-      // just look for partial match
-      name: /^Enter your email|^Continue to your/,
-    });
+    // Match by role/level only — the heading text can be overridden by CMS
+    // configuration per relying party, so asserting on copy is fragile.
+    return this.page.getByRole('heading', { level: 1 });
   }
 
   get emailTextbox() {
@@ -80,6 +78,7 @@ export class SignupPage extends BaseLayout {
 
   async fillOutEmailForm(email: string) {
     await expect(this.emailFormHeading).toBeVisible();
+    await expect(this.emailTextbox).toBeVisible();
 
     await this.emailTextbox.fill(email);
     await this.submitButton.click();

--- a/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
+++ b/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
@@ -98,6 +98,10 @@ test.describe('severity-1 #smoke', () => {
         testAccountTracker,
         gleanEventsHelper,
       }) => {
+        test.fixme(
+          true,
+          'FXA-13789: This has been flaky against stage and production, needs investigation'
+        );
         const { email } =
           testAccountTracker.generatePasswordlessAccountDetails();
 


### PR DESCRIPTION
Because:
 - The 'Sync desktop and send-tab' test was having issues having used a cms controlled text as a locator
 - And the 'passwordless code resend' test is also flaky but needs further investigation

This Commit:
 - Fixes the Sync test to use a less strict/flaky locator method
 - Marks the passwordless test as fixme to address later

Closes:

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
