### PR TITLE
[experiment] Parallelize recovery phone functional tests for PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,13 @@ parameters:
   enable_nightly:
     type: boolean
     default: true
+  # Kill switch for the PR functional-test experiment: when true, #phone tests
+  # run in the parallel timings split instead of serially on node 0. If PR runs
+  # start hitting phone-number conflicts or Twilio rate limits, set this to
+  # false to revert to the previous serial-on-node-0 behavior.
+  parallelize_phone_tests:
+    type: boolean
+    default: true
   force-deploy-fxa-ci-images:
     type: boolean
     default: false
@@ -1099,7 +1106,7 @@ workflows:
       - playwright-functional-tests:
           name: Firefox Functional Tests - Playwright (PR)
           workflow: test_pull_request
-          parallelize_phone_tests: true
+          parallelize_phone_tests: << pipeline.parameters.parallelize_phone_tests >>
           requires:
             - Build (PR)
             - Approve Functional Tests (PR)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,11 @@ executors:
       RECOVERY_PHONE__ENABLED: true
       # use test mode except for smoke tests
       RECOVERY_PHONE__TWILIO__CREDENTIAL_MODE: 'test'
+      # Recovery-phone functional tests share a single magic test number. When
+      # the PR job runs them in parallel (parallelize_phone_tests), many
+      # accounts register that number concurrently, so raise the per-number
+      # registration cap well above the worker count. Harmless for serial runs.
+      RECOVERY_PHONE__MAX_REGISTRATIONS_PER_NUMBER: 1000
       CUSTOMS_SERVER_URL: none
       HUSKY_SKIP_INSTALL: 1
       AUTH_CLOUDTASKS_USE_LOCAL_EMULATOR: true
@@ -346,6 +351,9 @@ commands:
       fail_fast:
         type: boolean
         default: true
+      phone_parallel:
+        type: string
+        default: 'false'
     steps:
       - run:
           name: Running Playwright tests
@@ -383,6 +391,9 @@ commands:
             RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
             UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
             PLAYWRIGHT_FAIL_FAST: << parameters.fail_fast >>
+            # When 'true', #phone-tagged tests run in parallel (PR only). They
+            # are included in the timings split rather than pinned to node 0.
+            PLAYWRIGHT_PHONE_PARALLEL: << parameters.phone_parallel >>
 
   # DRY helper to run phone-tagged tests in a single worker on node 0
   run-phone-tests-serialized:
@@ -840,6 +851,13 @@ jobs:
       fail_fast:
         type: boolean
         default: true
+      # When true, #phone-tagged tests join the parallel timings split across
+      # all nodes instead of running serially on node 0. Safe only against the
+      # local target (codes read from Redis per-uid). Enabled for the PR
+      # workflow; smoke/nightly/tag keep the serial default.
+      parallelize_phone_tests:
+        type: boolean
+        default: false
     executor: functional-test-executor
     parallelism: << parameters.parallelism >>
     steps:
@@ -860,12 +878,25 @@ jobs:
           environment:
             NODE_ENV: test
           no_output_timeout: 20m
-      - run-phone-tests-serialized:
-          project: local
-      - run-playwright-tests:
-          project: local
-          grep_invert: '#phone'
-          fail_fast: << parameters.fail_fast >>
+      # PR: run everything (including #phone) in the parallel timings split.
+      - when:
+          condition: << parameters.parallelize_phone_tests >>
+          steps:
+            - run-playwright-tests:
+                project: local
+                fail_fast: << parameters.fail_fast >>
+                phone_parallel: 'true'
+      # Default (smoke/nightly/tag): #phone tests run serially on node 0, the
+      # rest run in parallel with phone tests excluded.
+      - unless:
+          condition: << parameters.parallelize_phone_tests >>
+          steps:
+            - run-phone-tests-serialized:
+                project: local
+            - run-playwright-tests:
+                project: local
+                grep_invert: '#phone'
+                fail_fast: << parameters.fail_fast >>
       - store-artifacts
       - upload_to_gcs:
           workflow: << parameters.workflow >>
@@ -1068,6 +1099,7 @@ workflows:
       - playwright-functional-tests:
           name: Firefox Functional Tests - Playwright (PR)
           workflow: test_pull_request
+          parallelize_phone_tests: true
           requires:
             - Build (PR)
             - Approve Functional Tests (PR)

