### PR TITLE
fix(payments-next): Consolidate Glean free trial checks

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -762,6 +762,9 @@ describe('CartService', () => {
       jest
         .spyOn(checkoutService, 'getFreeTrialEligibility')
         .mockResolvedValue({ offer: null, userEligible: false });
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(null);
     });
 
     it('calls createCart with expected parameters', async () => {
@@ -1096,6 +1099,55 @@ describe('CartService', () => {
         isFreeTrial: false,
       });
       expect(result).toEqual(mockResultCart);
+    });
+
+    it('persists isFreeTrial=true for anonymous cart when product has a free-trial offer', async () => {
+      const mockResolvedCurrency = faker.finance.currencyCode().toLowerCase();
+      const mockOffer = FreeTrialFactory();
+      const anonymousArgs = { ...args, uid: undefined };
+
+      jest
+        .spyOn(promotionCodeManager, 'assertValidForPriceAndCustomer')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(currencyManager, 'getCurrencyForCountry')
+        .mockReturnValue(mockResolvedCurrency);
+      jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(mockOffer);
+
+      await cartService.setupCart(anonymousArgs);
+
+      expect(checkoutService.getProductFreeTrialOffer).toHaveBeenCalledWith({
+        offeringConfigId: anonymousArgs.offeringConfigId,
+        countryCode: taxAddress.countryCode,
+        interval: anonymousArgs.interval,
+      });
+      expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
+      expect(cartManager.createCart).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: undefined, isFreeTrial: true })
+      );
+    });
+
+    it('persists isFreeTrial=false for anonymous cart when product has no free-trial offer', async () => {
+      const mockResolvedCurrency = faker.finance.currencyCode().toLowerCase();
+      const anonymousArgs = { ...args, uid: undefined };
+
+      jest
+        .spyOn(promotionCodeManager, 'assertValidForPriceAndCustomer')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(currencyManager, 'getCurrencyForCountry')
+        .mockReturnValue(mockResolvedCurrency);
+      jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
+
+      await cartService.setupCart(anonymousArgs);
+
+      expect(checkoutService.getProductFreeTrialOffer).toHaveBeenCalled();
+      expect(cartManager.createCart).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: undefined, isFreeTrial: false })
+      );
     });
   });
 
