### PR TITLE
fix(settings): record cad_mobile_pair_view in the events ping

### DIFF
--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -470,6 +470,9 @@ const recordEventMetric = (
     case 'cad_approve_device_submit':
       cadApproveDevice.submit.record();
       break;
+    case 'cad_mobile_pair_view':
+      cadMobilePair.view.record();
+      break;
     case 'cad_mobile_pair_submit':
       cadMobilePair.submit.record();
       break;


### PR DESCRIPTION
## Because

- The React glean events map was missing the `cad_mobile_pair_view` case, the mobile-pair page impression stopped reaching the `events` ping once the React pairing page rolled out, while the legacy `accounts_events` ping kept recording it.
- BTW we need to stop sending `accounts_events` pings at some point.

## This pull request

- Adds the `cad_mobile_pair_view` case to match the content-server handler

## Issue that this pull request solves

- https://bugzilla.mozilla.org/show_bug.cgi?id=2036353

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
