### PR TITLE
fix(ci): checkout FxA code before setup-node in l10n-gettext-extract

### DIFF
--- a/.github/workflows/l10n-gettext-extract.yml
+++ b/.github/workflows/l10n-gettext-extract.yml
@@ -11,10 +11,16 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gettext -y
+      - name: Clone FxA code repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 2
+          path: 'fxa-code'
+          persist-credentials: false
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'fxa-code/.nvmrc'
       - name: Install global npm packages
         run: |
           yarn global add grunt-cli
@@ -23,12 +29,6 @@ jobs:
         with:
           repository: mozilla/fxa-content-server-l10n
           path: 'fxa-l10n'
-          persist-credentials: false
-      - name: Clone FxA code repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 2
-          path: 'fxa-code'
           persist-credentials: false
       - name: Install npm packages
         run: |


### PR DESCRIPTION
## Because

- Follow-up to #20683. In `.github/workflows/l10n-gettext-extract.yml` the `setup-node` step uses `node-version-file`, but the FxA repo (which contains `.nvmrc`) is checked out into a `fxa-code/` subdirectory *after* `setup-node` runs. As Copilot pointed out on the merged PR, this means `setup-node` cannot find `.nvmrc` on disk yet and the step would fail with "Unable to locate '.nvmrc'".

## This pull request

- Moves the "Clone FxA code repository" step ahead of "Set up Node" in `.github/workflows/l10n-gettext-extract.yml` and points `node-version-file` at `fxa-code/.nvmrc` so `setup-node` can resolve the file.
- Leaves the l10n repo checkout after `setup-node`, since it is not needed for Node setup.

## Issue that this pull request solves

Closes: N/A (chore-only CI fix, no ticket)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This addresses the Copilot review comment on #20683 that landed after that PR was merged. The two other workflows touched in #20683 (`docker.yml`, `deploy-storybooks.yml`) already check out the repo at the runner root before `setup-node`, so they did not need the same reorder.