### PR TITLE
test(payments): Add integration, unit, and component tests for Subscription Management flows

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.test.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.test.tsx
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render } from '@testing-library/react';
+import { SessionFactory } from '@fxa/payments/ui-auth/testing';
+import CancelSubscriptionPage from './page';
+
+const mockGetCancelFlowContentAction = jest.fn();
+const mockAuth = jest.fn();
+const mockRedirect = jest.fn();
+const mockNotFound = jest.fn();
+const mockHeaders = jest.fn();
+const mockCancelSubscription = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  getCancelFlowContentAction: (...args: unknown[]) =>
+    mockGetCancelFlowContentAction(...args),
+}));
+
+jest.mock('apps/payments/next/auth', () => ({
+  __esModule: true,
+  auth: () => mockAuth(),
+}));
+
+jest.mock('apps/payments/next/config', () => ({
+  __esModule: true,
+  config: {
+    paymentsNextHostedUrl: 'https://payments.example.com',
+  },
+}));
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  redirect: (...args: unknown[]) => mockRedirect(...args),
+  notFound: (...args: unknown[]) => mockNotFound(...args),
+}));
+
+jest.mock('next/headers', () => ({
+  __esModule: true,
+  headers: () => mockHeaders(),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  CancelSubscription: (props: Record<string, unknown>) => {
+    mockCancelSubscription(props);
+    return <div data-testid="cancel-subscription" />;
+  },
+}));
+
+const MOCK_SUBSCRIPTION_ID = 'sub_abc123';
+const MOCK_LOCALE = 'en';
+
+const defaultParams = Promise.resolve({
+  locale: MOCK_LOCALE,
+  subscriptionId: MOCK_SUBSCRIPTION_ID,
+});
+
+const defaultSearchParams = Promise.resolve({});
+
+const baseSession = SessionFactory();
+
+const basePageContent = {
+  flowType: 'cancel',
+  productName: 'Test Product',
+};
+
+async function renderPage(
+  paramsOverride?: Promise<Record<string, string>>,
+  searchParamsOverride?: Promise<Record<string, string>>
+) {
+  const jsx = await CancelSubscriptionPage({
+    params: (paramsOverride ?? defaultParams) as any,
+    searchParams: (searchParamsOverride ?? defaultSearchParams) as any,
+  });
+  return render(jsx);
+}
+
+describe('CancelSubscriptionPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHeaders.mockResolvedValue({
+      get: () => 'en-US',
+    });
+    mockAuth.mockResolvedValue(baseSession);
+    mockGetCancelFlowContentAction.mockResolvedValue(basePageContent);
+  });
+
+  it('redirects unauthenticated users to the landing page', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await renderPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('redirects users with no session user id to the landing page', async () => {
+    mockAuth.mockResolvedValue({ user: { id: undefined } });
+
+    await renderPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('preserves search params in the redirect URL for unauthenticated users', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await renderPage(
+      defaultParams,
+      Promise.resolve({ utm_source: 'email', plan: 'pro' })
+    );
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing?utm_source=email&plan=pro'
+    );
+  });
+
+  it('calls notFound when pageContent.flowType is not_found', async () => {
+    mockGetCancelFlowContentAction.mockResolvedValue({
+      flowType: 'not_found',
+    });
+
+    await renderPage();
+
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it('renders CancelSubscription component with correct props', async () => {
+    await renderPage();
+
+    expect(mockCancelSubscription).toHaveBeenCalledWith({
+      subscriptionId: MOCK_SUBSCRIPTION_ID,
+      locale: MOCK_LOCALE,
+      pageContent: basePageContent,
+    });
+  });
+
+  it('passes subscriptionId and locale from params to CancelSubscription', async () => {
+    const customParams = Promise.resolve({
+      locale: 'fr',
+      subscriptionId: 'sub_custom456',
+    });
+
+    await renderPage(customParams);
+
+    expect(mockCancelSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriptionId: 'sub_custom456',
+        locale: 'fr',
+      })
+    );
+  });
+
+  it('passes subscriptionId and acceptLanguage to getCancelFlowContentAction', async () => {
+    await renderPage();
+
+    expect(mockGetCancelFlowContentAction).toHaveBeenCalledWith(
+      MOCK_SUBSCRIPTION_ID,
+      'en-US'
+    );
+  });
+});

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.test.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.test.tsx
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render } from '@testing-library/react';
+import { SessionFactory } from '@fxa/payments/ui-auth/testing';
+import StaySubscribedPage from './page';
+
+const mockGetStaySubscribedFlowContentAction = jest.fn();
+const mockAuth = jest.fn();
+const mockRedirect = jest.fn();
+const mockNotFound = jest.fn();
+const mockHeaders = jest.fn();
+const mockStaySubscribed = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  getStaySubscribedFlowContentAction: (...args: unknown[]) =>
+    mockGetStaySubscribedFlowContentAction(...args),
+}));
+
+jest.mock('apps/payments/next/auth', () => ({
+  __esModule: true,
+  auth: () => mockAuth(),
+}));
+
+jest.mock('apps/payments/next/config', () => ({
+  __esModule: true,
+  config: {
+    paymentsNextHostedUrl: 'https://payments.example.com',
+  },
+}));
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  redirect: (...args: unknown[]) => mockRedirect(...args),
+  notFound: (...args: unknown[]) => mockNotFound(...args),
+}));
+
+jest.mock('next/headers', () => ({
+  __esModule: true,
+  headers: () => mockHeaders(),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  StaySubscribed: (props: Record<string, unknown>) => {
+    mockStaySubscribed(props);
+    return <div data-testid="stay-subscribed" />;
+  },
+}));
+
+const MOCK_SUBSCRIPTION_ID = 'sub_abc123';
+const MOCK_LOCALE = 'en';
+
+const defaultParams = Promise.resolve({
+  locale: MOCK_LOCALE,
+  subscriptionId: MOCK_SUBSCRIPTION_ID,
+});
+
+const defaultSearchParams = Promise.resolve({});
+
+const baseSession = SessionFactory();
+
+const basePageContent = {
+  flowType: 'stay_subscribed',
+  productName: 'Test Product',
+};
+
+async function renderPage(
+  paramsOverride?: Promise<Record<string, string>>,
+  searchParamsOverride?: Promise<Record<string, string>>
+) {
+  const jsx = await StaySubscribedPage({
+    params: (paramsOverride ?? defaultParams) as any,
+    searchParams: (searchParamsOverride ?? defaultSearchParams) as any,
+  });
+  return render(jsx);
+}
+
+describe('StaySubscribedPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHeaders.mockResolvedValue({
+      get: () => 'en-US',
+    });
+    mockAuth.mockResolvedValue(baseSession);
+    mockGetStaySubscribedFlowContentAction.mockResolvedValue(basePageContent);
+  });
+
+  it('redirects unauthenticated users to the landing page', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await renderPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('redirects users with no session user id to the landing page', async () => {
+    mockAuth.mockResolvedValue({ user: { id: undefined } });
+
+    await renderPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('preserves search params in the redirect URL for unauthenticated users', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await renderPage(
+      defaultParams,
+      Promise.resolve({ utm_source: 'email', plan: 'pro' })
+    );
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing?utm_source=email&plan=pro'
+    );
+  });
+
+  it('calls notFound when pageContent.flowType is not_found', async () => {
+    mockGetStaySubscribedFlowContentAction.mockResolvedValue({
+      flowType: 'not_found',
+    });
+
+    await renderPage();
+
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it('renders StaySubscribed component with correct props', async () => {
+    await renderPage();
+
+    expect(mockStaySubscribed).toHaveBeenCalledWith({
+      subscriptionId: MOCK_SUBSCRIPTION_ID,
+      locale: MOCK_LOCALE,
+      pageContent: basePageContent,
+    });
+  });
+
+  it('passes subscriptionId and acceptLanguage to getStaySubscribedFlowContentAction', async () => {
+    await renderPage();
+
+    expect(mockGetStaySubscribedFlowContentAction).toHaveBeenCalledWith(
+      MOCK_SUBSCRIPTION_ID,
+      'en-US'
+    );
+  });
+});

--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.test.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.test.tsx
@@ -131,7 +131,10 @@ jest.mock('@fxa/shared/react', () => ({
     href: string;
     [key: string]: unknown;
   }) => (
-    <a href={href} {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
+    <a
+      href={href}
+      {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+    >
       {children}
     </a>
   ),
@@ -147,26 +150,20 @@ jest.mock(
   () => 'alert-yellow.svg',
   { virtual: true }
 );
-jest.mock(
-  '@fxa/shared/assets/images/arrow-down.svg',
-  () => 'arrow-down.svg',
-  { virtual: true }
-);
-jest.mock(
-  '@fxa/shared/assets/images/apple-logo.svg',
-  () => 'apple-logo.svg',
-  { virtual: true }
-);
+jest.mock('@fxa/shared/assets/images/arrow-down.svg', () => 'arrow-down.svg', {
+  virtual: true,
+});
+jest.mock('@fxa/shared/assets/images/apple-logo.svg', () => 'apple-logo.svg', {
+  virtual: true,
+});
 jest.mock(
   '@fxa/shared/assets/images/google-logo.svg',
   () => 'google-logo.svg',
   { virtual: true }
 );
-jest.mock(
-  '@fxa/shared/assets/images/new-window.svg',
-  () => 'new-window.svg',
-  { virtual: true }
-);
+jest.mock('@fxa/shared/assets/images/new-window.svg', () => 'new-window.svg', {
+  virtual: true,
+});
 jest.mock('@fxa/shared/assets/images/error.svg', () => 'error.svg', {
   virtual: true,
 });
@@ -293,6 +290,73 @@ describe('Manage page — payment method error banner', () => {
     expect(bannerLink).toHaveAttribute(
       'href',
       'https://payments.example.com/en/subscriptions/payments/paypal'
+    );
+  });
+
+  it('renders the credit balance section when balance is positive', async () => {
+    mockGetL10n.mockReturnValue({
+      ...mockL10n,
+      getLocalizedCurrencyString: () => '$5.00',
+    });
+    mockGetSubManPageContentAction.mockResolvedValue({
+      ...basePageContent,
+      accountCreditBalance: { balance: 500, currency: 'usd' },
+      subscriptions: [SubscriptionContentFactory()],
+    });
+
+    await renderPage();
+
+    expect(screen.getByText('Credit balance')).toBeInTheDocument();
+    expect(screen.getByText('$5.00')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Credit will automatically be applied to future invoices'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the credit balance section when balance is zero', async () => {
+    mockGetSubManPageContentAction.mockResolvedValue({
+      ...basePageContent,
+      accountCreditBalance: { balance: 0, currency: null },
+      subscriptions: [SubscriptionContentFactory()],
+    });
+
+    await renderPage();
+
+    expect(screen.queryByText('Credit balance')).not.toBeInTheDocument();
+  });
+
+  it('does not render payment method section when user is not a Stripe customer', async () => {
+    mockGetSubManPageContentAction.mockResolvedValue({
+      ...basePageContent,
+      isStripeCustomer: false,
+      subscriptions: [],
+    });
+
+    await renderPage();
+
+    expect(screen.queryByText('Payment method')).not.toBeInTheDocument();
+  });
+
+  it('renders "Get help" link with the subscription supportUrl', async () => {
+    const sub = SubscriptionContentFactory({
+      productName: 'Mozilla VPN',
+      supportUrl: 'https://support.mozilla.org/vpn',
+    });
+    mockGetSubManPageContentAction.mockResolvedValue({
+      ...basePageContent,
+      subscriptions: [sub],
+    });
+
+    await renderPage();
+
+    const helpLink = screen.getByRole('link', {
+      name: /Get help for Mozilla VPN/,
+    });
+    expect(helpLink).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/vpn'
     );
   });
 

--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -927,7 +927,7 @@ export default async function Manage({
                                         {
                                           vars: { date: nextBillDate },
                                         },
-                                        <p>Next bill &bull; {nextBillDate}</p>
+                                        <span>Next bill &bull; {nextBillDate}</span>
                                       )}
                                     </p>
                                   ) : (

--- a/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.test.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.test.tsx
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen } from '@testing-library/react';
+import { SessionFactory } from '@fxa/payments/ui-auth/testing';
+import StripePaymentManagementPage from './page';
+
+const mockAuth = jest.fn();
+const mockRedirect = jest.fn();
+const mockHeaders = jest.fn();
+const mockGetStripeClientSession = jest.fn();
+const mockStripeManagementWrapper = jest.fn();
+const mockPaymentMethodManagement = jest.fn();
+
+jest.mock('apps/payments/next/auth', () => ({
+  __esModule: true,
+  auth: () => mockAuth(),
+}));
+
+jest.mock('apps/payments/next/config', () => ({
+  __esModule: true,
+  config: {
+    paymentsNextHostedUrl: 'https://payments.example.com',
+  },
+}));
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  // Next.js redirect() throws to halt execution
+  redirect: (...args: unknown[]) => {
+    mockRedirect(...args);
+    throw new Error('NEXT_REDIRECT');
+  },
+}));
+
+jest.mock('next/headers', () => ({
+  __esModule: true,
+  headers: () => mockHeaders(),
+}));
+
+jest.mock('uuid', () => ({
+  __esModule: true,
+  v4: () => 'mock-uuid-value',
+}));
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  getStripeClientSession: (...args: unknown[]) =>
+    mockGetStripeClientSession(...args),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  StripeManagementWrapper: (props: Record<string, unknown>) => {
+    mockStripeManagementWrapper(props);
+    return (
+      <div data-testid="stripe-management-wrapper">
+        {props.children as React.ReactNode}
+      </div>
+    );
+  },
+  PaymentMethodManagement: (props: Record<string, unknown>) => {
+    mockPaymentMethodManagement(props);
+    return <div data-testid="payment-method-management" />;
+  },
+}));
+
+const baseSession = SessionFactory();
+const MOCK_USER_EMAIL = baseSession.user.email;
+const MOCK_CLIENT_SECRET = 'cs_test_secret_abc';
+const MOCK_CURRENCY = 'usd';
+
+const baseStripeClientSession = {
+  clientSecret: MOCK_CLIENT_SECRET,
+  currency: MOCK_CURRENCY,
+  defaultPaymentMethod: {
+    type: 'card',
+    id: 'pm_123',
+    brand: 'visa',
+    last4: '4242',
+  },
+};
+
+const defaultParams = Promise.resolve({ locale: 'en' });
+
+async function renderPage(paramsOverride?: Promise<Record<string, string>>) {
+  const jsx = await StripePaymentManagementPage({
+    params: (paramsOverride ?? defaultParams) as any,
+  });
+  return render(jsx);
+}
+
+describe('StripePaymentManagementPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue(baseSession);
+    mockGetStripeClientSession.mockResolvedValue(baseStripeClientSession);
+  });
+
+  it('redirects unauthenticated users to landing', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await expect(renderPage()).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('redirects when session user has no id', async () => {
+    mockAuth.mockResolvedValue({ user: { email: MOCK_USER_EMAIL } });
+
+    await expect(renderPage()).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('redirects when AccountCustomerNotFoundError is thrown', async () => {
+    const error = new Error('Customer not found');
+    error.name = 'AccountCustomerNotFoundError';
+    mockGetStripeClientSession.mockRejectedValue(error);
+
+    await expect(renderPage()).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('redirects when CurrencyForCustomerNotFoundError is thrown', async () => {
+    const error = new Error('Currency not found');
+    error.name = 'CurrencyForCustomerNotFoundError';
+    mockGetStripeClientSession.mockRejectedValue(error);
+
+    await expect(renderPage()).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      'https://payments.example.com/en/subscriptions/landing'
+    );
+  });
+
+  it('re-throws unexpected errors from getStripeClientSession', async () => {
+    const unexpectedError = new Error('Something went wrong');
+    mockGetStripeClientSession.mockRejectedValue(unexpectedError);
+
+    await expect(renderPage()).rejects.toThrow('Something went wrong');
+  });
+
+  it('renders StripeManagementWrapper with correct props', async () => {
+    await renderPage();
+
+    expect(screen.getByTestId('stripe-management-wrapper')).toBeInTheDocument();
+    expect(mockStripeManagementWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({
+        locale: 'en',
+        currency: MOCK_CURRENCY,
+        sessionSecret: MOCK_CLIENT_SECRET,
+        instanceKey: 'card-pm_123',
+      })
+    );
+  });
+
+  it('renders PaymentMethodManagement with defaultPaymentMethod and email', async () => {
+    await renderPage();
+
+    expect(screen.getByTestId('payment-method-management')).toBeInTheDocument();
+    expect(mockPaymentMethodManagement).toHaveBeenCalledWith({
+      defaultPaymentMethod: baseStripeClientSession.defaultPaymentMethod,
+      sessionEmail: MOCK_USER_EMAIL,
+      locale: 'en',
+    });
+  });
+
+  it('renders PaymentMethodManagement without defaultPaymentMethod (empty state)', async () => {
+    mockGetStripeClientSession.mockResolvedValue({
+      clientSecret: MOCK_CLIENT_SECRET,
+      currency: MOCK_CURRENCY,
+      defaultPaymentMethod: null,
+    });
+
+    await renderPage();
+
+    expect(mockPaymentMethodManagement).toHaveBeenCalledWith({
+      defaultPaymentMethod: null,
+      sessionEmail: MOCK_USER_EMAIL,
+      locale: 'en',
+    });
+  });
+
+  it('uses uuid as instanceKey when defaultPaymentMethod is null', async () => {
+    mockGetStripeClientSession.mockResolvedValue({
+      clientSecret: MOCK_CLIENT_SECRET,
+      currency: MOCK_CURRENCY,
+      defaultPaymentMethod: null,
+    });
+
+    await renderPage();
+
+    expect(mockStripeManagementWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceKey: 'mock-uuid-value',
+      })
+    );
+  });
+
+  it('renders the section with the correct data-testid', async () => {
+    await renderPage();
+
+    expect(screen.getByTestId('stripe-payment-management')).toBeInTheDocument();
+  });
+});