@@ -1521,6 +1573,9 @@ describe('CartService', () => {
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
           .mockResolvedValue({ offer: null, userEligible: false });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(null);
       });
 
       it('calls cartManager.updateFreshCart with no currency change', async () => {
@@ -1642,6 +1697,9 @@ describe('CartService', () => {
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
           .mockResolvedValue({ offer: null, userEligible: false });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(null);
       });
 
       it('success if coupon is valid for new customer', async () => {
@@ -1797,6 +1855,171 @@ describe('CartService', () => {
           mockPrice,
           mockCart.currency,
           mockCustomer
+        );
+      });
+    });
+
+    describe('isFreeTrial recomputation', () => {
+      const mockUid = faker.string.hexadecimal({
+        length: 32,
+        prefix: '',
+        casing: 'lower',
+      });
+      const mockTaxAddress = TaxAddressFactory();
+      const mockOffer = FreeTrialFactory();
+
+      beforeEach(() => {
+        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest
+          .spyOn(productConfigurationManager, 'retrieveStripePrice')
+          .mockResolvedValue(StripePriceFactory());
+        jest
+          .spyOn(promotionCodeManager, 'assertValidForPriceAndCustomer')
+          .mockResolvedValue(undefined);
+      });
+
+      it('preserves isFreeTrial=true on coupon apply for signed-in CREATE cart with an offer', async () => {
+        const mockCart = ResultCartFactory({
+          uid: mockUid,
+          taxAddress: mockTaxAddress,
+          eligibilityStatus: CartEligibilityStatus.CREATE,
+          isFreeTrial: true,
+          stripeCustomerId: undefined,
+          stripeSubscriptionId: undefined,
+        });
+        const mockInput = UpdateCartInputFactory({
+          couponCode: faker.word.noun(),
+        });
+
+        jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+        jest
+          .spyOn(checkoutService, 'getFreeTrialEligibility')
+          .mockResolvedValue({ offer: mockOffer, userEligible: true });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(null);
+
+        await cartService.updateCart(mockCart.id, mockCart.version, mockInput);
+
+        expect(checkoutService.getFreeTrialEligibility).toHaveBeenCalledWith({
+          uid: mockUid,
+          offeringConfigId: mockCart.offeringConfigId,
+          countryCode: mockTaxAddress.countryCode,
+          interval: mockCart.interval,
+          eligibilityStatus: EligibilityStatus.CREATE,
+        });
+        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+          mockCart.id,
+          mockCart.version,
+          expect.objectContaining({ isFreeTrial: true })
+        );
+      });
+
+      it('flips isFreeTrial to false when new country has no free-trial offer', async () => {
+        const newTaxAddress = TaxAddressFactory();
+        const mockCart = ResultCartFactory({
+          uid: mockUid,
+          taxAddress: mockTaxAddress,
+          eligibilityStatus: CartEligibilityStatus.CREATE,
+          isFreeTrial: true,
+          stripeCustomerId: undefined,
+          stripeSubscriptionId: undefined,
+        });
+        const mockInput = UpdateCartInputFactory({
+          taxAddress: newTaxAddress,
+        });
+
+        jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+        jest
+          .spyOn(currencyManager, 'getCurrencyForCountry')
+          .mockReturnValue(mockCart.currency);
+        jest
+          .spyOn(invoiceManager, 'previewUpcoming')
+          .mockResolvedValue(InvoicePreviewFactory());
+        jest
+          .spyOn(checkoutService, 'getFreeTrialEligibility')
+          .mockResolvedValue({ offer: null, userEligible: false });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(null);
+
+        await cartService.updateCart(mockCart.id, mockCart.version, mockInput);
+
+        expect(checkoutService.getFreeTrialEligibility).toHaveBeenCalledWith(
+          expect.objectContaining({ countryCode: newTaxAddress.countryCode })
+        );
+        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+          mockCart.id,
+          mockCart.version,
+          expect.objectContaining({ isFreeTrial: false })
+        );
+      });
+
+      it('preserves isFreeTrial=true for anonymous cart when product still has an offer', async () => {
+        const mockCart = ResultCartFactory({
+          uid: undefined,
+          taxAddress: mockTaxAddress,
+          eligibilityStatus: CartEligibilityStatus.CREATE,
+          isFreeTrial: true,
+          stripeCustomerId: undefined,
+          stripeSubscriptionId: undefined,
+        });
+        const mockInput = UpdateCartInputFactory({
+          couponCode: faker.word.noun(),
+        });
+
+        jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+        jest
+          .spyOn(checkoutService, 'getFreeTrialEligibility')
+          .mockResolvedValue({ offer: null, userEligible: false });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(mockOffer);
+
+        await cartService.updateCart(mockCart.id, mockCart.version, mockInput);
+
+        expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
+        expect(checkoutService.getProductFreeTrialOffer).toHaveBeenCalledWith({
+          offeringConfigId: mockCart.offeringConfigId,
+          countryCode: mockTaxAddress.countryCode,
+          interval: mockCart.interval,
+        });
+        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+          mockCart.id,
+          mockCart.version,
+          expect.objectContaining({ isFreeTrial: true })
+        );
+      });
+
+      it('returns isFreeTrial=false when signed-in cart eligibility is not CREATE', async () => {
+        const mockCart = ResultCartFactory({
+          uid: mockUid,
+          taxAddress: mockTaxAddress,
+          eligibilityStatus: CartEligibilityStatus.UPGRADE,
+          isFreeTrial: false,
+          stripeCustomerId: undefined,
+          stripeSubscriptionId: undefined,
+        });
+        const mockInput = UpdateCartInputFactory({
+          couponCode: faker.word.noun(),
+        });
+
+        jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+        jest
+          .spyOn(checkoutService, 'getFreeTrialEligibility')
+          .mockResolvedValue({ offer: mockOffer, userEligible: true });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(mockOffer);
+
+        await cartService.updateCart(mockCart.id, mockCart.version, mockInput);
+
+        expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
+        expect(checkoutService.getProductFreeTrialOffer).not.toHaveBeenCalled();
+        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+          mockCart.id,
+          mockCart.version,
+          expect.objectContaining({ isFreeTrial: false })
         );
       });
     });

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -368,6 +368,36 @@ export class CartService {
     };
   }
 
