### PR TITLE
feat(123done): vendor jwtool and add standalone Heroku deploy

### DIFF
--- a/packages/123done/Procfile
+++ b/packages/123done/Procfile
@@ -1,1 +1,1 @@
-web: node ./packages/123done/server.js
+web: node server.js

--- a/packages/123done/README.md
+++ b/packages/123done/README.md
@@ -19,7 +19,15 @@ See [fxa-dev 123done](https://github.com/mozilla/fxa-dev/tree/docker/roles/rp) A
 - This process is to deploy an existing FxA-integrated Heroku application. Separate steps are required to create a new Heroku app integrated with FxA, including updating the client URL redirect values in the FxA OAuth database.
 - Unless your tests require the untrusted 123Done app, you may just need to deploy the 123Done trusted app to stage and prod (i.e. deploy two instead of all four apps).
 
-#### Instructions
+#### How it works
+
+123Done is self-contained (it has no monorepo imports), so it deploys as a standalone slug:
+only the `packages/123done` subtree is published as the Heroku app's git root. The slug's
+`package.json` is 123Done's own, so `npm install` pulls just its dependencies, and the standard
+root `Procfile` (`web: node server.js`) starts it. There are no root-`package.json` overrides
+and no shared deploy branch to maintain.
+
+#### Account and access
 
 1. Sign up for Heroku at https://sso.heroku.com/login
 
@@ -28,46 +36,79 @@ See [fxa-dev 123done](https://github.com/mozilla/fxa-dev/tree/docker/roles/rp) A
   - You can see who is a Curator with add permissions here: https://people.mozilla.org/a/heroku-members/.
   - There are some additional one-time steps to complete as referenced in the Access Group invitation email.
 
-2. Install [heroku cli](https://devcenter.heroku.com/articles/heroku-cli) and login
+2. Install [heroku cli](https://devcenter.heroku.com/articles/heroku-cli) and login: `heroku login`
 
-- `heroku login`
+3. Ensure access to the 123Done apps. Have a `mozillacorporation` member [grant access](https://devcenter.heroku.com/articles/collaborating) (view, deploy, operate, manage) to the apps you need:
 
-3. Ensure access to 123Done apps
+- `production-123done`
+- `production-123done-untrusted`
+- `stage-123done`
+- `stage-123done-untrusted`
+- There is a trusted and an untrusted OAuth RP app per environment to test both flows; unless your tests require the untrusted app, you may only need the two trusted apps.
 
-- Search for and have a `mozillacorporation` member [grant access](https://devcenter.heroku.com/articles/collaborating) (view, deploy, operate, manage) to following apps:
-  - `production-123done`
-  - `production-123done-untrusted`
-  - `stage-123done`
-  - `stage-123done-untrusted`
-- You'll get an invitation email for each app.
-- Why are there four apps?
-  - There is a trusted and an untrusted OAuth RP app for each environment to test trusted and untrusted OAuth flows.
+#### One-time app setup (per app)
 
-4. Clone each app on the command line that you need to deploy with the provided instructions in the invitation email.
+The subtree deploy uses the plain Node buildpack and the standard root `Procfile`. Apps that
+previously deployed from the monorepo root used the multi-procfile buildpack with a `PROCFILE`
+config var, so reconfigure each of those once:
 
-- E.g. `heroku git:clone -a stage-123done`
-- Note: While app config for stage is in the 123Done package in our FxA monorepo, prod config is in environment variables in the Heroku dashboard to avoid exposing the OAuth client secret.
+```sh
+heroku buildpacks:clear -a stage-123done
+heroku buildpacks:set heroku/nodejs -a stage-123done
+heroku config:unset PROCFILE -a stage-123done
+```
 
-5. Deploy app
+These commands are required for an app that previously used the multi-procfile buildpack, and a
+harmless no-op on a brand-new app (which auto-detects the Node buildpack from `package.json`).
 
-- In the `fxa` repo, checkout branch `origin/heroku-updates` and create and checkout a local branch of the same name.
-  - This branch contains different root level `package.json` commands and/or (dev)dependencies that reduce the size of the Heroku deploy slug. There are limits to the size that can be deployed.
-  - The main differences are the `install` run script and to avoid the `check-package-manager.sh` script, since the command uses `npm` instead of `yarn`.
-    - Note: Heroku is compatible with `yarn`, but at the time of writing, only `npm` worked correctly.
-- Rebase `train-XXX` branch
-  - `git rebase origin/train-XXX`
-    - `XXX` is the train for the environment you want to deploy in.
-- Create a remote for your local repository for each app you want to deploy.
-  - E.g. `heroku git:remote -a stage-123done`
-- Deploy
-  - `git push <heroku remote origin> heroku-updates:main -f`
-    - Force push is needed here because of the commit with changes to `package.json`
-    - `<heroku remote origin>` is the git remote linked to the version of the heroku app you're deploying, i.e. stage/production and trusted/untrusted.
-    - N.B. There may have been breaking changes to the `fxa` root `package.json` since the last 123Done deploy. Confer with the team, but if needed, the root `package.json` can be modified and the last commit amended. Then retry the command.
+#### Config vars (per app)
 
-6. Push changes to back to FxA repo
+`config.js` reads its configuration from these env vars. Set them on the app (Heroku dashboard
+or `heroku config:set`); never commit secret values to the repo.
 
-- `git push origin heroku-updates -f`
+- `CLIENT_ID`, `CLIENT_SECRET_123DONE` — OAuth client id and secret
+- `REDIRECT_URI`, `ISSUER_URI`, `SCOPES`
+- `PKCE_CLIENT_ID`, `PKCE_REDIRECT_URI`
+- `COOKIE_SECRET`, `COOKIE_NAME`
+- `PORT` is provided by Heroku automatically.
+
+Heads up on older apps: some set the client secret as `CLIENT_SECRET` and omit `SCOPES` /
+`COOKIE_*`. The current code reads `CLIENT_SECRET_123DONE`, so check `heroku config -a <app>`
+and rename or add the vars to match the names above. If they do not match, the app still boots
+but the OAuth token exchange fails. Keep the client secret only in Heroku config vars.
+
+#### Deploy
+
+1. Check out the branch/ref that contains the 123Done code you want to ship (the deploy reads
+   `packages/123done` from that ref). For a normal release this is the train branch.
+2. Add a git remote for the target app: `heroku git:remote -a stage-123done` (creates a remote
+   named `heroku`).
+3. Run the deploy script from anywhere in the repo. It deploys your current `HEAD` by default,
+   or pass an explicit ref as the second argument:
+
+```sh
+# deploy the current checkout
+packages/123done/scripts/deploy-heroku.sh heroku
+
+# or deploy a specific ref (must be fetched locally)
+packages/123done/scripts/deploy-heroku.sh heroku train-XXX
+```
+
+The script builds a slug-root commit from the `packages/123done` tree at that ref (via git
+plumbing, so it is instant regardless of monorepo size), stamps a `version.json` so
+`/__version__` reports the source commit, then **confirms the resolved remote URL before
+force-pushing** to the app's `main`. It does not create or rewrite any shared branch. Set
+`DEPLOY_YES=1` to skip the prompt for non-interactive use. Repeat per app, pointing the remote
+at the right app (stage/prod, trusted/untrusted).
+
+#### Verify
+
+```sh
+heroku ps -a stage-123done                          # web dyno "up", running `node server.js`
+curl https://stage-123done.herokuapp.com/__version__ # "commit" matches the deployed source ref
+```
+
+Then open the app in a browser and complete a sign-in to confirm the OAuth flow end to end.
 
 ## Testing
 

--- a/packages/123done/lib/jwtool.js
+++ b/packages/123done/lib/jwtool.js
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Vendored from the shared FxA lib (@fxa/vendored/jwtool) so 123done stays
+// self-contained and deployable without the monorepo.
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+
+const { jwk2pem, pem2jwk } = require('./pem-jwk');
+
+const JWT_STRING = /^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$/;
+
+function base64url(str) {
+  const base64 = Buffer.from(str).toString('base64');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function sign(jwt, pem) {
+  const header = base64url(JSON.stringify(jwt.header));
+  const payload = base64url(JSON.stringify(jwt.payload));
+  const signed = header + '.' + payload;
+  const s = crypto.createSign('RSA-SHA256');
+  s.update(signed);
+  const sig = base64url(s.sign(pem));
+  return signed + '.' + sig;
+}
+
+function decode(str) {
+  const match = JWT_STRING.exec(str);
+  if (!match) {
+    return null;
+  }
+  try {
+    return {
+      header: JSON.parse(Buffer.from(match[1], 'base64').toString()),
+      payload: JSON.parse(Buffer.from(match[2], 'base64').toString()),
+      signature: Buffer.from(match[3], 'base64'),
+    };
+  } catch (e) {
+    return null;
+  }
+}
+
+function verify(str, pem) {
+  const jwt = decode(str);
+  if (!jwt) {
+    return false;
+  }
+  const signed = str.split('.', 2).join('.');
+  const v = crypto.createVerify('RSA-SHA256');
+  v.update(signed);
+  return v.verify(pem, jwt.signature) ? jwt.payload : false;
+}
+
+function addExtras(obj, extras) {
+  extras = extras || {};
+  Object.keys(extras).forEach((key) => {
+    obj[key] = extras[key];
+  });
+  return obj;
+}
+
+class JWK {
+  constructor(jwk, pem) {
+    this.jwk = jwk || (pem && pem2jwk(pem));
+    this.pem = pem || jwk2pem(jwk);
+  }
+
+  toJSON() {
+    return this.jwk;
+  }
+}
+
+class PrivateJWK extends JWK {
+  signSync(data) {
+    const payload = data || {};
+    payload.iss = this.jwk.iss;
+    return sign(
+      {
+        header: {
+          alg: 'RS256',
+          jku: this.jwk.jku,
+          kid: this.jwk.kid,
+        },
+        payload: payload,
+      },
+      this.pem
+    );
+  }
+
+  async sign(data) {
+    return Promise.resolve(this.signSync(data));
+  }
+}
+
+class PublicJWK extends JWK {
+  verifySync(str) {
+    return verify(str, this.pem);
+  }
+
+  async verify(str) {
+    return Promise.resolve(this.verifySync(str));
+  }
+}
+
+// Attached after the subclasses are defined so the factories can reference them.
+JWK.fromPEM = function (pem, extras) {
+  const obj = pem2jwk(pem, extras);
+  if (obj.d) {
+    return new PrivateJWK(obj, pem);
+  }
+  return new PublicJWK(obj, pem);
+};
+
+JWK.fromObject = function (obj, extras) {
+  obj = addExtras(obj, extras);
+  if (obj.d) {
+    return new PrivateJWK(obj);
+  }
+  return new PublicJWK(obj);
+};
+
+JWK.fromFile = function (filename, extras) {
+  const file = fs.readFileSync(filename, 'utf8');
+  if (file[0] === '{') {
+    return JWK.fromObject(JSON.parse(file), extras);
+  }
+  return JWK.fromPEM(file, extras);
+};
+
+class JWTVerificationError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = 'JWTVerificationError';
+    this.message = msg;
+  }
+}
+
+async function getJwkSet(jku) {
+  try {
+    const res = await fetch(jku, {
+      redirect: 'error',
+    });
+    const body = await res.text();
+    const json = JSON.parse(body);
+    const set = {};
+    json.keys.forEach((key) => {
+      set[key.kid] = new PublicJWK(key);
+    });
+    return set;
+  } catch (e) {
+    throw new JWTVerificationError('bad jku');
+  }
+}
+
+class JWTool {
+  constructor(trusted) {
+    this.trusted = trusted;
+    this.jwkSets = {};
+  }
+
+  async fetch(jku, kid) {
+    let set = this.jwkSets[jku];
+    if (set && set[kid]) {
+      return set[kid];
+    }
+    set = await getJwkSet(jku);
+    this.jwkSets[jku] = set;
+    if (!set[kid]) {
+      throw new JWTVerificationError('unknown kid');
+    }
+    return set[kid];
+  }
+
+  async verify(str, defaults) {
+    defaults = defaults || {};
+    let jwt = decode(str);
+    if (!jwt) {
+      throw new JWTVerificationError('malformed');
+    }
+
+    const jku = jwt.header.jku || defaults.jku;
+    const kid = jwt.header.kid || defaults.kid;
+    if (!this.trusted.includes(jku)) {
+      throw new JWTVerificationError('untrusted');
+    }
+    const jwk = await this.fetch(jku, kid);
+    jwt = await jwk.verify(str);
+    if (!jwt) {
+      throw new JWTVerificationError('invalid');
+    }
+    return jwt;
+  }
+}
+
+JWTool.JWK = JWK;
+JWTool.PublicJWK = PublicJWK;
+JWTool.PrivateJWK = PrivateJWK;
+JWTool.JWTVerificationError = JWTVerificationError;
+JWTool.unverify = decode;
+JWTool.verify = verify;
+JWTool.sign = sign;
+
+module.exports = {
+  JWK,
+  PublicJWK,
+  PrivateJWK,
+  JWTVerificationError,
+  JWTool,
+};

--- a/packages/123done/lib/pem-jwk.js
+++ b/packages/123done/lib/pem-jwk.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Vendored from the shared FxA lib (@fxa/shared/pem-jwk) so 123done stays
+// self-contained and deployable without the monorepo.
+
+'use strict';
+
+const { createPrivateKey, createPublicKey } = require('crypto');
+
+function pem2jwk(pem, extras) {
+  if (pem.includes('PUBLIC')) {
+    return Object.assign(
+      createPublicKey({ key: pem }).export({ format: 'jwk' }),
+      extras || {}
+    );
+  }
+  return Object.assign(
+    createPrivateKey({ key: pem }).export({ format: 'jwk' }),
+    extras || {}
+  );
+}
+
+function jwk2pem(jwk) {
+  if (jwk.d) {
+    return createPrivateKey({ key: jwk, format: 'jwk' })
+      .export({
+        format: 'pem',
+        type: 'pkcs1',
+      })
+      .toString()
+      .trim();
+  }
+  return createPublicKey({ key: jwk, format: 'jwk' })
+    .export({
+      format: 'pem',
+      type: 'pkcs1',
+    })
+    .toString()
+    .trim();
+}
+
+module.exports = { pem2jwk, jwk2pem };

--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -5,7 +5,7 @@ var config = require('./config').getProperties();
 var crypto = require('crypto');
 var request = require('request');
 var querystring = require('querystring');
-var { JWTool } = require('@fxa/vendored/jwtool');
+var { JWTool } = require('./lib/jwtool');
 
 // oauth flows are stored in memory
 var oauthFlows = {};

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/mozilla/fxa.git"
   },
   "private": true,
+  "engines": {
+    "node": "^22.15.1"
+  },
   "dependencies": {
     "convict": "^6.2.5",
     "convict-format-with-validator": "^6.2.0",

--- a/packages/123done/scripts/deploy-heroku.sh
+++ b/packages/123done/scripts/deploy-heroku.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Deploy the 123done package to a Heroku app as a standalone slug.
+#
+# 123done is self-contained (no monorepo imports), so we publish ONLY the
+# packages/123done subtree as the app's slug root. The slug's package.json is
+# 123done's own, so npm installs just its deps and the standard root Procfile
+# (web: node server.js) starts it.
+#
+# We build the slug commit with git plumbing (commit-tree on the subdirectory's
+# tree object) rather than `git subtree split`, which would walk the entire
+# monorepo history and take minutes. This is instant regardless of repo size.
+#
+# One-time app setup (per Heroku app), since this replaces the old monorepo-root
+# deploy that used the multi-procfile buildpack:
+#   heroku buildpacks:clear -a <app>
+#   heroku buildpacks:set heroku/nodejs -a <app>
+#   heroku config:unset PROCFILE -a <app>
+# OAuth config vars (CLIENT_ID, CLIENT_SECRET_123DONE, REDIRECT_URI, ISSUER_URI,
+# SCOPES, PKCE_*, COOKIE_*) stay set on the app as before.
+#
+# Usage:
+#   packages/123done/scripts/deploy-heroku.sh [heroku-remote] [source-ref]
+#
+#   heroku-remote   git remote pointing at the target app (default: heroku)
+#   source-ref      branch or commit to deploy from   (default: HEAD)
+#
+# This force-pushes to the target's main, so it confirms the resolved remote URL
+# before pushing. Set DEPLOY_YES=1 to skip the prompt (for non-interactive use).
+#
+set -euo pipefail
+
+REMOTE="${1:-heroku}"
+SOURCE_REF="${2:-HEAD}"
+PREFIX="packages/123done"
+
+# Run from the repo root so the prefix and config resolve.
+cd "$(git rev-parse --show-toplevel)"
+
+# Resolve the target remote up front so an unknown remote fails before any work.
+REMOTE_URL="$(git remote get-url "$REMOTE")"
+
+SRC_SHA="$(git rev-parse "$SOURCE_REF")"
+SRC_DESC="$(git rev-parse --short "$SOURCE_REF")"
+SOURCE_REPO="$(git config --get remote.origin.url || echo unknown)"
+
+# Tree of just the subdirectory at the source ref.
+SUBTREE="$(git rev-parse "${SOURCE_REF}:${PREFIX}")"
+
+# Stamp a version.json into the slug so /__version__ reports the real source
+# commit instead of the synthetic deploy commit. Built in a scratch index so the
+# working tree and HEAD are never touched.
+SCRATCH_INDEX="$(mktemp)"
+trap 'rm -f "$SCRATCH_INDEX"' EXIT
+export GIT_INDEX_FILE="$SCRATCH_INDEX"
+git read-tree "$SUBTREE"
+VERSION_BLOB="$(printf '{"version":{"hash":"%s","source":"%s"}}\n' "$SRC_SHA" "$SOURCE_REPO" | git hash-object -w --stdin)"
+git update-index --add --cacheinfo "100644,${VERSION_BLOB},version.json"
+SLUG_TREE="$(git write-tree)"
+unset GIT_INDEX_FILE
+
+SLUG_COMMIT="$(git commit-tree "$SLUG_TREE" -m "deploy 123done from ${SRC_DESC}")"
+
+echo "About to force-push 123done @ ${SRC_DESC} (slug commit ${SLUG_COMMIT}) to:"
+echo "  remote '${REMOTE}' -> ${REMOTE_URL} (refs/heads/main)"
+if [ "${DEPLOY_YES:-}" != "1" ]; then
+  read -r -p "Proceed? [y/N] " reply
+  case "$reply" in
+    [yY] | [yY][eE][sS]) ;;
+    *)
+      echo "Aborted."
+      exit 1
+      ;;
+  esac
+fi
+
+git push "$REMOTE" "${SLUG_COMMIT}:refs/heads/main" --force
+echo "Done."

--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -1,5 +1,3 @@
-require('module-alias/register');
-
 const express = require('express');
 const morgan = require('morgan');
 const path = require('path');


### PR DESCRIPTION
## Because

- 123Done imported `@fxa/vendored/jwtool`, which resolves to monorepo TypeScript source, so any standalone or scoped deploy crashed at boot (the live Heroku slug only survived because it predates the `@fxa/vendored` reorg)
- The previous Heroku deploy rebased a stale shared `heroku-updates` branch and force-pushed it, carrying fragile root `package.json` overrides

## This pull request

- Vendors `jwtool` and `pem-jwk` into `packages/123done/lib` (plain CommonJS, ~250 LOC, no new deps); points `oauth.js` at them and drops the dead `module-alias` require in `server.js`
- Adds `scripts/deploy-heroku.sh`: publishes only the `packages/123done` tree as the Heroku slug root via git plumbing, stamps a `version.json`, and confirms the target remote before force-pushing
- Sets `Procfile` to the slug-root path (`web: node server.js`) and pins `engines.node` to `^22.15.1`
- Rewrites the README Heroku section (one-time app setup, config vars, deploy, verify)

## Issue that this pull request solves

No associated Jira ticket (branch `heroku-simple`).

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:**
- Local dev is unaffected: `yarn start` (pm2 + ts-node) boots 123Done as before
- Deploy: point a `heroku` git remote at a 123Done app, run `packages/123done/scripts/deploy-heroku.sh heroku`, then check `heroku ps` and `curl <app>/__version__`
- Verified live on a test app (`vbudhram-123done-testing`): clean build, `web` dyno up, `/__version__` reports the source commit, `/` returns 200