### PR TITLE
fix(payments-cart): prevent two carts with same uid from processing

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -179,6 +179,17 @@ export class DeleteCartFailedError extends CartError {
   }
 }
 
+export class CartProcessingConflictError extends CartError {
+  constructor(cartId: string, uid: string, conflictingCartId: string) {
+    super('Account already has a cart in a processing state', {
+      cartId,
+      uid,
+      conflictingCartId,
+    });
+    this.name = 'CartProcessingConflictError';
+  }
+}
+
 export class CartStateProcessingError extends CartError {
   constructor(message: string, cartId: string, cause: Error) {
     super(message, { cartId }, cause);
@@ -597,10 +608,14 @@ export class PaidPaymentIntendOnFailedCartError extends CartError {
 
 export class CartSubscriptionDeletionFailedError extends CartError {
   constructor(cartId: string, subscriptionId: string, cause: Error) {
-    super('Subscription deletion failed during cart cleanup', {
-      cartId,
-      subscriptionId,
-    }, cause);
+    super(
+      'Subscription deletion failed during cart cleanup',
+      {
+        cartId,
+        subscriptionId,
+      },
+      cause
+    );
     this.name = 'CartSubscriptionDeletionFailedError';
   }
 }

--- a/libs/payments/cart/src/lib/cart.manager.in.spec.ts
+++ b/libs/payments/cart/src/lib/cart.manager.in.spec.ts
@@ -16,6 +16,7 @@ import {
   CartInvalidStateForActionError,
   CartNotCreatedError,
   CartNotFoundError,
+  CartProcessingConflictError,
   CartVersionMismatchError,
   DeleteCartFailedError,
 } from './cart.error';
@@ -40,6 +41,7 @@ function fail(reason = 'fail was called in a test.') {
 const CART_ID = '8730e0d5939c450286e6e6cc1bbeeab2';
 const RANDOM_ID = uuidv4({}, Buffer.alloc(16)).toString('hex');
 const RANDOM_VERSION = 1234;
+const TEST_TIMESTAMP = 1700000000000;
 
 async function directUpdate(
   db: AccountDatabase,
@@ -268,7 +270,7 @@ describe('CartManager', () => {
     });
   });
 
-  describe('updateProcessingCart', () => {
+  describe('dangerouslyUpdateProcessingCart', () => {
     it('succeeds', async () => {
       const updateItems = UpdateProcessingCartFactory({
         stripeSubscriptionId: 'sub_test123',
@@ -276,7 +278,7 @@ describe('CartManager', () => {
       await directUpdate(db, { state: CartState.PROCESSING }, testCart.id);
       testCart = await cartManager.fetchCartById(testCart.id);
 
-      await cartManager.updateProcessingCart(
+      await cartManager.dangerouslyUpdateProcessingCart(
         testCart.id,
         testCart.version,
         updateItems
@@ -288,12 +290,12 @@ describe('CartManager', () => {
 
     it('fails - rejects START state', async () => {
       try {
-        await cartManager.updateProcessingCart(
+        await cartManager.dangerouslyUpdateProcessingCart(
           testCart.id,
           testCart.version,
           UpdateProcessingCartFactory()
         );
-        fail('Error in updateProcessingCart');
+        fail('Error in dangerouslyUpdateProcessingCart');
       } catch (error) {
         expect(error).toBeInstanceOf(CartInvalidStateForActionError);
       }
@@ -306,12 +308,12 @@ describe('CartManager', () => {
         testCart.id
       );
       try {
-        await cartManager.updateProcessingCart(
+        await cartManager.dangerouslyUpdateProcessingCart(
           testCart.id,
           testCart.version,
           UpdateProcessingCartFactory()
         );
-        fail('Error in updateProcessingCart');
+        fail('Error in dangerouslyUpdateProcessingCart');
       } catch (error) {
         expect(error).toBeInstanceOf(CartVersionMismatchError);
       }
@@ -363,6 +365,196 @@ describe('CartManager', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(CartInvalidStateForActionError);
       }
+    });
+  });
+
+  describe('setProcessingCart', () => {
+    const FIRST_UID = '11111111111111111111111111111111';
+    const CONFLICT_PROCESSING_UID = '22222222222222222222222222222222';
+    const ALLOW_NEEDS_INPUT_UID = '33333333333333333333333333333333';
+    const SEPARATE_UID_A = '44444444444444444444444444444444';
+    const SEPARATE_UID_B = '55555555555555555555555555555555';
+    const INVALID_STATE_UID = '66666666666666666666666666666666';
+    const STALE_PROCESSING_UID = '77777777777777777777777777777777';
+    const CONCURRENT_UID = '88888888888888888888888888888888';
+    const TERMINAL_SIBLING_UID = '99999999999999999999999999999999';
+
+    async function seedAccount(db: AccountDatabase, uidHex: string) {
+      await db
+        .insertInto('accounts')
+        .values({
+          uid: Buffer.from(uidHex, 'hex'),
+          email: `${uidHex}@example.com`,
+          normalizedEmail: `${uidHex}@example.com`,
+          emailCode: Buffer.alloc(16),
+          emailVerified: 1,
+          kA: Buffer.alloc(32),
+          wrapWrapKb: Buffer.alloc(32),
+          authSalt: Buffer.alloc(32),
+          verifyHash: Buffer.alloc(32),
+          verifierVersion: 1,
+          verifierSetAt: TEST_TIMESTAMP,
+          createdAt: TEST_TIMESTAMP,
+        })
+        .execute();
+    }
+
+    it('succeeds - transitions a cart to processing', async () => {
+      await seedAccount(db, FIRST_UID);
+      const cart = await cartManager.createCart(
+        SetupCartFactory({ uid: FIRST_UID })
+      );
+
+      await cartManager.setProcessingCart(cart.id);
+      const updated = await cartManager.fetchCartById(cart.id);
+
+      expect(updated.state).toEqual(CartState.PROCESSING);
+    });
+
+    it('fails - another cart for the same uid is already processing', async () => {
+      await seedAccount(db, CONFLICT_PROCESSING_UID);
+      const firstCart = await cartManager.createCart(
+        SetupCartFactory({ uid: CONFLICT_PROCESSING_UID })
+      );
+      const secondCart = await cartManager.createCart(
+        SetupCartFactory({ uid: CONFLICT_PROCESSING_UID })
+      );
+      await cartManager.setProcessingCart(firstCart.id);
+
+      try {
+        await cartManager.setProcessingCart(secondCart.id);
+        fail('Error in setProcessingCart');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CartProcessingConflictError);
+      }
+
+      const secondCartAfter = await cartManager.fetchCartById(secondCart.id);
+      expect(secondCartAfter.state).toEqual(CartState.START);
+    });
+
+    it('succeeds - allows processing when another cart for the same uid has been processing past the stale timeout', async () => {
+      await seedAccount(db, STALE_PROCESSING_UID);
+      const staleCart = await cartManager.createCart(
+        SetupCartFactory({ uid: STALE_PROCESSING_UID })
+      );
+      const secondCart = await cartManager.createCart(
+        SetupCartFactory({ uid: STALE_PROCESSING_UID })
+      );
+      await directUpdate(
+        db,
+        { state: CartState.PROCESSING, updatedAt: TEST_TIMESTAMP },
+        staleCart.id
+      );
+
+      await cartManager.setProcessingCart(secondCart.id);
+      const updated = await cartManager.fetchCartById(secondCart.id);
+
+      expect(updated.state).toEqual(CartState.PROCESSING);
+    });
+
+    it('succeeds - allows processing when another cart for the same uid needs input', async () => {
+      await seedAccount(db, ALLOW_NEEDS_INPUT_UID);
+      const firstCart = await cartManager.createCart(
+        SetupCartFactory({ uid: ALLOW_NEEDS_INPUT_UID })
+      );
+      const secondCart = await cartManager.createCart(
+        SetupCartFactory({ uid: ALLOW_NEEDS_INPUT_UID })
+      );
+      await directUpdate(db, { state: CartState.NEEDS_INPUT }, firstCart.id);
+
+      await cartManager.setProcessingCart(secondCart.id);
+      const updated = await cartManager.fetchCartById(secondCart.id);
+
+      expect(updated.state).toEqual(CartState.PROCESSING);
+    });
+
+    it('succeeds - ignores processing carts belonging to a different uid', async () => {
+      await seedAccount(db, SEPARATE_UID_A);
+      await seedAccount(db, SEPARATE_UID_B);
+      const cartA = await cartManager.createCart(
+        SetupCartFactory({ uid: SEPARATE_UID_A })
+      );
+      const cartB = await cartManager.createCart(
+        SetupCartFactory({ uid: SEPARATE_UID_B })
+      );
+      await cartManager.setProcessingCart(cartA.id);
+
+      await cartManager.setProcessingCart(cartB.id);
+      const updatedB = await cartManager.fetchCartById(cartB.id);
+
+      expect(updatedB.state).toEqual(CartState.PROCESSING);
+    });
+
+    it('fails - rejects invalid state', async () => {
+      await seedAccount(db, INVALID_STATE_UID);
+      const cart = await cartManager.createCart(
+        SetupCartFactory({ uid: INVALID_STATE_UID })
+      );
+      await directUpdate(db, { state: CartState.SUCCESS }, cart.id);
+
+      try {
+        await cartManager.setProcessingCart(cart.id);
+        fail('Error in setProcessingCart');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CartInvalidStateForActionError);
+      }
+    });
+
+    it('succeeds - transitions a cart with no uid to processing', async () => {
+      const cart = await cartManager.createCart(SetupCartFactory());
+
+      await cartManager.setProcessingCart(cart.id);
+      const updated = await cartManager.fetchCartById(cart.id);
+
+      expect(updated.state).toEqual(CartState.PROCESSING);
+    });
+
+    it('succeeds - ignores a terminal (failed) cart for the same uid', async () => {
+      await seedAccount(db, TERMINAL_SIBLING_UID);
+      const failedCart = await cartManager.createCart(
+        SetupCartFactory({ uid: TERMINAL_SIBLING_UID })
+      );
+      const secondCart = await cartManager.createCart(
+        SetupCartFactory({ uid: TERMINAL_SIBLING_UID })
+      );
+      await directUpdate(db, { state: CartState.FAIL }, failedCart.id);
+
+      await cartManager.setProcessingCart(secondCart.id);
+      const updated = await cartManager.fetchCartById(secondCart.id);
+
+      expect(updated.state).toEqual(CartState.PROCESSING);
+    });
+
+    it('allows only one of two concurrent checkouts for the same uid to enter processing', async () => {
+      await seedAccount(db, CONCURRENT_UID);
+      const cartA = await cartManager.createCart(
+        SetupCartFactory({ uid: CONCURRENT_UID })
+      );
+      const cartB = await cartManager.createCart(
+        SetupCartFactory({ uid: CONCURRENT_UID })
+      );
+
+      const results = await Promise.allSettled([
+        cartManager.setProcessingCart(cartA.id),
+        cartManager.setProcessingCart(cartB.id),
+      ]);
+
+      const fulfillments = results.filter((r) => r.status === 'fulfilled');
+      const rejectionReasons = results.flatMap((r) =>
+        r.status === 'rejected' ? [r.reason] : []
+      );
+      expect(fulfillments).toHaveLength(1);
+      expect(rejectionReasons).toHaveLength(1);
+      expect(rejectionReasons[0]).toBeInstanceOf(CartProcessingConflictError);
+
+      const [updatedA, updatedB] = await Promise.all([
+        cartManager.fetchCartById(cartA.id),
+        cartManager.fetchCartById(cartB.id),
+      ]);
+      const processingCount = [updatedA, updatedB].filter(
+        (cart) => cart.state === CartState.PROCESSING
+      ).length;
+      expect(processingCount).toEqual(1);
     });
   });
 

--- a/libs/payments/cart/src/lib/cart.manager.ts
+++ b/libs/payments/cart/src/lib/cart.manager.ts
@@ -13,6 +13,7 @@ import {
   CartNotDeletedError,
   CartNotFoundError,
   CartNotUpdatedError,
+  CartProcessingConflictError,
   CartVersionMismatchError,
   DeleteCartFailedError,
   ErrorCartNotCreatedError,
@@ -28,6 +29,7 @@ import {
   deleteCart,
   fetchCartById,
   fetchCartsByUid,
+  setCartProcessing,
   updateCart,
 } from './cart.repository';
 import type {
@@ -53,7 +55,7 @@ import {
 // valid states listed in the array of CartStates below
 const ACTIONS_VALID_STATE = {
   updateFreshCart: [CartState.START],
-  updateProcessingCart: [CartState.PROCESSING],
+  dangerouslyUpdateProcessingCart: [CartState.PROCESSING],
   finishCart: [CartState.PROCESSING, CartState.NEEDS_INPUT],
   finishErrorCart: [
     CartState.START,
@@ -239,18 +241,18 @@ export class CartManager {
   }
 
   /**
-    * It is highly recommended to use updateFreshCart instead, adjusting your order of operations.
-    * Mutating a cart once it is already processing risks bugs that change the amount a customer may be charged.
+   * It is highly recommended to use updateFreshCart instead, adjusting your order of operations.
+   * Mutating a cart once it is already processing risks bugs that change the amount a customer may be charged.
    */
   @CaptureTimingWithStatsD()
-  public async updateProcessingCart(
+  public async dangerouslyUpdateProcessingCart(
     cartId: string,
     version: number,
     items: UpdateProcessingCart
   ) {
     const cart = await this.fetchAndValidateCartVersion(cartId, version);
 
-    this.checkActionForValidCartState(cart, 'updateProcessingCart');
+    this.checkActionForValidCartState(cart, 'dangerouslyUpdateProcessingCart');
 
     try {
       await updateCart(this.db, Buffer.from(cartId, 'hex'), version, {
@@ -319,10 +321,16 @@ export class CartManager {
     this.checkActionForValidCartState(cart, 'setProcessingCart');
 
     try {
-      await updateCart(this.db, Buffer.from(cartId, 'hex'), cart.version, {
-        state: CartState.PROCESSING,
-      });
+      await setCartProcessing(
+        this.db,
+        Buffer.from(cartId, 'hex'),
+        cart.uid ? Buffer.from(cart.uid, 'hex') : undefined,
+        cart.version
+      );
     } catch (error) {
+      if (error instanceof CartProcessingConflictError) {
+        throw error;
+      }
       const cause = error instanceof CartNotUpdatedError ? undefined : error;
       throw new SetProcessingCartFailedError(cart.id, cause);
     }

--- a/libs/payments/cart/src/lib/cart.repository.ts
+++ b/libs/payments/cart/src/lib/cart.repository.ts
@@ -3,12 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import {
   AccountDatabase,
+  CartState,
   CartUpdate,
   NewCart,
 } from '@fxa/shared/db/mysql/account';
 
 import { ResultCart } from './cart.types';
-import { CartNotUpdatedError } from './cart.error';
+import { CartNotUpdatedError, CartProcessingConflictError } from './cart.error';
+
+/**
+ * How long a cart may remain in the processing state before it is considered
+ * stale. A cart that has been processing for longer than this is treated as
+ * hung/stuck, so a user is not permanently blocked from using checkout.
+ */
+export const CART_PROCESSING_STALE_TIMEOUT_MS = 15 * 60 * 1000;
 
 /**
  * Creates a cart in the database.
@@ -74,6 +82,67 @@ export async function updateCart(
     throw new CartNotUpdatedError(cartId.toString());
   }
   return true;
+}
+
+/**
+ * Transition a cart to the processing state, enforcing that at most one cart
+ * per account (uid) is in the processing state at a given time.
+ *
+ * A cart that has been processing for longer than CART_PROCESSING_STALE_TIMEOUT_MS
+ * is considered hung and does not block a new checkout.
+ */
+export async function setCartProcessing(
+  db: AccountDatabase,
+  cartId: Buffer,
+  uid: Buffer | undefined,
+  version: number
+): Promise<boolean> {
+  const now = Date.now();
+  return db
+    .transaction()
+    .setIsolationLevel('repeatable read')
+    .execute(async (trx) => {
+      if (uid) {
+        const carts = await trx
+          .selectFrom('carts')
+          .select(['id', 'state', 'updatedAt'])
+          .where('uid', '=', uid)
+          .forUpdate()
+          .execute();
+
+        const conflictingCart = carts.find(
+          (cart) =>
+            !cart.id.equals(cartId) &&
+            cart.state === CartState.PROCESSING &&
+            cart.updatedAt > now - CART_PROCESSING_STALE_TIMEOUT_MS
+        );
+
+        if (conflictingCart) {
+          throw new CartProcessingConflictError(
+            cartId.toString('hex'),
+            uid.toString('hex'),
+            conflictingCart.id.toString('hex')
+          );
+        }
+      }
+
+      const updatedRows = await trx
+        .updateTable('carts')
+        .set({
+          state: CartState.PROCESSING,
+          updatedAt: now,
+          version: version + 1,
+        })
+        .where('id', '=', cartId)
+        .where('version', '=', version)
+        .executeTakeFirst();
+
+      if (updatedRows.numUpdatedRows === BigInt(0)) {
+        throw new CartNotUpdatedError(cartId.toString('hex'));
+      }
+
+      return true;
+    });
 }
 
 /**

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -336,7 +336,9 @@ describe('CheckoutService', () => {
       jest
         .spyOn(accountCustomerManager, 'createAccountCustomer')
         .mockResolvedValue(mockAccountCustomer);
-      jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+      jest
+        .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+        .mockResolvedValue();
       jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
         subscriptionEligibilityResult: EligibilityStatus.CREATE,
       });
@@ -407,7 +409,9 @@ describe('CheckoutService', () => {
       });
 
       it('does not update the cart', () => {
-        expect(cartManager.updateProcessingCart).not.toHaveBeenCalled();
+        expect(
+          cartManager.dangerouslyUpdateProcessingCart
+        ).not.toHaveBeenCalled();
       });
 
       it('checks that customer does not have existing subscription to price', () => {
@@ -824,7 +828,9 @@ describe('CheckoutService', () => {
       jest
         .spyOn(subscriptionManager, 'create')
         .mockResolvedValue(mockSubscription);
-      jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+      jest
+        .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+        .mockResolvedValue();
       jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
       jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
       jest
@@ -905,15 +911,13 @@ describe('CheckoutService', () => {
         expect(asyncLocalStorage.getStore).toHaveBeenCalled();
       });
 
-      it('calls updateProcessingCart', async () => {
-        expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
-          mockCart.id,
-          mockPrePayStepsResult.version,
-          {
-            stripeSubscriptionId: mockSubscription.id,
-            stripeIntentId: mockPaymentIntent.id,
-          }
-        );
+      it('calls dangerouslyUpdateProcessingCart', async () => {
+        expect(
+          cartManager.dangerouslyUpdateProcessingCart
+        ).toHaveBeenCalledWith(mockCart.id, mockPrePayStepsResult.version, {
+          stripeSubscriptionId: mockSubscription.id,
+          stripeIntentId: mockPaymentIntent.id,
+        });
       });
 
       it('calls calls paymentIntentManager.confirm', async () => {
@@ -1063,15 +1067,13 @@ describe('CheckoutService', () => {
           );
         });
 
-        it('calls updateProcessingCart', async () => {
-          expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
-            mockCart.id,
-            mockPrePayStepsResult.version,
-            {
-              stripeSubscriptionId: mockSubscription.id,
-              stripeIntentId: mockSetupIntent.id,
-            }
-          );
+        it('calls dangerouslyUpdateProcessingCart', async () => {
+          expect(
+            cartManager.dangerouslyUpdateProcessingCart
+          ).toHaveBeenCalledWith(mockCart.id, mockPrePayStepsResult.version, {
+            stripeSubscriptionId: mockSubscription.id,
+            stripeIntentId: mockSetupIntent.id,
+          });
         });
       });
 
@@ -1155,15 +1157,13 @@ describe('CheckoutService', () => {
           );
         });
 
-        it('calls updateProcessingCart with the confirmed setup intent id', () => {
-          expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
-            mockCart.id,
-            mockPrePayStepsResult.version,
-            {
-              stripeSubscriptionId: mockSubscriptionWithPendingSetup.id,
-              stripeIntentId: mockSetupIntent.id,
-            }
-          );
+        it('calls dangerouslyUpdateProcessingCart with the confirmed setup intent id', () => {
+          expect(
+            cartManager.dangerouslyUpdateProcessingCart
+          ).toHaveBeenCalledWith(mockCart.id, mockPrePayStepsResult.version, {
+            stripeSubscriptionId: mockSubscriptionWithPendingSetup.id,
+            stripeIntentId: mockSetupIntent.id,
+          });
         });
       });
 
@@ -1185,13 +1185,11 @@ describe('CheckoutService', () => {
             )
           ).rejects.toThrow();
 
-          expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
-            mockCart.id,
-            mockPrePayStepsResult.version,
-            {
-              stripeSubscriptionId: mockSubscription.id,
-            }
-          );
+          expect(
+            cartManager.dangerouslyUpdateProcessingCart
+          ).toHaveBeenCalledWith(mockCart.id, mockPrePayStepsResult.version, {
+            stripeSubscriptionId: mockSubscription.id,
+          });
         });
       });
     });
@@ -1249,7 +1247,9 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockSubscription);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
         jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
         jest
@@ -1387,7 +1387,9 @@ describe('CheckoutService', () => {
           jest
             .spyOn(subscriptionManager, 'create')
             .mockResolvedValue(mockTrialSubscription);
-          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+          jest
+            .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+            .mockResolvedValue();
           jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
           jest
             .spyOn(invoiceManager, 'retrieve')
@@ -1402,9 +1404,7 @@ describe('CheckoutService', () => {
           jest
             .spyOn(paymentMethodManager, 'retrieve')
             .mockResolvedValue(mockPaymentMethod);
-          jest
-            .spyOn(freeTrialManager, 'recordFreeTrial')
-            .mockResolvedValue();
+          jest.spyOn(freeTrialManager, 'recordFreeTrial').mockResolvedValue();
         });
 
         beforeEach(async () => {
@@ -1489,7 +1489,9 @@ describe('CheckoutService', () => {
           jest
             .spyOn(subscriptionManager, 'create')
             .mockResolvedValue(mockSubscription);
-          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+          jest
+            .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+            .mockResolvedValue();
           jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
           jest
             .spyOn(paymentIntentManager, 'confirm')
@@ -1501,9 +1503,7 @@ describe('CheckoutService', () => {
           jest
             .spyOn(paymentMethodManager, 'retrieve')
             .mockResolvedValue(mockPaymentMethod);
-          jest
-            .spyOn(freeTrialManager, 'recordFreeTrial')
-            .mockResolvedValue();
+          jest.spyOn(freeTrialManager, 'recordFreeTrial').mockResolvedValue();
         });
 
         beforeEach(async () => {
@@ -1619,7 +1619,9 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest
           .spyOn(invoiceManager, 'retrieve')
           .mockResolvedValue(mockTrialInvoice);
@@ -1696,7 +1698,9 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest
           .spyOn(invoiceManager, 'retrieve')
           .mockResolvedValue(mockTrialInvoice);
@@ -1759,7 +1763,9 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockSubscription);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
         jest
           .spyOn(paymentIntentManager, 'confirm')
@@ -1801,7 +1807,9 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockNonTrialingSubscription);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
         jest.spyOn(statsd, 'increment');
 
@@ -1855,7 +1863,9 @@ describe('CheckoutService', () => {
         jest
           .spyOn(checkoutService, 'upgradeSubscription')
           .mockResolvedValue(mockSubscription);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
         jest
           .spyOn(paymentIntentManager, 'confirm')
@@ -1876,9 +1886,7 @@ describe('CheckoutService', () => {
           mockCart.uid
         );
 
-        expect(
-          checkoutService.getFreeTrialEligibility
-        ).not.toHaveBeenCalled();
+        expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
         expect(checkoutService.upgradeSubscription).toHaveBeenCalled();
       });
 
@@ -1911,7 +1919,9 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
         jest
           .spyOn(invoiceManager, 'retrieve')
@@ -1921,9 +1931,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockRequiresActionSetupIntent);
         jest.spyOn(statsd, 'increment');
         jest.spyOn(asyncLocalStorage, 'getStore');
-        jest
-          .spyOn(freeTrialManager, 'recordFreeTrial')
-          .mockResolvedValue();
+        jest.spyOn(freeTrialManager, 'recordFreeTrial').mockResolvedValue();
 
         await checkoutService.payWithStripe(
           mockCart,
@@ -2009,7 +2017,9 @@ describe('CheckoutService', () => {
         jest.spyOn(subscriptionManager, 'cancel');
         jest.spyOn(paypalBillingAgreementManager, 'cancel').mockResolvedValue();
         jest.spyOn(checkoutService, 'postPaySteps').mockResolvedValue();
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
@@ -2115,12 +2125,12 @@ describe('CheckoutService', () => {
           },
         });
       });
-      it('calls cartManager.updateProcessingCart', () => {
-        expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
-          mockCart.id,
-          mockPrePayStepsResult.version,
-          { stripeSubscriptionId: mockSubscription.id }
-        );
+      it('calls cartManager.dangerouslyUpdateProcessingCart', () => {
+        expect(
+          cartManager.dangerouslyUpdateProcessingCart
+        ).toHaveBeenCalledWith(mockCart.id, mockPrePayStepsResult.version, {
+          stripeSubscriptionId: mockSubscription.id,
+        });
       });
       it('calls invoiceManager.processPayPalInvoice', async () => {
         expect(invoiceManager.processPayPalInvoice).toHaveBeenCalledWith(
@@ -2254,7 +2264,9 @@ describe('CheckoutService', () => {
             .spyOn(paypalBillingAgreementManager, 'cancel')
             .mockResolvedValue();
           jest.spyOn(checkoutService, 'postPaySteps').mockResolvedValue();
-          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+          jest
+            .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+            .mockResolvedValue();
           jest
             .spyOn(checkoutService, 'getFreeTrialEligibility')
             .mockResolvedValue({ offer: null, userEligible: false });
@@ -2346,14 +2358,12 @@ describe('CheckoutService', () => {
         );
 
         beforeEach(async () => {
-          jest
-            .spyOn(checkoutService, 'prePaySteps')
-            .mockResolvedValue(
-              PrePayStepsResultFactory({
-                ...mockPrePayStepsResult,
-                freeTrial: mockFreeTrial,
-              })
-            );
+          jest.spyOn(checkoutService, 'prePaySteps').mockResolvedValue(
+            PrePayStepsResultFactory({
+              ...mockPrePayStepsResult,
+              freeTrial: mockFreeTrial,
+            })
+          );
           jest
             .spyOn(subscriptionManager, 'getCustomerPayPalSubscriptions')
             .mockResolvedValue([]);
@@ -2376,14 +2386,12 @@ describe('CheckoutService', () => {
           jest
             .spyOn(paypalCustomerManager, 'createPaypalCustomer')
             .mockResolvedValue(mockPaypalCustomer);
+          jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
           jest
-            .spyOn(customerManager, 'update')
-            .mockResolvedValue(mockCustomer);
-          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
-          jest.spyOn(asyncLocalStorage, 'getStore');
-          jest
-            .spyOn(freeTrialManager, 'recordFreeTrial')
+            .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
             .mockResolvedValue();
+          jest.spyOn(asyncLocalStorage, 'getStore');
+          jest.spyOn(freeTrialManager, 'recordFreeTrial').mockResolvedValue();
           jest
             .spyOn(invoiceManager, 'retrieve')
             .mockResolvedValue(mockTrialInvoice);
@@ -2425,15 +2433,13 @@ describe('CheckoutService', () => {
         });
 
         it('calls processPayPalZeroInvoice for trial invoice', () => {
-          expect(
-            invoiceManager.processPayPalZeroInvoice
-          ).toHaveBeenCalledWith(mockTrialInvoice.id);
+          expect(invoiceManager.processPayPalZeroInvoice).toHaveBeenCalledWith(
+            mockTrialInvoice.id
+          );
         });
 
         it('does not call processPayPalInvoice for trial', () => {
-          expect(
-            invoiceManager.processPayPalInvoice
-          ).not.toHaveBeenCalled();
+          expect(invoiceManager.processPayPalInvoice).not.toHaveBeenCalled();
         });
 
         it('calls postPaySteps', () => {
@@ -2459,9 +2465,7 @@ describe('CheckoutService', () => {
         beforeEach(async () => {
           jest
             .spyOn(checkoutService, 'prePaySteps')
-            .mockResolvedValue(
-              PrePayStepsResultFactory(mockPrePayStepsResult)
-            );
+            .mockResolvedValue(PrePayStepsResultFactory(mockPrePayStepsResult));
           jest
             .spyOn(subscriptionManager, 'getCustomerPayPalSubscriptions')
             .mockResolvedValue([]);
@@ -2484,17 +2488,13 @@ describe('CheckoutService', () => {
           jest
             .spyOn(paypalCustomerManager, 'createPaypalCustomer')
             .mockResolvedValue(mockPaypalCustomer);
+          jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
           jest
-            .spyOn(customerManager, 'update')
-            .mockResolvedValue(mockCustomer);
-          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
-          jest.spyOn(asyncLocalStorage, 'getStore');
-          jest
-            .spyOn(freeTrialManager, 'recordFreeTrial')
+            .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
             .mockResolvedValue();
-          jest
-            .spyOn(invoiceManager, 'retrieve')
-            .mockResolvedValue(mockInvoice);
+          jest.spyOn(asyncLocalStorage, 'getStore');
+          jest.spyOn(freeTrialManager, 'recordFreeTrial').mockResolvedValue();
+          jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
           jest
             .spyOn(invoiceManager, 'processPayPalInvoice')
             .mockResolvedValue(mockInvoice);
@@ -2538,14 +2538,12 @@ describe('CheckoutService', () => {
           StripeSubscriptionFactory({ status: 'active' })
         );
 
-        jest
-          .spyOn(checkoutService, 'prePaySteps')
-          .mockResolvedValue(
-            PrePayStepsResultFactory({
-              ...mockPrePayStepsResult,
-              freeTrial: mockFreeTrial,
-            })
-          );
+        jest.spyOn(checkoutService, 'prePaySteps').mockResolvedValue(
+          PrePayStepsResultFactory({
+            ...mockPrePayStepsResult,
+            freeTrial: mockFreeTrial,
+          })
+        );
         jest
           .spyOn(subscriptionManager, 'getCustomerPayPalSubscriptions')
           .mockResolvedValue([]);
@@ -2569,7 +2567,9 @@ describe('CheckoutService', () => {
           .spyOn(paypalCustomerManager, 'createPaypalCustomer')
           .mockResolvedValue(mockPaypalCustomer);
         jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
 
         await expect(
@@ -2630,12 +2630,12 @@ describe('CheckoutService', () => {
           .spyOn(paypalCustomerManager, 'createPaypalCustomer')
           .mockResolvedValue(mockPaypalCustomer);
         jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
-        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
+        jest
+          .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+          .mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
         jest.spyOn(statsd, 'increment');
-        jest
-          .spyOn(invoiceManager, 'retrieve')
-          .mockResolvedValue(mockInvoice);
+        jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
         jest
           .spyOn(invoiceManager, 'processPayPalInvoice')
           .mockResolvedValue(mockInvoice);
@@ -2649,9 +2649,7 @@ describe('CheckoutService', () => {
           mockToken
         );
 
-        expect(
-          checkoutService.getFreeTrialEligibility
-        ).not.toHaveBeenCalled();
+        expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
         expect(checkoutService.upgradeSubscription).toHaveBeenCalled();
       });
     });
@@ -2805,9 +2803,7 @@ describe('CheckoutService', () => {
       jest
         .spyOn(subscriptionManager, 'update')
         .mockReset()
-        .mockResolvedValueOnce(
-          StripeResponseFactory(trialingSubscription)
-        );
+        .mockResolvedValueOnce(StripeResponseFactory(trialingSubscription));
 
       await checkoutService.upgradeSubscription(
         customerId,
@@ -3018,9 +3014,7 @@ describe('CheckoutService', () => {
     };
 
     it('returns null when Nimbus returns null', async () => {
-      jest
-        .spyOn(nimbusManager, 'fetchExperiments')
-        .mockResolvedValue(null);
+      jest.spyOn(nimbusManager, 'fetchExperiments').mockResolvedValue(null);
       jest
         .spyOn(nimbusManager, 'generateNimbusId')
         .mockReturnValue('nimbus-id');
@@ -3060,10 +3054,12 @@ describe('CheckoutService', () => {
       jest
         .spyOn(nimbusManager, 'generateNimbusId')
         .mockReturnValue('nimbus-id');
-      jest.spyOn(productConfigurationManager, 'getFreeTrial').mockResolvedValue({
-        getResult: jest.fn().mockReturnValue(undefined),
-        freeTrial: { freeTrials: [] },
-      } as any);
+      jest
+        .spyOn(productConfigurationManager, 'getFreeTrial')
+        .mockResolvedValue({
+          getResult: jest.fn().mockReturnValue(undefined),
+          freeTrial: { freeTrials: [] },
+        } as any);
 
       const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
@@ -3115,12 +3111,14 @@ describe('CheckoutService', () => {
       jest
         .spyOn(nimbusManager, 'generateNimbusId')
         .mockReturnValue('nimbus-id');
-      jest.spyOn(productConfigurationManager, 'getFreeTrial').mockResolvedValue({
-        getResult: jest.fn().mockReturnValue([
-          { ...mockFreeTrial, trialLengthDays: 0 },
-        ]),
-        freeTrial: { freeTrials: [{ ...mockFreeTrial, trialLengthDays: 0 }] },
-      } as any);
+      jest
+        .spyOn(productConfigurationManager, 'getFreeTrial')
+        .mockResolvedValue({
+          getResult: jest
+            .fn()
+            .mockReturnValue([{ ...mockFreeTrial, trialLengthDays: 0 }]),
+          freeTrial: { freeTrials: [{ ...mockFreeTrial, trialLengthDays: 0 }] },
+        } as any);
 
       const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -221,10 +221,14 @@ export class CheckoutService {
         stripeCustomerId,
       });
 
-      await this.cartManager.updateProcessingCart(cart.id, cart.version, {
-        uid,
-        stripeCustomerId,
-      });
+      await this.cartManager.dangerouslyUpdateProcessingCart(
+        cart.id,
+        cart.version,
+        {
+          uid,
+          stripeCustomerId,
+        }
+      );
       version += 1;
     }
 
@@ -511,13 +515,15 @@ export class CheckoutService {
           }
         );
       } else if (subscription.pending_setup_intent) {
-
         // Subscription metadata is required by welcome email dispatcher for zero-cost subscriptions
-        await this.setupIntentManager.update(subscription.pending_setup_intent, {
-          metadata: {
-            [STRIPE_SETUP_INTENT_METADATA.SubscriptionId]: subscription.id,
-          },
-        });
+        await this.setupIntentManager.update(
+          subscription.pending_setup_intent,
+          {
+            metadata: {
+              [STRIPE_SETUP_INTENT_METADATA.SubscriptionId]: subscription.id,
+            },
+          }
+        );
 
         intent = await this.setupIntentManager.confirm(
           subscription.pending_setup_intent,
@@ -549,14 +555,18 @@ export class CheckoutService {
 
       if (!intent) {
         // At least update the cart with the subscription ID before throwing
-        await this.cartManager.updateProcessingCart(cart.id, version, {
-          stripeSubscriptionId: subscription.id,
-        });
+        await this.cartManager.dangerouslyUpdateProcessingCart(
+          cart.id,
+          version,
+          {
+            stripeSubscriptionId: subscription.id,
+          }
+        );
         throw error;
       }
     }
 
-    await this.cartManager.updateProcessingCart(cart.id, version, {
+    await this.cartManager.dangerouslyUpdateProcessingCart(cart.id, version, {
       stripeSubscriptionId: subscription.id,
       stripeIntentId: intent.id,
     });
@@ -744,7 +754,7 @@ export class CheckoutService {
           [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: billingAgreementId,
         },
       }),
-      this.cartManager.updateProcessingCart(cart.id, version, {
+      this.cartManager.dangerouslyUpdateProcessingCart(cart.id, version, {
         stripeSubscriptionId: subscription.id,
       }),
     ]);


### PR DESCRIPTION
## Because

- We want to prevent an edge case where a user may submit two carts to a processing state in quick succession.

## This pull request

- Prevents two carts from entering the processing state simultaneously via a DB lock of the user's other cart rows
