### PR TITLE
fix(settings): record Glean element-clicks swallowed by stopPropagation

### DIFF
--- a/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
@@ -39,6 +39,7 @@ let mockAccount = {
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
   default: {
+    handleClickEvent: jest.fn(),
     accountPref: {
       passkeyDeleteView: jest.fn(),
       passkeyDeleteSuccessView: jest.fn(),
@@ -323,6 +324,7 @@ describe('PasskeySubRow', () => {
     (
       GleanMetrics.accountPref.passkeyDeleteSubmitFrontendError as jest.Mock
     ).mockClear();
+    (GleanMetrics.handleClickEvent as jest.Mock).mockClear();
     mockHasJwt = true;
     mockJwtSnapshot = { hasToken: true };
     mockJwtListeners.clear();
@@ -369,6 +371,19 @@ describe('PasskeySubRow', () => {
       screen.getByTestId('confirm-delete-passkey-button')
     ).toBeInTheDocument();
     expect(GleanMetrics.accountPref.passkeyDeleteView).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression (FXA-13881): the delete handler calls event.stopPropagation()
+  // to keep the opening click from closing the modal, which also prevents the
+  // click from reaching Glean's document-level auto-element-click listener.
+  // The handler must record the click explicitly so
+  // account_pref_passkey_delete_submit still reaches Looker.
+  it('records the delete-button click via Glean when the delete button is clicked', async () => {
+    renderPasskeySubRow();
+    const deleteButtons = screen.getAllByTitle(/Delete passkey/);
+    await userEvent.click(deleteButtons[0]);
+
+    expect(GleanMetrics.handleClickEvent).toHaveBeenCalledTimes(1);
   });
 
   it('closes modal when cancel button is clicked', async () => {

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -515,6 +515,9 @@ export const PasskeySubRow = ({ passkey }: PasskeySubRowProps) => {
         // TODO (passkeys phase 2): show upgrade prompt when passkey.prfEnabled
         onDeleteClick={(event) => {
           event.stopPropagation();
+          // stopPropagation keeps this click from reaching Glean's document-level
+          // auto-element-click listener, so record it explicitly.
+          GleanMetrics.handleClickEvent(event.nativeEvent);
           revealDeleteModal();
         }}
         localizedDeleteIconTitle={ftlMsgResolver.getMsg(

--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.test.tsx
@@ -3,12 +3,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import UnitRow from '.';
 import { renderWithRouter } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 import { SETTINGS_PATH } from '../../../constants';
+import GleanMetrics from '../../../lib/glean';
+
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    handleClickEvent: jest.fn(),
+  },
+}));
 
 describe('UnitRow', () => {
+  beforeEach(() => {
+    (GleanMetrics.handleClickEvent as jest.Mock).mockClear();
+  });
+
   it('renders as expected with minimal required attributes', () => {
     renderWithRouter(<UnitRow header="Foxy" />);
 
@@ -113,6 +126,54 @@ describe('UnitRow', () => {
     expect(
       screen.getByTestId('secondary-button-unit-row-modal-button').textContent
     ).toContain('Disable');
+  });
+
+  // Regression (FXA-13881): ModalButton calls event.stopPropagation() to keep the
+  // opening click from closing the modal, which also stops the click from reaching
+  // Glean's document-level auto-element-click listener. When glean data attrs are
+  // present, the click must be recorded explicitly so the event reaches Looker.
+  describe('Glean click recording', () => {
+    it('records the primary modal-button click when ctaGleanDataAttrs is set', async () => {
+      renderWithRouter(
+        <UnitRow
+          header="Two-step authentication"
+          revealModal={() => {}}
+          ctaGleanDataAttrs={{ id: 'account_pref_two_step_auth_add_click' }}
+        />
+      );
+
+      await userEvent.click(screen.getByTestId('unit-row-modal-button'));
+
+      expect(GleanMetrics.handleClickEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('records the secondary modal-button click when secondaryButtonGleanDataAttrs is set', async () => {
+      renderWithRouter(
+        <UnitRow
+          header="Two-step authentication"
+          headerValue="Enabled"
+          route="/two_step_authentication"
+          revealSecondaryModal={() => {}}
+          secondaryButtonGleanDataAttrs={{ id: 'two_step_auth_disable_click' }}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByTestId('secondary-button-unit-row-modal-button')
+      );
+
+      expect(GleanMetrics.handleClickEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not record a modal-button click when no glean data attrs are set', async () => {
+      renderWithRouter(
+        <UnitRow header="Display name" revealModal={() => {}} />
+      );
+
+      await userEvent.click(screen.getByTestId('unit-row-modal-button'));
+
+      expect(GleanMetrics.handleClickEvent).not.toHaveBeenCalled();
+    });
   });
 
   it('renders as expected with the default avatar', () => {

--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
@@ -11,6 +11,7 @@ import { Link, RouteComponentProps, useLocation } from '@reach/router';
 import { useLocalization } from '@fluent/react';
 import { AlertFullIcon, CheckmarkGreenIcon } from '../../Icons';
 import { GleanClickEventDataAttrs } from '../../../lib/types';
+import GleanMetrics from '../../../lib/glean';
 
 type ModalButtonProps = {
   ctaText: string;
@@ -58,6 +59,11 @@ export const ModalButton = ({
         // Prevent the click that opens the modal from immediately
         // bubbling to the overlay “outside click” handler and closing it.
         e.stopPropagation();
+        // stopPropagation also keeps this click from reaching Glean's
+        // document-level auto-element-click listener, so record it explicitly.
+        if (gleanDataAttrs) {
+          GleanMetrics.handleClickEvent(e.nativeEvent);
+        }
         revealModal();
       }}
       {...(gleanDataAttrs && {
@@ -256,6 +262,7 @@ export const UnitRow = ({
                             alertBarRevealed,
                             prefixDataTestId,
                           }}
+                          gleanDataAttrs={ctaGleanDataAttrs}
                         />
                       )}
                     </>


### PR DESCRIPTION
## Because

- Several Mozilla Accounts settings buttons emit no Glean `element_click` telemetry, so product analytics in Looker miss those interactions entirely. The passkey delete button click (`account_pref_passkey_delete_submit`) was confirmed absent in Looker (2026-06-02) while its sibling clicks reported normally.
- The same defect drops two 2FA telemetry events (`two_step_auth_disable_click` and the `revealModal` primary CTA `account_pref_two_step_auth_add_click`), leaving gaps in the two-step-authentication funnels.

## This pull request

- Records the click explicitly via `GleanMetrics.handleClickEvent(event.nativeEvent)` in `PasskeySubRow`'s delete handler (`packages/fxa-settings/src/components/Settings/SubRow/index.tsx`), so `account_pref_passkey_delete_submit` is emitted even though the handler calls `event.stopPropagation()`.
- Does the same in `ModalButton` (`packages/fxa-settings/src/components/Settings/UnitRow/index.tsx`), guarded on `gleanDataAttrs` being present, and plumbs `ctaGleanDataAttrs` into the primary `ModalButton` (which previously received no glean data attrs at all) — restoring `two_step_auth_disable_click` and `account_pref_two_step_auth_add_click`.
- Preserves the existing `stopPropagation` behaviour, so the opening click still does not bubble to the modal's outside-click handler and close it.
- Adds regression tests covering the passkey delete click and the primary / secondary / no-attrs `ModalButton` paths.

## Issue that this pull request solves

Closes: FXA-13881

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the `onClick` / `onDeleteClick` handlers in `UnitRow` and `SubRow` — note the `stopPropagation()` is intentional (it stops the modal's outside-click handler from closing the modal), and the explicit Glean recording is added alongside it.
- Suggested review order: `SubRow` delete handler → `ModalButton` handler + primary-button wiring → tests.
- Risky or complex parts: telemetry-only, no functional/user-facing change. Note there is no double-recording — route CTAs still record via Glean's document listener, `ModalButton` records explicitly, and the two paths are mutually exclusive.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
