### PR TITLE
chore(ci): [DISCOVERY] NX_PROFILE for the auth integration step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,9 +759,16 @@ jobs:
       - run:
           name: Run API Integration Tests
           command: |
+            mkdir -p artifacts
             NODE_OPTIONS="--max-old-space-size=7168" npx nx << parameters.nx_run >> << parameters.parallel >> << parameters.target >> << parameters.projects >>
           environment:
             NODE_ENV: test
+            # DISCOVERY (nshirley/nx-profile-integration): capture a per-task Nx profile
+            # (Chrome trace) for this step so we can break down cache-restore vs build-ts vs
+            # test time inside the long "Run API Integration Tests" step. The file lands in
+            # artifacts/ and is uploaded by store-artifacts as a downloadable CircleCI artifact.
+            # Load it in chrome://tracing or https://ui.perfetto.dev. REMOVE before merge.
+            NX_PROFILE: artifacts/nx-profile-integration.json
           no_output_timeout: 20m
       - store-artifacts
       - upload_to_gcs:

--- a/packages/fxa-auth-server/lib/time.ts
+++ b/packages/fxa-auth-server/lib/time.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// DISCOVERY (nshirley/nx-profile-integration): trivial edit to bust the
+// fxa-auth-server build/test cache so the integration job takes the full
+// cache-miss path and NX_PROFILE captures a representative trace. REMOVE before merge.
+
 export function startOfMinute(date: Date) {
   const year = date.getUTCFullYear();
   const month = date.getUTCMonth() + 1;

--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -19,15 +19,21 @@ elif [ "$TEST_TYPE" == 'scripts' ]; then
   npx jest --config jest.scripts.config.js --forceExit --ci --silent --reporters=default --reporters=jest-junit
 
 elif [ "$TEST_TYPE" == 'integration' ]; then
+  # DISCOVERY (nshirley/nx-profile-integration): time each Jest invocation separately
+  # to split the long test-integration span. REMOVE before merge.
   echo -e "\n\nRunning Jest integration tests (excluding test/scripts)"
+  __t=$SECONDS
   JEST_JUNIT_OUTPUT_DIR="../../artifacts/tests/fxa-auth-server" \
   JEST_JUNIT_OUTPUT_NAME="fxa-auth-server-jest-integration-results.xml" \
   npx jest --config jest.integration.config.js --forceExit --ci --reporters=default --reporters=jest-junit
+  echo "[test-ci timing] integration-config jest run: $((SECONDS - __t))s"
 
   echo -e "\n\nRunning Jest OAuth API integration tests (in-process server)"
+  __t=$SECONDS
   JEST_JUNIT_OUTPUT_DIR="../../artifacts/tests/fxa-auth-server" \
   JEST_JUNIT_OUTPUT_NAME="fxa-auth-server-jest-oauth-api-results.xml" \
   npx jest --config jest.oauth-api.config.js --forceExit --ci --reporters=default --reporters=jest-junit
+  echo "[test-ci timing] oauth-api jest run: $((SECONDS - __t))s"
 
   yarn run clean-up-old-ci-stripe-customers
 

--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -35,7 +35,10 @@ elif [ "$TEST_TYPE" == 'integration' ]; then
   npx jest --config jest.oauth-api.config.js --forceExit --ci --reporters=default --reporters=jest-junit
   echo "[test-ci timing] oauth-api jest run: $((SECONDS - __t))s"
 
+  echo -e "\n\nRunning customer clean up"
+  __t=$SECONDS
   yarn run clean-up-old-ci-stripe-customers
+  echo "[test-ci timing] clean-up-old-ci-stripe-customers: $((SECONDS - __t))s"
 
 else
   echo -e "\n\nRunning all Jest tests"

--- a/packages/fxa-auth-server/test/support/jest-global-setup.ts
+++ b/packages/fxa-auth-server/test/support/jest-global-setup.ts
@@ -139,6 +139,12 @@ function generateVersionJsonIfNeeded(): void {
 }
 
 export default async function globalSetup(): Promise<void> {
+  // DISCOVERY (nshirley/nx-profile-integration): time each setup phase to quantify
+  // server-boot vs the rest of the integration step. REMOVE before merge.
+  const __gsStart = Date.now();
+  const __phase = (label: string, since: number) =>
+    console.log(`[GS timing] ${label}: ${Date.now() - since}ms`);
+
   if (!process.env.CORS_ORIGIN) {
     process.env.CORS_ORIGIN = 'http://foo,http://bar';
   }
@@ -158,7 +164,9 @@ export default async function globalSetup(): Promise<void> {
 
   const printLogs = process.env.MAIL_HELPER_LOGS === 'true';
 
+  const __k0 = Date.now();
   generateKeysIfNeeded();
+  __phase('generateKeys', __k0);
   generateVersionJsonIfNeeded();
 
   // Kill stale auth servers from previous runs before starting new ones
@@ -219,7 +227,9 @@ export default async function globalSetup(): Promise<void> {
     SHARED_PROFILE_PORT,
     '...'
   );
+  const __p0 = Date.now();
   const sharedProfileHelper = await createProfileHelper(SHARED_PROFILE_PORT);
+  __phase('profile helper start', __p0);
   (global as any).__sharedProfileHelper = sharedProfileHelper;
   console.log(
     '[Jest Global Setup] Shared profile helper started on port',
@@ -235,6 +245,7 @@ export default async function globalSetup(): Promise<void> {
 
   killExistingProcess(SHARED_SERVER_PID_FILE, 'shared_server');
 
+  const __srv0 = Date.now();
   const sharedPublicUrl = `http://localhost:${SHARED_SERVER_PORT}`;
   const sharedProfileUrl = `http://${PROFILE_HELPER_HOST}:${SHARED_PROFILE_PORT}`;
   const sharedPrintLogs = process.env.REMOTE_TEST_LOGS === 'true';
@@ -276,6 +287,8 @@ export default async function globalSetup(): Promise<void> {
 
   try {
     await waitForServer(sharedPublicUrl);
+    __phase('shared auth server boot', __srv0);
+    __phase('TOTAL globalSetup', __gsStart);
     console.log(
       '[Jest Global Setup] Shared auth server started (PID:',
       sharedSpawned.process.pid,


### PR DESCRIPTION
## Discovery — not for merge

Temporary instrumentation to break down the long `Run API Integration Tests` step in **Integration Test - Servers - Auth (PR)**, which runs 8–11 min even when most nx tasks are cache hits. CircleCI only times the step as a whole, so this captures a per-task Nx trace to split it into cache-restore vs `build-ts` vs the tests.

### Changes
- `.circleci/config.yml`: `NX_PROFILE=artifacts/nx-profile-integration.json` on the integration test step (+ `mkdir -p artifacts`); uploaded via `store-artifacts`.
- `packages/fxa-auth-server/lib/time.ts`: trivial comment to force the cache-miss path so the trace is representative.

Both tagged `REMOVE before merge`. Load the artifact in `chrome://tracing` / Perfetto.

Related discovery for FXA-13673.