### PR TITLE
feat(rate-limit): add BigQuery writer shim for rate-limit check logging

### DIFF
--- a/libs/accounts/rate-limit/src/index.ts
+++ b/libs/accounts/rate-limit/src/index.ts
@@ -4,6 +4,7 @@
 
 export * from './lib/rate-limit';
 export * from './lib/rate-limit.provider';
+export * from './lib/bq-writer';
 export * from './lib/config';
 export * from './lib/error';
 export * from './lib/models';

--- a/libs/accounts/rate-limit/src/lib/bq-writer.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/bq-writer.spec.ts
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RateLimitBqWriter, BqWriterConfig } from './bq-writer';
+import { RateLimitCheckEvent } from './models';
+
+describe('RateLimitBqWriter', () => {
+  let writer: RateLimitBqWriter;
+  let mockInsert: jest.Mock;
+  let mockBq: any;
+  let config: BqWriterConfig;
+
+  const createEvent = (overrides?: Partial<RateLimitCheckEvent>): RateLimitCheckEvent => ({
+    timestamp: 1700000000000,
+    action: 'loginAttempt',
+    ip: '127.0.0.1',
+    email: 'test@example.com',
+    wasBlocked: false,
+    wasSkipped: false,
+    usedDefaultRule: false,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockInsert = jest.fn().mockResolvedValue(undefined);
+    mockBq = {
+      dataset: jest.fn().mockReturnValue({
+        table: jest.fn().mockReturnValue({
+          insert: mockInsert,
+        }),
+      }),
+    };
+    config = {
+      projectId: 'test-project',
+      dataset: 'fxa',
+      table: 'rate_limit_checks',
+      flushIntervalMs: 5000,
+      batchSize: 3,
+    };
+    writer = new RateLimitBqWriter(config, mockBq);
+  });
+
+  afterEach(async () => {
+    await writer.shutdown();
+    jest.useRealTimers();
+  });
+
+  it('buffers events without flushing below batch size', () => {
+    writer.write(createEvent());
+    writer.write(createEvent());
+
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('flushes when buffer reaches batch size', () => {
+    writer.write(createEvent({ action: 'a' }));
+    writer.write(createEvent({ action: 'b' }));
+    writer.write(createEvent({ action: 'c' }));
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ action: 'a' }),
+        expect.objectContaining({ action: 'b' }),
+        expect.objectContaining({ action: 'c' }),
+      ])
+    );
+  });
+
+  it('flushes on timer interval', async () => {
+    writer.write(createEvent());
+
+    jest.advanceTimersByTime(5000);
+    // Let the async flush complete
+    await Promise.resolve();
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockInsert).toHaveBeenCalledWith([expect.objectContaining({ action: 'loginAttempt' })]);
+  });
+
+  it('does not call insert when buffer is empty', async () => {
+    await writer.flush();
+
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('catches errors and never throws', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockInsert.mockRejectedValue(new Error('BQ unavailable'));
+
+    writer.write(createEvent());
+    await writer.flush();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'rate_limit.bq_writer.flush_error',
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('drains remaining events on shutdown', async () => {
+    writer.write(createEvent({ action: 'remaining' }));
+
+    await writer.shutdown();
+
+    expect(mockInsert).toHaveBeenCalledWith([
+      expect.objectContaining({ action: 'remaining' }),
+    ]);
+  });
+
+  it('clears buffer after flush', async () => {
+    writer.write(createEvent());
+    await writer.flush();
+
+    mockInsert.mockClear();
+    await writer.flush();
+
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/libs/accounts/rate-limit/src/lib/bq-writer.ts
+++ b/libs/accounts/rate-limit/src/lib/bq-writer.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BigQuery, Table } from '@google-cloud/bigquery';
+import { RateLimitCheckEvent } from './models';
+
+export interface BqWriterConfig {
+  projectId: string;
+  dataset: string;
+  table: string;
+  flushIntervalMs: number;
+  batchSize: number;
+}
+
+/**
+ * Non-blocking, batched BigQuery writer for rate-limit check events.
+ * Buffers events in memory and flushes on a timer or when the batch
+ * size is reached. Errors are caught and logged — a BigQuery outage
+ * must never affect the auth flow.
+ */
+export class RateLimitBqWriter {
+  private buffer: RateLimitCheckEvent[] = [];
+  private timer: NodeJS.Timeout | null = null;
+  private readonly tableRef: Table;
+
+  constructor(
+    private readonly config: BqWriterConfig,
+    bq?: BigQuery
+  ) {
+    const client = bq ?? new BigQuery({ projectId: config.projectId });
+    this.tableRef = client.dataset(config.dataset).table(config.table);
+    this.startTimer();
+  }
+
+  /** Append an event to the buffer. Flushes if batch size is reached. */
+  write(event: RateLimitCheckEvent): void {
+    this.buffer.push(event);
+    if (this.buffer.length >= this.config.batchSize) {
+      this.flush();
+    }
+  }
+
+  /** Send buffered events to BigQuery. Catches all errors. */
+  async flush(): Promise<void> {
+    if (this.buffer.length === 0) {
+      return;
+    }
+
+    const batch = this.buffer.splice(0);
+    try {
+      await this.tableRef.insert(batch);
+    } catch (err) {
+      // Log but never throw — BQ failures must not affect auth
+      console.error('rate_limit.bq_writer.flush_error', err);
+    }
+  }
+
+  /** Drain remaining events and stop the flush timer. */
+  async shutdown(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.flush();
+  }
+
+  private startTimer(): void {
+    this.timer = setInterval(() => this.flush(), this.config.flushIntervalMs);
+    // Don't prevent the process from exiting
+    this.timer.unref();
+  }
+}

--- a/libs/accounts/rate-limit/src/lib/models.ts
+++ b/libs/accounts/rate-limit/src/lib/models.ts
@@ -100,3 +100,59 @@ export type SearchOpts = {
   email?: string;
   uid?: string;
 };
+
+/** Writer interface for emitting rate-limit check events (e.g. to BigQuery). */
+export interface RateLimitEventWriter {
+  write(event: RateLimitCheckEvent): void;
+}
+
+/**
+ * Configuration for the RateLimit constructor.
+ *
+ * `rules` is a map of action name → Rule[]. Each rule string in config is
+ * parsed into this structure by `parseRules` in config.ts. The DSL format is:
+ *   action:blockOn:maxAttempts:windowDuration:blockDuration:policy
+ *
+ * A special "default" key provides fallback rules for actions without
+ * explicit entries.
+ */
+export type RateLimitRulesConfig = {
+  rules: Record<string, Rule[]>;
+  ignoreIPs?: Array<string>;
+  ignoreEmails?: Array<string>;
+  ignoreUIDs?: Array<string>;
+};
+
+/** Event emitted for every RateLimit.check() call, sent to BigQuery for analytics. */
+export type RateLimitCheckEvent = {
+  /** When the check occurred */
+  timestamp: number;
+  /** The action being checked */
+  action: string;
+  /** Client IP address */
+  ip?: string;
+  /** User email */
+  email?: string;
+  /** User ID */
+  uid?: string;
+  /** Which attribute the matched rule counts on */
+  blockingOn?: string;
+  /** Max attempts allowed by the matched rule */
+  ruleMaxAttempts?: number;
+  /** Window duration (seconds) of the matched rule */
+  ruleWindowSeconds?: number;
+  /** Block duration (seconds) of the matched rule */
+  ruleBlockSeconds?: number;
+  /** Current attempt count at time of check */
+  currentAttempts?: number;
+  /** Whether this check resulted in a block or ban */
+  wasBlocked: boolean;
+  /** The policy that triggered (block, ban, report) */
+  blockPolicy?: string;
+  /** How long the block lasts (seconds) */
+  blockDurationSeconds?: number;
+  /** Whether the check was skipped due to ignore lists */
+  wasSkipped: boolean;
+  /** Whether the default rule was used instead of an action-specific rule */
+  usedDefaultRule: boolean;
+};

--- a/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
@@ -5,6 +5,7 @@
 import { ConfigService } from '@nestjs/config';
 import { parseConfigRules, RateLimitConfig } from './config';
 import { RateLimit } from './rate-limit';
+import { RateLimitBqWriter, BqWriterConfig } from './bq-writer';
 import Redis, { RedisOptions } from 'ioredis';
 import { StatsD, StatsDService } from '@fxa/shared/metrics/statsd';
 import { Provider } from '@nestjs/common';
@@ -42,6 +43,13 @@ export const RateLimitProvider = {
     }
 
     const rules = parseConfigRules(rateLimitConfig.rules);
+
+    const bqConfig = config.get<BqWriterConfig & { enabled?: boolean }>(
+      'rateLimit.bigquery'
+    );
+    const bqWriter =
+      bqConfig && bqConfig.enabled ? new RateLimitBqWriter(bqConfig) : undefined;
+
     return new RateLimit(
       {
         rules,
@@ -50,7 +58,8 @@ export const RateLimitProvider = {
         ignoreUIDs: rateLimitConfig.ignoreUIDs,
       },
       redis,
-      statsd
+      statsd,
+      bqWriter
     );
   },
   inject: [ConfigService, RateLimitRedisClient, StatsDService],

--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -144,12 +144,12 @@ describe('rate-limit', () => {
       statsd
     );
 
-    expect(rateLimit.skip({ email: 'foo@mozilla.com' })).toBeTruthy();
-    expect(rateLimit.skip({ email: 'bar@mozilla.com' })).toBeTruthy();
-    expect(rateLimit.skip({ email: 'bar@mozilla.com ' })).toBeFalsy();
-    expect(rateLimit.skip({ email: 'foo@firefox.com' })).toBeTruthy();
-    expect(rateLimit.skip({ email: 'bar@firefox.com ' })).toBeFalsy();
-    expect(rateLimit.skip({})).toBeFalsy();
+    expect(rateLimit.skip('test', { email: 'foo@mozilla.com' })).toBeTruthy();
+    expect(rateLimit.skip('test', { email: 'bar@mozilla.com' })).toBeTruthy();
+    expect(rateLimit.skip('test', { email: 'bar@mozilla.com ' })).toBeFalsy();
+    expect(rateLimit.skip('test', { email: 'foo@firefox.com' })).toBeTruthy();
+    expect(rateLimit.skip('test', { email: 'bar@firefox.com ' })).toBeFalsy();
+    expect(rateLimit.skip('test', {})).toBeFalsy();
     expect(statsd.increment).toBeCalledWith('rate_limit.ignore.email');
   });
 
@@ -163,9 +163,9 @@ describe('rate-limit', () => {
       statsd
     );
 
-    expect(rateLimit.skip({ ip: '127.0.0.1' })).toBeTruthy();
-    expect(rateLimit.skip({ ip: '0.0.0.0' })).toBeFalsy();
-    expect(rateLimit.skip({})).toBeFalsy();
+    expect(rateLimit.skip('test', { ip: '127.0.0.1' })).toBeTruthy();
+    expect(rateLimit.skip('test', { ip: '0.0.0.0' })).toBeFalsy();
+    expect(rateLimit.skip('test', {})).toBeFalsy();
     expect(statsd.increment).toBeCalledWith('rate_limit.ignore.ip');
   });
 
@@ -179,9 +179,9 @@ describe('rate-limit', () => {
       statsd
     );
 
-    expect(rateLimit.skip({ uid: '000-000-000' })).toBeTruthy();
-    expect(rateLimit.skip({ uid: '000-000-001' })).toBeFalsy();
-    expect(rateLimit.skip({})).toBeFalsy();
+    expect(rateLimit.skip('test', { uid: '000-000-000' })).toBeTruthy();
+    expect(rateLimit.skip('test', { uid: '000-000-001' })).toBeFalsy();
+    expect(rateLimit.skip('test', {})).toBeFalsy();
     expect(statsd.increment).toBeCalledWith('rate_limit.ignore.uid');
   });
 
@@ -766,6 +766,96 @@ describe('rate-limit', () => {
 
       expect(result).toBe(2);
       expect(mockDel).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe('bqWriter integration', () => {
+    let mockWrite: jest.Mock;
+    let mockIncr: jest.Mock;
+    let mockExpire: jest.Mock;
+    let mockGet: jest.Mock;
+
+    beforeEach(() => {
+      mockWrite = jest.fn();
+      mockIncr = jest.fn().mockResolvedValue(1);
+      mockExpire = jest.fn().mockResolvedValue(1);
+      mockGet = jest.fn().mockResolvedValue(null);
+      redis.incr = mockIncr;
+      redis.expire = mockExpire;
+      redis.get = mockGet;
+    });
+
+    afterEach(() => {
+      mockWrite.mockReset();
+      mockIncr.mockReset();
+      mockExpire.mockReset();
+      mockGet.mockReset();
+    });
+
+    it('reports wasBlocked true when block is triggered', async () => {
+      mockIncr.mockResolvedValue(6); // exceeds maxAttempts of 5
+      redis.set = jest.fn().mockResolvedValue('OK');
+
+      rateLimit = new RateLimit(
+        { rules: parseConfigRules(['test:ip:5:1 minute:5 minutes:block']) },
+        redis,
+        statsd,
+        { write: mockWrite }
+      );
+
+      await rateLimit.check('test', { ip: '1.2.3.4' });
+
+      expect(mockWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          wasBlocked: true,
+          blockPolicy: 'block',
+        })
+      );
+    });
+
+    it('calls bqWriter.write on skip() with wasSkipped true', () => {
+      rateLimit = new RateLimit(
+        { rules: {}, ignoreIPs: ['127.0.0.1'] },
+        redis,
+        statsd,
+        { write: mockWrite }
+      );
+
+      rateLimit.skip('test', { ip: '127.0.0.1' });
+
+      expect(mockWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'test',
+          ip: '127.0.0.1',
+          wasBlocked: false,
+          wasSkipped: true,
+        })
+      );
+    });
+
+    it('does not call bqWriter.write on skip() when not skipped', () => {
+      rateLimit = new RateLimit(
+        { rules: {}, ignoreIPs: ['127.0.0.1'] },
+        redis,
+        statsd,
+        { write: mockWrite }
+      );
+
+      rateLimit.skip('test', { ip: '0.0.0.0' });
+
+      expect(mockWrite).not.toHaveBeenCalled();
+    });
+
+    it('works without bqWriter (undefined)', async () => {
+      rateLimit = new RateLimit(
+        { rules: parseConfigRules(['test:ip:5:1 minute:5 minutes:block']) },
+        redis,
+        statsd
+      );
+
+      // Should not throw
+      const result = await rateLimit.check('test', { ip: '1.2.3.4' });
+      expect(result).toBeNull();
     });
   });
 });

