### PR TITLE
fix(settings): defer AlertBar click-outside arming to next tick

### DIFF
--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.race.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.race.test.tsx
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import AlertBar from '.';
+import { alertContent, alertType, alertVisible } from '../../../models';
+
+// Click-outside-to-close must not fire on the same click that opened the
+// alert. These tests exercise the real reactive vars so we observe the actual
+// DOM-level race that mocks in `index.test.tsx` hide.
+
+const resetAlertVars = () => {
+  alertVisible(false);
+  alertContent('');
+  alertType('success');
+};
+
+const Harness = ({ message }: { message: string }) => (
+  <>
+    <button
+      type="button"
+      data-testid="trigger"
+      onClick={() => {
+        alertType('error');
+        alertContent(message);
+        alertVisible(true);
+      }}
+    >
+      open alert
+    </button>
+    <AlertBar />
+  </>
+);
+
+describe('AlertBar click-outside arming', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetAlertVars();
+    // Make sure nothing from a previous test leaves a #modal element around
+    // that would interfere with the modal-coexistence rule.
+    document.getElementById('modal')?.remove();
+  });
+
+  afterEach(() => {
+    act(() => {
+      resetAlertVars();
+    });
+    jest.useRealTimers();
+  });
+
+  it('survives the click that triggered it (Cancel-button race)', () => {
+    renderWithLocalizationProvider(<Harness message="canceled" />);
+
+    // Same-task: click an external button whose handler opens the alert. The
+    // click then bubbles to <body>. Before the fix this immediately closed
+    // the alert.
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(screen.getByTestId('alert-bar')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('canceled');
+
+    // After the arming delay the listener is attached; the triggering click
+    // must have been ignored, so the alert is still visible.
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.getByTestId('alert-bar')).toBeInTheDocument();
+  });
+
+  it('still closes on a subsequent outside click after the arming delay', () => {
+    renderWithLocalizationProvider(<Harness message="canceled" />);
+    fireEvent.click(screen.getByTestId('trigger'));
+    expect(screen.queryByTestId('alert-bar')).toBeInTheDocument();
+
+    // Advance past the arming setTimeout(0).
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    // A genuinely separate click outside the alert closes it.
+    fireEvent.click(document.body);
+    expect(screen.queryByTestId('alert-bar')).not.toBeInTheDocument();
+  });
+
+  it('does not close when a modal is present', () => {
+    const modal = document.createElement('div');
+    modal.id = 'modal';
+    modal.innerHTML = '<div>open modal content</div>';
+    document.body.appendChild(modal);
+
+    renderWithLocalizationProvider(<Harness message="canceled" />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    fireEvent.click(document.body);
+    expect(screen.queryByTestId('alert-bar')).toBeInTheDocument();
+
+    modal.remove();
+  });
+
+  it('clicking inside the alert does not close it', () => {
+    renderWithLocalizationProvider(<Harness message="canceled" />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    fireEvent.click(screen.getByTestId('alert-bar-inner'));
+    expect(screen.queryByTestId('alert-bar')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
@@ -7,7 +7,6 @@ import { useEscKeydownEffect, useChangeFocusEffect } from '../../../lib/hooks';
 import { ReactComponent as CloseIcon } from '@fxa/shared/assets/images/close.svg';
 import { alertContent, alertType, alertVisible } from '../../../models';
 import { useReactiveVar } from '../../../lib/reactive-var';
-import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import { useLocalization } from '@fluent/react';
 import classNames from 'classnames';
 
@@ -27,18 +26,45 @@ export const AlertBar = () => {
   const visible = useReactiveVar(alertVisible);
   const content = useReactiveVar(alertContent);
   const type = useReactiveVar(alertType);
-  const insideRef = useClickOutsideEffect<HTMLDivElement>(() => {
-    // TODO: cleanup Portal component and references, FXA-2463
-    // We don't want to automatically close the alert bar if a modal
-    // is also open. There's at least one case where a modal could be
-    // opened at the same time as the alert bar, and because the modal
-    // takes precedence, we want to allow the user to see and read the
-    // alert bar instead of closing them at the same time. We have to check
-    // for `innerHTML` because when a modal is closed it is still in the DOM.
-    if (!document.getElementById('modal')?.innerHTML) {
-      alertVisible(false);
-    }
-  });
+  const insideRef = useRef<HTMLDivElement>(null);
+
+  // Arm the click-outside-to-close behaviour one macrotask after `visible`
+  // flips to true. Without the delay, the click event that triggered
+  // alertBar.error/success (e.g. a "Cancel" button) bubbles to <body> in the
+  // same task as the React commit that mounted the alert — the listener then
+  // sees the now-attached ref, treats the click as "outside", and closes the
+  // alert before the user can see it.
+  useEffect(() => {
+    if (!visible) return;
+    let armed = false;
+    const armId = window.setTimeout(() => {
+      armed = true;
+    }, 0);
+
+    const onBodyClick = (ev: MouseEvent) => {
+      if (!armed) return;
+      // TODO: cleanup Portal component and references, FXA-2463
+      // We don't want to automatically close the alert bar if a modal
+      // is also open. There's at least one case where a modal could be
+      // opened at the same time as the alert bar, and because the modal
+      // takes precedence, we want to allow the user to see and read the
+      // alert bar instead of closing them at the same time. We have to check
+      // for `innerHTML` because when a modal is closed it is still in the DOM.
+      if (
+        insideRef.current instanceof HTMLElement &&
+        ev.target instanceof HTMLElement &&
+        !insideRef.current.contains(ev.target) &&
+        !document.getElementById('modal')?.innerHTML
+      ) {
+        alertVisible(false);
+      }
+    };
+    document.body.addEventListener('click', onBodyClick);
+    return () => {
+      window.clearTimeout(armId);
+      document.body.removeEventListener('click', onBodyClick);
+    };
+  }, [visible]);
 
   // Although `role="alert" is usually sufficient to trigger a screenreader
   // without having to reset focus, if this component is rerendered before


### PR DESCRIPTION
## Because

- The "Passkey setup was canceled. Try again." banner intermittently fails to appear on the first cancel after a fresh sign-in (QA repro on Stage 1.337.0), leaving the user without confirmation that their cancellation was processed.

## This pull request

- Replaces `useClickOutsideEffect` in `AlertBar` with an inline effect keyed on `visible` that arms the body-click listener one macrotask after `visible` flips to `true`, so the click that opened the alert cannot also close it.
- Only attaches the body-level click listener while the alert is visible (small correctness improvement over the previous always-on listener).
- Preserves the ESC-key close path and the existing modal-coexistence rule (FXA-2463 TODO) for clicks while a Settings Modal is open.
- Adds `index.race.test.tsx` to exercise real reactive vars + fake timers, covering the same-click race, the subsequent-click close, the modal coexistence rule, and inside-the-alert clicks.

## Issue that this pull request solves

Closes: FXA-13681

## Checklist

_Put an \`x\` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a follow-up to a previously merged fix for FXA-13681. The first attempt didn't catch the race because existing unit tests mocked \`alertBarInfo\` and never rendered the real \`AlertBar\`. The new \`index.race.test.tsx\` closes that coverage gap.