### PR TITLE
fix(ci): bump tag-workflow auth integration jobs to xlarge for node 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1254,6 +1254,7 @@ workflows:
           name: Integration Test - Servers - Auth
           projects: --exclude '*,!tag:scope:server:auth'
           start_customs: true
+          resource_class: xlarge
           target: -t test-integration
           test_suite: servers-auth-integration
           workflow: test_and_deploy_tag
@@ -1268,6 +1269,7 @@ workflows:
       - integration-test:
           name: Integration Test - Servers - Auth Scripts
           projects: --exclude '*,!tag:scope:server:auth'
+          resource_class: xlarge
           target: -t test-scripts
           test_suite: servers-auth-scripts
           workflow: test_and_deploy_tag
@@ -1384,6 +1386,7 @@ workflows:
       - integration-test:
           name: Integration Test - Servers - Auth Scripts (nightly)
           projects: --exclude '*,!tag:scope:server:auth'
+          resource_class: xlarge
           target: -t test-scripts
           test_suite: servers-auth-scripts
           workflow: nightly


### PR DESCRIPTION
  ## Because

  - train-338 is the first release train built on Node 24 (upgraded from 22.15 in `chore(all): Upgrade to node 24`), whose larger memory footprint pushed the `test_and_deploy_tag` auth integration jobs past the `large` container's ~8GB limit
  - The OOM killer SIGKILL'd jest workers mid-run, taking down the shared auth servers and cascading `socket hang up` + `ECONNREFUSED` (ports 9200/9301/9400) across the remote integration suites — 65 false failures, plus a timeout on Auth
  Scripts
  - The Node 24 upgrade already bumped the **PR** and **nightly** auth integration jobs to `xlarge`, but missed the **tag/deploy** variants

  ## This pull request

  - Adds `resource_class: xlarge` to the `test_and_deploy_tag` "Integration Test - Servers - Auth" job in `.circleci/config.yml`
  - Adds `resource_class: xlarge` to the `test_and_deploy_tag` "Integration Test - Servers - Auth Scripts" job
  - Mirrors the bump already applied to the PR and nightly variants; no test or source changes

  ## Issue that this pull request solves

  Closes: NA

  ## Checklist

  - [x] My commit is GPG signed.
  - [ ] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

This is ok I think since these workflows only are on deployment.