--- a/apps/payments/next/jest.config.ts
+++ b/apps/payments/next/jest.config.ts
@@ -13,6 +13,7 @@ const config: Config = {
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  setupFilesAfterEnv: ['<rootDir>/test/jest.setup.ts'],
   reporters: [
     'default',
     [

--- a/apps/payments/next/test/jest.setup.ts
+++ b/apps/payments/next/test/jest.setup.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom';

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -1187,6 +1187,37 @@ describe('CartService', () => {
         expect.objectContaining({ uid: undefined, isFreeTrial: false })
       );
     });
+
+    it('creates cart with CREATE eligibility when user has active subscription for unrelated product', async () => {
+      const mockResolvedCurrency = faker.finance.currencyCode().toLowerCase();
+
+      jest
+        .spyOn(promotionCodeManager, 'assertValidForPriceAndCustomer')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(currencyManager, 'getCurrencyForCountry')
+        .mockReturnValue(mockResolvedCurrency);
+      jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockResultCart);
+      jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
+        subscriptionEligibilityResult: EligibilityStatus.CREATE,
+      });
+
+      const result = await cartService.setupCart(args);
+
+      expect(cartManager.createCart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eligibilityStatus: CartEligibilityStatus.CREATE,
+          uid: args.uid,
+          stripeCustomerId: mockAccountCustomer.stripeCustomerId,
+        })
+      );
+      expect(cartManager.createCart).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          fromOfferingConfigId: expect.anything(),
+        })
+      );
+      expect(result).toEqual(mockResultCart);
+    });
   });
 
   describe('getCoupon', () => {
@@ -2094,6 +2125,125 @@ describe('CartService', () => {
           mockCart.id,
           mockCart.version,
           expect.objectContaining({ isFreeTrial: false })
+        );
+      });
+    });
+
+    describe('re-previews invoice when tax address country changes currency', () => {
+      it('updates cart amount to new invoice subtotal when currency changes', async () => {
+        const oldCurrency = 'usd';
+        const newCurrency = 'eur';
+        const mockPrice = StripePriceFactory();
+        const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+        const newSubtotal = 1299;
+        const mockPreviewInvoice = InvoicePreviewFactory({
+          subtotal: newSubtotal,
+        });
+        const mockCart = ResultCartFactory({
+          currency: oldCurrency,
+          stripeCustomerId: mockCustomer.id,
+          stripeSubscriptionId: undefined,
+          eligibilityStatus: CartEligibilityStatus.CREATE,
+        });
+        const newTaxAddress = TaxAddressFactory({
+          countryCode: 'DE',
+        });
+        const mockInput = UpdateCartInputFactory({
+          taxAddress: newTaxAddress,
+        });
+
+        jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest
+          .spyOn(currencyManager, 'getCurrencyForCountry')
+          .mockReturnValue(newCurrency);
+        jest
+          .spyOn(productConfigurationManager, 'retrieveStripePrice')
+          .mockResolvedValue(mockPrice);
+        jest
+          .spyOn(invoiceManager, 'previewUpcoming')
+          .mockResolvedValue(mockPreviewInvoice);
+        jest.spyOn(customerManager, 'retrieve').mockResolvedValue(mockCustomer);
+        jest
+          .spyOn(checkoutService, 'getFreeTrialEligibility')
+          .mockResolvedValue({ offer: null, userEligible: false });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(null);
+
+        await cartService.updateCart(mockCart.id, mockCart.version, mockInput);
+
+        expect(invoiceManager.previewUpcoming).toHaveBeenCalledWith({
+          priceId: mockPrice.id,
+          currency: newCurrency,
+          taxAddress: newTaxAddress,
+          couponCode: undefined,
+        });
+        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+          mockCart.id,
+          mockCart.version,
+          expect.objectContaining({
+            currency: newCurrency,
+            amount: newSubtotal,
+          })
+        );
+      });
+
+      it('clears coupon when currency changes and coupon is invalid for new currency', async () => {
+        const oldCurrency = 'usd';
+        const newCurrency = 'eur';
+        const mockPrice = StripePriceFactory();
+        const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+        const mockPreviewInvoice = InvoicePreviewFactory();
+        const mockCart = ResultCartFactory({
+          currency: oldCurrency,
+          couponCode: 'SAVE10',
+          stripeCustomerId: mockCustomer.id,
+          stripeSubscriptionId: undefined,
+          eligibilityStatus: CartEligibilityStatus.CREATE,
+        });
+        const newTaxAddress = TaxAddressFactory({
+          countryCode: 'DE',
+        });
+        const mockInput = UpdateCartInputFactory({
+          taxAddress: newTaxAddress,
+        });
+
+        jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest
+          .spyOn(currencyManager, 'getCurrencyForCountry')
+          .mockReturnValue(newCurrency);
+        jest
+          .spyOn(productConfigurationManager, 'retrieveStripePrice')
+          .mockResolvedValue(mockPrice);
+        jest
+          .spyOn(invoiceManager, 'previewUpcoming')
+          .mockResolvedValue(mockPreviewInvoice);
+        jest.spyOn(customerManager, 'retrieve').mockResolvedValue(mockCustomer);
+        jest
+          .spyOn(promotionCodeManager, 'assertValidForPriceAndCustomer')
+          .mockRejectedValue(new Error('coupon not valid for currency'));
+        jest
+          .spyOn(checkoutService, 'getFreeTrialEligibility')
+          .mockResolvedValue({ offer: null, userEligible: false });
+        jest
+          .spyOn(checkoutService, 'getProductFreeTrialOffer')
+          .mockResolvedValue(null);
+
+        await cartService.updateCart(mockCart.id, mockCart.version, mockInput);
+
+        expect(
+          promotionCodeManager.assertValidForPriceAndCustomer
+        ).toHaveBeenCalledWith('SAVE10', mockPrice, newCurrency, mockCustomer);
+        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+          mockCart.id,
+          mockCart.version,
+          expect.objectContaining({
+            couponCode: null,
+            currency: newCurrency,
+            amount: mockPreviewInvoice.subtotal,
+          })
         );
       });
     });

--- a/libs/payments/cart/src/lib/cart.utils.spec.ts
+++ b/libs/payments/cart/src/lib/cart.utils.spec.ts
@@ -2,8 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { StripeError } from '@stripe/stripe-js';
-import { stripeErrorToErrorReasonId } from './cart.utils';
-import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
+import type { Stripe } from 'stripe';
+import {
+  stripeErrorToErrorReasonId,
+  handleEligibilityStatusMap,
+  convertStripePaymentMethodTypeToSubPlat,
+} from './cart.utils';
+import {
+  CartEligibilityStatus,
+  CartErrorReasonId,
+} from '@fxa/shared/db/mysql/account';
+import { EligibilityStatus } from '@fxa/payments/eligibility';
+import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 
 describe('utils', () => {
   describe('stripeErrorReasonId', () => {
@@ -23,6 +33,100 @@ describe('utils', () => {
       mockStripeError.type = 'api_error';
       const result = stripeErrorToErrorReasonId(mockStripeError);
       expect(result).toBe(CartErrorReasonId.UNKNOWN);
+    });
+  });
+
+  describe('handleEligibilityStatusMap', () => {
+    it.each([
+      {
+        eligibility: EligibilityStatus.CREATE,
+        expected: CartEligibilityStatus.CREATE,
+      },
+      {
+        eligibility: EligibilityStatus.UPGRADE,
+        expected: CartEligibilityStatus.UPGRADE,
+      },
+      {
+        eligibility: EligibilityStatus.DOWNGRADE,
+        expected: CartEligibilityStatus.DOWNGRADE,
+      },
+      {
+        eligibility: EligibilityStatus.BLOCKED_IAP,
+        expected: CartEligibilityStatus.BLOCKED_IAP,
+      },
+      {
+        eligibility: EligibilityStatus.INVALID,
+        expected: CartEligibilityStatus.INVALID,
+      },
+      {
+        eligibility: EligibilityStatus.SAME,
+        expected: CartEligibilityStatus.INVALID,
+      },
+    ])(
+      'maps EligibilityStatus.$eligibility to CartEligibilityStatus.$expected',
+      ({ eligibility, expected }) => {
+        expect(handleEligibilityStatusMap[eligibility]).toBe(expected);
+      }
+    );
+  });
+
+  describe('convertStripePaymentMethodTypeToSubPlat', () => {
+    it('returns Card for a plain card payment method', () => {
+      const pm = {
+        type: 'card',
+        card: { wallet: null },
+      } as unknown as Stripe.PaymentMethod;
+      expect(convertStripePaymentMethodTypeToSubPlat(pm)).toBe(
+        SubPlatPaymentMethodType.Card
+      );
+    });
+
+    it('returns ApplePay for a card with apple_pay wallet', () => {
+      const pm = {
+        type: 'card',
+        card: { wallet: { type: 'apple_pay' } },
+      } as unknown as Stripe.PaymentMethod;
+      expect(convertStripePaymentMethodTypeToSubPlat(pm)).toBe(
+        SubPlatPaymentMethodType.ApplePay
+      );
+    });
+
+    it('returns GooglePay for a card with google_pay wallet', () => {
+      const pm = {
+        type: 'card',
+        card: { wallet: { type: 'google_pay' } },
+      } as unknown as Stripe.PaymentMethod;
+      expect(convertStripePaymentMethodTypeToSubPlat(pm)).toBe(
+        SubPlatPaymentMethodType.GooglePay
+      );
+    });
+
+    it('returns Link for a link payment method', () => {
+      const pm = {
+        type: 'link',
+      } as unknown as Stripe.PaymentMethod;
+      expect(convertStripePaymentMethodTypeToSubPlat(pm)).toBe(
+        SubPlatPaymentMethodType.Link
+      );
+    });
+
+    it('returns Stripe for an unmapped payment method type', () => {
+      const pm = {
+        type: 'sepa_debit',
+      } as unknown as Stripe.PaymentMethod;
+      expect(convertStripePaymentMethodTypeToSubPlat(pm)).toBe(
+        SubPlatPaymentMethodType.Stripe
+      );
+    });
+
+    it('returns Card for a card with unknown wallet type', () => {
+      const pm = {
+        type: 'card',
+        card: { wallet: { type: 'samsung_pay' } },
+      } as unknown as Stripe.PaymentMethod;
+      expect(convertStripePaymentMethodTypeToSubPlat(pm)).toBe(
+        SubPlatPaymentMethodType.Card
+      );
     });
   });
 });

