### PR TITLE
fix(functional-tests): add fxa bypass header to payments tests

### DIFF
--- a/packages/functional-tests/lib/fixtures/payments.ts
+++ b/packages/functional-tests/lib/fixtures/payments.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Page } from '@playwright/test';
-import { test as standardTest, expect } from './standard';
+import { test as standardTest, expect, addWafBypassHeader } from './standard';
 import { create as createPaymentPages } from '../../pages/payments';
 import { BaseTarget } from '../targets/base';
 
@@ -37,6 +37,7 @@ export const test = standardTest.extend<{
   paymentPages: PaymentPOMS;
 }>({
   page: async ({ page, target }, use) => {
+    await addWafBypassHeader(page, target);
     await addPaymentsWafBypassHeader(page, target);
     await use(page);
   },

--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -42,7 +42,7 @@ const CI_WAF_TOKEN = process.env.CI_WAF_TOKEN;
  * FXA-owned domains only, leaving third-party origins (Stripe, hCaptcha)
  * untouched. No-op when CI_WAF_TOKEN is unset.
  */
-async function addWafBypassHeader(page: Page, target: BaseTarget) {
+export async function addWafBypassHeader(page: Page, target: BaseTarget) {
   if (!CI_WAF_TOKEN) {
     if (target.name === 'stage' || target.name === 'production') {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Because

* Payments functional tests are shown the Fastly captcha on FxA pages when running on stage environments.

## This pull request

* Adds the FxA Fastly bypass header to payments functional tests

## Issue that this pull request solves

Closes: PAY-3755

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Can be run locally with the following command. (Tokens can be found [in the webservice-infra repo](https://github.com/mozilla/webservices-infra/blob/main/fxa/tf/stage/waf.tf))
```CI_WAF_TOKEN=xyz WAF_BYPASS_TOKEN=xyz npx playwright test --project=stage-payments-next```

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