--- a/packages/functional-tests/lib/phoneTestMode.ts
+++ b/packages/functional-tests/lib/phoneTestMode.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Recovery-phone tests (`#phone`) all share a single test phone number. How
+ * they may be parallelized depends on how the OTP code is retrieved:
+ *
+ *  - Against a real Twilio number (stage/prod smoke), codes are fetched from
+ *    the Twilio API filtered only by recipient number, so concurrent tests
+ *    cannot tell whose code is whose. These MUST run serially.
+ *  - Against the `local` target (PR/dev), codes are read from Redis keyed by
+ *    uid, so each test reads only its own code and tests can run in parallel.
+ *
+ * Default to `serial` so any environment (including stage/prod smoke) is safe
+ * unless it explicitly opts in. The PR CircleCI job sets
+ * `PLAYWRIGHT_PHONE_PARALLEL=true` to run the local suite in parallel.
+ *
+ * Usage:
+ * ```typescript
+ * test.describe('recovery phone #phone', () => {
+ *   test.describe.configure({ mode: phoneTestMode() });
+ * });
+ * ```
+ */
+export function phoneTestMode(): 'serial' | 'parallel' {
+  return process.env.PLAYWRIGHT_PHONE_PARALLEL === 'true'
+    ? 'parallel'
+    : 'serial';
+}

--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -220,7 +220,7 @@ test.describe('severity-1 #smoke', () => {
       expect(await relier.isLoggedIn()).toBe(true);
     });
 
-    test('enable 2FA and signin with recovery phone - 123Done', async ({
+    test('enable 2FA and signin with recovery phone - 123Done #phone', async ({
       target,
       page,
       pages: {

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -96,7 +96,7 @@ test.describe('severity-1 #smoke', () => {
       expect(await relier.isLoggedIn()).toBe(true);
     });
 
-    test('can setup TOTP inline with recovery phone choice', async ({
+    test('can setup TOTP inline with recovery phone choice #phone', async ({
       target,
       pages: { page, relier, signin, totp, recoveryPhone, inlineTotpSetup },
       testAccountTracker,

--- a/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
@@ -4,6 +4,7 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 import { getTotpCode } from '../../lib/totp';
+import { phoneTestMode } from '../../lib/phoneTestMode';
 
 test.describe('severity-1 #smoke', () => {
   test('can reset password with 2FA enabled', async ({
@@ -562,8 +563,8 @@ test.describe('severity-1 #smoke', () => {
   });
 });
 
-test.describe('reset password with recovery phone', () => {
-  test.describe.configure({ mode: 'serial' });
+test.describe('reset password with recovery phone #phone', () => {
+  test.describe.configure({ mode: phoneTestMode() });
   test.beforeAll(async ({ target }) => {
     target.smsClient.guardTestPhoneNumber();
   });

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -14,12 +14,15 @@ import { RecoveryPhoneSetupPage } from '../../pages/settings/recoveryPhone';
 import { FirefoxCommand } from '../../lib/channels';
 import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
 import { getTotpCode } from '../../lib/totp';
+import { phoneTestMode } from '../../lib/phoneTestMode';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('recovery phone #phone', () => {
-    // Run these tests sequentially. This must be done when using the Twilio API, because they rely on
-    // the same test phone number, and we cannot determine the order in which the messages were received.
-    test.describe.configure({ mode: 'serial' });
+    // These tests share a single test phone number. Against the Twilio API
+    // (stage/prod smoke) they must run serially because codes can't be
+    // attributed to a specific test; locally codes are read from Redis per-uid
+    // so they can run in parallel when PLAYWRIGHT_PHONE_PARALLEL is set.
+    test.describe.configure({ mode: phoneTestMode() });
 
     let testNumber: string;
 

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -106,7 +106,7 @@ test.describe('severity-2 #smoke', () => {
       await expect(settings.settingsHeading).toBeVisible();
     });
 
-    test('can change 2fa and use existing recovery phone to sign in', async ({
+    test('can change 2fa and use existing recovery phone to sign in #phone', async ({
       page,
       target,
       testAccountTracker,


### PR DESCRIPTION
> ⚠️ **Experimental — do not merge.** Opened to measure CI wall-clock impact.

## Purpose

Recovery phone (`#phone`) functional tests run serially on CI node 0, making it the long pole while the other parallel nodes finish and idle. This experiment runs them in the parallel timings split for the **PR workflow only** (codes are read from Redis per-uid locally, so parallel runs don't collide), and tags three stray phone tests that were running unserialized against the shared test number.

Goal: measure the functional-test wall-clock delta vs baseline, and surface any intra-file ordering or Twilio test-credential throttling issues under parallelism.

Smoke / nightly / tag workflows keep the existing serial-on-node-0 behavior.