### PR TITLE
fix(ui): Don't render empty div on signin

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
@@ -149,8 +149,8 @@ const SigninAlternativeAuthOptions = ({
 
       <TermsPrivacyAgreement legalTerms={legalTerms} />
 
-      <div className="flex flex-col mt-8 tablet:justify-between tablet:flex-row">
-        {!hideAccountSwitchLink && (
+      {!hideAccountSwitchLink && (
+        <div className="flex flex-col mt-8 tablet:justify-between tablet:flex-row">
           <FtlMsg id="signin-use-a-different-account-link">
             <a
               href="/"
@@ -176,8 +176,8 @@ const SigninAlternativeAuthOptions = ({
               Use a different account
             </a>
           </FtlMsg>
-        )}
-      </div>
+        </div>
+      )}
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
@@ -250,8 +250,8 @@ const SigninCached = ({
 
       <TermsPrivacyAgreement legalTerms={legalTerms} />
 
-      <div className="flex flex-col mt-8 tablet:justify-between tablet:flex-row">
-        {!hideAccountSwitchLink && (
+      {!hideAccountSwitchLink && (
+        <div className="flex flex-col mt-8 tablet:justify-between tablet:flex-row">
           <FtlMsg id="signin-use-a-different-account-link">
             <a
               href="/"
@@ -277,8 +277,8 @@ const SigninCached = ({
               Use a different account
             </a>
           </FtlMsg>
-        )}
-      </div>
+        </div>
+      )}
     </AppLayout>
   );
 };


### PR DESCRIPTION
Because:
* There was extra space at the bottom of cached signin when alternative auth isn't rendered

This commit:
* Moves two conditional renders to be outside of the div so that an empty div does not render
---

I'm going to mark this as closes FXA-13634 - I was looking at what tickets I have assigned to me in Jira and noticed QA had re-opened this ticket. I verified the issue in stage and commented back to QA, but I did notice this extra space rendered at the bottom of these pages due to the empty div. I've confirmed with Laurel that we want the space to be equal on all sides.


before & after

<img width="1107" height="749" alt="image" src="https://github.com/user-attachments/assets/1d59e8a2-34f2-4f36-96d3-d04bf236bc0e" />


<img width="597" height="511" alt="image" src="https://github.com/user-attachments/assets/09464131-ec6c-458a-b60f-75bd9f64a52c" />