--- a/libs/accounts/rate-limit/src/lib/rate-limit.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.ts
@@ -3,7 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Redis } from 'ioredis';
-import { BlockStatus, Rule, BlockOn, BlockOnOpts, SearchOpts } from './models';
+import {
+  BlockStatus,
+  Rule,
+  BlockOn,
+  BlockOnOpts,
+  SearchOpts,
+  RateLimitRulesConfig,
+  RateLimitEventWriter,
+} from './models';
 import { ActionNotFound, MissingOption } from './error';
 import {
   createBlockRecord,
@@ -30,14 +38,10 @@ export class RateLimit {
    * @param redis A Redis client
    */
   constructor(
-    public readonly config: {
-      rules: Record<string, Rule[]>;
-      ignoreIPs?: Array<string>;
-      ignoreEmails?: Array<string>;
-      ignoreUIDs?: Array<string>;
-    },
+    public readonly config: RateLimitRulesConfig,
     private readonly redis: Redis,
-    private readonly statsd?: StatsD
+    private readonly statsd?: StatsD,
+    private readonly bqWriter?: RateLimitEventWriter
   ) {}
 
   /**
@@ -103,32 +107,38 @@ export class RateLimit {
    * Determines if a check can be skipped, due to an ignored ip, email, or uid.
    * When testing and developing it's often helpful to disable customs rules for
    * certain users.
+   * @param action - The action being checked. Required so BQ events include context.
    * @param opts - The current properties being checked.
-   * @returns
+   * @returns True if the check should be skipped.
    */
-  skip(opts: BlockOnOpts) {
-    if (opts.ip != null && this.config.ignoreIPs?.some((x) => opts.ip === x)) {
-      this.statsd?.increment('rate_limit.ignore.ip');
-      return true;
-    }
-
-    if (
-      opts.uid != null &&
-      this.config.ignoreUIDs?.some((x) => opts.uid === x)
-    ) {
-      this.statsd?.increment('rate_limit.ignore.uid');
-      return true;
-    }
-
-    if (
+  skip(action: string, opts: BlockOnOpts) {
+    const ignoredIp =
+      opts.ip != null && this.config.ignoreIPs?.some((x) => opts.ip === x);
+    const ignoredUid =
+      opts.uid != null && this.config.ignoreUIDs?.some((x) => opts.uid === x);
+    const ignoredEmail =
       opts.email != null &&
-      this.config.ignoreEmails?.some((x) => opts.email?.match(x))
-    ) {
-      this.statsd?.increment('rate_limit.ignore.email');
-      return true;
+      this.config.ignoreEmails?.some((x) => opts.email?.match(x));
+    const skipped = ignoredIp || ignoredUid || ignoredEmail;
+
+    if (ignoredIp) this.statsd?.increment('rate_limit.ignore.ip');
+    if (ignoredUid) this.statsd?.increment('rate_limit.ignore.uid');
+    if (ignoredEmail) this.statsd?.increment('rate_limit.ignore.email');
+
+    if (skipped) {
+      this.bqWriter?.write({
+        timestamp: Date.now(),
+        action,
+        ip: opts.ip,
+        email: opts.email,
+        uid: opts.uid,
+        wasBlocked: false,
+        wasSkipped: true,
+        usedDefaultRule: false,
+      });
     }
 
-    return false;
+    return skipped;
   }
 
   /**
@@ -147,7 +157,9 @@ export class RateLimit {
     // also the lightest check.
     const bans = await this.findBans(now, opts);
     if (bans.length > 0) {
-      return getLargestRetryAfter(bans);
+      const result = getLargestRetryAfter(bans);
+      this.emitCheckEvent(now, action, opts, result, [], false);
+      return result;
     }
 
     // Second, see if there's any outstanding blocks. If so they should get blocked
@@ -158,17 +170,20 @@ export class RateLimit {
     // If an active block is located, short circuit and return the block
     const block = this.determineBlockStatus(action, blocks);
     if (block) {
+      this.emitCheckEvent(now, action, opts, block, rules, false);
       return block;
     }
 
     // Otherwise, start counting attempts for applicable rules.
     const newBlocks = new Array<BlockStatus>();
+    const attemptCounts = new Map<string, number>();
     const addAttempt = async (rule: Rule, blockedValue: string) => {
       // Check to see if there are any blocks or bans that currently exist in Redis.
       // Create a new block/ban and add set of openBlocks.
       const attemptsKey = getKey('attempts', action, rule, blockedValue);
 
       const attempts = await this.redis.incr(attemptsKey);
+      attemptCounts.set(rule.blockingOn, attempts);
       if (attempts === 1) {
         await this.redis.expire(attemptsKey, rule.windowDurationInSeconds);
       }
@@ -212,7 +227,49 @@ export class RateLimit {
     await Promise.all(rules.map((x) => addAttempt(x.rule, x.blockedValue)));
 
     // If new blocks were added, return the one with the largest retryAfter value.
-    return this.determineBlockStatus(action, newBlocks);
+    const result = this.determineBlockStatus(action, newBlocks);
+    this.emitCheckEvent(now, action, opts, result, rules, false, attemptCounts);
+    return result;
+  }
+
+  /**
+   * Emits a BigQuery check event. Non-blocking, fire-and-forget.
+   */
+  private emitCheckEvent(
+    now: number,
+    action: string,
+    opts: BlockOnOpts,
+    result: BlockStatus | null,
+    rules: Array<{ rule: Rule; isDefault: boolean; blockedValue: string }>,
+    wasSkipped: boolean,
+    attemptCounts?: Map<string, number>
+  ) {
+    if (!this.bqWriter) {
+      return;
+    }
+
+    const firstRule = rules[0];
+    this.bqWriter.write({
+      timestamp: now,
+      action,
+      ip: opts.ip,
+      email: opts.email,
+      uid: opts.uid,
+      blockingOn: result?.blockingOn ?? firstRule?.rule.blockingOn,
+      ruleMaxAttempts: firstRule?.rule.maxAttempts,
+      ruleWindowSeconds: firstRule?.rule.windowDurationInSeconds,
+      ruleBlockSeconds: firstRule?.rule.blockDurationInSeconds,
+      currentAttempts: attemptCounts?.get(
+        firstRule?.rule.blockingOn
+      ),
+      wasBlocked: result != null,
+      blockPolicy: result?.policy,
+      blockDurationSeconds: result
+        ? Math.round(result.duration / 1000)
+        : undefined,
+      wasSkipped,
+      usedDefaultRule: firstRule?.isDefault ?? false,
+    });
   }
 
   /**

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -270,6 +270,20 @@ async function run(config) {
     ...config.redis,
     ...config.redis.ratelimit,
   });
+
+  // Create BigQuery writer for rate limit check logging (if enabled)
+  const { RateLimitBqWriter } = require('@fxa/accounts/rate-limit');
+  const bqWriter =
+    config.rateLimit.bigquery && config.rateLimit.bigquery.enabled
+      ? new RateLimitBqWriter({
+          projectId: config.rateLimit.bigquery.projectId,
+          dataset: config.rateLimit.bigquery.dataset,
+          table: config.rateLimit.bigquery.table,
+          flushIntervalMs: config.rateLimit.bigquery.flushIntervalMs,
+          batchSize: config.rateLimit.bigquery.batchSize,
+        })
+      : undefined;
+
   const rateLimit = new RateLimit(
     {
       rules,
@@ -278,7 +292,8 @@ async function run(config) {
       ignoreUIDs: config.rateLimit.ignoreUIDs,
     },
     rateLimitRedis,
-    statsd
+    statsd,
+    bqWriter
   );
   Container.set(RateLimit, rateLimit);
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2509,6 +2509,44 @@ const convictConf = convict({
       env: 'RATE_LIMIT__EMAIL_ALIAS_NORMALIZATION',
       format: String,
     },
+    bigquery: {
+      enabled: {
+        default: false,
+        doc: 'Enable logging rate limit checks to BigQuery',
+        env: 'RATE_LIMIT__BIGQUERY__ENABLED',
+        format: Boolean,
+      },
+      projectId: {
+        default: '',
+        doc: 'GCP project ID for BigQuery',
+        env: 'RATE_LIMIT__BIGQUERY__PROJECT_ID',
+        format: String,
+      },
+      dataset: {
+        default: 'fxa',
+        doc: 'BigQuery dataset name',
+        env: 'RATE_LIMIT__BIGQUERY__DATASET',
+        format: String,
+      },
+      table: {
+        default: 'rate_limit_checks',
+        doc: 'BigQuery table name',
+        env: 'RATE_LIMIT__BIGQUERY__TABLE',
+        format: String,
+      },
+      flushIntervalMs: {
+        default: 5000,
+        doc: 'How often to flush buffered events to BigQuery (ms)',
+        env: 'RATE_LIMIT__BIGQUERY__FLUSH_INTERVAL_MS',
+        format: Number,
+      },
+      batchSize: {
+        default: 100,
+        doc: 'Max events to buffer before flushing to BigQuery',
+        env: 'RATE_LIMIT__BIGQUERY__BATCH_SIZE',
+        format: Number,
+      },
+    },
   },
   recoveryPhone: {
     enabled: {

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -345,7 +345,7 @@ class CustomsClient {
 
     // The config can specify that certain ips, emails, or uids should be excluded
     // from rate limit checks.
-    const skip = this.rateLimit.skip(opts);
+    const skip = this.rateLimit.skip(action, opts);
     if (skip) {
       this.statsd.increment(`${serviceName}.check.v2.skip`, [
         opts.ip_email ? 'ip_email' : '',

--- a/packages/fxa-auth-server/lib/customs.spec.ts
+++ b/packages/fxa-auth-server/lib/customs.spec.ts
@@ -535,7 +535,7 @@ describe('Customs', () => {
 
       await customs.check(request, email, 'accountStatusCheck');
 
-      expect(mockRateLimit.skip).toHaveBeenCalledWith({ ip, email, ip_email });
+      expect(mockRateLimit.skip).toHaveBeenCalledWith('accountStatusCheck', { ip, email, ip_email });
       expect(mockRateLimit.check).toHaveBeenCalledTimes(0);
     });
 


### PR DESCRIPTION
## Because
- Rate-limit check data lives only in Redis and expires. We need durable records in BigQuery for analytics and forensics.

## This pull request
- Adds RateLimitCheckEvent type, RateLimitConfig type, and RateLimitEventWriter interface to models.ts.
- Creates RateLimitBqWriter: a batched, non-blocking writer that buffers events and flushes to BigQuery on interval or batch size.
- Adds optional bqWriter param to RateLimit constructor; emits an event on every check() and skip() call.
- Flattens skip() else-if chain into boolean variables for clarity.
- Adds bqWriter param to skip() signature so events include action.
- Wires writer into key_server.js and NestJS provider behind a feature flag (off by default).
- Adds BigQuery config section to auth-server convict schema.
- Adds unit tests for BqWriter and bqWriter integration in RateLimit.

## Issue that this pull request solves
Closes: FXA-13811

## Checklist
_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code. (See https://github.com/groovecoder/fxa/pull/1)

## How to review (Optional)
  - Key files/areas to focus on:
    - `libs/accounts/rate-limit/src/lib/bq-writer.ts` — new batched BigQuery writer shim
    - `libs/accounts/rate-limit/src/lib/rate-limit.ts` — bqWriter integration into `check()` and `skip()`
    - `packages/fxa-auth-server/config/index.ts` — new `bigquery` config block under `rateLimit`
  - Suggested review order:
    1. `models.ts` — new types (`RateLimitCheckEvent`, `RateLimitConfig`, `RateLimitEventWriter`)
    2. `bq-writer.ts` — the writer shim itself
    3. `rate-limit.ts` — how events are emitted from `check()` and `skip()`
    4. `key_server.js` and `rate-limit.provider.ts` — wiring in both instantiation paths
    5. `config/index.ts` — feature flag and config schema
    6. Test files — `bq-writer.spec.ts` and `rate-limit.spec.ts`
  - Risky or complex parts:
    - `skip()` signature changed from `skip(opts)` to `skip(action, opts)`. One caller in `customs.js` is updated.
    - `emitCheckEvent()` is called from three code paths in `check()` (bans, existing blocks, new blocks). Verify each emits the right fields.

## Screenshots (Optional)

N/A - no UI changes.

## Other information (Optional)
  - Feature is off by default (`RATE_LIMIT__BIGQUERY__ENABLED=false`).
  - BQ writes are fire-and-forget. Errors are caught and logged. They never affect auth flow.
  - `@google-cloud/bigquery` was already in the repo's dependencies.