### PR TITLE
fix(payments-next): "Something went wrong" page shown when a user who is not a customer goes to payments/paypal

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
@@ -33,10 +33,23 @@ export default async function PaypalPaymentManagementPage({
   if (!session?.user?.id) {
     redirect(`${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`);
   }
-  const [paypalBillingAgreementId, currency] = await Promise.all([
-    getPayPalBillingAgreementId(),
-    determineCurrencyForCustomerAction(),
-  ]);
+  let paypalBillingAgreementId;
+  let currency;
+  try {
+    [paypalBillingAgreementId, currency] = await Promise.all([
+      getPayPalBillingAgreementId(),
+      determineCurrencyForCustomerAction(),
+    ]);
+  } catch (error) {
+    if (
+      error.name === 'AccountCustomerNotFoundError') {
+      redirect(
+        `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
+      );
+    } else {
+      throw error;
+    }
+  }
 
   if (paypalBillingAgreementId || !currency) {
     redirect(`${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`);

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -936,7 +936,9 @@ export class NextJSActionsService {
     };
   }
 
-  @SanitizeExceptions()
+  @SanitizeExceptions({
+    allowlist: [AccountCustomerNotFoundError],
+  })
   @NextIOValidator(
     DetermineCurrencyForCustomerActionArgs,
     DetermineCurrencyForCustomerActionResult


### PR DESCRIPTION
## Because

* When a user who doesn’t have any subscriptions navigates to subscriptions/payments/paypal, an AccountCustomerNotFoundError is thrown and the user sees the “Something went wrong” page.

## This pull request

* Mirrors what we do for the subscriptions/payments/stripe page and redirects the user to the SubManage page.

## Issue that this pull request solves

Closes #[PAY-3760](https://mozilla-hub.atlassian.net/browse/PAY-3760)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)


https://github.com/user-attachments/assets/202c351b-ab00-462d-acd9-f93b83e5a21b



## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3760]: https://mozilla-hub.atlassian.net/browse/PAY-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