### PR TITLE
follow-ups (fxa-13811): 

### DIFF
--- a/libs/accounts/rate-limit/src/lib/bq-writer.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/bq-writer.spec.ts
@@ -2,16 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as Sentry from '@sentry/node';
 import { RateLimitBqWriter, BqWriterConfig } from './bq-writer';
 import { RateLimitCheckEvent } from './models';
 
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
 describe('RateLimitBqWriter', () => {
   let writer: RateLimitBqWriter;
-  let mockInsert: jest.Mock;
-  let mockBq: any;
+  let mockTable: { insert: jest.Mock };
   let config: BqWriterConfig;
 
-  const createEvent = (overrides?: Partial<RateLimitCheckEvent>): RateLimitCheckEvent => ({
+  const createEvent = (
+    overrides?: Partial<RateLimitCheckEvent>
+  ): RateLimitCheckEvent => ({
     timestamp: 1700000000000,
     action: 'loginAttempt',
     ip: '127.0.0.1',
@@ -24,13 +30,8 @@ describe('RateLimitBqWriter', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    mockInsert = jest.fn().mockResolvedValue(undefined);
-    mockBq = {
-      dataset: jest.fn().mockReturnValue({
-        table: jest.fn().mockReturnValue({
-          insert: mockInsert,
-        }),
-      }),
+    mockTable = {
+      insert: jest.fn().mockResolvedValue(undefined),
     };
     config = {
       projectId: 'test-project',
@@ -39,9 +40,11 @@ describe('RateLimitBqWriter', () => {
       flushIntervalMs: 5000,
       batchSize: 3,
     };
-    writer = new RateLimitBqWriter(config, mockBq);
+    writer = new RateLimitBqWriter(config, mockTable as any);
   });
 
+  // shutdown() clears the setInterval timer started in the constructor.
+  // Without it, the timer leaks into the next test and causes flaky failures.
   afterEach(async () => {
     await writer.shutdown();
     jest.useRealTimers();
@@ -51,16 +54,20 @@ describe('RateLimitBqWriter', () => {
     writer.write(createEvent());
     writer.write(createEvent());
 
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockTable.insert).not.toHaveBeenCalled();
   });
 
-  it('flushes when buffer reaches batch size', () => {
+  it('flushes when buffer reaches batch size', async () => {
     writer.write(createEvent({ action: 'a' }));
     writer.write(createEvent({ action: 'b' }));
     writer.write(createEvent({ action: 'c' }));
 
-    expect(mockInsert).toHaveBeenCalledTimes(1);
-    expect(mockInsert).toHaveBeenCalledWith(
+    // write() calls flush() fire-and-forget (no await). Drain one
+    // microtask so the async insert resolves.
+    await Promise.resolve();
+
+    expect(mockTable.insert).toHaveBeenCalledTimes(1);
+    expect(mockTable.insert).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ action: 'a' }),
         expect.objectContaining({ action: 'b' }),
@@ -73,31 +80,37 @@ describe('RateLimitBqWriter', () => {
     writer.write(createEvent());
 
     jest.advanceTimersByTime(5000);
-    // Let the async flush complete
     await Promise.resolve();
 
-    expect(mockInsert).toHaveBeenCalledTimes(1);
-    expect(mockInsert).toHaveBeenCalledWith([expect.objectContaining({ action: 'loginAttempt' })]);
+    expect(mockTable.insert).toHaveBeenCalledTimes(1);
+    expect(mockTable.insert).toHaveBeenCalledWith([
+      expect.objectContaining({ action: 'loginAttempt' }),
+    ]);
   });
 
   it('does not call insert when buffer is empty', async () => {
     await writer.flush();
 
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockTable.insert).not.toHaveBeenCalled();
   });
 
-  it('catches errors and never throws', async () => {
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    mockInsert.mockRejectedValue(new Error('BQ unavailable'));
+  it('catches errors, emits statsd metric, reports to Sentry, and never throws', async () => {
+    const mockIncrement = jest.fn();
+    const statsd = { increment: mockIncrement } as any;
+    const insertError = new Error('BQ unavailable');
+    mockTable.insert.mockRejectedValue(insertError);
+
+    // Recreate writer with statsd
+    await writer.shutdown();
+    writer = new RateLimitBqWriter(config, mockTable as any, statsd);
 
     writer.write(createEvent());
     await writer.flush();
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'rate_limit.bq_writer.flush_error',
-      expect.any(Error)
+    expect(mockIncrement).toHaveBeenCalledWith(
+      'rate_limit.bq_writer.flush_error'
     );
-    consoleSpy.mockRestore();
+    expect(Sentry.captureException).toHaveBeenCalledWith(insertError);
   });
 
   it('drains remaining events on shutdown', async () => {
@@ -105,7 +118,7 @@ describe('RateLimitBqWriter', () => {
 
     await writer.shutdown();
 
-    expect(mockInsert).toHaveBeenCalledWith([
+    expect(mockTable.insert).toHaveBeenCalledWith([
       expect.objectContaining({ action: 'remaining' }),
     ]);
   });
@@ -114,9 +127,9 @@ describe('RateLimitBqWriter', () => {
     writer.write(createEvent());
     await writer.flush();
 
-    mockInsert.mockClear();
+    mockTable.insert.mockClear();
     await writer.flush();
 
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockTable.insert).not.toHaveBeenCalled();
   });
 });

--- a/libs/accounts/rate-limit/src/lib/bq-writer.ts
+++ b/libs/accounts/rate-limit/src/lib/bq-writer.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { BigQuery, Table } from '@google-cloud/bigquery';
+import * as Sentry from '@sentry/node';
+import { StatsD } from '@fxa/shared/metrics/statsd';
 import { RateLimitCheckEvent } from './models';
 
 export interface BqWriterConfig {
@@ -16,20 +18,34 @@ export interface BqWriterConfig {
 /**
  * Non-blocking, batched BigQuery writer for rate-limit check events.
  * Buffers events in memory and flushes on a timer or when the batch
- * size is reached. Errors are caught and logged — a BigQuery outage
+ * size is reached. Errors are caught and reported — a BigQuery outage
  * must never affect the auth flow.
+ *
+ * The target table must be pre-created by SRE. Insert failures are
+ * captured via Sentry and statsd.
  */
 export class RateLimitBqWriter {
   private buffer: RateLimitCheckEvent[] = [];
   private timer: NodeJS.Timeout | null = null;
   private readonly tableRef: Table;
 
+  /**
+   * @param config Writer configuration
+   * @param table  Optional Table instance for testing. When omitted, a real
+   *               BigQuery client is created from config.
+   * @param statsd Optional StatsD client for metrics
+   */
   constructor(
     private readonly config: BqWriterConfig,
-    bq?: BigQuery
+    table?: Table,
+    private readonly statsd?: StatsD
   ) {
-    const client = bq ?? new BigQuery({ projectId: config.projectId });
-    this.tableRef = client.dataset(config.dataset).table(config.table);
+    if (table) {
+      this.tableRef = table;
+    } else {
+      const client = new BigQuery({ projectId: config.projectId });
+      this.tableRef = client.dataset(config.dataset).table(config.table);
+    }
     this.startTimer();
   }
 
@@ -51,8 +67,9 @@ export class RateLimitBqWriter {
     try {
       await this.tableRef.insert(batch);
     } catch (err) {
-      // Log but never throw — BQ failures must not affect auth
-      console.error('rate_limit.bq_writer.flush_error', err);
+      // Never throw — BQ failures must not affect auth
+      this.statsd?.increment('rate_limit.bq_writer.flush_error');
+      Sentry.captureException(err);
     }
   }
 

--- a/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
@@ -48,7 +48,9 @@ export const RateLimitProvider = {
       'rateLimit.bigquery'
     );
     const bqWriter =
-      bqConfig && bqConfig.enabled ? new RateLimitBqWriter(bqConfig) : undefined;
+      bqConfig && bqConfig.enabled
+        ? new RateLimitBqWriter(bqConfig, undefined, statsd)
+        : undefined;
 
     return new RateLimit(
       {

--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -769,7 +769,7 @@ describe('rate-limit', () => {
     });
   });
 
-  describe('bqWriter integration', () => {
+  describe('bqWriter', () => {
     let mockWrite: jest.Mock;
     let mockIncr: jest.Mock;
     let mockExpire: jest.Mock;

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -275,13 +275,17 @@ async function run(config) {
   const { RateLimitBqWriter } = require('@fxa/accounts/rate-limit');
   const bqWriter =
     config.rateLimit.bigquery && config.rateLimit.bigquery.enabled
-      ? new RateLimitBqWriter({
-          projectId: config.rateLimit.bigquery.projectId,
-          dataset: config.rateLimit.bigquery.dataset,
-          table: config.rateLimit.bigquery.table,
-          flushIntervalMs: config.rateLimit.bigquery.flushIntervalMs,
-          batchSize: config.rateLimit.bigquery.batchSize,
-        })
+      ? new RateLimitBqWriter(
+          {
+            projectId: config.rateLimit.bigquery.projectId,
+            dataset: config.rateLimit.bigquery.dataset,
+            table: config.rateLimit.bigquery.table,
+            flushIntervalMs: config.rateLimit.bigquery.flushIntervalMs,
+            batchSize: config.rateLimit.bigquery.batchSize,
+          },
+          undefined,
+          statsd
+        )
       : undefined;
 
   const rateLimit = new RateLimit(


### PR DESCRIPTION
## Because
  - PR #20671 review feedback requested statsd metrics on BQ flush errors for monitoring and alerting ...
  - BigQuery tables can't be created via normal SQL migrations ...

## This pull request
  - Adds optional StatsD param to RateLimitBqWriter; emits `rate_limit.bq_writer.flush_error` on insert failures.
  - Self-creates the `rate_limit_checks` BigQuery table on startup via `ensureTable()` with `RATE_LIMIT_CHECK_SCHEMA`. (Non-fatal if permissions don't allow creation.)

## Issue that this pull request solves

Closes: FXA-13811

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] ~I have added necessary documentation (if appropriate).~
- [ ] ~I have verified that my changes render correctly in RTL (if appropriate).~
- [x] I have manually reviewed all AI generated code.

## Other information (Optional)
  - Feature remains off by default (`RATE_LIMIT__BIGQUERY__ENABLED=false`).