### PR TITLE
feat(auth): replace WAF "unexpected error" with more meaningful copy

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -11,7 +11,9 @@ import * as Sentry from '@sentry/browser';
 import { MetricsContext } from '@fxa/shared/metrics/glean';
 
 enum ERRORS {
+  THROTTLED = 114,
   INCORRECT_EMAIL_CASE = 120,
+  REQUEST_BLOCKED = 125,
 }
 
 enum tokenType {
@@ -434,7 +436,30 @@ export default class AuthClient {
         requestOptions,
         this.timeout
       );
-      const result = JSON.parse(await response.text());
+      const responseText = await response.text();
+      let result: any;
+      try {
+        result = JSON.parse(responseText);
+      } catch (parseError) {
+        // The WAF (Fastly) returns 406/429 directly with non-JSON bodies when
+        // it blocks a request, bypassing the auth server. Map to known errnos
+        // so the UI renders a localized message instead of "Unexpected error".
+        let errno: number;
+        if (response.status === 429) {
+          errno = ERRORS.THROTTLED;
+        } else if (response.status === 406) {
+          errno = ERRORS.REQUEST_BLOCKED;
+        } else {
+          throw parseError;
+        }
+        errorCaptured = true;
+        throw new AuthClientError(
+          'WAF blocked',
+          'Request blocked by WAF',
+          errno,
+          response.status
+        );
+      }
       if (result.errno) {
         // We want to monitor down spikes in known responses from the auth server.
         errorCaptured = true;
@@ -446,7 +471,7 @@ export default class AuthClient {
               method: requestOptions.method || '',
               errno: result.errno,
               code: result.code,
-            }
+            },
           }
         );
         throw result;
@@ -461,7 +486,7 @@ export default class AuthClient {
               path: path,
               method: requestOptions.method || '',
               status: response.status,
-            }
+            },
           }
         );
         throw new AuthClientError(
@@ -485,7 +510,7 @@ export default class AuthClient {
             },
             extra: {
               message: e instanceof Error ? e.message : 'unknown error',
-            }
+            },
           }
         );
       }

