### PR TITLE
fix(auth-client): make no-hawk-signing test ESM-compatible

### DIFF
--- a/packages/fxa-auth-client/test/no-hawk-signing.ts
+++ b/packages/fxa-auth-client/test/no-hawk-signing.ts
@@ -9,10 +9,13 @@ import path from 'path';
 // suspenders for re-exports, string builders, or vendored copies.
 
 const BANNED = /hawk\.header\(|\bhawkHeader\(|\bcalculateMac\(/;
+// path.resolve() against CWD instead of __dirname so the file works whether
+// loaded as CJS (ts-node/register) or ESM (Node's native loader). Mocha is
+// invoked from the package root via `mocha test/*` so CWD is stable.
 const ROOTS = [
-  path.join(__dirname, '..', 'lib'),
-  path.join(__dirname, '..', 'server.ts'),
-  path.join(__dirname, '..', 'browser.ts'),
+  path.resolve('lib'),
+  path.resolve('server.ts'),
+  path.resolve('browser.ts'),
 ];
 
 function* walk(p: string): Generator<string> {
@@ -31,7 +34,10 @@ describe('no-hawk-signing guard', () => {
   it('fxa-auth-client source is free of Hawk signing calls', () => {
     const offenders: string[] = [];
     for (const root of ROOTS) {
-      if (!fs.existsSync(root)) continue;
+      assert.ok(
+        fs.existsSync(root),
+        `Expected root ${root} not found — run from package root`
+      );
       for (const file of walk(root)) {
         if (!/\.(ts|js)$/.test(file)) continue;
         const text = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
## Because

- On Node 24 + mocha + ts-node (used in CI), `test/no-hawk-signing.ts` is sometimes loaded via Node's native ESM loader instead of ts-node's CJS register. `__dirname` is undefined in ESM scope, so the file throws on load and the entire `nx test-unit fxa-auth-client` task fails before any tests run. Local Node 22 doesn't hit this path. This is blocking [#20677](https://github.com/mozilla/fxa/pull/20677).

## This pull request

- Replaces `__dirname`-relative paths with `path.resolve()` against CWD. Mocha is invoked from the package root via `mocha test/*`, so CWD is stable in both CJS and ESM load contexts.

## Issue that this pull request solves

- fixes FXA-13889

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- One file, six lines. Verify the comment explains the rationale.
- cc @vbudhram (FXA-9392 owner) — heads-up that your guard file changed under you.