### PR TITLE
fix(passkeys): align cancel/timeout banner with Figma; fix click-outside

### DIFF
--- a/packages/fxa-react/lib/hooks.test.tsx
+++ b/packages/fxa-react/lib/hooks.test.tsx
@@ -58,19 +58,19 @@ describe('useClickOutsideEffect', () => {
     );
   };
 
-  it('triggers onDismiss on a click outside', () => {
+  it('triggers onDismiss on a mousedown outside', () => {
     const onDismiss = jest.fn();
     const { getByTestId } = render(<Subject onDismiss={onDismiss} />);
     const outside = getByTestId('outside');
-    fireEvent.click(outside);
+    fireEvent.mouseDown(outside);
     expect(onDismiss).toBeCalled();
   });
 
-  it('does not trigger onDismiss on a click inside', () => {
+  it('does not trigger onDismiss on a mousedown inside', () => {
     const onDismiss = jest.fn();
     const { getByTestId } = render(<Subject onDismiss={onDismiss} />);
     const inside = getByTestId('inside');
-    fireEvent.click(inside);
+    fireEvent.mouseDown(inside);
     expect(onDismiss).not.toBeCalled();
   });
 });

--- a/packages/fxa-react/lib/hooks.tsx
+++ b/packages/fxa-react/lib/hooks.tsx
@@ -15,12 +15,12 @@ export function useBooleanState(
 }
 
 /**
- * Effect hook to react to clicks outside of a given DOM node.
+ * Effect hook to react to pointer presses (mousedown) outside of a given DOM node.
  *
- * @param onClickOutside {Function} a function to be called when a click occurs outside the given node
+ * @param onClickOutside {Function} a function to be called when a mousedown occurs outside the given node
  * @return {React.RefObject} when used as a ref prop, the given node and children are considered inside
  * @example
- *   // This function will be called for clicks on elements outside of dialogInsideRef
+ *   // This function will be called for mousedowns on elements outside of dialogInsideRef
  *   const onClickoutside => () => window.alert("Clicked outside!")
  *   const dialogInsideRef = useClickOutsideEffect<HTMLDivElement>(onClickOutside);
  *   return (
@@ -33,7 +33,9 @@ export function useClickOutsideEffect<T>(onClickOutside: Function) {
   const insideEl = useRef<T>(null);
 
   useEffect(() => {
-    const onBodyClick = (ev: MouseEvent) => {
+    // FXA-13681: mousedown fires before React's onClick, so a button handler
+    // opening the watched element doesn't immediately self-dismiss it.
+    const onBodyMouseDown = (ev: MouseEvent) => {
       if (
         insideEl.current instanceof HTMLElement &&
         ev.target instanceof HTMLElement &&
@@ -42,8 +44,9 @@ export function useClickOutsideEffect<T>(onClickOutside: Function) {
         onClickOutside();
       }
     };
-    document.body.addEventListener('click', onBodyClick);
-    return () => document.body?.removeEventListener('click', onBodyClick);
+    document.body.addEventListener('mousedown', onBodyMouseDown);
+    return () =>
+      document.body?.removeEventListener('mousedown', onBodyMouseDown);
   }, [onClickOutside]);
 
   return insideEl;
@@ -107,7 +110,7 @@ export const resetPromiseState = () => ({
 export function useAwait<
   TFactoryArgs extends Array<any>,
   TResult = any,
-  TError = any
+  TError = any,
 >(
   factory: (...args: TFactoryArgs) => Promise<TResult>,
   {
@@ -123,7 +126,7 @@ export function useAwait<
 ): [
   PromiseState<TResult | undefined, TError>,
   (...args: TFactoryArgs) => Promise<TResult | undefined>,
-  () => void
+  () => void,
 ] {
   const [state, setState] = useState<PromiseState<TResult | undefined, TError>>(
     initialState || resetPromiseState()

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
@@ -100,7 +100,7 @@ describe('BentoMenu', () => {
     expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
   });
 
-  it('closes on click outside', () => {
+  it('closes on mousedown outside', () => {
     const { container } = renderWithLocalizationProvider(
       <div className="w-full flex justify-end">
         <div className="flex pr-10 pt-4">
@@ -111,7 +111,7 @@ describe('BentoMenu', () => {
 
     fireEvent.click(screen.getByTestId('drop-down-bento-menu-toggle'));
     expect(screen.queryByTestId(dropDownId)).toBeInTheDocument();
-    fireEvent.click(container);
+    fireEvent.mouseDown(container);
     expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
   });
 

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
@@ -111,7 +111,7 @@ describe('DropDownAvatarMenu', () => {
     expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
   });
 
-  it('closes on click outside', () => {
+  it('closes on mousedown outside', () => {
     const { container } = renderWithLocalizationProvider(
       <AppContext.Provider value={mockAppContext({ account })}>
         <div className="w-full flex justify-end">
@@ -124,7 +124,7 @@ describe('DropDownAvatarMenu', () => {
 
     fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
     expect(screen.queryByTestId(dropDownId)).toBeInTheDocument();
-    fireEvent.click(container);
+    fireEvent.mouseDown(container);
     expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
   });
 

--- a/packages/fxa-settings/src/components/Settings/Modal/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.test.tsx
@@ -105,7 +105,7 @@ it('accepts an alternate className', () => {
   );
 });
 
-it('calls onDismiss on click outside', () => {
+it('calls onDismiss on mousedown outside', () => {
   const ariaLabelledBy = 'some-modal-header';
   const ariaDescribedBy = 'some-modal-description';
   const onDismiss = jest.fn();
@@ -121,9 +121,9 @@ it('calls onDismiss on click outside', () => {
       </div>
     </Modal>
   );
-  fireEvent.click(screen.getByTestId('modal-content-container'));
+  fireEvent.mouseDown(screen.getByTestId('modal-content-container'));
   expect(onDismiss).not.toHaveBeenCalled();
-  fireEvent.click(container);
+  fireEvent.mouseDown(container);
   expect(onDismiss).toHaveBeenCalled();
 });
 

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -31,6 +31,12 @@ jest.mock('fxa-react/components/LoadingSpinner', () => () => (
   <div data-testid="loading-spinner">Loading…</div>
 ));
 
+// Mock the alert helpers so the dispatcher tests can assert which one was invoked.
+jest.mock('../../../lib/passkeys/unsupported-message', () => ({
+  unsupportedPasskeyMessage: () => 'mock-unsupported-message',
+  passkeyCanceledOrTimedOutMessage: () => 'mock-canceled-or-timed-out-message',
+}));
+
 // Mock Sentry
 const mockCaptureException = jest.fn();
 jest.mock('@sentry/browser', () => ({
@@ -191,7 +197,11 @@ describe('PagePasskeyAdd', () => {
     );
   });
 
-  it('handles user cancel (NotAllowedError)', async () => {
+  it('shows the generic categorizer fallback and navigates to settings on NotAllowedError', async () => {
+    // NotAllowedError is the WebAuthn anti-fingerprinting catch-all: cancel,
+    // UV failure, no-suitable-authenticator, and other denials are all
+    // indistinguishable behind it. We deliberately do NOT route it through
+    // the cancel/timeout banner — see PagePasskeyAdd dispatcher comment.
     const cancelError = new DOMException('User cancelled', 'NotAllowedError');
     mockCreateCredential.mockRejectedValue(cancelError);
     mockHandleWebAuthnError.mockReturnValue({
@@ -205,7 +215,9 @@ describe('PagePasskeyAdd', () => {
 
     renderPage();
     await waitFor(() => {
-      expect(mockAlertError).toHaveBeenCalled();
+      expect(mockAlertError).toHaveBeenCalledWith(
+        'Passkey setup failed or is unavailable. Try again or choose another method.'
+      );
     });
     expect(
       GleanMetrics.accountPref.passkeyCreateSubmitFrontendError
@@ -269,15 +281,14 @@ describe('PagePasskeyAdd', () => {
     await waitFor(() => {
       expect(mockAlertError).toHaveBeenCalledTimes(1);
     });
-    const [alertContent] = mockAlertError.mock.calls[0];
-    expect(React.isValidElement(alertContent)).toBe(true);
+    expect(mockAlertError).toHaveBeenCalledWith('mock-unsupported-message');
     // Defensive case: pre-check at MfaGuardPagePasskeyAdd is the
     // primary handler. If we reach here (race), don't auto-redirect — the user
     // can use Cancel to navigate away.
     expect(mockNavigateWithQuery).not.toHaveBeenCalled();
   });
 
-  it('handles timeout error', async () => {
+  it('shows the cancel/timeout banner and navigates to settings on TimeoutError', async () => {
     const timeoutError = new DOMException('Timeout', 'TimeoutError');
     mockCreateCredential.mockRejectedValue(timeoutError);
     mockHandleWebAuthnError.mockReturnValue({
@@ -290,7 +301,9 @@ describe('PagePasskeyAdd', () => {
 
     renderPage();
     await waitFor(() => {
-      expect(mockAlertError).toHaveBeenCalled();
+      expect(mockAlertError).toHaveBeenCalledWith(
+        'mock-canceled-or-timed-out-message'
+      );
     });
     expect(
       GleanMetrics.accountPref.passkeyCreateSubmitFrontendError
@@ -429,7 +442,6 @@ describe('PagePasskeyAdd', () => {
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
-
   it('shows localized message for a known non-throttle auth error', async () => {
     // errno 226 (PASSKEY_LIMIT_REACHED) is a known auth error.
     mockBeginPasskeyRegistration.mockRejectedValue({
@@ -459,7 +471,7 @@ describe('PagePasskeyAdd', () => {
     renderPage();
     fireEvent.click(screen.getByTestId('passkey-add-cancel'));
     expect(mockAlertError).toHaveBeenCalledWith(
-      'Passkey setup was canceled. Try again.'
+      'mock-canceled-or-timed-out-message'
     );
     expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
       replace: true,
@@ -499,7 +511,7 @@ describe('PagePasskeyAdd', () => {
     expect(mockCompletePasskeyRegistration).not.toHaveBeenCalled();
     expect(mockAlertSuccess).not.toHaveBeenCalled();
     expect(mockAlertError).toHaveBeenCalledWith(
-      'Passkey setup was canceled. Try again.'
+      'mock-canceled-or-timed-out-message'
     );
   });
 
@@ -520,7 +532,7 @@ describe('PagePasskeyAdd', () => {
     // Only the cancel banner — the catch block must not fire its own banner.
     expect(mockAlertError).toHaveBeenCalledTimes(1);
     expect(mockAlertError).toHaveBeenCalledWith(
-      'Passkey setup was canceled. Try again.'
+      'mock-canceled-or-timed-out-message'
     );
     expect(mockHandleWebAuthnError).not.toHaveBeenCalled();
   });

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -211,7 +211,10 @@ export const PagePasskeyAdd = () => {
           return;
         }
 
-        // Server error
+        // Server error. Also catches the plain `Error` that some
+        // password-manager extensions (e.g. Bitwarden)
+        // throw on cancel instead of a DOMException — those bypass
+        // the WebAuthn branch above.
         const handledError = error as HandledError;
         const isKnownAuthError = !!(
           handledError?.errno && AuthUiErrorNos[handledError.errno]

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -32,7 +32,10 @@ import {
   HandledError,
 } from '../../../lib/error-utils';
 import { AuthUiErrorNos } from '../../../lib/auth-errors/auth-errors';
-import { unsupportedPasskeyMessage } from '../../../lib/passkeys/unsupported-message';
+import {
+  passkeyCanceledOrTimedOutMessage,
+  unsupportedPasskeyMessage,
+} from '../../../lib/passkeys/unsupported-message';
 
 export const MfaGuardPagePasskeyAdd = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
@@ -85,14 +88,9 @@ export const PagePasskeyAdd = () => {
     // alert/navigate.
     wasCanceled.current = true;
     abortController.current?.abort();
-    alertBar.error(
-      ftlMsgResolver.getMsg(
-        'passkey-registration-canceled',
-        'Passkey setup was canceled. Try again.'
-      )
-    );
+    alertBar.error(passkeyCanceledOrTimedOutMessage());
     navigateToSettings();
-  }, [alertBar, ftlMsgResolver, navigateToSettings]);
+  }, [alertBar, navigateToSettings]);
 
   useEffect(() => {
     isMounted.current = true;
@@ -176,6 +174,7 @@ export const PagePasskeyAdd = () => {
           );
           const reasonMap: Record<string, string> = {
             [WebAuthnErrorType.NotAllowed]: 'not_allowed',
+            [WebAuthnErrorType.Abort]: 'abort',
             [WebAuthnErrorType.Timeout]: 'timeout',
             [WebAuthnErrorType.NotSupported]: 'not_supported',
             [WebAuthnErrorType.Security]: 'security',
@@ -193,6 +192,18 @@ export const PagePasskeyAdd = () => {
             alertBar.error(unsupportedPasskeyMessage());
             return;
           }
+          if (
+            categorized.errorType === WebAuthnErrorType.Abort ||
+            categorized.errorType === WebAuthnErrorType.Timeout
+          ) {
+            // FXA-13805/13806: timeouts and aborts share the cancel/timeout
+            // banner (per Figma). NotAllowedError is excluded — WebAuthn
+            // conflates cancel with UV failure under that name, so it falls
+            // through to the generic categorizer below.
+            alertBar.error(passkeyCanceledOrTimedOutMessage());
+            navigateToSettings();
+            return;
+          }
           alertBar.error(
             ftlMsgResolver.getMsg(categorized.ftlId, categorized.fallbackText)
           );
@@ -208,7 +219,9 @@ export const PagePasskeyAdd = () => {
 
         GleanMetrics.accountPref.passkeyCreateSubmitFrontendError({
           event: {
-            reason: isKnownAuthError ? `auth_error_${handledError.errno}` : 'server_error',
+            reason: isKnownAuthError
+              ? `auth_error_${handledError.errno}`
+              : 'server_error',
           },
         });
 

--- a/packages/fxa-settings/src/lib/passkeys/en.ftl
+++ b/packages/fxa-settings/src/lib/passkeys/en.ftl
@@ -14,8 +14,9 @@ passkey-registration-error-not-allowed-existing = Passkey setup isn’t availabl
 # The ceremony timed out before the user responded
 passkey-registration-error-timeout = Passkey setup was canceled. Try again.
 
-# User clicked the in-page Cancel link while the ceremony was still pending
-passkey-registration-canceled = Passkey setup was canceled. Try again.
+passkey-registration-canceled-v2 = Passkey setup timed out or was cancelled.
+# Link label appended after passkey-registration-canceled-v2, opens a SUMO support article.
+passkey-registration-canceled-link = Learn more
 
 # Browser or platform does not support passkeys or the requested options (e.g., user verification, discoverable credential).
 passkey-registration-error-not-supported-v2 = Your browser or device doesn’t support passkeys.

--- a/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
@@ -19,3 +19,25 @@ export const unsupportedPasskeyMessage = (): ReactNode => (
     </FtlMsg>
   </>
 );
+
+/**
+ * Shown when the passkey ceremony is cancelled or times out — covers the
+ * in-page Cancel link, the AbortError surfaced by our timeout wrapper, and
+ * the TimeoutError raised by browsers that distinguish it. NotAllowedError
+ * is NOT routed here: WebAuthn conflates cancel with UV failure and other
+ * denials behind that DOMException, so it falls through to the generic
+ * categorizer fallback — see PagePasskeyAdd dispatcher. Matches the Figma
+ * spec for FXA-13805 / FXA-13806.
+ */
+export const passkeyCanceledOrTimedOutMessage = (): ReactNode => (
+  <>
+    <FtlMsg id="passkey-registration-canceled-v2">
+      <span>Passkey setup timed out or was cancelled.</span>
+    </FtlMsg>{' '}
+    <FtlMsg id="passkey-registration-canceled-link">
+      <LinkExternal href={PASSKEY_TROUBLESHOOT_URL} className="link-blue">
+        Learn more
+      </LinkExternal>
+    </FtlMsg>
+  </>
+);

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.ts
@@ -217,7 +217,12 @@ function toCredentialJSON(
 
 // ─── Wrapper functions ────────────────────────────────────────────────────────
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+// Aligned with the server-side challenge TTL (`PASSKEYS__CHALLENGE_TIMEOUT`,
+// 5 min). Keeping the client wrapper at 60s while the server gives the user
+// 5 min meant users who stepped away briefly were cut off long before the
+// request expired. On Safari/WebKit (which ignores `options.timeout` per spec)
+// this wrapper is the only timeout in play.
+const DEFAULT_TIMEOUT_MS = 300_000;
 
 /**
  * Wraps navigator.credentials.create() for passkey registration.


### PR DESCRIPTION
## Because

- After cancelling the OS/browser passkey prompt or letting it time out, the FxA banner showed "Passkey setup was canceled. Try again." without the Learn-more link the Figma spec called for, and the same banner was reused for both outcomes so the copy couldn't honestly name either. (FXA-13805, FXA-13806)
- On the first passkey-setup attempt after sign-in, the in-page Cancel link silently navigated back to settings with no banner at all — the same click that mounted the banner was bubbling to the document and dismissing it via the click-outside handler. (FXA-13681)
- The client-side WebAuthn wrapper was hard-coded to 60s while the server-side challenge TTL is 5 min. Users who stepped away briefly were cut off long before the request actually expired — especially noticeable on Safari/WebKit where the wrapper is the only timeout in play.

## This pull request

- Adds `passkeyCanceledOrTimedOutMessage()` to `packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx`, paired with FTL `passkey-registration-canceled-v2` ("Passkey setup timed out or was cancelled.") and a `-link` Learn-more pointing at the SUMO troubleshoot article.
- Routes the in-page Cancel handler and `PagePasskeyAdd`'s catch-block `AbortError` / `TimeoutError` branches through the new helper. `NotAllowedError` is deliberately NOT routed there — WebAuthn lumps cancel, UV failure, and other denials behind that DOMException name, so it falls through to the existing generic categorizer fallback instead of claiming a cancel/timeout that may not be one.
- Switches `useClickOutsideEffect` in `packages/fxa-react/lib/hooks.tsx` from a `click` body-listener to `mousedown`. `mousedown` fires before React's `onClick`, so when a button's handler mounts a watched element the body listener no-ops cleanly instead of dismissing it. Industry-standard pattern (Radix, react-aria, headless-ui). Also tightens dismiss timing for the other three hook consumers (BentoMenu, DropDownAvatarMenu, Modal).
- Bumps `DEFAULT_TIMEOUT_MS` in `packages/fxa-settings/src/lib/passkeys/webauthn.ts` from 60_000 to 300_000 to match `PASSKEYS__CHALLENGE_TIMEOUT` and the WebAuthn spec's recommended registration timeout.

## Issue that this pull request solves

Closes: FXA-13805
Closes: FXA-13806
Closes: FXA-13681

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- **The two commits are independent units of work and can be reviewed separately.**
  - The **`fix(passkeys)`** commit covers the cancel/timeout copy fix (FXA-13805 + FXA-13806) and the 60s→5min wrapper timeout.
  - The **`fix(react)`** commit covers the `useClickOutsideEffect` mousedown swap (FXA-13681) plus the four consumer-test updates that come with it. Without this commit, the cancel/timeout banner from the first commit doesn't appear on the first attempt after sign-in.
- Key files/areas to focus on:
  - `packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx` — new helper alongside the existing `unsupportedPasskeyMessage`
  - `packages/fxa-settings/src/lib/passkeys/en.ftl` — `-v2` copy + Learn-more link string
  - `packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx` — dispatcher routing
  - `packages/fxa-react/lib/hooks.tsx` — `'click'` → `'mousedown'` (1-line core change)
- Manual test cases (all from **Settings → Security → Passkeys**):

  | # | Trigger | Expected banner | Navigation |
  |---|---|---|---|
  | 1 | In-page Cancel link, **first attempt** after fresh sign-in | "Passkey setup timed out or was cancelled. Learn more" | `/settings#security` |
  | 2 | Wait for browser/wrapper timeout (~5 min) | Same as `#1` | `/settings#security` |
  | 3 | Browser-native Cancel button (NotAllowedError) | "Passkey setup failed or is unavailable. Try again or choose another method." | `/settings#security` |
  | 4 | Open avatar / Bento menu, click outside | Menu closes cleanly | — |
  | 5 | Approve passkey on the prompt | "Passkey created" | `/settings#security` |

  For Test 2: temporarily lower `DEFAULT_TIMEOUT_MS` to e.g. `10_000` if you don't have 5 min to spare. Revert before merging.

## Screenshots (Optional)

_N/A — copy-only changes; banner appearance unchanged besides the new wording and link._

## Other information (Optional)

Known limitations (out of scope for this PR, documented in code):

- **Bitwarden cancel produces a non-timeout error.** Chrome/Edge users with the Bitwarden extension installed see a plain `Error` (not a `DOMException`) thrown when the popup is dismissed. That bypasses the WebAuthn-error branch and lands in the system-error banner. Documented inline in `PagePasskeyAdd`'s catch block. Not handled here because production Firefox doesn't allow extensions to intercept WebAuthn — Firefox users on the canonical path aren't affected.
- **Some authenticators never time out, or take much longer than 5 min.** Apple/WebKit ignores the `options.timeout` hint per spec; our wrapper is the only timeout. Even with the 5-min wrapper, platform authenticators behind certain integrations (some password managers, virtual authenticators) may not surface a timeout until the user dismisses manually. The cancel/timeout banner still fires correctly when the user does cancel — it just may not fire automatically.

Pre-merge: `/fxa-review-quick` returned APPROVE (0 blocking, 3 LOW optional findings noted in chat).

