### PR TITLE
fix(payments): align Glean checkout conversion numbers (PAY-3758)

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
@@ -99,10 +99,7 @@ export default async function NeedsInputPage({
         locale={locale}
         cart={cart}
       >
-        <PaymentInputHandler
-          cartId={resolvedParams.cartId}
-          isFreeTrial={cart.isFreeTrial}
-        />
+        <PaymentInputHandler cartId={resolvedParams.cartId} />
       </StripeWrapper>
       <h2 id="processing-payment-heading">
         {l10n.getString(

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
@@ -49,7 +49,7 @@ export default async function ProcessingPage({
   const acceptLanguage = (await headers()).get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/checkout/${resolvedParams.cartId}/processing`;
-  const { isFreeTrial } = await validateCartStateAndRedirectAction(
+  await validateCartStateAndRedirectAction(
     resolvedParams.cartId,
     SupportedPages.PROCESSING,
     currentPathname,
@@ -62,10 +62,7 @@ export default async function ProcessingPage({
       aria-labelledby="processing-payment-heading"
     >
       <LoadingSpinner className="w-10 h-10" />
-      <PaymentStateObserver
-        cartId={resolvedParams.cartId}
-        isFreeTrial={isFreeTrial}
-      />
+      <PaymentStateObserver cartId={resolvedParams.cartId} />
       <h2 id="processing-payment-heading">
         {l10n.getString(
           'next-payment-processing-message',

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
@@ -97,10 +97,7 @@ export default async function NeedsInputPage({
         locale={locale}
         cart={cart}
       >
-        <PaymentInputHandler
-          cartId={resolvedParams.cartId}
-          isFreeTrial={cart.isFreeTrial}
-        />
+        <PaymentInputHandler cartId={resolvedParams.cartId} />
       </StripeWrapper>
       <h2 id="processing-payment-heading">
         {l10n.getString(

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
@@ -49,7 +49,7 @@ export default async function ProcessingPage({
   const acceptLanguage = (await headers()).get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/upgrade/${resolvedParams.cartId}/processing`;
-  const { isFreeTrial } = await validateCartStateAndRedirectAction(
+  await validateCartStateAndRedirectAction(
     resolvedParams.cartId,
     SupportedPages.PROCESSING,
     currentPathname,
@@ -62,10 +62,7 @@ export default async function ProcessingPage({
       aria-labelledby="processing-payment-heading"
     >
       <LoadingSpinner className="w-10 h-10" />
-      <PaymentStateObserver
-        cartId={resolvedParams.cartId}
-        isFreeTrial={isFreeTrial}
-      />
+      <PaymentStateObserver cartId={resolvedParams.cartId} />
       <h2 id="processing-payment-heading">
         {l10n.getString(
           'next-payment-processing-message',

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -96,6 +96,8 @@ import {
 import { CartManager } from './cart.manager';
 import { CartService } from './cart.service';
 import { CheckoutService } from './checkout.service';
+import { CHECKOUT_EVENT_EMITTER_TOKEN } from '@fxa/payments/metrics';
+import type { CheckoutEventEmitter } from '@fxa/payments/metrics';
 import { FreeTrialManager } from './free-trial.manager';
 import { MockFreeTrialConfigProvider } from './free-trial.config';
 import {
@@ -169,6 +171,7 @@ describe('CartService', () => {
   let cartService: CartService;
   let cartManager: CartManager;
   let checkoutService: CheckoutService;
+  let checkoutEmitter: CheckoutEventEmitter;
   let customerManager: CustomerManager;
   let customerSessionManager: CustomerSessionManager;
   let currencyManager: CurrencyManager;
@@ -200,6 +203,10 @@ describe('CartService', () => {
         CartManager,
         CartService,
         CheckoutService,
+        {
+          provide: CHECKOUT_EVENT_EMITTER_TOKEN,
+          useValue: { emit: jest.fn().mockResolvedValue(undefined) },
+        },
         ConfirmationTokenManager,
         CustomerManager,
         CustomerSessionManager,
@@ -267,6 +274,7 @@ describe('CartService', () => {
     cartManager = moduleRef.get(CartManager);
     cartService = moduleRef.get(CartService);
     checkoutService = moduleRef.get(CheckoutService);
+    checkoutEmitter = moduleRef.get(CHECKOUT_EVENT_EMITTER_TOKEN);
     customerManager = moduleRef.get(CustomerManager);
     customerSessionManager = moduleRef.get(CustomerSessionManager);
     currencyManager = moduleRef.get(CurrencyManager);
@@ -311,6 +319,30 @@ describe('CartService', () => {
       ).rejects.toThrow(Error);
 
       expect(cartManager.finishErrorCart).toHaveBeenCalled();
+    });
+
+    it('does not emit pay_setup.fail for non-submit failures', async () => {
+      // finalizeProcessingCart wraps with wrapWithCartCatch but does NOT
+      // pass onCheckoutFail, so a failure during its body must not be
+      // counted as a checkout submit failure in Glean conversion numbers.
+      const mockCart = ResultCartFactory({
+        state: CartState.PROCESSING,
+        stripeSubscriptionId: null,
+        stripeCustomerId: null,
+      });
+      jest
+        .spyOn(cartManager, 'fetchCartById')
+        .mockRejectedValueOnce(new Error('test'))
+        .mockResolvedValue(mockCart);
+      jest.spyOn(cartManager, 'finishErrorCart').mockResolvedValue();
+      const emitSpy = jest.spyOn(checkoutEmitter, 'emit');
+
+      await expect(
+        cartService.finalizeProcessingCart(mockCart.id)
+      ).rejects.toThrow(Error);
+
+      expect(cartManager.finishErrorCart).toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalledWith('checkoutFail', expect.anything());
     });
 
     it('cancels and stamps suppression metadata for a created subscription with paid zero-cost invoice', async () => {
@@ -1324,6 +1356,42 @@ describe('CartService', () => {
 
       expect(checkoutService.payWithStripe).not.toHaveBeenCalled();
       expect(cartManager.finishErrorCart).toHaveBeenCalled();
+    });
+
+    it('emits pay_setup.fail when checkout fails', async () => {
+      const mockCart = ResultCartFactory();
+      const mockPaymentMethodId = faker.string.uuid();
+
+      jest
+        .spyOn(cartManager, 'fetchAndValidateCartVersion')
+        .mockRejectedValue(new Error('boom'));
+      jest.spyOn(cartManager, 'finishErrorCart').mockResolvedValue();
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+      const emitSpy = jest.spyOn(checkoutEmitter, 'emit');
+
+      await expect(
+        cartService.checkoutCartWithStripe(
+          mockCart.id,
+          mockCart.version,
+          mockPaymentMethodId,
+          mockAttributionData,
+          mockRequestArgs,
+          mockCart.uid
+        )
+      ).rejects.toBeInstanceOf(CartStateProcessingError);
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        'checkoutFail',
+        expect.objectContaining({
+          ipAddress: mockRequestArgs.ipAddress,
+          userAgent: mockRequestArgs.userAgent,
+          params: expect.objectContaining({
+            cartId: mockCart.id,
+            offeringId: mockCart.offeringConfigId,
+            interval: mockCart.interval,
+          }),
+        })
+      );
     });
   });
 
@@ -3150,6 +3218,7 @@ describe('CartService', () => {
         casing: 'lower',
       }),
     });
+    const mockRequestArgs = CommonMetricsFactory();
     const mockPaymentMethod = StripeResponseFactory(
       StripePaymentMethodFactory()
     );
@@ -3189,7 +3258,7 @@ describe('CartService', () => {
     });
 
     it('changes the cart state and calls postPaySteps', async () => {
-      await cartService.submitNeedsInput(mockCart.id);
+      await cartService.submitNeedsInput(mockCart.id, mockRequestArgs);
 
       expect(paymentIntentManager.retrieve).toHaveBeenCalledWith(
         mockCart.stripeIntentId
@@ -3210,6 +3279,7 @@ describe('CartService', () => {
         paymentProvider: 'stripe',
         paymentForm: SubPlatPaymentMethodType.Card,
         isCancelInterstitialOffer: false,
+        requestArgs: mockRequestArgs,
       });
       expect(cartManager.finishErrorCart).not.toHaveBeenCalled();
     });
@@ -3223,7 +3293,7 @@ describe('CartService', () => {
         .spyOn(cartManager, 'fetchCartById')
         .mockResolvedValue(mockCartWithSetupIntent);
 
-      await cartService.submitNeedsInput(mockCart.id);
+      await cartService.submitNeedsInput(mockCart.id, mockRequestArgs);
 
       expect(setupIntentManager.retrieve).toHaveBeenCalledWith(
         mockCartWithSetupIntent.stripeIntentId
@@ -3244,6 +3314,7 @@ describe('CartService', () => {
         paymentProvider: 'stripe',
         paymentForm: SubPlatPaymentMethodType.Card,
         isCancelInterstitialOffer: false,
+        requestArgs: mockRequestArgs,
       });
       expect(cartManager.finishErrorCart).not.toHaveBeenCalled();
     });
@@ -3255,7 +3326,7 @@ describe('CartService', () => {
       };
       jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(localMockCart);
 
-      await expect(cartService.submitNeedsInput(mockCart.id)).rejects.toThrow(
+      await expect(cartService.submitNeedsInput(mockCart.id, mockRequestArgs)).rejects.toThrow(
         /SubmitNeedsInputCustomerIdMissingError/
       );
     });
@@ -3266,7 +3337,7 @@ describe('CartService', () => {
       };
       jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(localMockCart);
 
-      await expect(cartService.submitNeedsInput(mockCart.id)).rejects.toThrow(
+      await expect(cartService.submitNeedsInput(mockCart.id, mockRequestArgs)).rejects.toThrow(
         /SubmitNeedsInputSubscriptionIdMissingError/
       );
     });
@@ -3277,7 +3348,7 @@ describe('CartService', () => {
       };
       jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(localMockCart);
 
-      await expect(cartService.submitNeedsInput(mockCart.id)).rejects.toThrow(
+      await expect(cartService.submitNeedsInput(mockCart.id, mockRequestArgs)).rejects.toThrow(
         /SubmitNeedsInputUidMissingError/
       );
     });

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -51,7 +51,11 @@ import {
 } from '@fxa/shared/db/mysql/account';
 import { SanitizeExceptions } from '@fxa/shared/error';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
-import type { CommonMetrics } from '@fxa/payments/metrics';
+import {
+  CHECKOUT_EVENT_EMITTER_TOKEN,
+  type CheckoutEventEmitter,
+  type CommonMetrics,
+} from '@fxa/payments/metrics';
 
 import {
   PaidInvoiceOnFailedCartError,
@@ -122,7 +126,15 @@ import type { CartStore } from './cart-als.types';
 
 type Constructor<T> = new (...args: any[]) => T;
 interface WrapWithCartCatchOptions {
-  errorAllowList: Constructor<Error>[];
+  errorAllowList?: Constructor<Error>[];
+  // Invoked after the cart is finalized to FAIL. Only the submit-attempt call
+  // sites (checkoutCartWithStripe, checkoutCartWithPaypal, submitNeedsInput)
+  // pass this so that pay_setup.fail Glean telemetry fires for genuine
+  // checkout failures and not for incidental wrapWithCartCatch failures in
+  // other cart operations (updateCart, restartCart, getNeedsInput, …).
+  // The cart has its errorReasonId already set by finishErrorCart, so the
+  // callback can read it from the cart record itself.
+  onCheckoutFail?: (cart: ResultCart) => Promise<void>;
 }
 
 const IGNORED_EXPECTED_ERRORS_STATSD = new Set([
@@ -140,6 +152,8 @@ export class CartService {
     private asyncLocalStorage: AsyncLocalStorage<CartStore>,
     private cartManager: CartManager,
     private checkoutService: CheckoutService,
+    @Inject(CHECKOUT_EVENT_EMITTER_TOKEN)
+    private checkoutEmitter: CheckoutEventEmitter,
     private currencyManager: CurrencyManager,
     private customerManager: CustomerManager,
     private customerSessionManager: CustomerSessionManager,
@@ -214,6 +228,15 @@ export class CartService {
         const store = this.asyncLocalStorage.getStore();
         const subscriptionId =
           cart.stripeSubscriptionId || store?.checkout.subscriptionId;
+
+        // Gated emission: pay_setup.fail fires only when the caller opts
+        // in via onCheckoutFail. Submit-attempt call sites do; cart-edit
+        // / read-only paths (updateCart, restartCart, getNeedsInput) do
+        // not, so an incidental error in those paths does not skew the
+        // checkout conversion numbers.
+        if (options?.onCheckoutFail) {
+          await options.onCheckoutFail(cart);
+        }
 
         if (subscriptionId) {
           const subscription =
@@ -624,7 +647,18 @@ export class CartService {
     requestArgs: CommonMetrics,
     sessionUid?: string
   ) {
-    return this.wrapWithCartCatch(cartId, async () => {
+    const onCheckoutFail = async (cart: ResultCart) => {
+      await this.checkoutEmitter.emit('checkoutFail', {
+        ...requestArgs,
+        params: {
+          ...requestArgs.params,
+          cartId: cart.id,
+          offeringId: cart.offeringConfigId,
+          interval: cart.interval,
+        },
+      });
+    };
+    return this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
       let updatedCart: ResultCart | null = null;
       try {
         //Ensure that the cart version matches the value passed in from FE
@@ -645,7 +679,7 @@ export class CartService {
         { checkout: { subscriptionId: undefined } },
         () => {
           // Intentionally non-blocking
-          this.wrapWithCartCatch(cartId, async () => {
+          this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
             await this.checkoutService.payWithStripe(
               updatedCart,
               confirmationTokenId,
@@ -677,7 +711,18 @@ export class CartService {
     sessionUid?: string,
     token?: string
   ) {
-    return this.wrapWithCartCatch(cartId, async () => {
+    const onCheckoutFail = async (cart: ResultCart) => {
+      await this.checkoutEmitter.emit('checkoutFail', {
+        ...requestArgs,
+        params: {
+          ...requestArgs.params,
+          cartId: cart.id,
+          offeringId: cart.offeringConfigId,
+          interval: cart.interval,
+        },
+      });
+    };
+    return this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
       let updatedCart: ResultCart | null = null;
       try {
         //Ensure that the cart version matches the value passed in from FE
@@ -698,7 +743,7 @@ export class CartService {
         { checkout: { subscriptionId: undefined } },
         () => {
           // Intentionally non-blocking
-          this.wrapWithCartCatch(cartId, async () => {
+          this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
             await this.checkoutService.payWithPaypal(
               updatedCart,
               attribution,
@@ -1244,8 +1289,19 @@ export class CartService {
   }
 
   @SanitizeExceptions()
-  async submitNeedsInput(cartId: string) {
-    return this.wrapWithCartCatch(cartId, async () => {
+  async submitNeedsInput(cartId: string, requestArgs: CommonMetrics) {
+    const onCheckoutFail = async (cart: ResultCart) => {
+      await this.checkoutEmitter.emit('checkoutFail', {
+        ...requestArgs,
+        params: {
+          ...requestArgs.params,
+          cartId: cart.id,
+          offeringId: cart.offeringConfigId,
+          interval: cart.interval,
+        },
+      });
+    };
+    return this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
       const cart = await this.cartManager.fetchCartById(cartId);
       assert(
         cart.stripeCustomerId,
@@ -1297,6 +1353,7 @@ export class CartService {
             this.subscriptionManager.getPaymentProvider(subscription),
           paymentForm,
           isCancelInterstitialOffer: false,
+          requestArgs,
         });
       } else if (intent.status === 'requires_payment_method') {
         const errorCode = isPaymentIntent(intent)

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -107,6 +107,7 @@ import {
 } from './cart.error';
 import { AccountCustomerAlreadyExistsError } from './checkout.error';
 import { CheckoutService } from './checkout.service';
+import { CHECKOUT_EVENT_EMITTER_TOKEN } from '@fxa/payments/metrics';
 import { PrePayStepsResultFactory } from './checkout.factories';
 import { AccountManager } from '@fxa/shared/account/account';
 import { CurrencyManager } from '@fxa/payments/currency';
@@ -190,6 +191,10 @@ describe('CheckoutService', () => {
         CartManager,
         CartService,
         CheckoutService,
+        {
+          provide: CHECKOUT_EVENT_EMITTER_TOKEN,
+          useValue: { emit: jest.fn().mockResolvedValue(undefined) },
+        },
         ConfirmationTokenManager,
         CustomerManager,
         CustomerSessionManager,

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -93,7 +93,11 @@ import { throwIntentFailedError } from './util/throwIntentFailedError';
 import type { AsyncLocalStorage } from 'async_hooks';
 import { AsyncLocalStorageCart } from './cart-als.provider';
 import type { CartStore } from './cart-als.types';
-import { type CommonMetrics } from '@fxa/payments/metrics';
+import {
+  CHECKOUT_EVENT_EMITTER_TOKEN,
+  type CheckoutEventEmitter,
+  type CommonMetrics,
+} from '@fxa/payments/metrics';
 import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import { isCancelInterstitialOffer } from './util/isCancelInterstitialOffer';
 import { FreeTrialManager } from './free-trial.manager';
@@ -127,6 +131,8 @@ export class CheckoutService {
     private freeTrialManager: FreeTrialManager,
     private nimbusManager: NimbusManager,
     private gleanService: PaymentsMetricsAggregatorService,
+    @Inject(CHECKOUT_EVENT_EMITTER_TOKEN)
+    private checkoutEmitter: CheckoutEventEmitter,
     @Inject(StatsDService) private statsd: StatsD
   ) {}
 
@@ -358,6 +364,34 @@ export class CheckoutService {
       payment_form: paymentForm,
       offering_id: cart.offeringConfigId,
       interval: cart.interval,
+    });
+
+    // Emit the Glean conversion event server-side so it fires even when the
+    // user has already navigated away from the checkout page. The frontend
+    // PaymentStateObserver no longer emits this event. The emitter handler
+    // in PaymentsEmitterService enriches via retrieveAdditionalMetricsData,
+    // so we merge cart-derived params (cartId/offeringId/interval) onto the
+    // request CommonMetrics — guarantees the handler can look up the cart
+    // even when args.requestArgs is undefined (e.g. cron-driven finalize).
+    const baseMetrics: CommonMetrics = args.requestArgs ?? {
+      ipAddress: '',
+      deviceType: '',
+      userAgent: '',
+      experimentationId: '',
+      isFreeTrial: false,
+      params: {},
+      searchParams: {},
+    };
+    await this.checkoutEmitter.emit('checkoutSuccess', {
+      ...baseMetrics,
+      params: {
+        ...baseMetrics.params,
+        cartId: cart.id,
+        offeringId: cart.offeringConfigId,
+        interval: cart.interval,
+      },
+      paymentProvider,
+      paymentMethod: paymentForm,
     });
   }
 

--- a/libs/payments/events/src/lib/emitter.service.spec.ts
+++ b/libs/payments/events/src/lib/emitter.service.spec.ts
@@ -15,10 +15,8 @@ import {
 import {
   MockStripeConfigProvider,
   StripeClient,
-  StripeCustomerFactory,
   StripePriceFactory,
   StripeResponseFactory,
-  StripeSubscriptionFactory,
 } from '@fxa/payments/stripe';
 import {
   MockStatsDProvider,
@@ -32,7 +30,6 @@ import {
   PaymentMethodManager,
   PaymentProvider,
   SubPlatPaymentMethodType,
-  StripePaymentMethodTypeResponseFactory,
 } from '@fxa/payments/customer';
 import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import {
@@ -92,15 +89,12 @@ jest.mock('@sentry/nestjs', () => ({
 describe('PaymentsEmitterService', () => {
   let accountManager: AccountManager;
   let cartManager: CartManager;
-  let customerManager: CustomerManager;
   let paymentsEmitterService: PaymentsEmitterService;
   let paymentsGleanManager: PaymentsGleanManager;
-  let paymentMethodManager: PaymentMethodManager;
   let productConfigurationManager: ProductConfigurationManager;
   let nimbusManager: NimbusManager;
   let statsd: StatsD;
   let logger: Logger;
-  let subscriptionManager: SubscriptionManager;
   let paymentsGleanService: PaymentsMetricsAggregatorService;
 
   const additionalMetricsData = AdditionalMetricsDataFactory();
@@ -156,16 +150,13 @@ describe('PaymentsEmitterService', () => {
     }).compile();
 
     accountManager = moduleRef.get(AccountManager);
-    customerManager = moduleRef.get(CustomerManager);
     paymentsEmitterService = moduleRef.get(PaymentsEmitterService);
     paymentsGleanManager = moduleRef.get(PaymentsGleanManager);
-    paymentMethodManager = moduleRef.get(PaymentMethodManager);
     productConfigurationManager = moduleRef.get(ProductConfigurationManager);
     nimbusManager = moduleRef.get(NimbusManager);
     cartManager = moduleRef.get(CartManager);
     statsd = moduleRef.get<StatsD>(StatsDService);
     logger = moduleRef.get<Logger>(Logger);
-    subscriptionManager = moduleRef.get(SubscriptionManager);
     paymentsGleanService = moduleRef.get(PaymentsMetricsAggregatorService);
   });
 
@@ -409,32 +400,17 @@ describe('PaymentsEmitterService', () => {
   });
 
   describe('handleCheckoutSuccess', () => {
-    const mockCustomer = StripeCustomerFactory();
-    const mockSubscription = StripeSubscriptionFactory();
-    const mockPaymentMethod = StripePaymentMethodTypeResponseFactory();
     beforeEach(() => {
-      jest
-        .spyOn(customerManager, 'retrieve')
-        .mockResolvedValue(StripeResponseFactory(mockCustomer));
-      jest
-        .spyOn(subscriptionManager, 'listForCustomer')
-        .mockResolvedValue(StripeResponseFactory([mockSubscription]));
-      jest
-        .spyOn(paymentMethodManager, 'determineType')
-        .mockResolvedValue(mockPaymentMethod);
       jest
         .spyOn(paymentsGleanManager, 'recordFxaPaySetupSuccess')
         .mockReturnValue();
     });
 
-    it('should call manager record method', async () => {
+    it('enriches via retrieveAdditionalMetricsData and calls recordFxaPaySetupSuccess', async () => {
       await paymentsEmitterService.handleCheckoutSuccess(
         mockCheckoutPaymentEvents
       );
 
-      expect(customerManager.retrieve).toHaveBeenCalled();
-      expect(subscriptionManager.listForCustomer).toHaveBeenCalled();
-      expect(paymentMethodManager.determineType).toHaveBeenCalled();
       expect(mockedRetrieveAdditionalMetricsData).toHaveBeenCalledWith(
         productConfigurationManager,
         cartManager,
@@ -448,26 +424,32 @@ describe('PaymentsEmitterService', () => {
           experimentationData: { nimbusUserId },
           ...additionalMetricsData,
         },
-        mockPaymentMethod.provider,
-        mockPaymentMethod.type
+        mockCheckoutPaymentEvents.paymentProvider,
+        mockCheckoutPaymentEvents.paymentMethod
       );
     });
 
-    it('should not record glean event if user opts out', async () => {
-      jest
-        .spyOn(paymentsEmitterService as any, 'retrieveOptOut')
-        .mockResolvedValue(true);
+    it('skips emission when the account has opted out', async () => {
+      retrieveOptOutMock.mockResolvedValue(true);
+
       await paymentsEmitterService.handleCheckoutSuccess(
         mockCheckoutPaymentEvents
       );
-      expect(mockedRetrieveAdditionalMetricsData).toHaveBeenCalledWith(
-        productConfigurationManager,
-        cartManager,
-        mockCommonMetricsData.params
-      );
+
       expect(
         paymentsGleanManager.recordFxaPaySetupSuccess
       ).not.toHaveBeenCalled();
+    });
+
+    it('swallows errors so telemetry failures cannot break checkout', async () => {
+      mockedRetrieveAdditionalMetricsData.mockRejectedValue(
+        new Error('db down')
+      );
+
+      await expect(
+        paymentsEmitterService.handleCheckoutSuccess(mockCheckoutPaymentEvents)
+      ).resolves.toBeUndefined();
+      expect(Sentry.captureException).toHaveBeenCalled();
     });
   });
 
@@ -478,10 +460,8 @@ describe('PaymentsEmitterService', () => {
         .mockReturnValue();
     });
 
-    it('should call manager record method', async () => {
-      await paymentsEmitterService.handleCheckoutFail(
-        mockCheckoutPaymentEvents
-      );
+    it('enriches via retrieveAdditionalMetricsData and calls recordFxaPaySetupFail', async () => {
+      await paymentsEmitterService.handleCheckoutFail(mockCommonMetricsData);
 
       expect(mockedRetrieveAdditionalMetricsData).toHaveBeenCalledWith(
         productConfigurationManager,
@@ -489,25 +469,20 @@ describe('PaymentsEmitterService', () => {
         mockCommonMetricsData.params
       );
       expect(paymentsGleanManager.recordFxaPaySetupFail).toHaveBeenCalledWith({
-        commonMetricsData: mockCheckoutPaymentEvents,
+        commonMetricsData: mockCommonMetricsData,
         experimentationData: { nimbusUserId },
         ...additionalMetricsData,
       });
     });
 
-    it('should not record glean event if user opts out', async () => {
-      jest
-        .spyOn(paymentsEmitterService as any, 'retrieveOptOut')
-        .mockResolvedValue(true);
-      await paymentsEmitterService.handleCheckoutFail(
-        mockCheckoutPaymentEvents
-      );
-      expect(mockedRetrieveAdditionalMetricsData).toHaveBeenCalledWith(
-        productConfigurationManager,
-        cartManager,
-        mockCommonMetricsData.params
-      );
-      expect(paymentsGleanManager.recordFxaPaySetupFail).not.toHaveBeenCalled();
+    it('skips emission when the account has opted out', async () => {
+      retrieveOptOutMock.mockResolvedValue(true);
+
+      await paymentsEmitterService.handleCheckoutFail(mockCommonMetricsData);
+
+      expect(
+        paymentsGleanManager.recordFxaPaySetupFail
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/payments/events/src/lib/emitter.service.ts
+++ b/libs/payments/events/src/lib/emitter.service.ts
@@ -20,15 +20,12 @@ import {
   TrialConvertedEvents,
   type AuthEvents,
 } from './emitter.types';
+import type {
+  CheckoutFailPayload,
+  CheckoutSuccessPayload,
+} from '@fxa/payments/metrics';
 import { AccountManager } from '@fxa/shared/account/account';
-import {
-  getSubplatInterval,
-  CustomerManager,
-  SubscriptionManager,
-  PaymentMethodManager,
-  PaymentProvidersType,
-  type SubPlatPaymentMethodType,
-} from '@fxa/payments/customer';
+import { getSubplatInterval } from '@fxa/payments/customer';
 import * as Sentry from '@sentry/nestjs';
 import { StatsD, StatsDService } from '@fxa/shared/metrics/statsd';
 import { EmitterServiceHandleAuthError } from './emitter.error';
@@ -42,15 +39,12 @@ export class PaymentsEmitterService {
   constructor(
     private accountManager: AccountManager,
     private cartManager: CartManager,
-    private customerManager: CustomerManager,
     private log: Logger,
     private nimbusManager: NimbusManager,
     private paymentsGleanManager: PaymentsGleanManager,
     private paymentsGleanService: PaymentsMetricsAggregatorService,
-    private paymentMethodManager: PaymentMethodManager,
     private productConfigurationManager: ProductConfigurationManager,
-    @Inject(StatsDService) public statsd: StatsD,
-    private subscriptionManager: SubscriptionManager
+    @Inject(StatsDService) public statsd: StatsD
   ) {
     this.emitter = new Emittery<PaymentsEmitterEvents>();
     this.emitter.on('checkoutView', this.handleCheckoutView.bind(this));
@@ -212,18 +206,27 @@ export class PaymentsEmitterService {
     }
   }
 
-  async handleCheckoutSuccess(eventData: CheckoutPaymentEvents) {
-    const additionalData = await retrieveAdditionalMetricsData(
-      this.productConfigurationManager,
-      this.cartManager,
-      eventData.params
-    );
+  /**
+   * Backend-triggered: cart-side code emits this after a cart transitions
+   * to terminal SUCCESS. Mirrors handleCheckoutSubmit — eventData carries
+   * the request CommonMetrics and the handler uses retrieveAdditionalMetricsData
+   * to look up the cart and CMS data.
+   */
+  async handleCheckoutSuccess(eventData: CheckoutSuccessPayload) {
+    try {
+      const additionalData = await retrieveAdditionalMetricsData(
+        this.productConfigurationManager,
+        this.cartManager,
+        eventData.params
+      );
 
-    const metricsOptOut = await this.retrieveOptOut(
-      additionalData.cartMetricsData.uid
-    );
+      const metricsOptOut = await this.retrieveOptOut(
+        additionalData.cartMetricsData.uid
+      );
+      if (metricsOptOut) {
+        return;
+      }
 
-    if (!metricsOptOut) {
       const nimbusUserId = await this.getNimbusUserId({
         uid: additionalData.cartMetricsData.uid,
         language: additionalData.locale,
@@ -233,55 +236,41 @@ export class PaymentsEmitterService {
           eventData?.searchParams?.['experimentationPreview'] === 'true',
       });
 
-      // Determine payment provider and method
-      let paymentProvider: PaymentProvidersType | undefined;
-      let paymentMethod: SubPlatPaymentMethodType | undefined;
-      if (additionalData.cartMetricsData.stripeCustomerId) {
-        const { stripeCustomerId } = additionalData.cartMetricsData;
-        const customer = await this.customerManager.retrieve(stripeCustomerId);
-        const subscriptions =
-          await this.subscriptionManager.listForCustomer(stripeCustomerId);
-        const paymentMethodTypeResponse =
-          await this.paymentMethodManager.determineType(
-            customer,
-            subscriptions
-          );
-
-        if (paymentMethodTypeResponse?.type) {
-          paymentProvider = paymentMethodTypeResponse.provider;
-          paymentMethod = paymentMethodTypeResponse.type;
-        }
-      }
-
       this.paymentsGleanManager.recordFxaPaySetupSuccess(
         {
           commonMetricsData: eventData,
           ...additionalData,
           experimentationData: { nimbusUserId },
         },
-        paymentProvider,
-        paymentMethod
+        eventData.paymentProvider,
+        eventData.paymentMethod
       );
+    } catch (error) {
+      Sentry.captureException(error);
     }
   }
 
-  async handleGenericSubManageGleanEvent(
-    eventData: GenericGleanSubManageEvent
-  ) {
-    await this.paymentsGleanService.recordGenericSubManageEvent(eventData);
-  }
+  /**
+   * Backend-triggered: cart-side code emits this after a cart transitions
+   * to terminal FAIL via a checkout-submit path (gated by onCheckoutFail).
+   * The errorReasonId is read from the cart record (finishErrorCart wrote
+   * it before this emit), surfaced via retrieveAdditionalMetricsData.
+   */
+  async handleCheckoutFail(eventData: CheckoutFailPayload) {
+    try {
+      const additionalData = await retrieveAdditionalMetricsData(
+        this.productConfigurationManager,
+        this.cartManager,
+        eventData.params
+      );
 
-  async handleCheckoutFail(eventData: CheckoutPaymentEvents) {
-    const additionalData = await retrieveAdditionalMetricsData(
-      this.productConfigurationManager,
-      this.cartManager,
-      eventData.params
-    );
+      const metricsOptOut = await this.retrieveOptOut(
+        additionalData.cartMetricsData.uid
+      );
+      if (metricsOptOut) {
+        return;
+      }
 
-    const metricsOptOut = await this.retrieveOptOut(
-      additionalData.cartMetricsData.uid
-    );
-    if (!metricsOptOut) {
       const nimbusUserId = await this.getNimbusUserId({
         uid: additionalData.cartMetricsData.uid,
         language: additionalData.locale,
@@ -296,7 +285,15 @@ export class PaymentsEmitterService {
         ...additionalData,
         experimentationData: { nimbusUserId },
       });
+    } catch (error) {
+      Sentry.captureException(error);
     }
+  }
+
+  async handleGenericSubManageGleanEvent(
+    eventData: GenericGleanSubManageEvent
+  ) {
+    await this.paymentsGleanService.recordGenericSubManageEvent(eventData);
   }
 
   async handleSubscriptionEnded(eventData: SubscriptionEndedEvents) {

--- a/libs/payments/events/src/lib/emitter.types.ts
+++ b/libs/payments/events/src/lib/emitter.types.ts
@@ -5,6 +5,8 @@
 import {
   CancellationReason,
   CartMetrics,
+  type CheckoutFailPayload,
+  type CheckoutSuccessPayload,
   CmsMetricsData,
   CommonMetrics,
   type GenericGleanSubManageEvent,
@@ -59,8 +61,6 @@ export const PaymentsEmitterEventsKeys = [
   'checkoutView',
   'checkoutEngage',
   'checkoutSubmit',
-  'checkoutSuccess',
-  'checkoutFail',
 ] as const;
 export type PaymentsEmitterEventsKeysType =
   (typeof PaymentsEmitterEventsKeys)[number];
@@ -86,8 +86,11 @@ export type PaymentsEmitterEvents = {
   checkoutView: CheckoutEvents;
   checkoutEngage: CheckoutEvents;
   checkoutSubmit: CheckoutPaymentEvents;
-  checkoutSuccess: CheckoutPaymentEvents;
-  checkoutFail: CheckoutPaymentEvents;
+  // Backend-triggered events emitted at the cart state transition rather
+  // than from frontend polling. See @fxa/payments/metrics for the typed
+  // payloads consumed by cart-side code via CHECKOUT_EVENT_EMITTER_TOKEN.
+  checkoutSuccess: CheckoutSuccessPayload;
+  checkoutFail: CheckoutFailPayload;
   genericGleanEvent: GenericGleanEvent;
   genericGleanSubManageEvent: GenericGleanSubManageEvent;
   subscriptionEnded: SubscriptionEndedEvents;

--- a/libs/payments/events/src/lib/util/retrieveAdditionalMetricsData.spec.ts
+++ b/libs/payments/events/src/lib/util/retrieveAdditionalMetricsData.spec.ts
@@ -35,6 +35,7 @@ const expectedCartMetricsData = {
   currency: mockCart.currency,
   stripeCustomerId: mockCart.stripeCustomerId,
   taxAddress: mockCart.taxAddress,
+  isFreeTrial: mockCart.isFreeTrial,
 };
 
 const emptyCmsMetricsData = {
@@ -51,6 +52,7 @@ const emptyCartMetricsData = {
     countryCode: '',
     postalCode: '',
   },
+  isFreeTrial: false,
 };
 
 describe('retrieveAdditionalMetricsData', () => {

--- a/libs/payments/events/src/lib/util/retrieveAdditionalMetricsData.ts
+++ b/libs/payments/events/src/lib/util/retrieveAdditionalMetricsData.ts
@@ -56,6 +56,7 @@ export async function retrieveAdditionalMetricsData(
           currency: cartData.value.currency,
           stripeCustomerId: cartData.value.stripeCustomerId,
           taxAddress: cartData.value.taxAddress,
+          isFreeTrial: cartData.value.isFreeTrial,
         }
       : {
           uid: '',
@@ -64,6 +65,7 @@ export async function retrieveAdditionalMetricsData(
           currency: '',
           stripeCustomerId: '',
           taxAddress: { countryCode: '', postalCode: '' },
+          isFreeTrial: false,
         };
 
   return {

--- a/libs/payments/metrics/src/index.ts
+++ b/libs/payments/metrics/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/glean/glean.manager';
 export * from './lib/glean/glean.config';
 export * from './lib/glean/glean.factory';
 export * from './lib/glean/glean.test-provider';
+export * from './lib/checkout-event-emitter';

--- a/libs/payments/metrics/src/lib/checkout-event-emitter.ts
+++ b/libs/payments/metrics/src/lib/checkout-event-emitter.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type {
+  CommonMetrics,
+  PaymentProvidersType,
+  SubPlatPaymentMethodType,
+} from './glean/glean.types';
+
+/**
+ * DI token for the checkout-conversion event emitter.
+ *
+ * Defined in the metrics leaf lib so cart-side code can publish backend-
+ * triggered pay_setup.success / pay_setup.fail events without importing
+ * @fxa/payments/events directly (which would create an import cycle —
+ * events already depends on cart for CartManager).
+ *
+ * The provider binding lives in the Nest app module; it resolves to the
+ * Emittery instance returned by PaymentsEmitterService.getEmitter(). The
+ * registered handlers fetch the cart, run opt-out / nimbus / CMS lookups
+ * via the same retrieveAdditionalMetricsData helper the existing
+ * view/engage/submit handlers use, then call PaymentsGleanManager.
+ */
+export const CHECKOUT_EVENT_EMITTER_TOKEN = Symbol('CHECKOUT_EVENT_EMITTER');
+
+/**
+ * Payload for `checkoutSuccess` — extends CommonMetrics so the handler can
+ * forward the same object straight into PaymentsGleanManager and use
+ * `params` for the existing retrieveAdditionalMetricsData enrichment.
+ * Cart-side code merges `params` with cart-derived cartId / offeringId /
+ * interval before emitting.
+ */
+export type CheckoutSuccessPayload = CommonMetrics & {
+  paymentProvider: PaymentProvidersType;
+  paymentMethod: SubPlatPaymentMethodType;
+};
+
+/**
+ * Payload for `checkoutFail` — CommonMetrics alone. The errorReasonId is
+ * read from the cart record by the handler (finishErrorCart wrote it
+ * before this emit fires).
+ */
+export type CheckoutFailPayload = CommonMetrics;
+
+export interface CheckoutEventEmitter {
+  emit(
+    event: 'checkoutSuccess',
+    payload: CheckoutSuccessPayload
+  ): Promise<unknown>;
+  emit(event: 'checkoutFail', payload: CheckoutFailPayload): Promise<unknown>;
+}

--- a/libs/payments/metrics/src/lib/glean/glean.factory.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.factory.ts
@@ -68,6 +68,7 @@ export const CartMetricsFactory = (
   currency: faker.finance.currencyCode().toLowerCase(),
   stripeCustomerId: `cus_${faker.string.alphanumeric({ length: 14 })}`,
   taxAddress: undefined,
+  isFreeTrial: false,
   ...override,
 });
 

--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -95,8 +95,7 @@ export class PaymentsGleanManager {
         ...this.populateCommonMetrics(metrics, paymentProvider, paymentMethod),
         subscription_payment_provider:
           normalizeGleanFalsyValues(paymentProvider),
-        subscription_payment_method:
-          normalizeGleanFalsyValues(paymentMethod),
+        subscription_payment_method: normalizeGleanFalsyValues(paymentMethod),
       });
     }
   }
@@ -111,15 +110,18 @@ export class PaymentsGleanManager {
     paymentProvider?: PaymentProvidersType,
     paymentMethod?: SubPlatPaymentMethodType
   ) {
-    const commonMetrics = this.populateCommonMetrics(metrics, paymentProvider, paymentMethod);
+    const commonMetrics = this.populateCommonMetrics(
+      metrics,
+      paymentProvider,
+      paymentMethod
+    );
 
     if (this.isEnabled) {
       this.paymentsGleanServerEventsLogger.recordPaySetupSuccess({
         ...commonMetrics,
         subscription_payment_provider:
           normalizeGleanFalsyValues(paymentProvider),
-        subscription_payment_method:
-          normalizeGleanFalsyValues(paymentMethod),
+        subscription_payment_method: normalizeGleanFalsyValues(paymentMethod),
       });
     }
   }
@@ -182,8 +184,7 @@ export class PaymentsGleanManager {
         subscription_provider_event_id: normalizeGleanFalsyValues(
           metrics.trialConversionData.providerEventId
         ),
-        trial_conversion_status:
-          metrics.trialConversionData.conversionStatus,
+        trial_conversion_status: metrics.trialConversionData.conversionStatus,
         subscription_billing_country: normalizeGleanFalsyValues(
           metrics.trialConversionData.billingCountry
         ),
@@ -259,9 +260,7 @@ export class PaymentsGleanManager {
         subscriptionCancellationData?.cancellationReason ?? '',
       subscription_provider_event_id:
         subscriptionCancellationData?.providerEventId ?? '',
-      subscription_is_free_trial: commonMetricsData.isFreeTrial
-        ? 'true'
-        : '',
+      subscription_is_free_trial: commonMetricsData.isFreeTrial ? 'true' : '',
       trial_conversion_status: '',
       subscription_billing_country: '',
       utm_campaign: searchParams['utm_campaign'] ?? '',
@@ -301,6 +300,7 @@ export class PaymentsGleanManager {
       couponCode: '',
       currency: '',
       taxAddress: { countryCode: '', postalCode: '' },
+      isFreeTrial: false,
     };
     const emptyCmsMetricsData: CmsMetricsData = {
       priceId: '',
@@ -339,7 +339,6 @@ export class PaymentsGleanManager {
         subscriptionCancellationData,
         paymentProvider,
         paymentMethod,
-        isFreeTrial: commonMetricsData.isFreeTrial,
       }),
       ...mapUtm(commonMetricsData.searchParams),
       nimbus_user_id: experimentationData.nimbusUserId,

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -62,6 +62,7 @@ export type CartMetrics = {
   currency?: string | null;
   stripeCustomerId?: string | null;
   taxAddress?: TaxAddress | null;
+  isFreeTrial: boolean;
 };
 
 export type ExperimentationData = {

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscription.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscription.spec.ts
@@ -50,13 +50,12 @@ describe('mapSubscription', () => {
     const mockCommonData = CommonMetricsFactory({
       params: CheckoutParamsFactory(),
     });
-    const mockCartData = CartMetricsFactory();
+    const mockCartData = CartMetricsFactory({ isFreeTrial: true });
     const mockCmsMetricsData = CmsMetricsDataFactory();
     const result = mapSubscription({
       commonMetricsData: mockCommonData,
       cartMetricsData: mockCartData,
       cmsMetricsData: mockCmsMetricsData,
-      isFreeTrial: true,
     });
     expect(result.subscription_is_free_trial).toBe('true');
   });
@@ -65,13 +64,12 @@ describe('mapSubscription', () => {
     const mockCommonData = CommonMetricsFactory({
       params: CheckoutParamsFactory(),
     });
-    const mockCartData = CartMetricsFactory();
+    const mockCartData = CartMetricsFactory({ isFreeTrial: false });
     const mockCmsMetricsData = CmsMetricsDataFactory();
     const result = mapSubscription({
       commonMetricsData: mockCommonData,
       cartMetricsData: mockCartData,
       cmsMetricsData: mockCmsMetricsData,
-      isFreeTrial: false,
     });
     expect(result.subscription_is_free_trial).toBe('');
   });

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscription.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscription.ts
@@ -27,7 +27,6 @@ export function mapSubscription({
   subscriptionCancellationData,
   paymentProvider,
   paymentMethod,
-  isFreeTrial,
 }: {
   commonMetricsData: CommonMetrics;
   cartMetricsData: CartMetrics;
@@ -35,7 +34,6 @@ export function mapSubscription({
   subscriptionCancellationData?: SubscriptionCancellationData;
   paymentProvider?: PaymentProvidersType;
   paymentMethod?: SubPlatPaymentMethodType;
-  isFreeTrial?: boolean;
 }) {
   const mappedParams = mapParams(commonMetricsData.params);
   return {
@@ -69,6 +67,6 @@ export function mapSubscription({
     subscription_provider_event_id: normalizeGleanFalsyValues(
       subscriptionCancellationData?.providerEventId
     ),
-    subscription_is_free_trial: isFreeTrial ? 'true' : '',
+    subscription_is_free_trial: cartMetricsData.isFreeTrial ? 'true' : '',
   };
 }

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.spec.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.spec.ts
@@ -36,63 +36,38 @@ describe('recordEmitterEventAction', () => {
     mockRecordEmitterEvent.mockReset();
   });
 
-  it('forwards isFreeTrial=true through requestArgs', async () => {
+  it('forwards requestArgs with route params and search params', async () => {
     await recordEmitterEventAction(
       'checkoutView',
-      { offeringId: 'foo' },
-      {},
-      undefined,
-      undefined,
-      true
+      { offeringId: 'foo', cartId: 'cart-1' },
+      { utm_source: 'newsletter' }
     );
 
-    expect(mockRecordEmitterEvent).toHaveBeenCalledTimes(1);
     expect(mockRecordEmitterEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         eventName: 'checkoutView',
-        requestArgs: expect.objectContaining({ isFreeTrial: true }),
+        requestArgs: expect.objectContaining({
+          params: expect.objectContaining({ offeringId: 'foo', cartId: 'cart-1' }),
+          searchParams: expect.objectContaining({ utm_source: 'newsletter' }),
+        }),
       })
     );
   });
 
-  it('defaults isFreeTrial to false when omitted', async () => {
-    await recordEmitterEventAction('checkoutView', { offeringId: 'foo' }, {});
-
-    expect(mockRecordEmitterEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        requestArgs: expect.objectContaining({ isFreeTrial: false }),
-      })
-    );
-  });
-
-  it('defaults isFreeTrial to false when explicitly undefined', async () => {
+  it('forwards paymentProvider and paymentMethod for checkoutSubmit', async () => {
     await recordEmitterEventAction(
-      'checkoutSuccess',
+      'checkoutSubmit',
+      { cartId: 'cart-1' },
       {},
-      {},
-      undefined,
-      undefined,
-      undefined
+      'stripe',
+      'card'
     );
 
     expect(mockRecordEmitterEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        requestArgs: expect.objectContaining({ isFreeTrial: false }),
+        eventName: 'checkoutSubmit',
+        paymentProvider: 'stripe',
       })
     );
-  });
-
-  it('overrides the isFreeTrial default from getAdditionalRequestArgs', async () => {
-    await recordEmitterEventAction(
-      'checkoutFail',
-      {},
-      {},
-      undefined,
-      undefined,
-      true
-    );
-
-    const call = mockRecordEmitterEvent.mock.calls[0][0];
-    expect(call.requestArgs.isFreeTrial).toBe(true);
   });
 });

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
@@ -25,32 +25,24 @@ async function recordEmitterEventAction(
   params: Record<string, string | string[] | undefined>,
   searchParams: Record<string, string | string[] | undefined>,
   paymentProvider: PaymentProvidersType,
-  paymentMethod: string,
-  isFreeTrial?: boolean
+  paymentMethod: string
 ): Promise<void>;
 async function recordEmitterEventAction(
-  eventName:
-    | 'checkoutView'
-    | 'checkoutEngage'
-    | 'checkoutSuccess'
-    | 'checkoutFail',
+  eventName: 'checkoutView' | 'checkoutEngage',
   params: Record<string, string | string[] | undefined>,
-  searchParams: Record<string, string | string[] | undefined>,
-  paymentProvider?: undefined,
-  paymentMethod?: undefined,
-  isFreeTrial?: boolean
+  searchParams: Record<string, string | string[] | undefined>
 ): Promise<void>;
 async function recordEmitterEventAction(
   eventName: PaymentsEmitterEventsKeysType,
   params: Record<string, string | string[] | undefined>,
   searchParams: Record<string, string | string[] | undefined>,
   paymentProvider?: PaymentProvidersType,
-  paymentMethod?: string,
-  isFreeTrial?: boolean
+  paymentMethod?: string
 ) {
+  // isFreeTrial is resolved cart-side in populateCommonMetrics, so the FE
+  // no longer needs to thread it through.
   const requestArgs = {
     ...(await getAdditionalRequestArgs()),
-    isFreeTrial: isFreeTrial ?? false,
     params: flattenRouteParams(params),
     searchParams: flattenRouteParams(searchParams),
   };

--- a/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
@@ -7,53 +7,37 @@
 import { getApp } from '../nestapp/app';
 import { redirect } from 'next/navigation';
 import { URLSearchParams } from 'url';
-import { recordEmitterEventAction } from './recordEmitterEvent';
 import { flattenRouteParams } from '../utils/flatParam';
+import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
 import { sanitizePathname } from '../utils/sanitizePathname';
 
 export const submitNeedsInputAndRedirectAction = async (
   cartId: string,
   params: Record<string, string | string[] | undefined>,
   currentPathname: string,
-  searchParams?: Record<string, string | string[] | undefined>,
-  isFreeTrial?: boolean
+  searchParams?: Record<string, string | string[] | undefined>
 ) => {
   let redirectPath: string | undefined;
   const urlSearchParams = new URLSearchParams(searchParams ? flattenRouteParams(searchParams) : undefined);
   const searchParamsString = searchParams
     ? `?${urlSearchParams.toString()}`
     : '';
+  const requestArgs = {
+    ...(await getAdditionalRequestArgs()),
+    params: flattenRouteParams(params),
+    searchParams: flattenRouteParams(searchParams ?? {}),
+  };
   try {
-    await getApp().getActionsService().submitNeedsInput({ cartId });
-
-    await recordEmitterEventAction(
-      'checkoutSuccess',
-      { ...params },
-      { ...searchParams },
-      undefined,
-      undefined,
-      isFreeTrial
-    );
-
+    await getApp().getActionsService().submitNeedsInput({ cartId, requestArgs });
     redirectPath = 'success';
   } catch (error) {
     getApp().getLogger().error('Error submitting needs input', { error });
-
-    await recordEmitterEventAction(
-      'checkoutFail',
-      { ...params },
-      { ...searchParams },
-      undefined,
-      undefined,
-      isFreeTrial
-    );
-
     redirectPath = 'error';
   }
 
   // Sanitize pathname to prevent open redirect vulnerabilities
   const safePath = sanitizePathname(currentPathname);
-  
+
   // Replace the last segment with the redirect path to maintain the full path structure
   const pathSegments = safePath.split('/');
   pathSegments[pathSegments.length - 1] = redirectPath;

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -170,10 +170,7 @@ export function CheckoutForm({
     recordEmitterEventAction(
       'checkoutEngage',
       { ...params },
-      Object.fromEntries(searchParams),
-      undefined,
-      undefined,
-      isFreeTrial
+      Object.fromEntries(searchParams)
     );
 
     if (interstitialOfferBase) {
@@ -239,8 +236,7 @@ export function CheckoutForm({
         { ...params },
         Object.fromEntries(searchParams),
         'paypal',
-        'external_paypal',
-        isFreeTrial
+        'external_paypal'
       );
       if (interstitialOfferBase) {
         glean.recordInterstitialOfferSubmit({
@@ -321,8 +317,7 @@ export function CheckoutForm({
       { ...params },
       Object.fromEntries(searchParams),
       paymentProvider,
-      selectedPaymentMethod,
-      isFreeTrial
+      selectedPaymentMethod
     );
     if (interstitialOfferBase) {
       glean.recordInterstitialOfferSubmit({

--- a/libs/payments/ui/src/lib/client/components/MetricsWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/MetricsWrapper.tsx
@@ -31,9 +31,6 @@ export function MetricsWrapper({
         'checkoutView',
         { ...params },
         Object.fromEntries(searchParams),
-        undefined,
-        undefined,
-        cart.isFreeTrial
       );
     }
   }, []);

--- a/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
@@ -6,7 +6,6 @@
 
 import {
   getNeedsInputAction,
-  recordEmitterEventAction,
   submitNeedsInputAndRedirectAction,
   validateCartStateAndRedirectAction,
 } from '@fxa/payments/ui/actions';
@@ -14,13 +13,7 @@ import { useEffect } from 'react';
 import { useStripe } from '@stripe/react-stripe-js';
 import { SupportedPages } from '@fxa/payments/ui';
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
-export function PaymentInputHandler({
-  cartId,
-  isFreeTrial,
-}: {
-  cartId: string;
-  isFreeTrial?: boolean;
-}) {
+export function PaymentInputHandler({ cartId }: { cartId: string }) {
   const stripe = useStripe();
   const params = useParams();
   const pathname = usePathname();
@@ -42,7 +35,7 @@ export function PaymentInputHandler({
             await stripe.handleNextAction({
               clientSecret: inputRequest.data.clientSecret,
             });
-            await submitNeedsInputAndRedirectAction(cartId, params, pathname, searchParamsRecord, isFreeTrial);
+            await submitNeedsInputAndRedirectAction(cartId, params, pathname, searchParamsRecord);
             break;
           case 'notRequired':
             const redirectResponse = await validateCartStateAndRedirectAction(
@@ -53,28 +46,6 @@ export function PaymentInputHandler({
             );
 
             if (redirectResponse?.state && redirectResponse?.redirectToUrl) {
-              if (redirectResponse.state === 'success') {
-                await recordEmitterEventAction(
-                  'checkoutSuccess',
-                  { ...params },
-                  searchParamsRecord,
-                  undefined,
-                  undefined,
-                  isFreeTrial
-                );
-              }
-
-              if (redirectResponse.state === 'fail') {
-                await recordEmitterEventAction(
-                  'checkoutFail',
-                  { ...params },
-                  searchParamsRecord,
-                  undefined,
-                  undefined,
-                  isFreeTrial
-                );
-              }
-
               router.push(redirectResponse.redirectToUrl);
             }
             break;

--- a/libs/payments/ui/src/lib/client/components/PaymentStateObserver/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentStateObserver/index.tsx
@@ -5,22 +5,14 @@
 'use client';
 
 import { SupportedPages } from '@fxa/payments/ui';
-import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { validateCartStateAndRedirectAction } from '../../../actions/validateCartStateAndRedirect';
-import { recordEmitterEventAction } from '../../../actions';
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
-export function PaymentStateObserver({
-  cartId,
-  isFreeTrial,
-}: {
-  cartId: string;
-  isFreeTrial?: boolean;
-}) {
+export function PaymentStateObserver({ cartId }: { cartId: string }) {
   const searchParams = useSearchParams();
-  const params = useParams();
   const pathname = usePathname();
   const router = useRouter();
   const searchParamsRecord: Record<string, string> = {};
@@ -43,28 +35,6 @@ export function PaymentStateObserver({
       );
 
       if (redirectResponse?.state && redirectResponse?.redirectToUrl) {
-        if (redirectResponse.state === 'success') {
-          await recordEmitterEventAction(
-            'checkoutSuccess',
-            { ...params },
-            searchParamsRecord,
-            undefined,
-            undefined,
-            isFreeTrial
-          );
-        }
-
-        if (redirectResponse.state === 'fail') {
-          await recordEmitterEventAction(
-            'checkoutFail',
-            { ...params },
-            searchParamsRecord,
-            undefined,
-            undefined,
-            isFreeTrial
-          );
-        }
-
         isPolling = false;
         router.push(redirectResponse.redirectToUrl);
 

--- a/libs/payments/ui/src/lib/nestapp/app.module.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.module.ts
@@ -42,7 +42,10 @@ import {
   CustomerSessionManager,
   SetupIntentManager,
 } from '@fxa/payments/customer';
-import { PaymentsGleanManager } from '@fxa/payments/metrics';
+import {
+  CHECKOUT_EVENT_EMITTER_TOKEN,
+  PaymentsGleanManager,
+} from '@fxa/payments/metrics';
 import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import { PaymentsGleanFactory } from '@fxa/payments/metrics/provider';
 import { AccountCustomerManager, StripeClient } from '@fxa/payments/stripe';
@@ -156,6 +159,12 @@ import { NimbusManager } from '@fxa/payments/experiments';
     PaymentsGleanManager,
     PaymentsMetricsAggregatorService,
     PaymentsEmitterService,
+    {
+      provide: CHECKOUT_EVENT_EMITTER_TOKEN,
+      useFactory: (emitterService: PaymentsEmitterService) =>
+        emitterService.getEmitter(),
+      inject: [PaymentsEmitterService],
+    },
     StripeEventManager,
     SubscriptionEventsService,
     StripeWebhookService,

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -747,9 +747,7 @@ export class NextJSActionsService {
         });
         break;
       }
-      case 'checkoutSubmit':
-      case 'checkoutSuccess':
-      case 'checkoutFail': {
+      case 'checkoutSubmit': {
         this.emitterService.getEmitter().emit(eventName, {
           ...requestArgs,
           paymentProvider,
@@ -775,8 +773,8 @@ export class NextJSActionsService {
   @NextIOValidator(SubmitNeedsInputActionArgs, undefined)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
-  async submitNeedsInput(args: { cartId: string }) {
-    await this.cartService.submitNeedsInput(args.cartId);
+  async submitNeedsInput(args: { cartId: string; requestArgs: CommonMetrics }) {
+    await this.cartService.submitNeedsInput(args.cartId, args.requestArgs);
   }
 
   @SanitizeExceptions()

--- a/libs/payments/ui/src/lib/nestapp/validators/SubmitNeedsInputActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/SubmitNeedsInputActionArgs.ts
@@ -2,9 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsString, ValidateNested } from 'class-validator';
+import { RequestArgs } from './common/RequestArgs';
 
 export class SubmitNeedsInputActionArgs {
   @IsString()
   cartId!: string;
+
+  @Type(() => RequestArgs)
+  @ValidateNested()
+  requestArgs!: RequestArgs;
 }


### PR DESCRIPTION
## Because

- pay_setup.submit and pay_setup.success+fail counts have diverged because the frontend emits success/fail only after polling sees a terminal cart state — users who close the tab between Subscribe and the next poll never produce success/fail events.

## This pull request

- Moves success/fail emission from the frontend (PaymentStateObserver, PaymentInputHandler, submitNeedsInputAndRedirect) to backend cart-state transitions in CheckoutService.postPaySteps and CartService.wrapWithCartCatch so events fire deterministically regardless of FE state.
- Publishes via PaymentsEmitterService through a new CHECKOUT_EVENT_EMITTER_TOKEN in @fxa/payments/metrics, avoiding a cart ↔ events import cycle.
- Adds handleCheckoutSuccess / handleCheckoutFail handlers matching the existing handleCheckoutSubmit shape (retrieveAdditionalMetricsData, retrieveOptOut, getNimbusUserId, PaymentsGleanManager).
- Gates fail emission to genuine checkout-submit call sites only, so incidental wrapWithCartCatch failures in updateCart / restartCart / getNeedsInput / finalizeProcessingCart do not skew the funnel.
- Threads requestArgs through submitNeedsInput for full 3DS-resume attribution.
- Sources isFreeTrial from the cart record in populateCommonMetrics so all five funnel events (view/engage/submit/success/fail) report the authoritative value.

## Issue that this pull request solves

Closes: #PAY-3758

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
