### PR TITLE
feat(admin): expose accountAuthorizations on the admin panel

### DIFF
--- a/packages/functional-tests/tests/admin/adminPanel.spec.ts
+++ b/packages/functional-tests/tests/admin/adminPanel.spec.ts
@@ -5,7 +5,8 @@
 import { expect, test } from '../../lib/fixtures/standard';
 
 const ADMIN_PANEL_URL = process.env.ADMIN_PANEL_URL ?? 'http://localhost:8091';
-const ADMIN_SERVER_URL = process.env.ADMIN_SERVER_URL ?? 'http://localhost:8095';
+const ADMIN_SERVER_URL =
+  process.env.ADMIN_SERVER_URL ?? 'http://localhost:8095';
 
 // Admin panel tests only run locally (stage/prod require SSO)
 test.skip(({ target }) => target.name !== 'local');

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
@@ -100,6 +100,7 @@ let accountResponse: AccountProps = {
   linkedAccounts: [],
   accountEvents: [],
   passkeys: [],
+  accountAuthorizations: [],
 };
 
 it('renders without imploding', () => {
@@ -317,6 +318,41 @@ it('displays the locale', async () => {
   const { getByTestId } = render(<Account {...accountResponse} />);
   expect(getByTestId('account-locale')).toHaveTextContent('en-US');
   expect(getByTestId('edit-account-locale')).toBeInTheDocument();
+});
+
+it('shows "no authorizations" message when authorizations list is empty', () => {
+  const { getByTestId } = render(<Account {...accountResponse} />);
+  expect(getByTestId('account-authorizations-none')).toBeInTheDocument();
+});
+
+it('displays authorized browser services', () => {
+  const withAuthorizations = {
+    ...accountResponse,
+    accountAuthorizations: [
+      {
+        service: 'sync',
+        scope: 'https://identity.mozilla.com/apps/oldsync',
+        clientId: '5882386c6d801776',
+        firstAuthorizedTosAt: 1589467100316,
+        lastAuthorizedTosAt: 1589467100316,
+      },
+      {
+        service: 'relay',
+        scope: 'https://identity.mozilla.com/apps/relay',
+        clientId: '9ebfe2c2f9ea3c58',
+        firstAuthorizedTosAt: 1589467200000,
+        lastAuthorizedTosAt: 1589467200000,
+      },
+    ],
+  };
+  const { getAllByTestId, getByRole } = render(
+    <Account {...withAuthorizations} />
+  );
+
+  expect(
+    getByRole('heading', { name: /authorized browser services/i })
+  ).toBeInTheDocument();
+  expect(getAllByTestId('account-authorization-service')).toHaveLength(2);
 });
 
 it('displays key-stretch-version', async () => {

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -16,6 +16,7 @@ import { AdminPanelFeature } from '@fxa/shared/guards';
 import Guard from '../../Guard';
 import Subscription from '../Subscription';
 import { ConnectedServices } from '../ConnectedServices';
+import { AccountAuthorizations } from '../AccountAuthorizations';
 import { TableRowYHeader, TableYHeaders } from '../../TableYHeaders';
 import { TableRowXHeader, TableXHeaders } from '../../TableXHeaders';
 import EmailBounces from '../EmailBounces';
@@ -94,6 +95,7 @@ export const Account = ({
   backupCodes,
   recoveryPhone,
   passkeys,
+  accountAuthorizations,
 }: AccountProps) => {
   const createdAtDate = getFormattedDate(createdAt);
   const disabledAtDate = getFormattedDate(disabledAt);
@@ -417,6 +419,17 @@ export const Account = ({
         <Guard features={[AdminPanelFeature.ConnectedServices]}>
           <h3 className="header-lg">Connected Services</h3>
           <ConnectedServices services={attachedClients} />
+
+          <h3 className="header-lg">Authorized Browser Services</h3>
+          <p className="mb-2">
+            OAuth consent records, not a record of active usage. A row means the
+            account has authorized the service through a Firefox flow at some
+            point. Note: a Sync row can appear for any browser-service sign-in
+            (Smart Window, Relay, VPN), because Firefox Desktop currently mints
+            a Sync-scoped refresh token on every flow even when the user did not
+            sign in to Sync.
+          </p>
+          <AccountAuthorizations authorizations={accountAuthorizations} />
         </Guard>
 
         <h3 className="header-lg">Account History</h3>

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.test.tsx
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen } from '@testing-library/react';
+import { AccountAuthorization } from 'fxa-admin-server/src/types';
+import { AccountAuthorizations } from '.';
+
+const AUTHORIZATIONS: AccountAuthorization[] = [
+  {
+    service: 'sync',
+    scope: 'https://identity.mozilla.com/apps/oldsync',
+    clientId: '5882386c6d801776',
+    firstAuthorizedTosAt: new Date('2026-01-01T00:00:00Z').getTime(),
+    lastAuthorizedTosAt: new Date('2026-01-15T00:00:00Z').getTime(),
+  },
+  {
+    service: 'relay',
+    scope: 'https://identity.mozilla.com/apps/relay',
+    clientId: '9ebfe2c2f9ea3c58',
+    firstAuthorizedTosAt: new Date('2026-02-01T00:00:00Z').getTime(),
+    lastAuthorizedTosAt: new Date('2026-02-20T00:00:00Z').getTime(),
+  },
+];
+
+it('renders the empty state when there are no authorizations', () => {
+  render(<AccountAuthorizations authorizations={[]} />);
+  expect(screen.getByTestId('account-authorizations-none')).toHaveTextContent(
+    'This account has not authorized any browser services.'
+  );
+});
+
+it('renders the empty state when authorizations is null', () => {
+  render(<AccountAuthorizations authorizations={null} />);
+  expect(screen.getByTestId('account-authorizations-none')).toBeInTheDocument();
+});
+
+it('renders one row per authorization', () => {
+  render(<AccountAuthorizations authorizations={AUTHORIZATIONS} />);
+  const services = screen.getAllByTestId('account-authorization-service');
+  const scopes = screen.getAllByTestId('account-authorization-scope');
+  const clientIds = screen.getAllByTestId('account-authorization-client-id');
+  const firstDates = screen.getAllByTestId(
+    'account-authorization-first-authorized-at'
+  );
+  const lastDates = screen.getAllByTestId(
+    'account-authorization-last-authorized-at'
+  );
+
+  expect(services).toHaveLength(2);
+  expect(scopes).toHaveLength(2);
+  expect(clientIds).toHaveLength(2);
+  expect(firstDates).toHaveLength(2);
+  expect(lastDates).toHaveLength(2);
+
+  expect(services[0]).toHaveTextContent('sync');
+  expect(scopes[0]).toHaveTextContent(
+    'https://identity.mozilla.com/apps/oldsync'
+  );
+  expect(clientIds[0]).toHaveTextContent('5882386c6d801776');
+  expect(services[1]).toHaveTextContent('relay');
+  expect(clientIds[1]).toHaveTextContent('9ebfe2c2f9ea3c58');
+});

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.tsx
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AccountAuthorization } from 'fxa-admin-server/src/types';
+import { TableRowXHeader, TableXHeaders } from '../../TableXHeaders';
+import { getFormattedDate } from '../../../lib/utils';
+
+export const AccountAuthorizations = ({
+  authorizations,
+}: {
+  authorizations?: Nullable<AccountAuthorization[]>;
+}) => {
+  if (!authorizations || authorizations.length === 0) {
+    return (
+      <p data-testid="account-authorizations-none" className="result-none">
+        This account has not authorized any browser services.
+      </p>
+    );
+  }
+
+  return (
+    <TableXHeaders
+      rowHeaders={[
+        'Service',
+        'Scope',
+        'Client ID',
+        'First Authorized',
+        'Last Authorized',
+      ]}
+    >
+      {authorizations.map(
+        ({
+          service,
+          scope,
+          clientId,
+          firstAuthorizedTosAt,
+          lastAuthorizedTosAt,
+        }) => (
+          <TableRowXHeader key={`${service}-${scope}-${clientId}`}>
+            <td data-testid="account-authorization-service">{service}</td>
+            <td data-testid="account-authorization-scope">{scope}</td>
+            <td data-testid="account-authorization-client-id">{clientId}</td>
+            <td data-testid="account-authorization-first-authorized-at">
+              {getFormattedDate(firstAuthorizedTosAt)}
+            </td>
+            <td data-testid="account-authorization-last-authorized-at">
+              {getFormattedDate(lastAuthorizedTosAt)}
+            </td>
+          </TableRowXHeader>
+        )
+      )}
+    </TableXHeaders>
+  );
+};

--- a/packages/fxa-admin-server/src/database/database.service.spec.ts
+++ b/packages/fxa-admin-server/src/database/database.service.spec.ts
@@ -18,6 +18,18 @@ describe('#integration - DatabaseService', () => {
 
   beforeAll(async () => {
     knex = await testDatabaseSetup();
+    // Create inline so a stale fxa-shared:build cache cannot drop the fixture.
+    await knex.raw(
+      'CREATE TABLE IF NOT EXISTS `accountAuthorizations` (' +
+        '`uid` BINARY(16) NOT NULL,' +
+        "`scope` VARCHAR(256) NOT NULL DEFAULT '', " +
+        "`service` VARCHAR(64) NOT NULL DEFAULT '', " +
+        '`clientId` BINARY(8) NOT NULL,' +
+        '`firstAuthorizedTosAt` BIGINT UNSIGNED NOT NULL,' +
+        '`lastAuthorizedTosAt` BIGINT UNSIGNED NOT NULL,' +
+        'PRIMARY KEY (`uid`, `scope`, `service`, `clientId`)' +
+        ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
   });
 
   afterAll(async () => {
@@ -88,5 +100,57 @@ describe('#integration - DatabaseService', () => {
 
   it('should be able to invoke attachedDevices', async () => {
     await service.attachedDevices('AB12');
+  });
+
+  it('returns rows ordered by lastAuthorizedTosAt descending', async () => {
+    const uid = 'aabbccddeeff00112233445566778899';
+    const uidBuffer = Buffer.from(uid, 'hex');
+    const syncClientId = '5882386c6d801776';
+    const relayClientId = '9ebfe2c2f9ea3c58';
+    const now = Date.now();
+    await service.knexOauth('accountAuthorizations').insert([
+      {
+        uid: uidBuffer,
+        scope: 'https://identity.mozilla.com/apps/oldsync',
+        service: 'sync',
+        clientId: Buffer.from(syncClientId, 'hex'),
+        firstAuthorizedTosAt: now - 5000,
+        lastAuthorizedTosAt: now - 1000,
+      },
+      {
+        uid: uidBuffer,
+        scope: 'https://identity.mozilla.com/apps/relay',
+        service: 'relay',
+        clientId: Buffer.from(relayClientId, 'hex'),
+        firstAuthorizedTosAt: now - 2000,
+        lastAuthorizedTosAt: now,
+      },
+    ]);
+
+    const rows = await service.accountAuthorizations(uid);
+
+    expect(rows).toEqual([
+      {
+        scope: 'https://identity.mozilla.com/apps/relay',
+        service: 'relay',
+        clientId: relayClientId,
+        firstAuthorizedTosAt: now - 2000,
+        lastAuthorizedTosAt: now,
+      },
+      {
+        scope: 'https://identity.mozilla.com/apps/oldsync',
+        service: 'sync',
+        clientId: syncClientId,
+        firstAuthorizedTosAt: now - 5000,
+        lastAuthorizedTosAt: now - 1000,
+      },
+    ]);
+  });
+
+  it('returns an empty array when the uid has no authorizations', async () => {
+    const rows = await service.accountAuthorizations(
+      '00000000000000000000000000000001'
+    );
+    expect(rows).toEqual([]);
   });
 });

--- a/packages/fxa-admin-server/src/database/database.service.ts
+++ b/packages/fxa-admin-server/src/database/database.service.ts
@@ -33,6 +33,8 @@ import { MozLoggerService } from '@fxa/shared/mozlog';
 import { StatsD } from 'hot-shots';
 import { Knex, knex } from 'knex';
 import { AppConfig } from '../config';
+import { AccountAuthorization } from '../types';
+import { uuidTransformer } from './transformers';
 
 function typeCasting(field: any, next: any) {
   if (field.type === 'TINY' && field.length === 1) {
@@ -135,6 +137,42 @@ export class DatabaseService implements OnModuleDestroy {
     const cachedSessionTokens =
       await this.connectedServicesDb.cache.getSessionTokens(uid);
     return mergeCachedSessionTokens(dbSessionTokens, cachedSessionTokens, true);
+  }
+
+  public async accountAuthorizations(
+    uid: string
+  ): Promise<AccountAuthorization[]> {
+    const uidBuffer = uuidTransformer.to(uid);
+    const rows = await this.knexOauth('accountAuthorizations')
+      .select(
+        'scope',
+        'service',
+        'clientId',
+        'firstAuthorizedTosAt',
+        'lastAuthorizedTosAt'
+      )
+      .where('uid', uidBuffer)
+      .orderBy([
+        { column: 'lastAuthorizedTosAt', order: 'desc' },
+        { column: 'service', order: 'asc' },
+        { column: 'clientId', order: 'asc' },
+      ])
+      .limit(50);
+    return rows.map(
+      (row: {
+        scope: string;
+        service: string;
+        clientId: Buffer;
+        firstAuthorizedTosAt: number | string;
+        lastAuthorizedTosAt: number | string;
+      }) => ({
+        scope: row.scope,
+        service: row.service,
+        clientId: row.clientId.toString('hex'),
+        firstAuthorizedTosAt: Number(row.firstAuthorizedTosAt),
+        lastAuthorizedTosAt: Number(row.lastAuthorizedTosAt),
+      })
+    );
   }
 
   public async attachedDevices(uid: string) {

--- a/packages/fxa-admin-server/src/rest/account/account.controller.ts
+++ b/packages/fxa-admin-server/src/rest/account/account.controller.ts
@@ -58,6 +58,7 @@ import { BasketService } from '../../newsletters/basket.service';
 import { FidoMdsService } from '../../backend/fido-mds.service';
 import { SubscriptionsService } from '../../subscriptions/subscriptions.service';
 import {
+  AccountAuthorization,
   AccountDeleteResponse,
   AccountDeleteStatus,
   AccountDeleteTaskStatus,
@@ -187,6 +188,7 @@ export class AccountController {
       linkedAccounts,
       attachedClients,
       passkeys,
+      accountAuthorizations,
     ] = await Promise.all([
       this.emails(account),
       this.emailBounces(account),
@@ -201,6 +203,7 @@ export class AccountController {
       this.linkedAccounts(account),
       this.attachedClients(account),
       this.passkeys(account),
+      this.accountAuthorizations(account),
     ]);
 
     return {
@@ -218,6 +221,7 @@ export class AccountController {
       linkedAccounts,
       attachedClients,
       passkeys,
+      accountAuthorizations,
     };
   }
 
@@ -917,6 +921,13 @@ export class AccountController {
         }
       )
     );
+  }
+
+  @Features(AdminPanelFeature.ConnectedServices)
+  public async accountAuthorizations(
+    account: Account
+  ): Promise<AccountAuthorization[]> {
+    return this.db.accountAuthorizations(account.uid);
   }
 
   @Features(AdminPanelFeature.ConnectedServices)

--- a/packages/fxa-admin-server/src/types.ts
+++ b/packages/fxa-admin-server/src/types.ts
@@ -111,6 +111,14 @@ export interface Passkey {
   prfEnabled: boolean;
 }
 
+export interface AccountAuthorization {
+  scope: string;
+  service: string;
+  clientId: string;
+  firstAuthorizedTosAt: number;
+  lastAuthorizedTosAt: number;
+}
+
 export interface LinkedAccount {
   uid?: string;
   authAt?: number;
@@ -209,6 +217,7 @@ export interface Account {
   backupCodes: BackupCodes[];
   recoveryPhone: RecoveryPhone[];
   passkeys: Passkey[];
+  accountAuthorizations: AccountAuthorization[];
 }
 
 export interface RelyingPartyUpdateDto {


### PR DESCRIPTION
## Because

- Admins need visibility into which Firefox browser services (Sync, Smart Window, Relay, VPN) a user has authorized, to answer support questions about consent and connected services.
- An earlier admin-panel exposure of this data was closed when the underlying `accountAuthorizations` table was reverted; that table has since been rebuilt as a consent ledger, so the admin surface needs to be rebuilt against the new shape.

## This pull request

- Adds `DatabaseService.accountAuthorizations(uid)` that reads per-(scope, service, clientId) rows from `fxa_oauth`, hex-encoding `clientId` and coercing `BIGINT` timestamps to numbers. Sort is `lastAuthorizedTosAt desc` with `service` / `clientId` tiebreakers; capped at 50 rows.
- Resolves a new `accountAuthorizations` field on the account REST response in `account.controller.ts`, gated by the existing `ConnectedServices` admin feature.
- Adds an `AccountAuthorizations` React component that renders Service / Scope / Client ID / First Authorized / Last Authorized columns, with an empty state.
- Adds the new "Authorized Browser Services" section to the account detail page (`PageAccountSearch/Account/index.tsx`) with an explanatory note clarifying rows are OAuth consent records, not active usage.
- Extends the `AccountAuthorization` and `Account` interfaces in `fxa-admin-server/src/types.ts`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13668

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:**
1. Run `yarn start infrastructure` then `yarn start mza`.
2. Sign in to an account via fxa-settings and authorize a browser service flow (e.g. Sync, Relay).
3. In the admin panel, search for that account by email or uid.
4. Confirm an **Authorized Browser Services** section appears under Connected Services, with one row per (service, scope, clientId) showing the first and last consent timestamps.
5. For an account with no consents, confirm the "This account has not authorized any browser services" empty state renders.

**Notes:**
- Read-only against `fxa_oauth.accountAuthorizations`. No new migration or write path.
- Gated by `AdminPanelFeature.ConnectedServices` (existing admin feature flag).