### PR TITLE
fix(passkeys): validate base64url WebAuthn fields at the route boundary

### DIFF
--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { Schema } from 'joi';
 import { Container } from 'typedi';
 import { PasskeyService } from '@fxa/accounts/passkey';
 import { AppError } from '@fxa/accounts/errors';
@@ -1358,6 +1359,297 @@ describe('passkeys routes', () => {
       await expect(
         handler.createPasskeySessionToken(mockAccount, mockRequest as any)
       ).rejects.toThrow('DB unavailable');
+    });
+  });
+
+  describe('credentialId payload validation', () => {
+    const VALID_CRED_ID = 'A_z-09Aa';
+    const VALID_CHALLENGE = 'A_z-09';
+    const VALID_AUTH_INNER = {
+      clientDataJSON: 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0',
+      authenticatorData: 'SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MFAAAAAQ',
+      signature: 'MEUCIQCx',
+    };
+    const VALID_REG_INNER = {
+      clientDataJSON: 'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0',
+      attestationObject: 'o2NmbXRkbm9uZQ',
+    };
+
+    function getSchema(
+      path: string,
+      method: string,
+      kind: 'payload' | 'params'
+    ): Schema {
+      const all = passkeyRoutes(customs, db, config, statsd, glean, log);
+      const route = all.find(
+        (r: any) => r.path === path && r.method === method
+      );
+      if (!route) {
+        throw new Error(`Route not found: ${method} ${path}`);
+      }
+      return route.options.validate[kind];
+    }
+
+    const authPayload = (
+      responseOverride: Record<string, unknown> = {},
+      innerOverride: Record<string, unknown> = {},
+      challenge: string = VALID_CHALLENGE
+    ) => ({
+      response: {
+        id: VALID_CRED_ID,
+        type: 'public-key',
+        response: { ...VALID_AUTH_INNER, ...innerOverride },
+        ...responseOverride,
+      },
+      challenge,
+    });
+
+    const regPayload = (
+      responseOverride: Record<string, unknown> = {},
+      innerOverride: Record<string, unknown> = {},
+      challenge: string = VALID_CHALLENGE
+    ) => ({
+      response: {
+        id: VALID_CRED_ID,
+        type: 'public-key',
+        response: { ...VALID_REG_INNER, ...innerOverride },
+        ...responseOverride,
+      },
+      challenge,
+    });
+
+    describe('POST /passkey/authentication/finish', () => {
+      let schema: Schema;
+      beforeEach(() => {
+        schema = getSchema('/passkey/authentication/finish', 'POST', 'payload');
+      });
+
+      it('accepts a well-formed assertion payload', () => {
+        const { error } = schema.validate(authPayload());
+        expect(error).toBeUndefined();
+      });
+
+      it.each([
+        [
+          'shell-injection probe shape',
+          '(nslookup x.example.com||curl x.example.com)',
+          'string.pattern.base',
+        ],
+        ['contains slash', 'A/B', 'string.pattern.base'],
+        ['contains plus', 'A+B', 'string.pattern.base'],
+        ['contains equals padding', 'AA==', 'string.pattern.base'],
+        ['empty string', '', 'string.empty'],
+      ])('rejects response.id (%s)', (_label, badId, expectedType) => {
+        const { error } = schema.validate(authPayload({ id: badId }));
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['response', 'id'],
+            type: expectedType,
+          }),
+        ]);
+      });
+
+      it('rejects response.id that exceeds the max length', () => {
+        const { error } = schema.validate(
+          authPayload({ id: 'A'.repeat(1365) })
+        );
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['response', 'id'],
+            type: 'string.max',
+          }),
+        ]);
+      });
+
+      it('rejects a challenge longer than 64 chars', () => {
+        const { error } = schema.validate(authPayload({}, {}, 'A'.repeat(65)));
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['challenge'],
+            type: 'string.max',
+          }),
+        ]);
+      });
+
+      it('rejects a non-base64url challenge', () => {
+        const { error } = schema.validate(authPayload({}, {}, 'has/slash'));
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['challenge'],
+            type: 'string.pattern.base',
+          }),
+        ]);
+      });
+
+      it.each<[string, Record<string, string>]>([
+        ['clientDataJSON', { clientDataJSON: 'has/slash' }],
+        ['authenticatorData', { authenticatorData: 'has/slash' }],
+        ['signature', { signature: 'has/slash' }],
+        ['userHandle', { userHandle: 'has/slash' }],
+      ])(
+        'rejects a non-base64url response.response.%s',
+        (field: string, innerOverride: Record<string, string>) => {
+          const { error } = schema.validate(authPayload({}, innerOverride));
+          expect(error?.details).toEqual([
+            expect.objectContaining({
+              path: ['response', 'response', field],
+              type: 'string.pattern.base',
+            }),
+          ]);
+        }
+      );
+
+      it.each<[string]>([
+        ['clientDataJSON'],
+        ['authenticatorData'],
+        ['signature'],
+      ])(
+        'rejects when required response.response.%s is missing',
+        (field: string) => {
+          const inner: Record<string, string> = { ...VALID_AUTH_INNER };
+          delete inner[field];
+          const { error } = schema.validate({
+            response: {
+              id: VALID_CRED_ID,
+              type: 'public-key',
+              response: inner,
+            },
+            challenge: VALID_CHALLENGE,
+          });
+          expect(error?.details).toEqual([
+            expect.objectContaining({
+              path: ['response', 'response', field],
+              type: 'any.required',
+            }),
+          ]);
+        }
+      );
+    });
+
+    describe('POST /passkey/registration/finish', () => {
+      let schema: Schema;
+      beforeEach(() => {
+        schema = getSchema('/passkey/registration/finish', 'POST', 'payload');
+      });
+
+      it('accepts a well-formed attestation payload', () => {
+        const { error } = schema.validate(regPayload());
+        expect(error).toBeUndefined();
+      });
+
+      it('rejects a non-base64url response.id', () => {
+        const { error } = schema.validate(regPayload({ id: 'has/slash' }));
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['response', 'id'],
+            type: 'string.pattern.base',
+          }),
+        ]);
+      });
+
+      it('rejects a challenge longer than 64 chars', () => {
+        const { error } = schema.validate(regPayload({}, {}, 'A'.repeat(65)));
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['challenge'],
+            type: 'string.max',
+          }),
+        ]);
+      });
+
+      it('rejects a non-base64url challenge', () => {
+        const { error } = schema.validate(regPayload({}, {}, 'has/slash'));
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['challenge'],
+            type: 'string.pattern.base',
+          }),
+        ]);
+      });
+
+      it.each<[string, Record<string, string>]>([
+        ['clientDataJSON', { clientDataJSON: 'has/slash' }],
+        ['attestationObject', { attestationObject: 'has/slash' }],
+        ['authenticatorData', { authenticatorData: 'has/slash' }],
+        ['publicKey', { publicKey: 'has/slash' }],
+      ])(
+        'rejects a non-base64url response.response.%s',
+        (field: string, innerOverride: Record<string, string>) => {
+          const { error } = schema.validate(regPayload({}, innerOverride));
+          expect(error?.details).toEqual([
+            expect.objectContaining({
+              path: ['response', 'response', field],
+              type: 'string.pattern.base',
+            }),
+          ]);
+        }
+      );
+
+      it.each<[string]>([['clientDataJSON'], ['attestationObject']])(
+        'rejects when required response.response.%s is missing',
+        (field: string) => {
+          const inner: Record<string, string> = { ...VALID_REG_INNER };
+          delete inner[field];
+          const { error } = schema.validate({
+            response: {
+              id: VALID_CRED_ID,
+              type: 'public-key',
+              response: inner,
+            },
+            challenge: VALID_CHALLENGE,
+          });
+          expect(error?.details).toEqual([
+            expect.objectContaining({
+              path: ['response', 'response', field],
+              type: 'any.required',
+            }),
+          ]);
+        }
+      );
+    });
+
+    describe('DELETE /passkey/{credentialId}', () => {
+      let schema: Schema;
+      beforeEach(() => {
+        schema = getSchema('/passkey/{credentialId}', 'DELETE', 'params');
+      });
+
+      it('accepts a base64url credentialId', () => {
+        const { error } = schema.validate({ credentialId: VALID_CRED_ID });
+        expect(error).toBeUndefined();
+      });
+
+      it('rejects a non-base64url credentialId', () => {
+        const { error } = schema.validate({ credentialId: 'has/slash' });
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['credentialId'],
+            type: 'string.pattern.base',
+          }),
+        ]);
+      });
+    });
+
+    describe('PATCH /passkey/{credentialId}', () => {
+      let schema: Schema;
+      beforeEach(() => {
+        schema = getSchema('/passkey/{credentialId}', 'PATCH', 'params');
+      });
+
+      it('accepts a base64url credentialId', () => {
+        const { error } = schema.validate({ credentialId: VALID_CRED_ID });
+        expect(error).toBeUndefined();
+      });
+
+      it('rejects a non-base64url credentialId', () => {
+        const { error } = schema.validate({ credentialId: 'has/slash' });
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['credentialId'],
+            type: 'string.pattern.base',
+          }),
+        ]);
+      });
     });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -24,6 +24,17 @@ import { FxaMailer } from '../senders/fxa-mailer';
 import { FxaMailerFormat } from '../senders/fxa-mailer-format';
 import { reportSentryError } from '../sentry';
 
