### PR TITLE
fix(payments-next): CartNotCreatedError: Cart not created: Cannot add or update a child row

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/error/en.ftl
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/error/en.ftl
@@ -1,0 +1,5 @@
+## Error page
+
+error-page-account-not-found-heading = Account not found
+error-page-account-not-found-message = The account associated with your session does not exist. Please use a different account or create a new one to subscribe.
+error-page-account-not-found-continue-button = Continue

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/error/page.tsx
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Image from 'next/image';
+import { redirect } from 'next/navigation';
+import errorIcon from '@fxa/shared/assets/images/error.svg';
+import {
+  BaseButton,
+  ButtonVariant,
+  type BaseParams,
+  buildRedirectUrl,
+} from '@fxa/payments/ui';
+import { getApp } from '@fxa/payments/ui/server';
+import { auth, signOut } from 'apps/payments/next/auth';
+
+export default async function ErrorPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<BaseParams>;
+  searchParams: Promise<Record<string, string | string[]>>;
+}) {
+  const { locale, offeringId, interval } = await params;
+  const resolvedSearchParams = await searchParams;
+
+  const newPageSearchParams = { ...resolvedSearchParams };
+  delete newPageSearchParams.reason;
+  const newPageUrl = buildRedirectUrl(
+    offeringId,
+    interval,
+    'new',
+    'checkout',
+    {
+      locale,
+      searchParams: newPageSearchParams,
+    }
+  );
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect(newPageUrl);
+  }
+
+  const reason = Array.isArray(resolvedSearchParams.reason)
+    ? resolvedSearchParams.reason[0]
+    : resolvedSearchParams.reason;
+  if (!reason) {
+    redirect(newPageUrl);
+  }
+
+  const l10n = getApp().getL10n();
+
+  async function signOutAndRedirect() {
+    'use server';
+    await signOut({ redirect: false });
+    redirect(newPageUrl);
+  }
+
+  const getErrorContent = (reason: string) => {
+    switch (reason) {
+      case 'account-not-found':
+      default:
+        return {
+          heading: l10n.getString(
+            'error-page-account-not-found-heading',
+            'Account not found'
+          ),
+          message: l10n.getString(
+            'error-page-account-not-found-message',
+            'The account associated with your session does not exist. Please use a different account or create a new one to subscribe.'
+          ),
+          buttonLabel: l10n.getString(
+            'error-page-account-not-found-continue-button',
+            'Continue'
+          ),
+        };
+    }
+  };
+
+  const { heading, message, buttonLabel } = getErrorContent(reason);
+
+  return (
+    <section
+      className="flex flex-col items-center text-center max-w-lg mx-auto mt-6 p-16 tablet:my-10 gap-16 bg-white shadow tablet:rounded-xl border border-transparent"
+      aria-labelledby="error-page-heading"
+    >
+      <h1 id="error-page-heading" className="text-xl font-bold">
+        {heading}
+      </h1>
+      <Image src={errorIcon} alt="" aria-hidden="true" />
+      <div className="flex flex-col gap-6 items-center leading-6 text-grey-400 max-w-md text-sm">
+        {message}
+        <form action={signOutAndRedirect}>
+          <BaseButton
+            type="submit"
+            variant={ButtonVariant.Primary}
+            className="h-12 text-base"
+            aria-label={buttonLabel}
+          >
+            {buttonLabel}
+          </BaseButton>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -146,6 +146,23 @@ export default async function New({
       error.name === 'RetrieveStripePriceNotFoundError'
     ) {
       notFound();
+    } else if (error.name === 'SetupCartAccountNotFoundError') {
+      const searchParams = { ...resolvedSearchParams };
+      delete searchParams.cartId;
+      delete searchParams.cartVersion;
+      searchParams.reason = 'account-not-found';
+      redirect(
+        buildRedirectUrl(
+          resolvedParams.offeringId,
+          resolvedParams.interval,
+          'error',
+          'checkout',
+          {
+            locale: resolvedParams.locale,
+            searchParams,
+          }
+        )
+      );
     } else {
       throw error;
     }

--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -272,6 +272,13 @@ export class CartAccountNotFoundError extends CartError {
   }
 }
 
+export class SetupCartAccountNotFoundError extends CartError {
+  constructor(uid: string) {
+    super('Cart setup account not found', { uid });
+    this.name = 'SetupCartAccountNotFoundError';
+  }
+}
+
 export class CartUidNotFoundError extends CartError {
   constructor(cartId: string) {
     super('Cart uid not found', {

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -107,6 +107,7 @@ import {
   CartVersionMismatchError,
   CartSetupInvalidPromoCodeError,
   CartRestartInvalidPromoCodeError,
+  SetupCartAccountNotFoundError,
 } from './cart.error';
 import { CurrencyManager } from '@fxa/payments/currency';
 import {
@@ -732,6 +733,7 @@ describe('CartService', () => {
     };
 
     const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+    const mockAccount = AccountFactory();
     const mockAccountCustomer = ResultAccountCustomerFactory({
       stripeCustomerId: mockCustomer.id,
     });
@@ -743,6 +745,9 @@ describe('CartService', () => {
       jest
         .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
         .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(accountManager, 'getAccounts')
+        .mockResolvedValue([mockAccount]);
       jest.spyOn(customerManager, 'retrieve').mockResolvedValue(mockCustomer);
       jest.spyOn(geodbManager, 'getTaxAddress').mockReturnValue(taxAddress);
       jest
@@ -770,7 +775,6 @@ describe('CartService', () => {
         .spyOn(currencyManager, 'getCurrencyForCountry')
         .mockReturnValue(mockResolvedCurrency);
       jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
-      jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
 
       const result = await cartService.setupCart(args);
 
@@ -791,16 +795,12 @@ describe('CartService', () => {
     });
 
     it('throws an error when couponCode is invalid', async () => {
-      const mockAccount = AccountFactory();
       const mockResolvedCurrency = faker.finance.currencyCode().toLowerCase();
 
       jest
         .spyOn(promotionCodeManager, 'assertValidForPriceAndCustomer')
         .mockRejectedValue(undefined);
       jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
-      jest
-        .spyOn(accountManager, 'getAccounts')
-        .mockResolvedValue([mockAccount]);
       jest
         .spyOn(currencyManager, 'getCurrencyForCountry')
         .mockReturnValue(mockResolvedCurrency);
@@ -835,7 +835,6 @@ describe('CartService', () => {
         .spyOn(currencyManager, 'getCurrencyForCountry')
         .mockReturnValue(mockResolvedCurrency);
       jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
-      jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
       jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
         subscriptionEligibilityResult: EligibilityStatus.UPGRADE,
         fromOfferingConfigId: mockFromOfferingId,
@@ -902,7 +901,6 @@ describe('CartService', () => {
       jest
         .spyOn(cartManager, 'createErrorCart')
         .mockResolvedValue(mockErrorCart);
-      jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
       jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue(
         SubscriptionEligibilityResultFactory({
           subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
@@ -945,7 +943,6 @@ describe('CartService', () => {
       jest
         .spyOn(cartManager, 'createErrorCart')
         .mockResolvedValue(mockErrorCart);
-      jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
       jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue(
         SubscriptionEligibilityUpgradeDowngradeResultFactory({
           subscriptionEligibilityResult: EligibilityStatus.DOWNGRADE,
@@ -988,7 +985,6 @@ describe('CartService', () => {
       jest
         .spyOn(cartManager, 'createErrorCart')
         .mockResolvedValue(mockErrorCart);
-      jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
       jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
         subscriptionEligibilityResult: EligibilityStatus.INVALID,
       });
@@ -1029,7 +1025,6 @@ describe('CartService', () => {
       jest
         .spyOn(cartManager, 'createErrorCart')
         .mockResolvedValue(mockErrorCart);
-      jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
       jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
         subscriptionEligibilityResult: EligibilityStatus.SAME,
       });
@@ -1053,6 +1048,54 @@ describe('CartService', () => {
         CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME
       );
       expect(result).toEqual(mockErrorCart);
+    });
+
+    it('throws SetupCartAccountNotFoundError when account does not exist for uid', async () => {
+      const mockResolvedCurrency = faker.finance.currencyCode().toLowerCase();
+
+      jest
+        .spyOn(currencyManager, 'getCurrencyForCountry')
+        .mockReturnValue(mockResolvedCurrency);
+      jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
+      jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
+
+      await expect(cartService.setupCart(args)).rejects.toThrow(
+        SetupCartAccountNotFoundError
+      );
+
+      expect(accountManager.getAccounts).toHaveBeenCalledWith([args.uid]);
+      expect(cartManager.createCart).not.toHaveBeenCalled();
+    });
+
+    it('skips account validation when uid is not provided', async () => {
+      const anonArgs = { ...args, uid: undefined };
+      const mockResolvedCurrency = faker.finance.currencyCode().toLowerCase();
+
+      jest
+        .spyOn(promotionCodeManager, 'assertValidForPriceAndCustomer')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(currencyManager, 'getCurrencyForCountry')
+        .mockReturnValue(mockResolvedCurrency);
+      jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
+
+      const result = await cartService.setupCart(anonArgs);
+
+      expect(accountManager.getAccounts).not.toHaveBeenCalled();
+      expect(cartManager.createCart).toHaveBeenCalledWith({
+        interval: anonArgs.interval,
+        offeringConfigId: anonArgs.offeringConfigId,
+        amount: mockInvoicePreview.subtotal,
+        uid: undefined,
+        stripeCustomerId: undefined,
+        experiment: anonArgs.experiment,
+        taxAddress,
+        currency: mockResolvedCurrency,
+        eligibilityStatus: CartEligibilityStatus.CREATE,
+        couponCode: anonArgs.promoCode,
+        isFreeTrial: false,
+      });
+      expect(result).toEqual(mockResultCart);
     });
   });
 

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -67,6 +67,7 @@ import {
   CartCouldNotRetrievePriceForCurrencyWhenAttemptingToGetCartCartError,
   GetCartSubscriptionIdCartError,
   SetupCartCurrencyNotFoundError,
+  SetupCartAccountNotFoundError,
   UpdateCartCurrencyNotFoundError,
   FinalizeWithoutSubscriptionIdCartError,
   FinalizeWithoutSubscriptionCartError,
@@ -376,6 +377,7 @@ export class CartService {
       CouponErrorCannotRedeem,
       InvalidPromoCodeCartError,
       ProductConfigError,
+      SetupCartAccountNotFoundError,
     ],
   })
   async setupCart(args: {
@@ -394,6 +396,13 @@ export class CartService {
         currency,
         args.taxAddress.countryCode
       );
+    }
+
+    if (args.uid) {
+      const accounts = await this.accountManager.getAccounts([args.uid]);
+      if (accounts.length === 0) {
+        throw new SetupCartAccountNotFoundError(args.uid);
+      }
     }
 
     let accountCustomer;

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -102,6 +102,7 @@ import { GetTaxAddressResult } from './validators/GetTaxAddressResult';
 import {
   CartVersionMismatchError,
   InvalidPromoCodeCartError,
+  SetupCartAccountNotFoundError,
 } from 'libs/payments/cart/src/lib/cart.error';
 import { UpdateCartActionResult } from './validators/UpdateCartActionResult';
 import { ValidateLocationActionResult } from './validators/ValidateLocationActionResult';
@@ -511,6 +512,7 @@ export class NextJSActionsService {
       CouponErrorCannotRedeem,
       InvalidPromoCodeCartError,
       ProductConfigError,
+      SetupCartAccountNotFoundError,
     ],
   })
   @NextIOValidator(SetupCartActionArgs, SetupCartActionResult)

--- a/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
+++ b/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
@@ -23,11 +23,11 @@ export function buildRedirectUrl(
   const baseUrl = optional?.baseUrl ? optional?.baseUrl : '';
 
   const startUrl = baseUrl === '/' ? baseUrl : `${baseUrl}/`;
-  const pageTypeUrl = ['landing', 'new', 'location', 'page-not-found'].includes(
-    page
-  )
-    ? ''
-    : `${pageType}/`;
+  const pageTypeUrl =
+    ['landing', 'new', 'location', 'page-not-found'].includes(page) ||
+    (page === 'error' && !optional?.cartId)
+      ? ''
+      : `${pageType}/`;
   const endUrl = optional?.cartId ? `${optional?.cartId}/${page}` : page;
 
   const searchParamsString = optional?.searchParams


### PR DESCRIPTION
## Because

* If a user deletes their account and then navigates to the /new page from a tab where they were signed in, it throws a CartNotCreatedError and shows the 'something went wrong' page, since it attempts to create a cart row with a uid that no longer exists in the accounts table.

## This pull request

* Adds a SetupCartAccountNotFoundError, thrown from CartService.setupCart when the session uid does not resolve to an existing account.
* /new catches this error and redirects to a new /error page, where the user can sign out and continue with a different account.

## Issue that this pull request solves

Closes #[PAY-3707](https://mozilla-hub.atlassian.net/browse/PAY-3707)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

STRs:
1. Make an account, go to checkout
2. Open another tab, delete account
3. Go back to tab from step 1, navigate to monthly/new 

Screen record from Stage:

https://github.com/user-attachments/assets/219becdb-f208-48f8-9ed4-37ace7946f53

Fix (local):


https://github.com/user-attachments/assets/aace7417-4235-45d6-b942-aaf22b1406bb

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3707]: https://mozilla-hub.atlassian.net/browse/PAY-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