### PR TITLE
chore(ci): run only affected auth-server Jest specs on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -692,6 +692,13 @@ jobs:
       resource_class:
         type: string
         default: large
+      # Git ref the affected-spec narrowing diffs against (see fxa-auth-server's
+      # test-ci.sh, which feeds the changed files to Jest's --findRelatedTests).
+      # Set on PR workflows only so honoring suites run just the related specs;
+      # left empty on tag/nightly so they run the full suite as a regression guard.
+      jest_affected_base:
+        type: string
+        default: ''
       workflow:
         type: string
     executor: default-executor
@@ -708,6 +715,7 @@ jobs:
           command: NODE_OPTIONS="--max-old-space-size=7168" npx nx << parameters.nx_run >> --parallel=2 -t test-unit
           environment:
             NODE_ENV: test
+            JEST_AFFECTED_BASE: << parameters.jest_affected_base >>
       - store-artifacts
       - upload_to_gcs:
           workflow: << parameters.workflow >>
@@ -733,6 +741,12 @@ jobs:
         type: string
         default: large
       start_customs:
+        type: boolean
+        default: false
+      # Run the (slow, rate-limited) Stripe test-customer sweep. Housekeeping that
+      # only needs to happen periodically, so it's enabled on nightly only; PR and
+      # tag workflows leave it false so they don't pay the cost on every run.
+      run_stripe_cleanup:
         type: boolean
         default: false
       test_suite:
@@ -762,6 +776,7 @@ jobs:
             NODE_OPTIONS="--max-old-space-size=7168" npx nx << parameters.nx_run >> << parameters.parallel >> << parameters.target >> << parameters.projects >>
           environment:
             NODE_ENV: test
+            RUN_STRIPE_CLEANUP: << parameters.run_stripe_cleanup >>
           no_output_timeout: 20m
       - store-artifacts
       - upload_to_gcs:
@@ -989,6 +1004,7 @@ workflows:
           name: Unit Test (PR)
           resource_class: xlarge
           nx_run: affected --base=main --head=$CIRCLE_SHA1
+          jest_affected_base: main
           workflow: test_pull_request
           requires:
             - Build (PR)
@@ -1362,6 +1378,7 @@ workflows:
           test_suite: servers-auth-integration
           workflow: nightly
           nx_run: run-many --skipRemoteCache
+          run_stripe_cleanup: true
           requires:
             - Build (nightly)
       - integration-test:

--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -6,11 +6,54 @@ cd "$DIR/.."
 export NODE_ENV=dev
 export CORS_ORIGIN="http://foo,http://bar"
 
+# Affected-spec narrowing for the UNIT run. PRs set JEST_AFFECTED_BASE=main;
+# tag/nightly leave it unset and run the full suite (regression guard).
+#
+# How: diff the branch against a freshly-fetched base (two-dot `git diff <base> HEAD`)
+# and pass the changed files to Jest's --findRelatedTests. Two-dot is used, not
+# --changedSince, because the latter needs a merge-base the shallow --depth=1 CI
+# clone doesn't have. Trade-offs: a branch behind main over-includes (harmless --
+# rebase to shrink); a missing base ref falls back to the full suite.
+#
+# UNIT only. Integration specs (test/remote/*.in.spec.ts) are black-box -- they call
+# routes over HTTP against the globalSetup server and never import the handlers, so
+# --findRelatedTests would map a route change to zero specs (false negative). They
+# always run full, gated to affected *projects* by `nx affected`.
+JEST_AFFECTED_ARGS=()
+if [ -n "$JEST_AFFECTED_BASE" ]; then
+  base_ref="$JEST_AFFECTED_BASE"
+  if git fetch --no-tags --depth=1 origin "$JEST_AFFECTED_BASE" >/dev/null 2>&1; then
+    base_ref=FETCH_HEAD
+  else
+    echo "WARNING: could not refresh '$JEST_AFFECTED_BASE'; diffing against the local ref"
+  fi
+
+  if git rev-parse --verify --quiet "$base_ref" >/dev/null; then
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+    CHANGED_FILES=()
+    while IFS= read -r changed_file; do
+      [ -n "$changed_file" ] && CHANGED_FILES+=("$REPO_ROOT/$changed_file")
+    done < <(git diff --name-only "$base_ref" HEAD)
+
+    JEST_AFFECTED_ARGS+=(--passWithNoTests)
+    if [ "${#CHANGED_FILES[@]}" -gt 0 ]; then
+      echo "Narrowing Jest to specs related to ${#CHANGED_FILES[@]} changed file(s) vs '$JEST_AFFECTED_BASE'"
+      JEST_AFFECTED_ARGS+=(--findRelatedTests "${CHANGED_FILES[@]}")
+    else
+      echo "No files differ from '$JEST_AFFECTED_BASE'; running no Jest specs"
+      JEST_AFFECTED_ARGS+=(--testPathPattern '__affected_no_changes__')
+    fi
+  else
+    # Fail safe: if the base ref is missing, run the full suite rather than nothing.
+    echo "WARNING: base ref '$JEST_AFFECTED_BASE' not found; running the full Jest suite"
+  fi
+fi
+
 if [ "$TEST_TYPE" == 'unit' ]; then
   echo -e "\n\nRunning Jest unit tests"
   JEST_JUNIT_OUTPUT_DIR="../../artifacts/tests/fxa-auth-server" \
   JEST_JUNIT_OUTPUT_NAME="fxa-auth-server-jest-unit-results.xml" \
-  npx jest --coverage --forceExit --ci --silent --reporters=default --reporters=jest-junit
+  npx jest --coverage --forceExit --ci --silent --reporters=default --reporters=jest-junit "${JEST_AFFECTED_ARGS[@]}"
 
 elif [ "$TEST_TYPE" == 'scripts' ]; then
   echo -e "\n\nRunning Jest script integration tests (test/scripts/**/*.in.spec.ts)"
@@ -29,7 +72,13 @@ elif [ "$TEST_TYPE" == 'integration' ]; then
   JEST_JUNIT_OUTPUT_NAME="fxa-auth-server-jest-oauth-api-results.xml" \
   npx jest --config jest.oauth-api.config.js --forceExit --ci --reporters=default --reporters=jest-junit
 
-  yarn run clean-up-old-ci-stripe-customers
+  # Sweeping old Stripe test customers is housekeeping, not part of the test run,
+  # and the sweep is slow (paginates the test account via the rate-limited Stripe
+  # API). Only run it when RUN_STRIPE_CLEANUP is set (nightly workflow); PR and tag
+  # workflows leave it unset so they don't pay the cost on every run.
+  if [ "$RUN_STRIPE_CLEANUP" == "true" ]; then
+    yarn run clean-up-old-ci-stripe-customers
+  fi
 
 else
   echo -e "\n\nRunning all Jest tests"


### PR DESCRIPTION
Because:
- When [fxa-auth-server](https://mozilla-hub.atlassian.net/browse/FXA-auth-server) is affected, its full Jest suite ran on every PR.
- The stripe customer cleanup runs on every integration run but is just periodic housekeeping.

This commit:
- Narrows the UNIT run on PRs only: test-ci.sh diffs the branch against a fresh base and feeds changed files to Jest --findRelatedTests (two-dot diff; --changedSince needs a merge-base the shallow CI clone lacks). Wired via a jest_affected_base param set to `main` on test_pull_request only.
- Leaves integration un-narrowed -- its black-box HTTP specs don't import the handlers, so --findRelatedTests would miss route changes; still gated to affected projects by nx affected.
- Runs the stripe cleanup on the nightly auth job only, via RUN_STRIPE_CLEANUP.

Closes: FXA-13673

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