+// Without these, malformed base64url values throw inside SimpleWebAuthn /
+// `base64urlToBuffer` and Hapi surfaces a 500. Route-boundary validation
+// turns probes into 400s and keeps them out of Sentry. CredentialId max
+// matches the WebAuthn L2 ceiling (1023 bytes → 1364 base64url chars),
+// aligning with `passkeys.credentialId VARBINARY(1023)`.
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const base64urlString = (maxLen: number) =>
+  isA.string().max(maxLen).regex(BASE64URL_PATTERN);
+const base64urlCredentialId = () => base64urlString(1364);
+const base64urlChallenge = () => base64urlString(64);
+
 /** Subset of the Customs service used by passkey routes. */
 interface Customs {
   /**
@@ -662,8 +673,24 @@ export const passkeyRoutes = (
         },
         validate: {
           payload: isA.object({
-            response: isA.object().required(),
-            challenge: isA.string().required(),
+            response: isA
+              .object({
+                id: base64urlCredentialId().required(),
+                rawId: base64urlCredentialId().optional(),
+                type: isA.string().valid('public-key').required(),
+                response: isA
+                  .object({
+                    clientDataJSON: base64urlString(2048).required(),
+                    attestationObject: base64urlString(32768).required(),
+                    authenticatorData: base64urlString(16384).optional(),
+                    publicKey: base64urlString(1024).optional(),
+                  })
+                  .unknown(true)
+                  .required(),
+              })
+              .unknown(true)
+              .required(),
+            challenge: base64urlChallenge().required(),
           }),
         },
         response: {
@@ -730,7 +757,7 @@ export const passkeyRoutes = (
         },
         validate: {
           params: isA.object({
-            credentialId: isA.string().required(),
+            credentialId: base64urlCredentialId().required(),
           }),
         },
         response: {
@@ -785,16 +812,22 @@ export const passkeyRoutes = (
           payload: isA.object({
             response: isA
               .object({
-                id: isA.string().required(),
+                id: base64urlCredentialId().required(),
+                rawId: base64urlCredentialId().optional(),
                 type: isA.string().valid('public-key').required(),
+                response: isA
+                  .object({
+                    clientDataJSON: base64urlString(2048).required(),
+                    authenticatorData: base64urlString(16384).required(),
+                    signature: base64urlString(1024).required(),
+                    userHandle: base64urlString(128).optional(),
+                  })
+                  .unknown(true)
+                  .required(),
               })
               .unknown(true)
               .required(),
-            challenge: isA
-              .string()
-              .max(64)
-              .regex(/^[A-Za-z0-9_-]+$/)
-              .required(),
+            challenge: base64urlChallenge().required(),
             service: validators.service.optional(),
           }),
         },
@@ -826,7 +859,7 @@ export const passkeyRoutes = (
         },
         validate: {
           params: isA.object({
-            credentialId: isA.string().required(),
+            credentialId: base64urlCredentialId().required(),
           }),
           payload: isA.object({
             name: isA.string().min(1).max(255).required(),


### PR DESCRIPTION
## Because

- An OAST probe ([Sentry FXA-AUTH-2T4](https://mozilla.sentry.io/issues/7509756722/?project=6231056)) hit `POST /v1/passkey/authentication/finish` with a non-base64url `response.id`. Validation was deferred to `base64urlToBuffer` at the DB boundary, which throws an `Error` and surfaces as a 500 — polluting Sentry with what should be a 400.
- Same shape on three sibling passkey routes (`registration/finish`, DELETE, PATCH); future probes there would reproduce the pattern.

## This pull request

- Adds local Joi factories (`base64urlString(maxLen)`, `base64urlCredentialId()`, `base64urlChallenge()`) in `packages/fxa-auth-server/lib/routes/passkeys.ts`. Credential-ID `.max(1364)` matches the WebAuthn-L2 ceiling and the `passkeys.credentialId VARBINARY(1023)` column.
- Applies them to `response.id`, `rawId`, `challenge`, and the inner `response.response.*` base64url fields (`clientDataJSON`, `attestationObject`, `authenticatorData`, `signature`, `userHandle`, `publicKey`) on `registration/finish` + `authentication/finish`, and to `params.credentialId` on DELETE/PATCH.
- Tightens `challenge` on `registration/finish` to match `authentication/finish`.
- Adds Joi-direct schema tests in `packages/fxa-auth-server/lib/routes/passkeys.spec.ts` covering positive, alphabet/length rejection, and missing-required-field cases. Assertions pin to `error.details[].path` + `error.details[].type` (Joi-version-resilient).

## Issue that this pull request solves

Closes: FXA-13808

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files: `packages/fxa-auth-server/lib/routes/passkeys.ts` — factories at top + four route schemas.
- Suggested order: factories → route schemas → tests.
- Risky bit: strict base64url is narrower than SimpleWebAuthn's lenient internal decoder. Major browsers and `@simplewebauthn/browser` emit spec-strict, and the prior `base64urlToBuffer` already enforced strict on `response.id` with no real-client 500s in Sentry — so empirical risk is very low.

## Screenshots (Optional)

N/A — server-only change.

## Other information (Optional)

- Scope expansion vs ticket: the original "Affected Surface" listed only `response.id` / `challenge` / `params.credentialId`. During `/fxa-review`, the same defense-in-depth was extended to the inner `response.response.*` WebAuthn fields, which SimpleWebAuthn decodes internally and could throw to 500 the same way. Folded into this PR rather than a follow-up.
- Out of scope (deferred): promoting the factories to `lib/routes/validators.js` for cross-route reuse; rate-limit tuning for `passkeyAuthFinish` (separate, lives in `webservices-infra`).