--- a/libs/payments/cart/src/lib/util/isPaymentIntent.spec.ts
+++ b/libs/payments/cart/src/lib/util/isPaymentIntent.spec.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  StripePaymentIntentFactory,
+  StripeSetupIntentFactory,
+  StripeResponseFactory,
+} from '@fxa/payments/stripe';
+import { isPaymentIntent } from './isPaymentIntent';
+
+describe('isPaymentIntent', () => {
+  it('returns true for a PaymentIntent', () => {
+    const paymentIntent = StripeResponseFactory(
+      StripePaymentIntentFactory({ object: 'payment_intent' })
+    );
+    expect(isPaymentIntent(paymentIntent)).toBe(true);
+  });
+
+  it('returns false for a SetupIntent', () => {
+    const setupIntent = StripeResponseFactory(
+      StripeSetupIntentFactory({ object: 'setup_intent' })
+    );
+    expect(isPaymentIntent(setupIntent)).toBe(false);
+  });
+});

--- a/libs/payments/cart/src/lib/util/isPaymentIntentId.spec.ts
+++ b/libs/payments/cart/src/lib/util/isPaymentIntentId.spec.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { isPaymentIntentId } from './isPaymentIntentId';
+
+describe('isPaymentIntentId', () => {
+  it.each([
+    { intentId: 'pi_abc123', expected: true },
+    { intentId: 'pi_', expected: true },
+    { intentId: 'seti_abc123', expected: false },
+    { intentId: 'sub_abc123', expected: false },
+    { intentId: '', expected: false },
+  ])(
+    'returns $expected for "$intentId"',
+    ({ intentId, expected }) => {
+      expect(isPaymentIntentId(intentId)).toBe(expected);
+    }
+  );
+});

--- a/libs/payments/currency/src/lib/currency.manager.spec.ts
+++ b/libs/payments/currency/src/lib/currency.manager.spec.ts
@@ -22,6 +22,24 @@ describe('CurrencyManager', () => {
     mockCurrencyConfig = module.get(CurrencyConfig);
   });
 
