### PR TITLE
fix(ci): pin Node version via .nvmrc in setup-node steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
+          node-version-file: '.nvmrc'
           cache: yarn
 
       - run: ./_scripts/l10n/clone.sh

--- a/.github/workflows/l10n-gettext-extract.yml
+++ b/.github/workflows/l10n-gettext-extract.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
       - name: Install global npm packages
         run: |
           yarn global add grunt-cli


### PR DESCRIPTION
## Because

- The recent bump of `.nvmrc` to Node 24 caused the `preinstall` check (`_scripts/check-node-version.sh`) to fail in CI on workflows whose `setup-node` step didn't pin a version matching the new major.
- `docker.yml` relied on whatever Node version `ubuntu-latest` happens to ship preinstalled — it worked by coincidence under Node 22 but breaks under Node 24.
- `l10n-gettext-extract.yml` hardcoded `node-version: '24'`, which works today but drifts on the next major bump.

## This pull request

- Adds `node-version-file: '.nvmrc'` to the `setup-node` step in `.github/workflows/docker.yml` so it tracks the repo's required Node version automatically.
- Replaces the hardcoded `node-version: '24'` in `.github/workflows/l10n-gettext-extract.yml` with `node-version-file: '.nvmrc'`, matching the pattern already used in `deploy-storybooks.yml`.

## Issue that this pull request solves

Closes: N/A (chore-only CI fix, no ticket)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.