### PR TITLE
fix(settings): divert passkey AAL2 sessions without TOTP to inline TO…

### DIFF
--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -417,6 +417,96 @@ test.describe('severity-1 #smoke', () => {
       expect(await relier.hasAccountAAL2Badge()).toBe(true);
     });
 
+    test('AMO-style profile AAL2: cached passkey session (no fresh ceremony) without TOTP is diverted to inline TOTP setup, not looped', async ({
+      target,
+      pages: { page, relier, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'requires the local 123done /api/profile_aal2 toggle'
+      );
+
+      // Establish an active session-AAL2 session by signing in WITH the
+      // passkey (AMR {pwd, webauthn}). The account has no TOTP.
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await settings.signOut();
+      await signInWithRegisteredPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        email: credentials.email,
+      });
+
+      // Reuse the existing passkey session (cached-signin path, not a fresh
+      // ceremony). The cached grant satisfies session AAL2, so without the
+      // divert the RP bounces and the user loops on the cached-signin screen.
+      await relier.goto();
+      await relier.clickRequireProfileAAL2();
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      await signin.signInButton.click();
+
+      // No TOTP on the account, so FxA must divert to inline TOTP setup.
+      await page.waitForURL(/inline_totp_setup/);
+    });
+
+    test('AMO-style profile AAL2: cached passkey session with TOTP already enabled completes without the divert', async ({
+      target,
+      pages: { page, relier, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'requires the local 123done /api/profile_aal2 toggle'
+      );
+
+      // Account with a passkey AND TOTP already enrolled.
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      credentials.secret = await enableTotpOnAccount(
+        target.authClient,
+        credentials.sessionToken
+      );
+      await settings.signOut();
+      await signInWithRegisteredPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        email: credentials.email,
+      });
+
+      // Cached signin into the profile-AAL2 RP. Account 2FA is already
+      // satisfied (TOTP enrolled), so the user skips enrollment (no divert)
+      // and the grant completes.
+      await relier.goto();
+      await relier.clickRequireProfileAAL2();
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      await signin.signInButton.click();
+      await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
+
+      expect(page.url()).not.toContain('/inline_totp_setup');
+      expect(await relier.isLoggedIn()).toBe(true);
+      expect(await relier.hasSessionAAL2Badge()).toBe(true);
+      expect(await relier.hasAccountAAL2Badge()).toBe(true);
+    });
+
     test('shows the "passkey not recognized" banner when the server no longer knows the credential', async ({
       target,
       pages: { page, settings, settingsPasskeyAdd, signin },
@@ -560,6 +650,35 @@ async function setUpAccountWithPasskey({
   await settingsPasskeyAdd.registerNewPasskey(settings, credentials.email);
 
   return credentials;
+}
+
+/**
+ * Signs in with a previously registered passkey (assumes the user is signed
+ * out but the polyfill credential is still discoverable). Leaves the user on
+ * Settings with an active session-AAL2 session (AMR {pwd, webauthn}).
+ */
+async function signInWithRegisteredPasskey({
+  target,
+  page,
+  settings,
+  settingsPasskeyAdd,
+  signin,
+  email,
+}: {
+  target: BaseTarget;
+  page: Page;
+  settings: SettingsPage;
+  settingsPasskeyAdd: SettingsPasskeyAddPage;
+  signin: SigninPage;
+  email: string;
+}) {
+  await page.goto(target.contentServerUrl);
+  await signin.fillOutEmailFirstForm(email);
+  await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+    await signin.passkeySigninButton.click();
+    await page.waitForURL(/settings/);
+  });
+  await expect(settings.settingsHeading).toBeVisible();
 }
 
 // Signs out without clearing the polyfill installed via `addInitScript`,

--- a/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
@@ -130,6 +130,9 @@ const SigninCached = ({
           uid: data.uid,
           sessionToken,
         },
+        // Lets handleNavigation divert an AAL2 RP to inline TOTP setup; without
+        // it a passkey-AAL2 cached session with no TOTP would loop.
+        accountHasTotp: data.totpIsActive,
         integration,
         redirectTo:
           isWebIntegration(integration) && webRedirectCheck?.isValid

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -182,6 +182,7 @@ export interface CachedSigninHandlerResponse {
     uid: hexstring;
     sessionVerified: boolean;
     emailVerified: boolean;
+    totpIsActive: boolean;
   };
   error?: AuthUiError;
 }

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -316,6 +316,7 @@ export const CACHED_SIGNIN_HANDLER_RESPONSE = {
     sessionVerified: true,
     emailVerified: true,
     uid: MOCK_UID,
+    totpIsActive: false,
     ...MOCK_VERIFICATION,
   },
 };

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -395,6 +395,26 @@ describe('Signin utils', () => {
         );
       });
 
+      it('diverts a cached session (not a fresh passkey ceremony) when the account has no TOTP', async () => {
+        // A cached passkey session is session-AAL2 without isPasskeySession set.
+        // The divert must still fire so an AAL2 RP does not bounce indefinitely.
+        const finishOAuthFlowHandler = jest.fn();
+        const navigationOptions = buildPasskeyOAuthOptions({
+          isPasskeySession: false,
+          accountHasTotp: false,
+          finishOAuthFlowHandler,
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(finishOAuthFlowHandler).not.toHaveBeenCalled();
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/inline_totp_setup?client_id=abc',
+          expect.objectContaining({ replace: true })
+        );
+      });
+
       it('continues to OAuth redirect when the account already has TOTP', async () => {
         const finishOAuthFlowHandler = jest
           .fn()

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -564,10 +564,9 @@ const getOAuthNavigationTarget = async (
     };
   }
 
-  // Profile-level AMR omits webauthn, so AAL2 RPs (AMO) reject passkey-only
-  // grants. Force TOTP enrollment first when no TOTP is set.
+  // A passkey/passwordless session is session-AAL2 but has no account 2FA, so
+  // an AAL2 RP (AMO) loops unless we force TOTP enrollment when none is set.
   if (
-    navigationOptions.isPasskeySession &&
     isOAuthWebIntegration(navigationOptions.integration) &&
     navigationOptions.integration.wantsTwoStepAuthentication() &&
     navigationOptions.accountHasTotp === false


### PR DESCRIPTION
## Because

- A passkey or passwordless+passkey session is *session*-AAL2, so an AAL2 RP (e.g. AMO) is satisfied at the OAuth grant, but those RPs require *account*-level 2FA (TOTP), which a passkey does not provide.
- With no TOTP, the grant keeps succeeding while the RP keeps rejecting, leaving the user looping on the FxA cached-signin screen.

## This pull request

- Removes the `isPasskeySession` gate on the inline-TOTP-setup divert in `utils.ts`, so it fires for any session satisfying session-AAL2 without account 2FA (fresh passkey ceremony *or* cached passkey session); the divert stays gated on `wantsTwoStepAuthentication()` + `accountHasTotp === false`.
- Updates `SigninCached/index.tsx` to forward `accountHasTotp: data.totpIsActive` (already returned by the cached-signin handler, no new network call).
- Adds `totpIsActive` to `CachedSigninHandlerResponse` (`interfaces.ts`) and the mock (`mocks.tsx`).

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13883

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test (local, passkeys enabled):**
1. Create a passwordless or password account; register a passkey; sign out.
2. Sign in with the passkey (session-AAL2, no TOTP).
3. Hit a profile-AAL2 RP (123done "Sign In (Require Profile AAL2)").
4. Expect a divert to `/inline_totp_setup` (not a cached-signin loop). With TOTP enrolled, sign-in completes with no divert.