### PR TITLE
debug(settings): Investigate vpn sign in issue

### DIFF
--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
@@ -12,6 +12,7 @@ import { OAUTH_ERRORS, OAuthError } from '../../lib/oauth';
 
 jest.mock('@sentry/browser', () => ({
   captureException: jest.fn(),
+  captureMessage: jest.fn(),
 }));
 
 describe('models/integrations/oauth-relier', function () {
@@ -181,37 +182,6 @@ describe('models/integrations/oauth-relier', function () {
         return integration;
       }
 
-      /**
-       * If a test should expect an OAuth scope error, use this function to assert the error was captured.
-       * @param scope
-       */
-      function expectSentryOAuthScopeError(
-        scope: string,
-        trusted: boolean,
-        wantsConsent: boolean
-      ) {
-        expect(Sentry.captureException).toHaveBeenCalledTimes(1);
-
-        const sentryCall = (Sentry.captureException as jest.Mock).mock.calls[0];
-        const capturedError = sentryCall[0];
-        const sentryContext = sentryCall[1];
-
-        expect(capturedError).toBeInstanceOf(OAuthError);
-        expect(capturedError.errno).toBe(OAUTH_ERRORS.INVALID_PARAMETER.errno);
-        expect(sentryContext).toEqual({
-          tags: {
-            area: 'OAuthWebIntegration.getPermissions',
-            service: 'test-service',
-            clientId: 'a1b2c3d4e5f6789012345678901234567890abcd',
-          },
-          extra: {
-            scope,
-            trusted,
-            wantsConsent,
-          },
-        });
-      }
-
       beforeEach(() => {
         jest.clearAllMocks();
       });
@@ -229,7 +199,10 @@ describe('models/integrations/oauth-relier', function () {
           integration.getPermissions();
         }).toThrow(OAuthError);
 
-        expectSentryOAuthScopeError(EMPTY_SCOPE, isTrusted, wantsConsent);
+        const capturedError = (Sentry.captureException as jest.Mock).mock
+          .calls[0][0];
+        expect(capturedError).toBeInstanceOf(OAuthError);
+        expect(capturedError.errno).toBe(OAUTH_ERRORS.INVALID_PARAMETER.errno);
       });
 
       it('captures Sentry error and throws OAuthError when untrusted scope results in empty permissions', () => {
@@ -245,11 +218,10 @@ describe('models/integrations/oauth-relier', function () {
           integration.getPermissions();
         }).toThrow(OAuthError);
 
-        expectSentryOAuthScopeError(
-          INVALID_UNTRUSTED_SCOPE,
-          isTrusted,
-          wantsConsent
-        );
+        const capturedError = (Sentry.captureException as jest.Mock).mock
+          .calls[0][0];
+        expect(capturedError).toBeInstanceOf(OAuthError);
+        expect(capturedError.errno).toBe(OAUTH_ERRORS.INVALID_PARAMETER.errno);
       });
     });
 

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -224,6 +224,13 @@ export class OAuthWebIntegration extends GenericIntegration<
       // capture error to Sentry, but throw so it can be handled
       // in app/index. We check the integration type and present
       // an OAuthDataError component.
+      const extra = {
+        scope: this.data.scope || 'undefined',
+        wantsConsent: this.data.prompt || 'undefined',
+        clientId: this.data.clientId || 'undeifned',
+        service: this.data.service || 'undefined',
+        clientInfo: this.clientInfo || 'undefined',
+      };
       Sentry.captureException(err, {
         tags: {
           area: 'OAuthWebIntegration.getPermissions',
@@ -231,10 +238,8 @@ export class OAuthWebIntegration extends GenericIntegration<
           service: this.data.service,
         },
         extra: {
-          scope: this.data.scope,
-          trusted: this.isTrusted(),
-          wantsConsent: this.wantsConsent(),
-          clientInfo: this.clientInfo,
+          ...extra,
+          raw: btoa(JSON.stringify(extra)),
         },
       });
       throw err;
@@ -337,6 +342,17 @@ export class OAuthWebIntegration extends GenericIntegration<
         ) {
           wantsScopeThatHasKeys = true;
         } else {
+          const extra = {
+            scope,
+            redirectUris: validation[scope]?.redirectUris || 'undefined',
+            clientInfo: this.clientInfo || 'undefined',
+          };
+          Sentry.captureMessage(`Invalid redirect paramater`, {
+            extra: {
+              ...extra,
+              raw: btoa(JSON.stringify(extra)),
+            },
+          });
           throw new Error('Invalid redirect parameter');
         }
       }


### PR DESCRIPTION
## Because

- We are picking up some of these errors in Sentry, but context is getting lost.

## This pull request

- Adds debug context via `Sentry.captureMessage(...)` to help debug:
  - https://mozilla.sentry.io/issues/6966503332
  - https://mozilla.sentry.io/issues/7259555115  

## Issue that this pull request solves

Closes: NA

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

## Other information (Optional)

Both of these states are driven by configuration settings behind the scenes. It's quite possible either the RP is passing invalid scope values, or equally possible we just need to update some configs. 

Another thing worth pointing out here is that the `wantsKeys()` method was recently removed from the `OAuthNativeIntegration` class. As a result the `OAuthWebIntegration.wantsKeys()` method now gets invoked when ever `wantsKeys()` is called on a `OAuthNativeIntegration` instance since that's the parent. It's not yet entirely clear to me if this is as intended or not.
