### PR TITLE
fix(passkeys): handle ceremony NotSupportedError, auto-redirect on error

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -35,6 +35,7 @@ jest.mock('fxa-react/components/LoadingSpinner', () => () => (
 jest.mock('../../../lib/passkeys/unsupported-message', () => ({
   unsupportedPasskeyMessage: () => 'mock-unsupported-message',
   passkeyCanceledOrTimedOutMessage: () => 'mock-canceled-or-timed-out-message',
+  passkeyCouldNotCompleteMessage: () => 'mock-could-not-complete-message',
 }));
 
 // Mock Sentry
@@ -263,7 +264,7 @@ describe('PagePasskeyAdd', () => {
     );
   });
 
-  it('renders the unsupported-passkey alert (with Learn more link) on NotSupportedError', async () => {
+  it('shows the could-not-complete banner and navigates to settings on NotSupportedError from the ceremony', async () => {
     const notSupportedError = new DOMException(
       'not supported',
       'NotSupportedError'
@@ -279,13 +280,18 @@ describe('PagePasskeyAdd', () => {
 
     renderPage();
     await waitFor(() => {
-      expect(mockAlertError).toHaveBeenCalledTimes(1);
+      expect(mockAlertError).toHaveBeenCalledWith(
+        'mock-could-not-complete-message'
+      );
     });
-    expect(mockAlertError).toHaveBeenCalledWith('mock-unsupported-message');
-    // Defensive case: pre-check at MfaGuardPagePasskeyAdd is the
-    // primary handler. If we reach here (race), don't auto-redirect — the user
-    // can use Cancel to navigate away.
-    expect(mockNavigateWithQuery).not.toHaveBeenCalled();
+    expect(
+      GleanMetrics.accountPref.passkeyCreateSubmitFrontendError
+    ).toHaveBeenCalledWith({
+      event: { reason: 'not_supported' },
+    });
+    expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
+      replace: true,
+    });
   });
 
   it('shows the cancel/timeout banner and navigates to settings on TimeoutError', async () => {

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -34,6 +34,7 @@ import {
 import { AuthUiErrorNos } from '../../../lib/auth-errors/auth-errors';
 import {
   passkeyCanceledOrTimedOutMessage,
+  passkeyCouldNotCompleteMessage,
   unsupportedPasskeyMessage,
 } from '../../../lib/passkeys/unsupported-message';
 
@@ -185,11 +186,11 @@ export const PagePasskeyAdd = () => {
             },
           });
           if (categorized.errorType === WebAuthnErrorType.NotSupported) {
-            // Defensive: MfaGuardPagePasskeyAdd should have caught this before
-            // MFA, so we only reach here if detection raced. Push the alert and
-            // leave the user on the page — they can use Cancel to navigate
-            // away themselves.
-            alertBar.error(unsupportedPasskeyMessage());
+            // NotSupportedError at this stage means the ceremony was refused
+            // (e.g., algorithm/attestation mismatch, requireResidentKey on a non-RK authenticator, etc.),
+            // not that the browser doesn't support WebAuthn at all — the MfaGuard's pre-check would have caught that.
+            alertBar.error(passkeyCouldNotCompleteMessage());
+            navigateToSettings();
             return;
           }
           if (

--- a/packages/fxa-settings/src/lib/passkeys/en.ftl
+++ b/packages/fxa-settings/src/lib/passkeys/en.ftl
@@ -23,6 +23,13 @@ passkey-registration-error-not-supported-v2 = Your browser or device doesn’t s
 # Link label appended after passkey-registration-error-not-supported-v2, opens a SUMO support article.
 passkey-registration-error-not-supported-link = Learn more
 
+# Generic fallback shown when passkey setup fails for an indeterminate reason.
+# Keep the tone neutral; do not imply the device is unsupported or that the user cancelled.
+# "method" here means an alternative way to create the passkey (e.g. another password manager or security key), not a different account or sign-in option.
+passkey-registration-error-could-not-complete = Passkey setup couldn’t be completed. Try a different method or device.
+# Link label appended after passkey-registration-error-could-not-complete, opens a SUMO support article.
+passkey-registration-error-could-not-complete-link = Learn more
+
 # RP ID / origin mismatch, or insecure context (e.g., embedded iframe, wrong domain)
 passkey-registration-error-security = Passkeys can’t be set up on this page. Use the secure site and try again.
 

--- a/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
@@ -20,21 +20,27 @@ export const unsupportedPasskeyMessage = (): ReactNode => (
   </>
 );
 
-/**
- * Shown when the passkey ceremony is cancelled or times out — covers the
- * in-page Cancel link, the AbortError surfaced by our timeout wrapper, and
- * the TimeoutError raised by browsers that distinguish it. NotAllowedError
- * is NOT routed here: WebAuthn conflates cancel with UV failure and other
- * denials behind that DOMException, so it falls through to the generic
- * categorizer fallback — see PagePasskeyAdd dispatcher. Matches the Figma
- * spec for FXA-13805 / FXA-13806.
- */
 export const passkeyCanceledOrTimedOutMessage = (): ReactNode => (
   <>
     <FtlMsg id="passkey-registration-canceled-v2">
       <span>Passkey setup timed out or was cancelled.</span>
     </FtlMsg>{' '}
     <FtlMsg id="passkey-registration-canceled-link">
+      <LinkExternal href={PASSKEY_TROUBLESHOOT_URL} className="link-blue">
+        Learn more
+      </LinkExternal>
+    </FtlMsg>
+  </>
+);
+
+export const passkeyCouldNotCompleteMessage = (): ReactNode => (
+  <>
+    <FtlMsg id="passkey-registration-error-could-not-complete">
+      <span>
+        Passkey setup couldn’t be completed. Try a different method or device.
+      </span>
+    </FtlMsg>{' '}
+    <FtlMsg id="passkey-registration-error-could-not-complete-link">
       <LinkExternal href={PASSKEY_TROUBLESHOOT_URL} className="link-blue">
         Learn more
       </LinkExternal>


### PR DESCRIPTION
## Because

- Runtime-refusing authenticators / WebAuthn-intercepting extensions throw `NotSupportedError` from the ceremony itself. The page showed "Your browser or device doesn't support passkeys." — inaccurate, since WebAuthn works on the user's setup; only the specific authenticator couldn't complete the ceremony. (FXA-13777)
- After any setup error, the user was stranded on the "Creating passkey…" spinner and had to click the in-page Cancel link to escape — while the success flow already auto-redirects. (FXA-13876)

## This pull request

- Adds FTL string `passkey-registration-error-could-not-complete` and a `passkeyCouldNotCompleteMessage()` helper, with copy that stays neutral on cause. (The "no WebAuthn at all" case is already caught pre-ceremony by `MfaGuardPagePasskeyAdd`'s support check.)
- Routes the dispatcher's `NotSupportedError` branch through the new helper and calls `navigateToSettings()`, so every error path now redirects to `/settings#security`.

## Issue that this pull request solves

Closes: FXA-13876
Closes: FXA-13777

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Single commit, four files in `packages/fxa-settings/`: new FTL strings, the new helper, the `NotSupportedError` reroute in `PagePasskeyAdd/index.tsx`, and updated tests.
- Manual: ceremony `NotSupportedError` → neutral "couldn't be completed" banner + redirect; any ceremony error → redirect (no longer stranded); no-WebAuthn browser → unchanged "doesn't support" pre-check.

## Screenshots (Optional)

_N/A — behaviour change; no new UI._

## Other information (Optional)

- Note (FXA-13777): the original Bitwarden + macOS repro surfaced `NotAllowedError` (handled by the broader redirect); this PR's `NotSupportedError` reroute covers any authenticator that surfaces it.
- All `fxa-settings` unit tests pass locally.