+  describe('getCurrencyForCountry', () => {
+    it('returns usd for US country code', () => {
+      const result = currencyManager.getCurrencyForCountry('US');
+      expect(result).toEqual('usd');
+    });
+
+    it('returns eur for EU country codes', () => {
+      expect(currencyManager.getCurrencyForCountry('FR')).toEqual('eur');
+      expect(currencyManager.getCurrencyForCountry('DE')).toEqual('eur');
+      expect(currencyManager.getCurrencyForCountry('NL')).toEqual('eur');
+    });
+
+    it('returns undefined for unknown country code', () => {
+      const result = currencyManager.getCurrencyForCountry('ZZ');
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('getTaxId', () => {
     it('returns the correct tax id for currency', async () => {
       const mockCurrency = Object.entries(mockCurrencyConfig.taxIds)[0];

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -11,8 +11,11 @@ import {
 import {
   StripeClient,
   StripeConfig,
+  StripeApiListFactory,
   StripeCustomerFactory,
   StripePriceFactory,
+  StripeSubscriptionFactory,
+  StripeSubscriptionItemFactory,
 } from '@fxa/payments/stripe';
 import {
   EligibilityContentByOfferingResultFactory,
@@ -485,6 +488,64 @@ describe('EligibilityService', () => {
         mockOffering,
         interval,
         []
+      );
+    });
+
+    it('returns CREATE when user has active subscription for a different product with no offering overlap', async () => {
+      const mockCustomer = StripeCustomerFactory();
+      const interval = SubplatInterval.Monthly;
+      const mockOffering = EligibilityContentOfferingResultFactory();
+      const vpnPriceId = 'price_vpn_monthly';
+      const vpnPrice = StripePriceFactory({ id: vpnPriceId });
+      const mockSubscription = StripeSubscriptionFactory({
+        items: StripeApiListFactory([
+          StripeSubscriptionItemFactory({ price: vpnPrice }),
+        ]),
+      });
+
+      jest.spyOn(appleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      jest.spyOn(googleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      jest
+        .spyOn(productConfigurationManager, 'getEligibilityContentByOffering')
+        .mockResolvedValue(
+          new EligibilityContentByOfferingResultUtil(
+            EligibilityContentByOfferingResultFactory({
+              offerings: [mockOffering],
+            })
+          )
+        );
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockSubscription]);
+      jest
+        .spyOn(eligibilityManager, 'getOfferingOverlap')
+        .mockResolvedValue([]);
+      jest.spyOn(eligibilityManager, 'compareOverlaps').mockResolvedValue({
+        subscriptionEligibilityResult: EligibilityStatus.CREATE,
+      });
+
+      const result = await eligibilityService.checkEligibility(
+        interval,
+        mockOffering.apiIdentifier,
+        faker.string.uuid(),
+        mockCustomer.id
+      );
+
+      expect(result).toEqual({
+        subscriptionEligibilityResult: EligibilityStatus.CREATE,
+      });
+      expect(subscriptionManager.listForCustomer).toHaveBeenCalledWith(
+        mockCustomer.id
+      );
+      expect(eligibilityManager.getOfferingOverlap).toHaveBeenCalledWith({
+        priceIds: [vpnPriceId],
+        targetOffering: mockOffering,
+      });
+      expect(eligibilityManager.compareOverlaps).toHaveBeenCalledWith(
+        [],
+        mockOffering,
+        interval,
+        [vpnPrice]
       );
     });
   });

--- a/libs/payments/management/src/lib/factories/subscriptionContent.factory.ts
+++ b/libs/payments/management/src/lib/factories/subscriptionContent.factory.ts
@@ -8,9 +8,11 @@ import {
   AppleIapPurchase,
   AppleIapPurchaseResult,
   AppleIapSubscriptionContent,
+  CancelFlowResult,
   GoogleIapPurchase,
   GoogleIapPurchaseResult,
   GoogleIapSubscriptionContent,
+  StaySubscribedFlowResult,
   SubscriptionContent,
   TrialSubscriptionContent,
 } from '../types';
@@ -90,10 +92,47 @@ export const SubscriptionContentFactory = (
   nextInvoiceDate: faker.date.future().getDate(),
   nextInvoiceTax: faker.number.int({ min: 1, max: 1000 }),
   nextInvoiceTotal: faker.number.int({ min: 1, max: 1000 }),
+  currentInvoiceUrl: faker.internet.url(),
+  nextPromotionName: null,
+  promotionName: null,
   isEligibleForChurnCancel: faker.datatype.boolean(),
   isEligibleForChurnStaySubscribed: faker.datatype.boolean(),
   isEligibleForOffer: faker.datatype.boolean(),
   churnStaySubscribedCtaMessage: faker.string.sample(),
+  ...override,
+});
+
+type CancelFlowContent = Extract<CancelFlowResult, { flowType: 'cancel' }>;
+
+export const CancelFlowContentFactory = (
+  override?: Partial<CancelFlowContent>
+): CancelFlowContent => ({
+  flowType: 'cancel',
+  active: true,
+  cancelAtPeriodEnd: false,
+  currency: faker.finance.currencyCode().toLowerCase(),
+  currentPeriodEnd: faker.date.future().getDate(),
+  productName: faker.string.sample(),
+  supportUrl: faker.internet.url(),
+  webIcon: faker.internet.url(),
+  ...override,
+});
+
+type StaySubscribedFlowContent = Extract<
+  StaySubscribedFlowResult,
+  { flowType: 'stay_subscribed' }
+>;
+
+export const StaySubscribedFlowContentFactory = (
+  override?: Partial<StaySubscribedFlowContent>
+): StaySubscribedFlowContent => ({
+  flowType: 'stay_subscribed',
+  active: true,
+  cancelAtPeriodEnd: true,
+  currency: faker.finance.currencyCode().toLowerCase(),
+  currentPeriodEnd: faker.date.future().getDate(),
+  productName: faker.string.sample(),
+  webIcon: faker.internet.url(),
   ...override,
 });
 

--- a/libs/payments/management/src/lib/subscriptionManagement.service.in.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.in.spec.ts
@@ -1,0 +1,1638 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import {
+  ChurnInterventionManager,
+  MockChurnInterventionConfigProvider,
+  TaxService,
+} from '@fxa/payments/cart';
+import {
+  GeoDBManager,
+  GeoDBManagerConfig,
+  MockGeoDBNestFactory,
+} from '@fxa/shared/geodb';
+import {
+  CurrencyManager,
+  MockCurrencyConfigProvider,
+} from '@fxa/payments/currency';
+import {
+  CustomerManager,
+  InvoiceManager,
+  InvoicePreviewFactory,
+  PaymentMethodManager,
+  PriceManager,
+  SubscriptionManager,
+  SetupIntentManager,
+  CustomerSessionManager,
+  STRIPE_CUSTOMER_METADATA,
+  STRIPE_SUBSCRIPTION_METADATA,
+} from '@fxa/payments/customer';
+import {
+  EligibilityManager,
+  EligibilityService,
+  LocationConfig,
+  MockLocationConfigProvider,
+} from '@fxa/payments/eligibility';
+import {
+  AppleIapClient,
+  AppleIapPurchaseManager,
+  GoogleIapClient,
+  GoogleIapPurchaseManager,
+  MockAppleIapClientConfigProvider,
+  MockGoogleIapClientConfigProvider,
+} from '@fxa/payments/iap';
+import {
+  SubscriptionManagementService,
+} from '@fxa/payments/management';
+import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
+import {
+  MockPaypalClientConfigProvider,
+  PaypalBillingAgreementManager,
+  PayPalClient,
+  PaypalCustomerManager,
+  ResultPaypalCustomerFactory,
+} from '@fxa/payments/paypal';
+import {
+  AccountCustomerManager,
+  MockStripeConfigProvider,
+  ResultAccountCustomerFactory,
+  StripeAddressFactory,
+  StripeClient,
+  StripeConfig,
+  StripeCustomerFactory,
+  StripePaymentMethodFactory,
+  StripeResponseFactory,
+  StripeSetupIntentFactory,
+  StripeSubscriptionFactory,
+} from '@fxa/payments/stripe';
+import {
+  MockStrapiClientConfigProvider,
+  PageContentByPriceIdsPurchaseResultFactory,
+  PageContentByPriceIdsResultUtil,
+  ProductConfigurationManager,
+  StrapiClient,
+} from '@fxa/shared/cms';
+import { ChurnInterventionService } from './churn-intervention.service';
+import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
+import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
+import {
+  CancelSubscriptionCustomerMismatch,
+  CreateBillingAgreementActiveBillingAgreement,
+  CreateBillingAgreementAccountCustomerMissingStripeId,
+  CreateBillingAgreementCurrencyNotFound,
+  CreateBillingAgreementPaypalSubscriptionNotFound,
+  ResubscribeSubscriptionCustomerMismatch,
+} from './subscriptionManagement.error';
+import {
+  MockNotifierSnsConfigProvider,
+  NotifierService,
+  NotifierSnsProvider,
+} from '@fxa/shared/notifier';
+import {
+  MockProfileClientConfigProvider,
+  ProfileClient,
+} from '@fxa/profile/client';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
+
+jest.mock('@fxa/shared/error', () => ({
+  ...jest.requireActual('@fxa/shared/error'),
+  SanitizeExceptions: jest.fn(() => {
+    return function (_: any, __: string, descriptor: PropertyDescriptor) {
+      return descriptor;
+    };
+  }),
+}));
+
+describe('SubscriptionManagementService integration', () => {
+  let accountCustomerManager: AccountCustomerManager;
+  let appleIapPurchaseManager: AppleIapPurchaseManager;
+  let churnInterventionService: ChurnInterventionService;
+  let customerManager: CustomerManager;
+  let googleIapPurchaseManager: GoogleIapPurchaseManager;
+  let invoiceManager: InvoiceManager;
+  let paymentMethodManager: PaymentMethodManager;
+  let paypalBillingAgreementManager: PaypalBillingAgreementManager;
+  let paypalCustomerManager: PaypalCustomerManager;
+  let productConfigurationManager: ProductConfigurationManager;
+  let subscriptionManager: SubscriptionManager;
+  let subscriptionManagementService: SubscriptionManagementService;
+  let notifierService: NotifierService;
+  let profileClient: ProfileClient;
+  let setupIntentManager: SetupIntentManager;
+  let taxService: TaxService;
+
+  const mockLogger = {
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        Logger,
+        AccountCustomerManager,
+        AppleIapClient,
+        AppleIapPurchaseManager,
+        ChurnInterventionManager,
+        ChurnInterventionService,
+        CurrencyManager,
+        CustomerManager,
+        EligibilityManager,
+        EligibilityService,
+        GoogleIapClient,
+        GoogleIapPurchaseManager,
+        InvoiceManager,
+        LocationConfig,
+        MockAccountDatabaseNestFactory,
+        MockAppleIapClientConfigProvider,
+        MockCurrencyConfigProvider,
+        MockFirestoreProvider,
+        MockGoogleIapClientConfigProvider,
+        MockNotifierSnsConfigProvider,
+        MockPaypalClientConfigProvider,
+        MockProfileClientConfigProvider,
+        MockStatsDProvider,
+        MockStrapiClientConfigProvider,
+        MockStripeConfigProvider,
+        NotifierService,
+        NotifierSnsProvider,
+        PaymentMethodManager,
+        PaypalBillingAgreementManager,
+        PayPalClient,
+        PaypalCustomerManager,
+        PriceManager,
+        ProductConfigurationManager,
+        ProfileClient,
+        StrapiClient,
+        StripeClient,
+        StripeConfig,
+        SubscriptionManager,
+        SubscriptionManagementService,
+        SetupIntentManager,
+        CustomerSessionManager,
+        CurrencyManager,
+        MockCurrencyConfigProvider,
+        MockChurnInterventionConfigProvider,
+        MockLocationConfigProvider,
+        TaxService,
+        GeoDBManager,
+        GeoDBManagerConfig,
+        MockGeoDBNestFactory,
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: mockLogger,
+        },
+      ],
+    }).compile();
+
+    accountCustomerManager = moduleRef.get(AccountCustomerManager);
+    appleIapPurchaseManager = moduleRef.get(AppleIapPurchaseManager);
+    churnInterventionService = moduleRef.get(ChurnInterventionService);
+    customerManager = moduleRef.get(CustomerManager);
+    googleIapPurchaseManager = moduleRef.get(GoogleIapPurchaseManager);
+    invoiceManager = moduleRef.get(InvoiceManager);
+    paymentMethodManager = moduleRef.get(PaymentMethodManager);
+    paypalBillingAgreementManager = moduleRef.get(
+      PaypalBillingAgreementManager
+    );
+    paypalCustomerManager = moduleRef.get(PaypalCustomerManager);
+    productConfigurationManager = moduleRef.get(ProductConfigurationManager);
+    subscriptionManager = moduleRef.get(SubscriptionManager);
+    subscriptionManagementService = moduleRef.get(
+      SubscriptionManagementService
+    );
+    notifierService = moduleRef.get(NotifierService);
+    profileClient = moduleRef.get(ProfileClient);
+    setupIntentManager = moduleRef.get(SetupIntentManager);
+    taxService = moduleRef.get(TaxService);
+
+    jest.spyOn(profileClient, 'deleteCache').mockResolvedValue(undefined);
+    jest.spyOn(notifierService, 'send').mockReturnValue(undefined);
+  });
+
+  describe('cancelSubscriptionAtPeriodEnd', () => {
+    it('calls subscription.update with cancel_at_period_end=true, correct metadata', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
+
+      await subscriptionManagementService.cancelSubscriptionAtPeriodEnd(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(subscriptionManager.update).toHaveBeenCalledWith(
+        mockSubscription.id,
+        {
+          cancel_at_period_end: true,
+          metadata: {
+            [STRIPE_SUBSCRIPTION_METADATA.CancelledForCustomerAt]:
+              expect.any(Number),
+          },
+        }
+      );
+      expect(profileClient.deleteCache).toHaveBeenCalledWith(
+        mockAccountCustomer.uid
+      );
+    });
+
+    it('throws CancelSubscriptionCustomerMismatch when UID does not own subscription', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: 'cus_different_customer',
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest.spyOn(subscriptionManager, 'update');
+
+      await expect(
+        subscriptionManagementService.cancelSubscriptionAtPeriodEnd(
+          mockAccountCustomer.uid,
+          mockSubscription.id
+        )
+      ).rejects.toBeInstanceOf(CancelSubscriptionCustomerMismatch);
+
+      expect(subscriptionManager.update).not.toHaveBeenCalled();
+      expect(profileClient.deleteCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelSubscriptionImmediately', () => {
+    it('calls subscription.cancel with immediate flag', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'cancel')
+        .mockResolvedValue(mockSubscription);
+
+      await subscriptionManagementService.cancelSubscriptionImmediately(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(subscriptionManager.cancel).toHaveBeenCalledWith(
+        mockSubscription.id
+      );
+      expect(profileClient.deleteCache).toHaveBeenCalledWith(
+        mockAccountCustomer.uid
+      );
+    });
+
+    it('throws CancelSubscriptionCustomerMismatch when UID does not own subscription', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: 'cus_different_customer',
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest.spyOn(subscriptionManager, 'cancel');
+
+      await expect(
+        subscriptionManagementService.cancelSubscriptionImmediately(
+          mockAccountCustomer.uid,
+          mockSubscription.id
+        )
+      ).rejects.toBeInstanceOf(CancelSubscriptionCustomerMismatch);
+
+      expect(subscriptionManager.cancel).not.toHaveBeenCalled();
+      expect(profileClient.deleteCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resubscribeSubscription', () => {
+    it('removes cancel_at_period_end, subscription returns to active', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+          cancel_at_period_end: true,
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
+
+      await subscriptionManagementService.resubscribeSubscription(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(subscriptionManager.update).toHaveBeenCalledWith(
+        mockSubscription.id,
+        {
+          cancel_at_period_end: false,
+          metadata: {
+            [STRIPE_SUBSCRIPTION_METADATA.CancelledForCustomerAt]: '',
+          },
+        }
+      );
+      expect(profileClient.deleteCache).toHaveBeenCalledWith(
+        mockAccountCustomer.uid
+      );
+    });
+
+    it('throws ResubscribeSubscriptionCustomerMismatch when UID does not own subscription', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: 'cus_different_customer',
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest.spyOn(subscriptionManager, 'update');
+
+      await expect(
+        subscriptionManagementService.resubscribeSubscription(
+          mockAccountCustomer.uid,
+          mockSubscription.id
+        )
+      ).rejects.toBeInstanceOf(ResubscribeSubscriptionCustomerMismatch);
+
+      expect(subscriptionManager.update).not.toHaveBeenCalled();
+      expect(profileClient.deleteCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancel → resubscribe round-trip', () => {
+    it('cancel then resubscribe → subscription metadata correct at each step', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
+
+      // Step 1: Cancel at period end
+      await subscriptionManagementService.cancelSubscriptionAtPeriodEnd(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(subscriptionManager.update).toHaveBeenCalledWith(
+        mockSubscription.id,
+        {
+          cancel_at_period_end: true,
+          metadata: {
+            [STRIPE_SUBSCRIPTION_METADATA.CancelledForCustomerAt]:
+              expect.any(Number),
+          },
+        }
+      );
+
+      // Step 2: Resubscribe
+      await subscriptionManagementService.resubscribeSubscription(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(subscriptionManager.update).toHaveBeenCalledWith(
+        mockSubscription.id,
+        {
+          cancel_at_period_end: false,
+          metadata: {
+            [STRIPE_SUBSCRIPTION_METADATA.CancelledForCustomerAt]: '',
+          },
+        }
+      );
+
+      expect(profileClient.deleteCache).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('updateStripePaymentDetails', () => {
+    const mockIp = '127.0.0.1';
+
+    const customerWithShipping = () =>
+      StripeResponseFactory(
+        StripeCustomerFactory({
+          shipping: {
+            name: 'test',
+            address: StripeAddressFactory({
+              country: 'US',
+              postal_code: '10001',
+            }),
+            phone: null,
+          },
+        })
+      );
+
+    beforeEach(() => {
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(customerWithShipping());
+    });
+
+    it('updates default payment method on customer, new payment method attached', async () => {
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory()
+      );
+      const mockCustomer = StripeResponseFactory(
+        StripeCustomerFactory({
+          currency: faker.finance.currencyCode().toLowerCase(),
+          invoice_settings: {
+            custom_fields: null,
+            default_payment_method: mockPaymentMethod.id,
+            footer: null,
+            rendering_options: null,
+          },
+        })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomer.id,
+      });
+      const mockSetupIntent = StripeResponseFactory(
+        StripeSetupIntentFactory({
+          customer: mockCustomer.id,
+          payment_method: mockPaymentMethod.id,
+          status: 'succeeded',
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(setupIntentManager, 'createAndConfirm')
+        .mockResolvedValue(mockSetupIntent);
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+      jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
+
+      const result =
+        await subscriptionManagementService.updateStripePaymentDetails(
+          mockAccountCustomer.uid,
+          'tok_confirmation_123',
+          mockIp
+        );
+
+      expect(result).toEqual({
+        id: mockSetupIntent.id,
+        clientSecret: mockSetupIntent.client_secret,
+        status: mockSetupIntent.status,
+      });
+      expect(customerManager.update).toHaveBeenCalledWith(
+        mockSetupIntent.customer,
+        {
+          invoice_settings: {
+            default_payment_method: mockSetupIntent.payment_method,
+          },
+          name: mockPaymentMethod.billing_details.name ?? undefined,
+        }
+      );
+    });
+
+    it('validates tax address from confirmation token', async () => {
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory()
+      );
+      const mockCustomerWithoutShipping = StripeResponseFactory(
+        StripeCustomerFactory({ shipping: null })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomerWithoutShipping.id,
+      });
+      const mockSetupIntent = StripeResponseFactory(
+        StripeSetupIntentFactory({
+          customer: mockCustomerWithoutShipping.id,
+          payment_method: mockPaymentMethod.id,
+          status: 'succeeded',
+        })
+      );
+      const resolvedTaxAddress = {
+        countryCode: 'CA',
+        postalCode: 'K1A 0B1',
+      };
+
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(taxService, 'getTaxAddress')
+        .mockResolvedValue(resolvedTaxAddress);
+      jest
+        .spyOn(setupIntentManager, 'createAndConfirm')
+        .mockResolvedValue(mockSetupIntent);
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+      jest
+        .spyOn(customerManager, 'update')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+
+      await subscriptionManagementService.updateStripePaymentDetails(
+        mockAccountCustomer.uid,
+        'tok_confirmation_123',
+        mockIp
+      );
+
+      expect(taxService.getTaxAddress).toHaveBeenCalledWith(
+        mockIp,
+        mockAccountCustomer.uid
+      );
+      expect(customerManager.update).toHaveBeenCalledWith(
+        mockCustomerWithoutShipping.id,
+        {
+          shipping: {
+            name: mockCustomerWithoutShipping.email || '',
+            address: {
+              country: resolvedTaxAddress.countryCode,
+              postal_code: resolvedTaxAddress.postalCode,
+            },
+          },
+        }
+      );
+    });
+
+    it('throws PaymentMethodUpdateFailedError when SetupIntent fails', async () => {
+      const mockCustomer = StripeResponseFactory(
+        StripeCustomerFactory({
+          currency: faker.finance.currencyCode().toLowerCase(),
+        })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomer.id,
+      });
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest.spyOn(setupIntentManager, 'createAndConfirm').mockRejectedValue({
+        setup_intent: {
+          status: 'requires_payment_method',
+          last_setup_error: {
+            code: 'processing_error',
+            decline_code: undefined,
+          },
+        },
+      });
+
+      await expect(
+        subscriptionManagementService.updateStripePaymentDetails(
+          mockAccountCustomer.uid,
+          'tok_confirmation_123',
+          mockIp
+        )
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('setDefaultStripePaymentDetails', () => {
+    const mockIp = '127.0.0.1';
+
+    const customerWithShipping = () =>
+      StripeResponseFactory(
+        StripeCustomerFactory({
+          shipping: {
+            name: 'test',
+            address: StripeAddressFactory({
+              country: 'US',
+              postal_code: '10001',
+            }),
+            phone: null,
+          },
+        })
+      );
+
+    beforeEach(() => {
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(customerWithShipping());
+    });
+
+    it('sets payment method as default on customer', async () => {
+      const mockAccountCustomer = ResultAccountCustomerFactory();
+      const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockPaymentMethodId = `pm_${faker.string.alphanumeric(24)}`;
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
+
+      await subscriptionManagementService.setDefaultStripePaymentDetails(
+        mockAccountCustomer.uid,
+        mockPaymentMethodId,
+        mockIp
+      );
+
+      expect(customerManager.update).toHaveBeenCalledWith(
+        mockAccountCustomer.stripeCustomerId,
+        {
+          invoice_settings: {
+            default_payment_method: mockPaymentMethodId,
+          },
+        }
+      );
+    });
+
+    it('validates tax address on payment method', async () => {
+      const mockCustomerWithoutShipping = StripeResponseFactory(
+        StripeCustomerFactory({ shipping: null })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomerWithoutShipping.id,
+      });
+      const resolvedTaxAddress = {
+        countryCode: 'DE',
+        postalCode: '10115',
+      };
+      const mockPaymentMethodId = `pm_${faker.string.alphanumeric(24)}`;
+
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(taxService, 'getTaxAddress')
+        .mockResolvedValue(resolvedTaxAddress);
+      jest
+        .spyOn(customerManager, 'update')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+
+      await subscriptionManagementService.setDefaultStripePaymentDetails(
+        mockAccountCustomer.uid,
+        mockPaymentMethodId,
+        mockIp
+      );
+
+      expect(taxService.getTaxAddress).toHaveBeenCalledWith(
+        mockIp,
+        mockAccountCustomer.uid
+      );
+      expect(customerManager.update).toHaveBeenNthCalledWith(
+        1,
+        mockCustomerWithoutShipping.id,
+        {
+          shipping: {
+            name: mockCustomerWithoutShipping.email || '',
+            address: {
+              country: resolvedTaxAddress.countryCode,
+              postal_code: resolvedTaxAddress.postalCode,
+            },
+          },
+        }
+      );
+      expect(customerManager.update).toHaveBeenNthCalledWith(
+        2,
+        mockCustomerWithoutShipping.id,
+        {
+          invoice_settings: {
+            default_payment_method: mockPaymentMethodId,
+          },
+        }
+      );
+    });
+  });
+
+  describe('getPageContent — no active subscriptions', () => {
+    it('returns empty subscriptions when customer has no Stripe subscriptions or IAP purchases', async () => {
+      const mockUid = faker.string.uuid();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: null,
+      });
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(googleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+
+      const result =
+        await subscriptionManagementService.getPageContent(mockUid);
+
+      expect(result.subscriptions).toEqual([]);
+      expect(result.trialSubscriptions).toEqual([]);
+      expect(result.appleIapSubscriptions).toEqual([]);
+      expect(result.googleIapSubscriptions).toEqual([]);
+      expect(result.defaultPaymentMethod).toBeUndefined();
+      expect(result.isStripeCustomer).toBe(false);
+    });
+
+    it('returns the full page content shape expected by the manage page component', async () => {
+      const mockUid = faker.string.uuid();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: null,
+      });
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(googleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+
+      const result =
+        await subscriptionManagementService.getPageContent(mockUid);
+
+      // Verify the full shape: the manage page destructures all these keys
+      expect(result).toEqual({
+        accountCreditBalance: expect.objectContaining({
+          balance: expect.any(Number),
+          currency: null,
+        }),
+        appleIapSubscriptions: [],
+        defaultPaymentMethod: undefined,
+        googleIapSubscriptions: [],
+        isStripeCustomer: false,
+        subscriptions: [],
+        trialSubscriptions: [],
+      });
+    });
+  });
+
+  describe('getPageContent — Stripe customer with no active subscriptions', () => {
+    it('returns empty subscriptions but isStripeCustomer=true and payment method when customer exists with no subs', async () => {
+      const mockUid = faker.string.uuid();
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockPaymentMethodInfo = {
+        type: SubPlatPaymentMethodType.Card,
+        brand: 'visa',
+        last4: '4242',
+        expMonth: 12,
+        expYear: 2030,
+        hasPaymentMethodError: undefined,
+      };
+      const mockProductMap = {
+        purchaseForPriceId: jest.fn(),
+      };
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(paymentMethodManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(mockPaymentMethodInfo);
+      jest
+        .spyOn(productConfigurationManager, 'getPageContentByPriceIds')
+        .mockResolvedValue(
+          mockProductMap as unknown as PageContentByPriceIdsResultUtil
+        );
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(googleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+
+      const result =
+        await subscriptionManagementService.getPageContent(mockUid);
+
+      expect(result.subscriptions).toEqual([]);
+      expect(result.trialSubscriptions).toEqual([]);
+      expect(result.appleIapSubscriptions).toEqual([]);
+      expect(result.googleIapSubscriptions).toEqual([]);
+      expect(result.isStripeCustomer).toBe(true);
+      expect(result.defaultPaymentMethod).toEqual(mockPaymentMethodInfo);
+    });
+  });
+
+  describe('getPageContent — with active subscriptions', () => {
+    it('returns subscriptions in the subscriptions array when customer has active Stripe subs', async () => {
+      const mockUid = faker.string.uuid();
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeSubscriptionFactory({
+        status: 'active',
+      });
+      const mockPaymentMethodInfo = {
+        type: SubPlatPaymentMethodType.Card,
+        brand: 'visa',
+        last4: '4242',
+        expMonth: 12,
+        expYear: 2030,
+        hasPaymentMethodError: undefined,
+      };
+      const mockProductMap = {
+        purchaseForPriceId: jest.fn(),
+      };
+      mockProductMap.purchaseForPriceId.mockReturnValue(
+        PageContentByPriceIdsPurchaseResultFactory({
+          purchaseDetails: {
+            productName: 'Mozilla VPN',
+            webIcon: 'https://example.com/icon.png',
+            localizations: [
+              {
+                productName: 'Mozilla VPN',
+                webIcon: 'https://example.com/icon.png',
+              },
+            ],
+          },
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockSubscription]);
+      jest
+        .spyOn(paymentMethodManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(mockPaymentMethodInfo);
+      jest
+        .spyOn(productConfigurationManager, 'getPageContentByPriceIds')
+        .mockResolvedValue(
+          mockProductMap as unknown as PageContentByPriceIdsResultUtil
+        );
+      jest
+        .spyOn(invoiceManager, 'preview')
+        .mockResolvedValue(InvoicePreviewFactory());
+      jest
+        .spyOn(invoiceManager, 'previewUpcomingSubscription')
+        .mockResolvedValue(InvoicePreviewFactory());
+      jest
+        .spyOn(churnInterventionService, 'determineStaySubscribedEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'feature_disabled',
+          cmsChurnInterventionEntry: null,
+          cmsOfferingContent: null,
+        });
+      jest
+        .spyOn(churnInterventionService, 'determineCancellationIntervention')
+        .mockResolvedValue({
+          cancelChurnInterventionType: 'none',
+          reason: 'feature_disabled',
+          cmsOfferContent: null,
+        });
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(googleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([]);
+
+      const result =
+        await subscriptionManagementService.getPageContent(mockUid);
+
+      expect(result.subscriptions).toHaveLength(1);
+      expect(result.subscriptions[0].productName).toBe('Mozilla VPN');
+      expect(result.isStripeCustomer).toBe(true);
+      expect(result.defaultPaymentMethod).toEqual(mockPaymentMethodInfo);
+    });
+  });
+
+  describe('createPaypalBillingAgreementId', () => {
+    const mockToken = 'EC-1234567890';
+    const mockBillingAgreementId = 'B-1234567890';
+
+    it('creates billing agreement, stores ID in Stripe metadata, and notifies profile', async () => {
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeSubscriptionFactory({
+        customer: mockStripeCustomer.id,
+        collection_method: 'send_invoice',
+      });
+
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(customerManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockSubscription]);
+      jest
+        .spyOn(paypalCustomerManager, 'deletePaypalCustomersByUid')
+        .mockResolvedValue(BigInt(0));
+      jest
+        .spyOn(paypalBillingAgreementManager, 'create')
+        .mockResolvedValue(mockBillingAgreementId);
+      jest
+        .spyOn(customerManager, 'update')
+        .mockResolvedValue(mockStripeCustomer);
+
+      await subscriptionManagementService.createPaypalBillingAgreementId(
+        mockAccountCustomer.uid,
+        mockToken
+      );
+
+      expect(paypalBillingAgreementManager.create).toHaveBeenCalledWith(
+        mockAccountCustomer.uid,
+        mockToken
+      );
+      expect(customerManager.update).toHaveBeenCalledWith(
+        mockStripeCustomer.id,
+        {
+          metadata: {
+            [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: mockBillingAgreementId,
+          },
+        }
+      );
+      expect(profileClient.deleteCache).toHaveBeenCalledWith(
+        mockAccountCustomer.uid
+      );
+    });
+
+    it('deletes existing PayPal customer records before creating new agreement', async () => {
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockOldPaypalCustomer = ResultPaypalCustomerFactory({
+        uid: mockAccountCustomer.uid,
+        status: 'Cancelled',
+        endedAt: 1700000000000,
+      });
+      const mockSubscription = StripeSubscriptionFactory({
+        customer: mockStripeCustomer.id,
+        collection_method: 'send_invoice',
+      });
+
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
+        .mockResolvedValue([mockOldPaypalCustomer]);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(customerManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockSubscription]);
+      jest
+        .spyOn(paypalCustomerManager, 'deletePaypalCustomersByUid')
+        .mockResolvedValue(BigInt(1));
+      jest
+        .spyOn(paypalBillingAgreementManager, 'create')
+        .mockResolvedValue(mockBillingAgreementId);
+      jest
+        .spyOn(customerManager, 'update')
+        .mockResolvedValue(mockStripeCustomer);
+
+      await subscriptionManagementService.createPaypalBillingAgreementId(
+        mockAccountCustomer.uid,
+        mockToken
+      );
+
+      expect(
+        paypalCustomerManager.deletePaypalCustomersByUid
+      ).toHaveBeenCalledWith(mockAccountCustomer.uid);
+      expect(paypalBillingAgreementManager.create).toHaveBeenCalledWith(
+        mockAccountCustomer.uid,
+        mockToken
+      );
+    });
+
+    it('throws CreateBillingAgreementActiveBillingAgreement when user already has active agreement', async () => {
+      const mockUid = faker.string.uuid();
+
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValue('B-existing-agreement');
+      const createSpy = jest.spyOn(paypalBillingAgreementManager, 'create');
+
+      await expect(
+        subscriptionManagementService.createPaypalBillingAgreementId(
+          mockUid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(CreateBillingAgreementActiveBillingAgreement);
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(profileClient.deleteCache).not.toHaveBeenCalled();
+    });
+
+    it('throws CreateBillingAgreementAccountCustomerMissingStripeId when no Stripe customer', async () => {
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: null,
+      });
+
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      const createSpy = jest.spyOn(paypalBillingAgreementManager, 'create');
+
+      await expect(
+        subscriptionManagementService.createPaypalBillingAgreementId(
+          mockAccountCustomer.uid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(
+        CreateBillingAgreementAccountCustomerMissingStripeId
+      );
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(profileClient.deleteCache).not.toHaveBeenCalled();
+    });
+
+    it('throws CreateBillingAgreementCurrencyNotFound when currency cannot be determined', async () => {
+      const mockStripeCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(customerManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(undefined);
+      const createSpy = jest.spyOn(paypalBillingAgreementManager, 'create');
+
+      await expect(
+        subscriptionManagementService.createPaypalBillingAgreementId(
+          mockAccountCustomer.uid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(CreateBillingAgreementCurrencyNotFound);
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(profileClient.deleteCache).not.toHaveBeenCalled();
+    });
+
+    it('throws CreateBillingAgreementPaypalSubscriptionNotFound when no send_invoice subscription exists', async () => {
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockCardSubscription = StripeSubscriptionFactory({
+        customer: mockStripeCustomer.id,
+        collection_method: 'charge_automatically',
+      });
+
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(customerManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockCardSubscription]);
+      const createSpy = jest.spyOn(paypalBillingAgreementManager, 'create');
+
+      await expect(
+        subscriptionManagementService.createPaypalBillingAgreementId(
+          mockAccountCustomer.uid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(
+        CreateBillingAgreementPaypalSubscriptionNotFound
+      );
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(profileClient.deleteCache).not.toHaveBeenCalled();
+    });
+
+    it('cancels newly created billing agreement on error after creation', async () => {
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeSubscriptionFactory({
+        customer: mockStripeCustomer.id,
+        collection_method: 'send_invoice',
+      });
+
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
+        .mockResolvedValue([]);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(customerManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockSubscription]);
+      jest
+        .spyOn(paypalCustomerManager, 'deletePaypalCustomersByUid')
+        .mockResolvedValue(BigInt(0));
+      jest
+        .spyOn(paypalBillingAgreementManager, 'create')
+        .mockResolvedValue(mockBillingAgreementId);
+      jest
+        .spyOn(customerManager, 'update')
+        .mockRejectedValue(new Error('Stripe update failed'));
+      jest
+        .spyOn(paypalBillingAgreementManager, 'cancel')
+        .mockResolvedValue(undefined);
+
+      await expect(
+        subscriptionManagementService.createPaypalBillingAgreementId(
+          mockAccountCustomer.uid,
+          mockToken
+        )
+      ).rejects.toThrow('Stripe update failed');
+
+      expect(paypalBillingAgreementManager.cancel).toHaveBeenCalledWith(
+        mockBillingAgreementId
+      );
+    });
+  });
+
+  describe('updateStripePaymentDetails — new card last4 visible', () => {
+    it('sets the new payment method as default so last4 reflects updated card', async () => {
+      const mockIp = '127.0.0.1';
+      const newLast4 = '4242';
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory({
+          card: {
+            brand: 'visa',
+            last4: newLast4,
+            exp_month: 12,
+            exp_year: 2030,
+            country: 'US',
+            funding: 'credit',
+            fingerprint: faker.string.alphanumeric(16),
+            generated_from: null,
+            networks: null,
+            three_d_secure_usage: null,
+            wallet: null,
+            checks: null,
+            display_brand: null,
+          } as any,
+        })
+      );
+      const mockCustomer = StripeResponseFactory(
+        StripeCustomerFactory({
+          shipping: {
+            name: 'test',
+            address: StripeAddressFactory({
+              country: 'US',
+              postal_code: '10001',
+            }),
+            phone: null,
+          },
+        })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomer.id,
+      });
+      const mockSetupIntent = StripeResponseFactory(
+        StripeSetupIntentFactory({
+          customer: mockCustomer.id,
+          payment_method: mockPaymentMethod.id,
+          status: 'succeeded',
+        })
+      );
+
+      jest.spyOn(customerManager, 'retrieve').mockResolvedValue(mockCustomer);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(setupIntentManager, 'createAndConfirm')
+        .mockResolvedValue(mockSetupIntent);
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+      jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
+
+      await subscriptionManagementService.updateStripePaymentDetails(
+        mockAccountCustomer.uid,
+        'tok_confirmation_new_card',
+        mockIp
+      );
+
+      // Verify the new payment method is set as default
+      expect(customerManager.update).toHaveBeenCalledWith(
+        mockCustomer.id,
+        expect.objectContaining({
+          invoice_settings: {
+            default_payment_method: mockPaymentMethod.id,
+          },
+        })
+      );
+
+      // Verify the service retrieved the payment method to update billing details
+      expect(paymentMethodManager.retrieve).toHaveBeenCalledWith(
+        mockPaymentMethod.id
+      );
+    });
+  });
+
+  describe('getCancelFlowContent', () => {
+    it('returns cancel flow data for an active subscription', async () => {
+      const mockUid = faker.string.uuid();
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        uid: mockUid,
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+          status: 'active',
+          cancel_at_period_end: false,
+          currency: 'usd',
+          current_period_end: 1735689600,
+        })
+      );
+      const mockPaymentMethodInfo = {
+        type: SubPlatPaymentMethodType.Card,
+        brand: 'visa',
+        last4: '4242',
+        expMonth: 12,
+        expYear: 2030,
+        hasPaymentMethodError: undefined,
+      };
+      const mockCmsPurchase = PageContentByPriceIdsPurchaseResultFactory();
+      const mockProductMap = {
+        purchaseForPriceId: jest.fn().mockReturnValue(mockCmsPurchase),
+      };
+      const mockUpcomingInvoice = InvoicePreviewFactory({
+        subsequentAmount: 999,
+        subsequentAmountExcludingTax: 900,
+        subsequentTax: [{ amount: 99, inclusive: false, title: 'Tax' }],
+      });
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(paymentMethodManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(mockPaymentMethodInfo);
+      jest
+        .spyOn(productConfigurationManager, 'getPageContentByPriceIds')
+        .mockResolvedValue(
+          mockProductMap as unknown as PageContentByPriceIdsResultUtil
+        );
+      jest
+        .spyOn(invoiceManager, 'previewUpcomingSubscription')
+        .mockResolvedValue(mockUpcomingInvoice);
+
+      const result = await subscriptionManagementService.getCancelFlowContent(
+        mockUid,
+        mockSubscription.id
+      );
+
+      expect(result).toEqual({
+        flowType: 'cancel',
+        active: true,
+        cancelAtPeriodEnd: false,
+        currency: 'usd',
+        currentPeriodEnd: 1735689600,
+        defaultPaymentMethodType: SubPlatPaymentMethodType.Card,
+        last4: '4242',
+        nextInvoiceTax: 99,
+        nextInvoiceTotal: 900,
+        productName: expect.any(String),
+        supportUrl: expect.any(String),
+        webIcon: expect.any(String),
+      });
+    });
+
+    it('returns not_found when subscription does not exist', async () => {
+      const mockUid = faker.string.uuid();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        uid: mockUid,
+        stripeCustomerId: null,
+      });
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+
+      const result = await subscriptionManagementService.getCancelFlowContent(
+        mockUid,
+        'sub_nonexistent'
+      );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
+
+    it('returns not_found when subscription is not active or trialing', async () => {
+      const mockUid = faker.string.uuid();
+      const mockStripeCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        uid: mockUid,
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+          status: 'canceled',
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+
+      const result = await subscriptionManagementService.getCancelFlowContent(
+        mockUid,
+        mockSubscription.id
+      );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
+  });
+
+  describe('getStaySubscribedFlowContent', () => {
+    it('returns stay_subscribed flow data for an active subscription', async () => {
+      const mockUid = faker.string.uuid();
+      const mockStripeCustomer = StripeResponseFactory(
+        StripeCustomerFactory({ currency: 'usd' })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        uid: mockUid,
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+          status: 'active',
+          cancel_at_period_end: true,
+          currency: 'usd',
+          current_period_end: 1735689600,
+        })
+      );
+      const mockPaymentMethodInfo = {
+        type: SubPlatPaymentMethodType.Card,
+        brand: 'visa',
+        last4: '4242',
+        expMonth: 12,
+        expYear: 2030,
+        hasPaymentMethodError: undefined,
+      };
+      const mockCmsPurchase = PageContentByPriceIdsPurchaseResultFactory();
+      const mockProductMap = {
+        purchaseForPriceId: jest.fn().mockReturnValue(mockCmsPurchase),
+      };
+      const mockUpcomingInvoice = InvoicePreviewFactory({
+        subsequentAmount: 999,
+        subsequentAmountExcludingTax: 900,
+        subsequentTax: [{ amount: 99, inclusive: false, title: 'Tax' }],
+      });
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(paymentMethodManager, 'getDefaultPaymentMethod')
+        .mockResolvedValue(mockPaymentMethodInfo);
+      jest
+        .spyOn(productConfigurationManager, 'getPageContentByPriceIds')
+        .mockResolvedValue(
+          mockProductMap as unknown as PageContentByPriceIdsResultUtil
+        );
+      jest
+        .spyOn(invoiceManager, 'previewUpcomingSubscription')
+        .mockResolvedValue(mockUpcomingInvoice);
+
+      const result =
+        await subscriptionManagementService.getStaySubscribedFlowContent(
+          mockUid,
+          mockSubscription.id
+        );
+
+      expect(result).toEqual({
+        flowType: 'stay_subscribed',
+        active: true,
+        cancelAtPeriodEnd: true,
+        currency: 'usd',
+        currentPeriodEnd: 1735689600,
+        defaultPaymentMethodType: SubPlatPaymentMethodType.Card,
+        last4: '4242',
+        nextInvoiceTax: 99,
+        nextInvoiceTotal: 900,
+        productName: expect.any(String),
+        webIcon: expect.any(String),
+      });
+    });
+
+    it('returns not_found when subscription does not exist', async () => {
+      const mockUid = faker.string.uuid();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        uid: mockUid,
+        stripeCustomerId: null,
+      });
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+
+      const result =
+        await subscriptionManagementService.getStaySubscribedFlowContent(
+          mockUid,
+          'sub_nonexistent'
+        );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
+
+    it('returns not_found when subscription is not active or trialing', async () => {
+      const mockUid = faker.string.uuid();
+      const mockStripeCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        uid: mockUid,
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+          status: 'canceled',
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+
+      const result =
+        await subscriptionManagementService.getStaySubscribedFlowContent(
+          mockUid,
+          mockSubscription.id
+        );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/CancelSubscription/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CancelSubscription/index.test.tsx
@@ -2,7 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CancelFlowContentFactory } from '@fxa/payments/management/testing';
+
+jest.mock('@fxa/payments/customer', () => ({
+  SubplatInterval: {
+    Daily: 'daily',
+    Weekly: 'weekly',
+    Monthly: 'monthly',
+    HalfYearly: 'halfyearly',
+    Yearly: 'yearly',
+  },
+  SubPlatPaymentMethodType: {
+    Stripe: 'stripe',
+    PayPal: 'paypal',
+    GoogleIap: 'google_iap',
+    AppleIap: 'apple_iap',
+  },
+}));
 
 jest.mock('@radix-ui/react-form');
 
@@ -99,17 +117,15 @@ jest.mock('@fxa/shared/react', () => ({
 
 import { CancelSubscription } from './index';
 
+const basePageContent = CancelFlowContentFactory({
+  productName: 'Mozilla VPN',
+  currentPeriodEnd: 1735689600,
+});
+
 const baseProps = {
   subscriptionId: 'sub-id',
   locale: 'en',
-  pageContent: {
-    active: true,
-    cancelAtPeriodEnd: false,
-    productName: 'Mozilla VPN',
-    currentPeriodEnd: 1735689600,
-    supportUrl: 'https://support.example.com',
-    webIcon: 'https://example.com/icon.png',
-  },
+  pageContent: basePageContent,
 };
 
 describe('CancelSubscription', () => {
@@ -123,7 +139,7 @@ describe('CancelSubscription', () => {
       render(
         <CancelSubscription
           {...baseProps}
-          pageContent={{ ...baseProps.pageContent, cancelAtPeriodEnd: true }}
+          pageContent={{ ...basePageContent, cancelAtPeriodEnd: true }}
         />
       );
 
@@ -147,17 +163,68 @@ describe('CancelSubscription', () => {
     });
   });
 
-  describe('Active subscription error path', () => {
-    it('shows an error, keeps the form interactive, and preserves the checked checkbox when the cancel action fails', async () => {
+  describe('Active subscription cancel flow', () => {
+    it('cancel button disabled until checkbox checked', async () => {
+      const user = userEvent.setup();
+      render(<CancelSubscription {...baseProps} />);
+
+      const submitButton = screen.getByRole('button', {
+        name: /Cancel your subscription/i,
+      });
+      expect(submitButton).toBeDisabled();
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    it('shows "sorry to see you go" message after successful cancel', async () => {
+      const user = userEvent.setup();
+      mockCancelSubscriptionAtPeriodEndAction.mockResolvedValue({ ok: true });
+
+      render(<CancelSubscription {...baseProps} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      await user.click(
+        screen.getByRole('button', { name: /Cancel your subscription/i })
+      );
+
+      await waitFor(() => {
+        expect(mockCancelSubscriptionAtPeriodEndAction).toHaveBeenCalledWith(
+          'sub-id'
+        );
+      });
+    });
+
+    it('shows expiry date after cancellation completes', () => {
+      render(
+        <CancelSubscription
+          {...baseProps}
+          pageContent={{ ...basePageContent, cancelAtPeriodEnd: true }}
+        />
+      );
+
+      expect(
+        screen.getByText(/subscription has been cancelled/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /Back to subscriptions/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows error alert when cancel action rejects', async () => {
+      const user = userEvent.setup();
       mockCancelSubscriptionAtPeriodEndAction.mockResolvedValue({ ok: false });
 
       render(<CancelSubscription {...baseProps} />);
 
       const checkbox = screen.getByRole('checkbox');
-      fireEvent.click(checkbox);
-      expect(checkbox).toBeChecked();
+      await user.click(checkbox);
 
-      fireEvent.click(
+      await user.click(
         screen.getByRole('button', { name: /Cancel your subscription/i })
       );
 
@@ -167,15 +234,10 @@ describe('CancelSubscription', () => {
         ).toBeInTheDocument();
       });
 
-      expect(mockCancelSubscriptionAtPeriodEndAction).toHaveBeenCalledWith(
-        'sub-id'
-      );
-
-      expect(checkbox).toBeChecked();
-      const submitButton = screen.getByRole('button', {
-        name: /Cancel your subscription/i,
-      });
-      expect(submitButton).not.toBeDisabled();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Cancel your subscription/i })
+      ).not.toBeDisabled();
     });
   });
 });

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
@@ -378,6 +378,13 @@ describe('CheckoutForm', () => {
     });
   });
 
+  it('renders both Stripe PaymentElement and PayPal buttons when PayPal payment type is selected', async () => {
+    await renderAndSelectPaypal();
+
+    expect(screen.getByTestId('payment-element')).toBeInTheDocument();
+    expect(screen.getByTestId('paypal-buttons')).toBeInTheDocument();
+  });
+
   describe('Checkout legal links', () => {
     it('renders the Terms of Service link with the correct href', () => {
       render(<CheckoutForm {...baseProps} />);

--- a/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.test.tsx
@@ -1,0 +1,565 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {
+  Stripe,
+  StripeElements,
+  StripePaymentElementChangeEvent,
+  ConfirmationTokenResult,
+  PaymentIntentOrSetupIntentResult,
+} from '@stripe/stripe-js';
+import { PaymentMethodManagement } from './index';
+
+jest.mock('@radix-ui/react-form');
+
+let mockPaymentElementChangeHandler:
+  | ((event: StripePaymentElementChangeEvent) => void)
+  | undefined;
+let mockPaymentElementLoaderStartHandler: (() => void) | undefined;
+
+jest.mock('@stripe/react-stripe-js', () => ({
+  __esModule: true,
+  PaymentElement: (props: {
+    onChange?: (event: StripePaymentElementChangeEvent) => void;
+    onLoaderStart?: () => void;
+  }) => {
+    mockPaymentElementChangeHandler = props.onChange;
+    mockPaymentElementLoaderStartHandler = props.onLoaderStart;
+    return <div data-testid="stripe-payment-element">PaymentElement</div>;
+  },
+  useStripe: () => mockStripe,
+  useElements: () => mockElements,
+}));
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLocalization: () => ({
+    l10n: {
+      getString: (
+        _id: string,
+        _vars?: Record<string, unknown>,
+        fallback?: string
+      ) => fallback || _id,
+    },
+  }),
+}));
+
+const mockRouterPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, className }: { alt?: string; className?: string }) => (
+    <img alt={alt ?? ''} className={className} src="mock-image" />
+  ),
+}));
+
+const mockUpdateStripePaymentDetails = jest.fn();
+const mockSetDefaultStripePaymentDetails = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  updateStripePaymentDetails: (...args: unknown[]) =>
+    mockUpdateStripePaymentDetails(...args),
+  setDefaultStripePaymentDetails: (...args: unknown[]) =>
+    mockSetDefaultStripePaymentDetails(...args),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  BaseButton: ({
+    children,
+    className,
+    disabled,
+    'aria-disabled': ariaDisabled,
+    type,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    disabled?: boolean;
+    'aria-disabled'?: boolean;
+    type?: string;
+  }) => (
+    <button
+      type={type as 'submit' | 'button' | 'reset'}
+      className={className}
+      disabled={disabled}
+      aria-disabled={ariaDisabled}
+    >
+      {children}
+    </button>
+  ),
+  ButtonVariant: { Primary: 'primary' },
+  getManagePaymentMethodErrorFtlInfo: (errorMessage?: string) => ({
+    messageFtl: 'error-ftl-id',
+    message: errorMessage || 'An error occurred',
+  }),
+}));
+
+jest.mock('../LoadingSpinner', () => ({
+  __esModule: true,
+  LoadingSpinner: ({ className }: { className?: string }) => (
+    <div data-testid="loading-spinner" className={className}>
+      Loading...
+    </div>
+  ),
+}));
+
+let mockStripe: jest.Mocked<
+  Pick<Stripe, 'createConfirmationToken' | 'handleNextAction'>
+>;
+let mockElements: jest.Mocked<Pick<StripeElements, 'submit'>>;
+
+function buildChangeEvent(
+  overrides: Pick<StripePaymentElementChangeEvent, 'complete' | 'value'>
+): StripePaymentElementChangeEvent {
+  return {
+    elementType: 'payment',
+    empty: false,
+    collapsed: false,
+    ...overrides,
+  };
+}
+
+function simulateLoaderStart() {
+  act(() => {
+    mockPaymentElementLoaderStartHandler?.();
+  });
+}
+
+function simulatePaymentChange(event: StripePaymentElementChangeEvent) {
+  act(() => {
+    mockPaymentElementChangeHandler?.(event);
+  });
+}
+
+describe('PaymentMethodManagement', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+    mockUpdateStripePaymentDetails.mockReset();
+    mockSetDefaultStripePaymentDetails.mockReset();
+    mockStripe = {
+      createConfirmationToken: jest.fn(),
+      handleNextAction: jest.fn(),
+    } as jest.Mocked<
+      Pick<Stripe, 'createConfirmationToken' | 'handleNextAction'>
+    >;
+    mockElements = {
+      submit: jest.fn(),
+    } as jest.Mocked<Pick<StripeElements, 'submit'>>;
+    mockPaymentElementChangeHandler = undefined;
+    mockPaymentElementLoaderStartHandler = undefined;
+  });
+
+  it('renders the heading and Stripe PaymentElement', () => {
+    render(<PaymentMethodManagement locale="en" />);
+
+    expect(
+      screen.getByRole('heading', { name: /manage payment methods/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('stripe-payment-element')).toBeInTheDocument();
+  });
+
+  it('shows loading spinner before PaymentElement is ready', () => {
+    render(<PaymentMethodManagement locale="en" />);
+
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  });
+
+  it('hides loading spinner after PaymentElement fires onLoaderStart', () => {
+    render(<PaymentMethodManagement locale="en" />);
+
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+
+    simulateLoaderStart();
+
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  });
+
+  it('does not show save button before card details are entered', () => {
+    render(<PaymentMethodManagement locale="en" />);
+
+    simulateLoaderStart();
+
+    expect(
+      screen.queryByRole('button', { name: /save payment method/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows "Save payment method" button when new card details are entered', () => {
+    render(<PaymentMethodManagement locale="en" />);
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: { type: 'card' },
+      })
+    );
+
+    expect(
+      screen.getByRole('button', { name: /save payment method/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Set as default" button when a non-default saved card is selected', () => {
+    render(
+      <PaymentMethodManagement
+        locale="en"
+        defaultPaymentMethod={{ id: 'pm_default_123', type: 'card' }}
+      />
+    );
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: {
+          type: 'card',
+          payment_method: {
+            id: 'pm_other_456',
+            type: 'card',
+            billing_details: {
+              address: {
+                city: null,
+                country: null,
+                line1: null,
+                line2: null,
+                postal_code: null,
+                state: null,
+              },
+              name: null,
+              email: null,
+              phone: null,
+            },
+          },
+        },
+      })
+    );
+
+    expect(
+      screen.getByRole('button', { name: /set as default payment method/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not show button when the current default card is re-selected', () => {
+    render(
+      <PaymentMethodManagement
+        locale="en"
+        defaultPaymentMethod={{ id: 'pm_default_123', type: 'card' }}
+      />
+    );
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: {
+          type: 'card',
+          payment_method: {
+            id: 'pm_default_123',
+            type: 'card',
+            billing_details: {
+              address: {
+                city: null,
+                country: null,
+                line1: null,
+                line2: null,
+                postal_code: null,
+                state: null,
+              },
+              name: null,
+              email: null,
+              phone: null,
+            },
+          },
+        },
+      })
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /set as default payment method/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /save payment method/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls updateStripePaymentDetails on submit with new card and redirects on success', async () => {
+    const user = userEvent.setup();
+
+    mockElements.submit.mockResolvedValue({ error: undefined });
+    mockStripe.createConfirmationToken.mockResolvedValue({
+      confirmationToken: { id: 'ctoken_123' },
+      error: undefined,
+    } as ConfirmationTokenResult);
+    mockUpdateStripePaymentDetails.mockResolvedValue({
+      ok: true,
+      result: { status: 'succeeded', clientSecret: null },
+    });
+
+    render(
+      <PaymentMethodManagement locale="en" sessionEmail="user@example.com" />
+    );
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: { type: 'card' },
+      })
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /save payment method/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockUpdateStripePaymentDetails).toHaveBeenCalledWith('ctoken_123');
+    });
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/en/subscriptions/manage');
+    });
+  });
+
+  it('calls setDefaultStripePaymentDetails on submit when a non-default saved card is selected', async () => {
+    const user = userEvent.setup();
+
+    mockElements.submit.mockResolvedValue({ error: undefined });
+    mockStripe.createConfirmationToken.mockResolvedValue({
+      confirmationToken: { id: 'ctoken_456' },
+      error: undefined,
+    } as ConfirmationTokenResult);
+    mockUpdateStripePaymentDetails.mockResolvedValue({
+      ok: true,
+      result: { status: 'requires_action', clientSecret: 'seti_secret_abc' },
+    });
+    mockStripe.handleNextAction.mockResolvedValue({
+      setupIntent: {
+        status: 'succeeded',
+        payment_method: 'pm_other_789',
+        client_secret: 'seti_secret_abc',
+      },
+      error: undefined,
+    } as PaymentIntentOrSetupIntentResult);
+    mockSetDefaultStripePaymentDetails.mockResolvedValue({});
+
+    render(
+      <PaymentMethodManagement
+        locale="en"
+        defaultPaymentMethod={{ id: 'pm_default_123', type: 'card' }}
+      />
+    );
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: {
+          type: 'card',
+          payment_method: {
+            id: 'pm_other_789',
+            type: 'card',
+            billing_details: {
+              address: {
+                city: null,
+                country: null,
+                line1: null,
+                line2: null,
+                postal_code: null,
+                state: null,
+              },
+              name: null,
+              email: null,
+              phone: null,
+            },
+          },
+        },
+      })
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /set as default payment method/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockStripe.handleNextAction).toHaveBeenCalledWith({
+        clientSecret: 'seti_secret_abc',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockSetDefaultStripePaymentDetails).toHaveBeenCalledWith(
+        'pm_other_789'
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/en/subscriptions/manage');
+    });
+  });
+
+  it('shows "Set as default" button when a non-default saved non-card method is selected', () => {
+    render(
+      <PaymentMethodManagement
+        locale="en"
+        defaultPaymentMethod={{ id: 'pm_default_123', type: 'card' }}
+      />
+    );
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: {
+          type: 'link',
+          payment_method: {
+            id: 'pm_link_456',
+            type: 'link',
+            billing_details: {
+              address: {
+                city: null,
+                country: null,
+                line1: null,
+                line2: null,
+                postal_code: null,
+                state: null,
+              },
+              name: null,
+              email: null,
+              phone: null,
+            },
+          },
+        },
+      })
+    );
+
+    expect(
+      screen.getByRole('button', { name: /set as default payment method/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not show "Set as default" when re-selecting the current default Link method', () => {
+    render(
+      <PaymentMethodManagement
+        locale="en"
+        defaultPaymentMethod={{ id: 'pm_link_123', type: 'link' }}
+      />
+    );
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: {
+          type: 'link',
+          payment_method: {
+            id: 'pm_link_123',
+            type: 'link',
+            billing_details: {
+              address: {
+                city: null,
+                country: null,
+                line1: null,
+                line2: null,
+                postal_code: null,
+                state: null,
+              },
+              name: null,
+              email: null,
+              phone: null,
+            },
+          },
+        },
+      })
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /set as default payment method/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /save payment method/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays error message when updateStripePaymentDetails returns not ok', async () => {
+    const user = userEvent.setup();
+
+    mockElements.submit.mockResolvedValue({ error: undefined });
+    mockStripe.createConfirmationToken.mockResolvedValue({
+      confirmationToken: { id: 'ctoken_123' },
+      error: undefined,
+    } as ConfirmationTokenResult);
+    mockUpdateStripePaymentDetails.mockResolvedValue({
+      ok: false,
+      result: null,
+      errorMessage: 'Card was declined',
+    });
+
+    render(<PaymentMethodManagement locale="en" />);
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: { type: 'card' },
+      })
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /save payment method/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Card was declined')).toBeInTheDocument();
+    });
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it('displays error message when elements.submit returns an error', async () => {
+    const user = userEvent.setup();
+
+    mockElements.submit.mockResolvedValue({
+      error: {
+        type: 'validation_error',
+        message: 'Your card number is incomplete.',
+      },
+    });
+
+    render(<PaymentMethodManagement locale="en" />);
+
+    simulateLoaderStart();
+    simulatePaymentChange(
+      buildChangeEvent({
+        complete: true,
+        value: { type: 'card' },
+      })
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /save payment method/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your card number is incomplete.')
+      ).toBeInTheDocument();
+    });
+
+    expect(mockStripe.createConfirmationToken).not.toHaveBeenCalled();
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/PaypalManagement/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaypalManagement/index.test.tsx
@@ -1,0 +1,203 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PaypalManagement } from './index';
+import * as Sentry from '@sentry/nextjs';
+
+let capturedCreateOrder: (() => Promise<string>) | undefined;
+let capturedOnApprove:
+  | ((data: { orderID: string }) => Promise<void>)
+  | undefined;
+let capturedOnError: ((error: unknown) => void) | undefined;
+let mockScriptReducerState = { isPending: false, isRejected: false };
+
+jest.mock('@paypal/react-paypal-js', () => ({
+  __esModule: true,
+  PayPalScriptProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  PayPalButtons: (props: {
+    createOrder?: () => Promise<string>;
+    onApprove?: (data: { orderID: string }) => Promise<void>;
+    onError?: (error: unknown) => void;
+    className?: string;
+  }) => {
+    capturedCreateOrder = props.createOrder;
+    capturedOnApprove = props.onApprove;
+    capturedOnError = props.onError;
+    return (
+      <button
+        data-testid="paypal-button"
+        onClick={async () => {
+          if (capturedCreateOrder && capturedOnApprove) {
+            const orderId = await capturedCreateOrder();
+            await capturedOnApprove({ orderID: orderId });
+          }
+        }}
+      >
+        PayPal
+      </button>
+    );
+  },
+  usePayPalScriptReducer: () => [mockScriptReducerState],
+}));
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockRouterPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockRouterPush }),
+  useParams: () => ({ locale: 'en' }),
+  useSearchParams: () => ({
+    toString: () => '',
+  }),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, className }: { alt?: string; className?: string }) => (
+    <img alt={alt ?? ''} className={className} src="mock-image" />
+  ),
+}));
+
+const mockGetPayPalCheckoutToken = jest.fn();
+const mockCreatePayPalBillingAgreementId = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  getPayPalCheckoutToken: (...args: unknown[]) =>
+    mockGetPayPalCheckoutToken(...args),
+  createPayPalBillingAgreementId: (...args: unknown[]) =>
+    mockCreatePayPalBillingAgreementId(...args),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  __esModule: true,
+  captureMessage: jest.fn(),
+}));
+
+describe('PaypalManagement', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+    mockGetPayPalCheckoutToken.mockReset();
+    mockCreatePayPalBillingAgreementId.mockReset();
+    capturedCreateOrder = undefined;
+    capturedOnApprove = undefined;
+    capturedOnError = undefined;
+    mockScriptReducerState = { isPending: false, isRejected: false };
+  });
+
+  it('renders the PayPal button when script is loaded', () => {
+    render(
+      <PaypalManagement
+        paypalClientId="test-client-id"
+        currency="usd"
+      />
+    );
+
+    expect(screen.getByTestId('paypal-button')).toBeInTheDocument();
+  });
+
+  it('shows a spinner while the PayPal script is loading', () => {
+    mockScriptReducerState = { isPending: true, isRejected: false };
+
+    render(
+      <PaypalManagement
+        paypalClientId="test-client-id"
+        currency="usd"
+      />
+    );
+
+    expect(screen.getByRole('presentation')).toBeInTheDocument();
+    expect(screen.queryByTestId('paypal-button')).not.toBeInTheDocument();
+  });
+
+  it('shows an error message and reports to Sentry when PayPal script fails to load', () => {
+    mockScriptReducerState = { isPending: false, isRejected: true };
+
+    render(
+      <PaypalManagement
+        paypalClientId="test-client-id"
+        currency="usd"
+      />
+    );
+
+    expect(
+      screen.getByText(/PayPal is currently unavailable/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('paypal-button')).not.toBeInTheDocument();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'PayPal script failed to load'
+    );
+  });
+
+  it('calls getPayPalCheckoutToken with lowercase currency on createOrder', async () => {
+    mockGetPayPalCheckoutToken.mockResolvedValue('EC-TOKEN123');
+
+    render(
+      <PaypalManagement
+        paypalClientId="test-client-id"
+        currency="USD"
+      />
+    );
+
+    if (!capturedCreateOrder) {
+      throw new Error('createOrder callback was not captured');
+    }
+    const token = await capturedCreateOrder();
+
+    expect(mockGetPayPalCheckoutToken).toHaveBeenCalledWith('usd');
+    expect(token).toBe('EC-TOKEN123');
+  });
+
+  it('creates billing agreement and redirects to manage page on approval', async () => {
+    const user = userEvent.setup();
+    mockGetPayPalCheckoutToken.mockResolvedValue('EC-TOKEN123');
+    mockCreatePayPalBillingAgreementId.mockResolvedValue(undefined);
+
+    render(
+      <PaypalManagement
+        paypalClientId="test-client-id"
+        currency="usd"
+      />
+    );
+
+    await user.click(screen.getByTestId('paypal-button'));
+
+    await waitFor(() => {
+      expect(mockCreatePayPalBillingAgreementId).toHaveBeenCalledWith(
+        'EC-TOKEN123'
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        '/en/subscriptions/manage'
+      );
+    });
+  });
+
+  it('propagates PayPal checkout errors via onError handler', () => {
+    render(
+      <PaypalManagement
+        paypalClientId="test-client-id"
+        currency="usd"
+      />
+    );
+
+    if (!capturedOnError) {
+      throw new Error('onError callback was not captured');
+    }
+    const onError = capturedOnError;
+    const testError = new Error('PayPal checkout failed');
+    expect(() => onError(testError)).toThrow('PayPal checkout failed');
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/StaySubscribed/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/StaySubscribed/index.test.tsx
@@ -2,7 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StaySubscribedFlowContentFactory } from '@fxa/payments/management/testing';
+
+jest.mock('@fxa/payments/customer', () => ({
+  SubplatInterval: {
+    Daily: 'daily',
+    Weekly: 'weekly',
+    Monthly: 'monthly',
+    HalfYearly: 'halfyearly',
+    Yearly: 'yearly',
+  },
+  SubPlatPaymentMethodType: {
+    Stripe: 'stripe',
+    PayPal: 'paypal',
+    GoogleIap: 'google_iap',
+    AppleIap: 'apple_iap',
+  },
+}));
 
 jest.mock('@radix-ui/react-form');
 
@@ -79,14 +97,11 @@ jest.mock('@fxa/payments/ui', () => ({
 
 import { StaySubscribed } from './index';
 
-const basePageContent = {
-  active: true,
-  cancelAtPeriodEnd: true,
+const basePageContent = StaySubscribedFlowContentFactory({
   currency: 'usd',
   currentPeriodEnd: 1735689600,
   productName: 'Mozilla VPN',
-  webIcon: 'https://example.com/icon.png',
-};
+});
 
 const baseProps = {
   subscriptionId: 'sub-id',
@@ -143,8 +158,74 @@ describe('StaySubscribed', () => {
     });
   });
 
+  describe('Resubscribe charge display', () => {
+    it('renders next charge amount before resubscribe', () => {
+      render(
+        <StaySubscribed
+          {...baseProps}
+          pageContent={{
+            ...basePageContent,
+            nextInvoiceTotal: 999,
+          }}
+        />
+      );
+
+      expect(screen.getByText(/\$9\.99/)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Resubscribe to Mozilla VPN/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Resubscribe success path', () => {
+    it('calls resubscribeSubscriptionAction and shows success view after prop update', async () => {
+      const user = userEvent.setup();
+      mockResubscribeSubscriptionAction.mockResolvedValue({ ok: true });
+
+      const { rerender } = render(
+        <StaySubscribed
+          {...baseProps}
+          pageContent={{
+            ...basePageContent,
+            nextInvoiceTotal: 999,
+          }}
+        />
+      );
+
+      const submitButton = screen.getByRole('button', {
+        name: /Resubscribe to Mozilla VPN/i,
+      });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockResubscribeSubscriptionAction).toHaveBeenCalledWith(
+          'sub-id'
+        );
+      });
+
+      // Simulate parent re-rendering with updated props after successful resubscribe
+      rerender(
+        <StaySubscribed
+          {...baseProps}
+          pageContent={{
+            ...basePageContent,
+            cancelAtPeriodEnd: false,
+          }}
+        />
+      );
+
+      expect(screen.getByText(/Thanks! You’re all set/i)).toBeInTheDocument();
+      const backLink = screen.getByRole('link', {
+        name: /Back to subscriptions/i,
+      });
+      expect(backLink).toBeInTheDocument();
+      expect(backLink).toHaveAttribute('href', '/en/subscriptions/landing');
+    });
+  });
+
   describe('Resubscribe error path', () => {
-    it('shows an error message and keeps the form interactive when the resubscribe action fails', async () => {
+    it('shows error alert when resubscribe action rejects', async () => {
+      const user = userEvent.setup();
       mockResubscribeSubscriptionAction.mockResolvedValue({ ok: false });
 
       render(
@@ -160,7 +241,7 @@ describe('StaySubscribed', () => {
       const submitButton = screen.getByRole('button', {
         name: /Resubscribe to Mozilla VPN/i,
       });
-      fireEvent.click(submitButton);
+      await user.click(submitButton);
 
       await waitFor(() => {
         expect(
@@ -168,10 +249,8 @@ describe('StaySubscribed', () => {
         ).toBeInTheDocument();
       });
 
-      expect(mockResubscribeSubscriptionAction).toHaveBeenCalledWith(
-        'sub-id'
-      );
-
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(mockResubscribeSubscriptionAction).toHaveBeenCalledWith('sub-id');
       expect(submitButton).not.toBeDisabled();
     });
   });

--- a/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.test.tsx
@@ -1,0 +1,428 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  SubscriptionContentFactory,
+  type SubscriptionContent as SubscriptionContentType,
+} from '@fxa/payments/management/testing';
+import { SubscriptionContent } from './index';
+
+jest.mock('@fxa/payments/customer', () => ({
+  SubplatInterval: {
+    Daily: 'daily',
+    Weekly: 'weekly',
+    Monthly: 'monthly',
+    HalfYearly: 'halfyearly',
+    Yearly: 'yearly',
+  },
+  SubPlatPaymentMethodType: {
+    Stripe: 'stripe',
+    PayPal: 'paypal',
+    GoogleIap: 'google_iap',
+    AppleIap: 'apple_iap',
+  },
+}));
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLocalization: () => ({
+    l10n: {
+      getString: (
+        _id: string,
+        _vars?: Record<string, unknown>,
+        fallback?: string
+      ) => fallback || _id,
+    },
+  }),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, className }: { alt?: string; className?: string }) => (
+    <img alt={alt ?? ''} className={className} src="mock-image" />
+  ),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+    'aria-label': ariaLabel,
+  }: {
+    children: React.ReactNode;
+    href: string | { pathname: string; query?: Record<string, unknown> };
+    className?: string;
+    'aria-label'?: string;
+  }) => {
+    const hrefStr = typeof href === 'string' ? href : href.pathname;
+    return (
+      <a href={hrefStr} className={className} aria-label={ariaLabel}>
+        {children}
+      </a>
+    );
+  },
+}));
+
+jest.mock('@fxa/shared/react', () => ({
+  __esModule: true,
+  LinkExternal: ({
+    children,
+    href,
+    className,
+    'data-testid': testId,
+    'aria-label': ariaLabel,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+    'data-testid'?: string;
+    'aria-label'?: string;
+  }) => (
+    <a
+      href={href}
+      className={className}
+      data-testid={testId}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+const MOCK_LOCALE = 'en';
+
+function buildSubscription(overrides?: Partial<SubscriptionContentType>) {
+  return SubscriptionContentFactory({
+    productName: 'Mozilla VPN',
+    offeringApiIdentifier: 'vpn',
+    canResubscribe: false,
+    currency: 'usd',
+    interval: 'monthly' as SubscriptionContentType['interval'],
+    currentInvoiceTax: 100,
+    currentInvoiceTotal: 999,
+    currentInvoiceUrl: 'https://invoice.stripe.com/inv_123',
+    currentPeriodEnd: 1702600000,
+    nextInvoiceDate: 1702600000,
+    nextInvoiceTax: 100,
+    nextInvoiceTotal: 999,
+    nextPromotionName: null,
+    promotionName: null,
+    isEligibleForChurnCancel: false,
+    isEligibleForChurnStaySubscribed: false,
+    isEligibleForOffer: false,
+    churnStaySubscribedCtaMessage: null,
+    ...overrides,
+  });
+}
+
+describe('SubscriptionContent', () => {
+  describe('active subscription', () => {
+    it('renders product name', async () => {
+      const subscription = buildSubscription({ productName: 'Mozilla VPN' });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', {
+            name: /Cancel your subscription to Mozilla VPN/i,
+          })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('renders plan interval — monthly', async () => {
+      const subscription = buildSubscription({
+        interval: 'monthly' as SubscriptionContentType['interval'],
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last bill/)).toBeInTheDocument();
+      });
+    });
+
+    it('renders plan interval — yearly', async () => {
+      const subscription = buildSubscription({
+        interval: 'yearly' as SubscriptionContentType['interval'],
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last bill/)).toBeInTheDocument();
+      });
+    });
+
+    it('renders price with currency symbol', async () => {
+      const subscription = buildSubscription({
+        currentInvoiceTotal: 999,
+        currentInvoiceTax: 0,
+        currency: 'usd',
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('$9.99')).toBeInTheDocument();
+      });
+    });
+
+    it('renders next billing date', async () => {
+      const subscription = buildSubscription({
+        canResubscribe: false,
+        nextInvoiceTotal: 999,
+        currentPeriodEnd: 1702600000,
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Next bill/)).toBeInTheDocument();
+      });
+    });
+
+    it('renders last bill date and amount', async () => {
+      const subscription = buildSubscription({
+        currentInvoiceTotal: 1499,
+        currentInvoiceTax: 150,
+        currency: 'usd',
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last bill/)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/\$14\.99/)).toBeInTheDocument();
+      expect(screen.getByText(/\$1\.50/)).toBeInTheDocument();
+    });
+
+    it('renders cancel button with product name', async () => {
+      const subscription = buildSubscription({
+        canResubscribe: false,
+        productName: 'Mozilla VPN',
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', {
+            name: /Cancel your subscription to Mozilla VPN/i,
+          })
+        ).toBeInTheDocument();
+        expect(screen.getByText('Cancel subscription')).toBeInTheDocument();
+      });
+    });
+
+    it('does not render expiry date or stay-subscribed button', async () => {
+      const subscription = buildSubscription({ canResubscribe: false });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last bill/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Expires on/)).not.toBeInTheDocument();
+      expect(screen.queryByText('Stay subscribed')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('cancelled subscription (canResubscribe=true)', () => {
+    it('renders expiry date instead of next billing date', async () => {
+      const subscription = buildSubscription({
+        canResubscribe: true,
+        currentPeriodEnd: 1702600000,
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Expires on/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Next bill/)).not.toBeInTheDocument();
+    });
+
+    it('renders "Stay subscribed" button', async () => {
+      const subscription = buildSubscription({
+        canResubscribe: true,
+        productName: 'Mozilla VPN',
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Stay subscribed')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', {
+            name: /Stay subscribed to Mozilla VPN/i,
+          })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('hides cancel button', async () => {
+      const subscription = buildSubscription({ canResubscribe: true });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Stay subscribed')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Cancel subscription')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('active subscription — edge cases', () => {
+    it('renders without invoice URL when currentInvoiceUrl is null', async () => {
+      const subscription = buildSubscription({
+        currentInvoiceUrl: null,
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last bill/)).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByTestId('link-external-view-invoice')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders last bill amount without tax line when currentInvoiceTax is 0', async () => {
+      const subscription = buildSubscription({
+        currentInvoiceTotal: 1499,
+        currentInvoiceTax: 0,
+        nextInvoiceTotal: 1499,
+        nextInvoiceTax: 0,
+        currency: 'usd',
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      // The billing content renders after the isClient useEffect fires
+      await waitFor(() => {
+        expect(screen.getByText(/Last bill/)).toBeInTheDocument();
+      });
+
+      // Should show amounts without a separate tax line
+      expect(screen.getAllByText('$14.99').length).toBeGreaterThan(0);
+      expect(screen.queryByText(/\+ .* tax/)).not.toBeInTheDocument();
+    });
+
+    it('renders next bill without tax when nextInvoiceTax is undefined', async () => {
+      const subscription = buildSubscription({
+        canResubscribe: false,
+        nextInvoiceTotal: 499,
+        nextInvoiceTax: undefined,
+        currency: 'usd',
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Next bill/)).toBeInTheDocument();
+        expect(screen.getByText('$4.99')).toBeInTheDocument();
+      });
+    });
+
+    it('does not render next bill section when nextInvoiceTotal is undefined', async () => {
+      const subscription = buildSubscription({
+        canResubscribe: false,
+        nextInvoiceTotal: undefined,
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last bill/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Next bill/)).not.toBeInTheDocument();
+    });
+
+    it('renders view invoice link with correct aria-label', async () => {
+      const subscription = buildSubscription({
+        productName: 'Relay Premium',
+        currentInvoiceUrl: 'https://invoice.stripe.com/inv_abc',
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        const invoiceLink = screen.getByTestId('link-external-view-invoice');
+        expect(invoiceLink).toHaveAttribute(
+          'aria-label',
+          'View invoice for Relay Premium'
+        );
+        expect(invoiceLink).toHaveAttribute(
+          'href',
+          'https://invoice.stripe.com/inv_abc'
+        );
+      });
+    });
+  });
+
+  describe('with coupon', () => {
+    it('renders coupon discount information', async () => {
+      const subscription = buildSubscription({
+        canResubscribe: false,
+        nextPromotionName: 'SAVE20',
+        nextInvoiceTotal: 799,
+      });
+
+      render(
+        <SubscriptionContent subscription={subscription} locale={MOCK_LOCALE} />
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/SAVE20 discount will be applied/)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/libs/payments/ui/src/lib/utils/formatPlanInterval.spec.ts
+++ b/libs/payments/ui/src/lib/utils/formatPlanInterval.spec.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { formatPlanInterval } from './helpers';
+
+describe('formatPlanInterval', () => {
+  it.each([
+    { interval: 'monthly', expected: 'Monthly' },
+    { interval: 'yearly', expected: 'Yearly' },
+    { interval: 'halfyearly', expected: '6-month' },
+    { interval: 'weekly', expected: 'Weekly' },
+    { interval: 'daily', expected: 'Daily' },
+  ])(
+    'formats "$interval" as "$expected"',
+    ({ interval, expected }) => {
+      expect(formatPlanInterval(interval)).toBe(expected);
+    }
+  );
+});

--- a/libs/payments/ui/src/lib/utils/getCardIcon.spec.ts
+++ b/libs/payments/ui/src/lib/utils/getCardIcon.spec.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { LocalizerRsc } from '@fxa/shared/l10n/server';
+import { getCardIcon } from './getCardIcon';
+
+const mockL10n: LocalizerRsc = {
+  getString: (_id: string, fallback: string) => fallback,
+} as unknown as LocalizerRsc;
+
+describe('getCardIcon', () => {
+  it.each([
+    { brand: 'amex', altText: 'American Express logo' },
+    { brand: 'apple_pay', altText: 'Apple Pay logo' },
+    { brand: 'diners', altText: 'Diners logo' },
+    { brand: 'discover', altText: 'Discover logo' },
+    { brand: 'google_pay', altText: 'Google Pay logo' },
+    { brand: 'jcb', altText: 'JCB logo' },
+    { brand: 'link', altText: 'Link logo' },
+    { brand: 'mastercard', altText: 'Mastercard logo' },
+    { brand: 'paypal', altText: 'PayPal logo' },
+    { brand: 'external_paypal', altText: 'PayPal logo' },
+    { brand: 'unionpay', altText: 'Union Pay logo' },
+    { brand: 'visa', altText: 'Visa logo' },
+  ])('returns correct icon and alt text for "$brand"', ({ brand, altText }) => {
+    const result = getCardIcon(brand, mockL10n);
+    expect(result.altText).toBe(altText);
+    expect(result.img).toBeDefined();
+  });
+
+  it('returns unbranded icon for unknown brand', () => {
+    const result = getCardIcon('unknown_brand', mockL10n);
+    expect(result.altText).toBe('Unbranded logo');
+    expect(result.width).toBe(32);
+    expect(result.height).toBe(20);
+  });
+
+  it.each([
+    { brand: 'apple_pay', width: 45, height: 24 },
+    { brand: 'google_pay', width: 45, height: 24 },
+    { brand: 'link', width: 72, height: 24 },
+    { brand: 'paypal', width: 91, height: 24 },
+  ])('returns custom dimensions for "$brand"', ({ brand, width, height }) => {
+    const result = getCardIcon(brand, mockL10n);
+    expect(result.width).toBe(width);
+    expect(result.height).toBe(height);
+  });
+});

--- a/libs/payments/ui/src/lib/utils/terms-and-privacy.spec.ts
+++ b/libs/payments/ui/src/lib/utils/terms-and-privacy.spec.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  buildPaymentTerms,
+  PaymentProviders,
+} from './terms-and-privacy';
+
+describe('buildPaymentTerms', () => {
+  it('returns Stripe privacy link for Stripe provider with active subscription', () => {
+    const result = buildPaymentTerms(
+      { type: PaymentProviders.stripe },
+      true
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toContain('Stripe');
+    expect(result[0].items).toEqual([
+      expect.objectContaining({
+        href: 'https://stripe.com/privacy',
+        text: 'Stripe privacy policy',
+      }),
+    ]);
+  });
+
+  it('returns PayPal privacy link for PayPal provider with active subscription', () => {
+    const result = buildPaymentTerms(
+      { type: PaymentProviders.paypal },
+      true
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toContain('PayPal');
+    expect(result[0].items).toEqual([
+      expect.objectContaining({
+        href: 'https://www.paypal.com/webapps/mpp/ua/privacy-full',
+        text: 'PayPal privacy policy',
+      }),
+    ]);
+  });
+
+  it('returns both Stripe and PayPal links when no active subscription', () => {
+    const result = buildPaymentTerms(undefined, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toContain('Stripe and PayPal');
+    expect(result[0].items).toHaveLength(2);
+    expect(result[0].items[0]).toEqual(
+      expect.objectContaining({
+        href: 'https://stripe.com/privacy',
+      })
+    );
+    expect(result[0].items[1]).toEqual(
+      expect.objectContaining({
+        href: 'https://www.paypal.com/webapps/mpp/ua/privacy-full',
+      })
+    );
+  });
+
+  it('returns Stripe privacy link for Link provider with active subscription', () => {
+    const result = buildPaymentTerms(
+      { type: PaymentProviders.link },
+      true
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toContain('Stripe');
+    expect(result[0].items).toEqual([
+      expect.objectContaining({
+        href: 'https://stripe.com/privacy',
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## This pull request

- Adds integration tests for `SubscriptionManagementService`, covering cancel, resubscribe, Stripe payment method updates, PayPal billing agreement creation, and manage page content retrieval
- Adds component tests for `CancelSubscription`, `StaySubscribed`, `PaymentMethodManagement`, `PaypalManagement`, and `SubscriptionContent`
- Adds unit tests for `formatPlanInterval`, `getCardIcon`, `isPaymentIntent`, and `isPaymentIntentId`
- Extends existing test coverage for `CartService`, `cart.utils`, and `EligibilityService`

## Issue that this pull request solves

Closes: PAY-3687

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.