--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -95,7 +95,10 @@ describe('lib/client', () => {
     let httpClient: AuthClient;
     let originalFetch: typeof globalThis.fetch;
     let originalCaptureMessage: (...args: any[]) => any;
-    let capturedMessages: Array<{ message: string; context: Record<string, any> }>;
+    let capturedMessages: Array<{
+      message: string;
+      context: Record<string, any>;
+    }>;
 
     before(() => {
       httpClient = new AuthClient('http://localhost:9000');
@@ -130,7 +133,11 @@ describe('lib/client', () => {
       beforeEach(() => {
         globalThis.fetch = async () =>
           new Response(
-            JSON.stringify({ errno: 102, code: 400, message: 'Unknown account' }),
+            JSON.stringify({
+              errno: 102,
+              code: 400,
+              message: 'Unknown account',
+            }),
             { status: 400 }
           );
       });
@@ -170,8 +177,7 @@ describe('lib/client', () => {
 
     describe('non-ok response without errno', () => {
       beforeEach(() => {
-        globalThis.fetch = async () =>
-          new Response('{}', { status: 500 });
+        globalThis.fetch = async () => new Response('{}', { status: 500 });
       });
 
       it('calls captureMessage with the non-ok message', async () => {
@@ -228,7 +234,10 @@ describe('lib/client', () => {
         try {
           await httpClient.accountStatus('0123456789abcdef');
         } catch {}
-        assert.equal(capturedMessages[0].context.extra.message, 'Network failure');
+        assert.equal(
+          capturedMessages[0].context.extra.message,
+          'Network failure'
+        );
       });
 
       it('uses "unknown error" in extra when fetch throws a non-Error value', async () => {
@@ -239,7 +248,10 @@ describe('lib/client', () => {
         try {
           await httpClient.accountStatus('0123456789abcdef');
         } catch {}
-        assert.equal(capturedMessages[0].context.extra.message, 'unknown error');
+        assert.equal(
+          capturedMessages[0].context.extra.message,
+          'unknown error'
+        );
       });
 
       it('tags the capture with path and method', async () => {
@@ -255,6 +267,70 @@ describe('lib/client', () => {
           `expected path to include /account/status, got "${tags.path}"`
         );
         assert.equal(typeof tags.method, 'string');
+      });
+    });
+
+    describe('WAF-blocked response (406/429 with non-JSON body)', () => {
+      it('throws errno 125 with status 406 when body is not JSON', async () => {
+        globalThis.fetch = async () =>
+          new Response('<html>Blocked</html>', { status: 406 });
+        let caught: any;
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch (e) {
+          caught = e;
+        }
+        assert.equal(caught?.errno, 125);
+        assert.equal(caught?.code, 406);
+      });
+
+      it('throws errno 114 with status 429 when body is not JSON', async () => {
+        globalThis.fetch = async () =>
+          new Response('rate limited', { status: 429 });
+        let caught: any;
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch (e) {
+          caught = e;
+        }
+        assert.equal(caught?.errno, 114);
+        assert.equal(caught?.code, 429);
+      });
+
+      it('still rethrows the parse error on non-2xx with non-JSON body and a non-WAF status', async () => {
+        globalThis.fetch = async () =>
+          new Response('<html>Server Error</html>', { status: 500 });
+        let caught: any;
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch (e) {
+          caught = e;
+        }
+        // Falls through to the catch block as an unexpected error — preserves prior behavior.
+        assert.ok(caught instanceof SyntaxError);
+      });
+
+      it('preserves auth server errno when 429 response has a JSON body with errno', async () => {
+        // The auth server itself can return 429 with errno 114 and a retryAfter.
+        // We must not override that with our synthesized WAF mapping.
+        globalThis.fetch = async () =>
+          new Response(
+            JSON.stringify({
+              errno: 114,
+              code: 429,
+              message: 'Client has sent too many requests',
+              retryAfter: 30,
+            }),
+            { status: 429 }
+          );
+        let caught: any;
+        try {
+          await httpClient.accountStatus('0123456789abcdef');
+        } catch (e) {
+          caught = e;
+        }
+        assert.equal(caught?.errno, 114);
+        assert.equal(caught?.retryAfter, 30);
       });
     });
   });

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
@@ -71,3 +71,29 @@ export const ResendError: Story = {
     </LocationProvider>
   ),
 };
+
+const ErrorBlockedAppCtx = mockAppContext({
+  account: {
+    ...mockAppContext().account,
+    loading: false,
+    resendSecondaryEmailCodeWithJwt: async () => {
+      const err: any = { errno: 125 };
+      throw err;
+    },
+    verifySecondaryEmail: async () => Promise.resolve(),
+  } as any,
+});
+
+export const ResendErrorBlocked: Story = {
+  render: () => (
+    <LocationProvider>
+      <AppContext.Provider value={ErrorBlockedAppCtx}>
+        <SettingsLayout>
+          <MfaContext.Provider value="email">
+            <PageSecondaryEmailVerify location={mockLocation} />
+          </MfaContext.Provider>
+        </SettingsLayout>
+      </AppContext.Provider>
+    </LocationProvider>
+  ),
+};


### PR DESCRIPTION
## Because

- The WAF (Fastly) returns 406/429 directly with non-JSON bodies, bypassing the auth server. The auth client's `JSON.parse` fails and the UI falls back to "Unexpected error", giving devs and false-positive users no guidance.

## This pull request

- Catches the JSON parse failure on 406/429 and throws an `AuthClientError` with `errno: 125` (`REQUEST_BLOCKED`) for 406 and `errno: 114` (`THROTTLED`) for 429.
- Reuses existing localized strings (`auth-error-125`, `auth-error-114-generic`) 
- Adds unit tests covering both status codes, the Sentry tag shape, the non-WAF passthrough, and that auth-server JSON-bodied 429s are not overridden.

## Issue that this pull request solves

Closes: FXA-13612

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key file: `packages/fxa-auth-client/lib/client.ts` — the parse-failure branch in `AuthClient.request()`.
- The frontend path is unchanged; verify by reading `getLocalizedErrorMessage` in `packages/fxa-settings/src/lib/error-utils.ts` — it looks up by `errno`, so 114/125 already work.

## Other information (Optional)

- Sentry signal change: 406/429-with-non-JSON-body events previously surfaced as "unexpected error" with a `SyntaxError` extra. They now surface as "WAF-blocked response" with `status` and `errno` tags. Intentional, but worth knowing for any saved searches.

[FXA-13612]: https://mozilla-hub.atlassian.net/browse/FXA-13612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="531" height="475" alt="Screenshot 2026-06-03 at 11 05 21 AM" src="https://github.com/user-attachments/assets/e10e263b-43e4-44ca-9ee5-c688d551188b" />

