### PR TITLE
chore(ci): Remove dependency on build for approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1056,15 +1056,13 @@ workflows:
           workflow: test_pull_request
           requires:
             - Build (PR)
-      # Functional tests are heavy and expensive, so they're gated behind this
-      # manual approval. Approve the "Approve Functional Tests (PR)" job in
-      # the CircleCI UI, use the script under _scripts, or use the Claude skill
-      # to run them against the PR's already-built workspace.
+      # Approval step is to reduce how often we run the functional tests
+      # but still allow them to be run on demand.
+      # No `requires` on this job so it can be approved as soon as a PR
+      # is opened.
       - approve-functional-tests:
           name: Approve Functional Tests (PR)
           type: approval
-          requires:
-            - Build (PR)
       - playwright-functional-tests:
           name: Firefox Functional Tests - Playwright (PR)
           workflow: test_pull_request


### PR DESCRIPTION
Because:
 - We would like to be able to approve functional tests sooner

This Commit:
 - Removes the dependency on build for approval step since it's a dependency for running tests already

Closes: FXA-13895

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