+  private async evaluateIsFreeTrial(args: {
+    uid?: string;
+    offeringConfigId: string;
+    countryCode: string;
+    interval: SubplatInterval;
+    cartEligibilityStatus: CartEligibilityStatus;
+  }): Promise<boolean> {
+    if (args.cartEligibilityStatus !== CartEligibilityStatus.CREATE) {
+      return false;
+    }
+
+    if (!args.uid) {
+      return !!(await this.checkoutService.getProductFreeTrialOffer({
+        offeringConfigId: args.offeringConfigId,
+        countryCode: args.countryCode,
+        interval: args.interval,
+      }));
+    } else {
+      const { offer, userEligible } =
+        await this.checkoutService.getFreeTrialEligibility({
+          uid: args.uid,
+          offeringConfigId: args.offeringConfigId,
+          countryCode: args.countryCode,
+          interval: args.interval,
+          eligibilityStatus: EligibilityStatus.CREATE,
+        });
+      return !!offer && !!userEligible;
+    }
+  }
+
   /**
    * Initialize a brand new cart
    * **Note**: This method is currently a placeholder. The arguments will likely change, and the internal implementation is far from complete.
@@ -468,15 +498,13 @@ export class CartService {
       }
     }
 
-    const freeTrialResult = args.uid
-      ? await this.checkoutService.getFreeTrialEligibility({
-          uid: args.uid,
-          offeringConfigId: args.offeringConfigId,
-          countryCode: args.taxAddress.countryCode,
-          interval: args.interval,
-          eligibilityStatus: eligibility.subscriptionEligibilityResult,
-        })
-      : { offer: null, userEligible: false };
+    const isFreeTrial = await this.evaluateIsFreeTrial({
+      uid: args.uid,
+      offeringConfigId: args.offeringConfigId,
+      countryCode: args.taxAddress.countryCode,
+      interval: args.interval,
+      cartEligibilityStatus,
+    });
 
     const createCartParams: SetupCart = {
       interval: args.interval,
@@ -489,7 +517,7 @@ export class CartService {
       currency,
       eligibilityStatus: cartEligibilityStatus,
       couponCode,
-      isFreeTrial: !!freeTrialResult.offer && !!freeTrialResult.userEligible,
+      isFreeTrial,
     };
 
     if (eligibility.subscriptionEligibilityResult === EligibilityStatus.SAME) {
@@ -861,26 +889,16 @@ export class CartService {
           );
         }
 
-        const effectiveUid = cartDetailsInput.uid ?? oldCart.uid;
-        if (
-          effectiveUid &&
-          oldCart.eligibilityStatus === CartEligibilityStatus.CREATE
-        ) {
-          const freeTrialResult =
-            await this.checkoutService.getFreeTrialEligibility({
-              uid: effectiveUid,
-              offeringConfigId: oldCart.offeringConfigId,
-              countryCode:
-                cartDetailsInput.taxAddress?.countryCode ??
-                oldCart.taxAddress?.countryCode ??
-                '',
-              interval: oldCart.interval as SubplatInterval,
-              eligibilityStatus: EligibilityStatus.CREATE,
-            });
-          cartDetails.isFreeTrial = !!freeTrialResult.offer && !!freeTrialResult.userEligible;
-        } else {
-          cartDetails.isFreeTrial = false;
-        }
+        cartDetails.isFreeTrial = await this.evaluateIsFreeTrial({
+          uid: cartDetailsInput.uid ?? oldCart.uid,
+          offeringConfigId: oldCart.offeringConfigId,
+          countryCode:
+            cartDetailsInput.taxAddress?.countryCode ??
+            oldCart.taxAddress?.countryCode ??
+            '',
+          interval: oldCart.interval as SubplatInterval,
+          cartEligibilityStatus: oldCart.eligibilityStatus,
+        });
 
         await this.cartManager.updateFreshCart(cartId, version, cartDetails);
 


### PR DESCRIPTION
Because:

* The carts.isFreeTrial DB column went stale for anonymous carts and was force-flipped to false on coupon/tax changes, so checkoutView and checkoutSuccess emitted is_free_trial='' for real free-trial flows.

This commit:

* Extracts a single CartService.evaluateIsFreeTrial helper and routes setupCart and updateCart through it, persisting the offer-lookup result for anonymous carts and removing the unconditional false override.

Closes #PAY-3757

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
