### PR TITLE
fix(passwordless): Show a11y text on passwordless signin

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Subject, createMockWebIntegration } from './mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
-import { AppContext } from '../../../models';
+import { AppContext, RelierCmsInfo } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
 import { createMockSigninOAuthNativeIntegration } from '../mocks';
 
@@ -51,6 +51,24 @@ export const WithCmsInfo = () => (
       email="user@example.com"
       expirationMinutes={5}
       integration={createMockWebIntegration(MOCK_CMS_INFO)}
+      isSignup={false}
+    />
+  </AppContext.Provider>
+);
+
+const accessibilityOnlyCmsInfo = {
+  shared: {
+    additionalAccessibilityInfo:
+      MOCK_CMS_INFO.shared.additionalAccessibilityInfo,
+  },
+} as unknown as RelierCmsInfo;
+
+export const WithAdditionalAccessibilityInfo = () => (
+  <AppContext.Provider value={mockAppContext()}>
+    <Subject
+      email="user@example.com"
+      expirationMinutes={5}
+      integration={createMockWebIntegration(accessibilityOnlyCmsInfo)}
       isSignup={false}
     />
   </AppContext.Provider>

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -12,8 +12,13 @@ import { mockAppContext } from '../../../models/mocks';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { AppContext } from '../../../models';
 import { SigninPasswordlessCodeProps } from './interfaces';
-import { Subject, MOCK_PASSWORDLESS_CODE } from './mocks';
 import {
+  Subject,
+  MOCK_PASSWORDLESS_CODE,
+  createOAuthNativeIntegration,
+} from './mocks';
+import {
+  MOCK_CMS_INFO,
   MOCK_EMAIL,
   MOCK_OAUTH_FLOW_HANDLER_RESPONSE,
   MOCK_SESSION_TOKEN,
@@ -243,6 +248,23 @@ describe('SigninPasswordlessCode page', () => {
       render({ isSignup: false });
 
       screen.getByRole('link', { name: 'Use a different account' });
+    });
+
+    it('renders additional accessibility info from CMS', () => {
+      const integration = createOAuthNativeIntegration(true, MOCK_CMS_INFO);
+      render({ integration, isSignup: false });
+
+      expect(
+        screen.getByText(MOCK_CMS_INFO.shared.additionalAccessibilityInfo)
+      ).toBeInTheDocument();
+    });
+
+    it('does not render additional accessibility info when CMS info is absent', () => {
+      render({ isSignup: false });
+
+      expect(
+        screen.queryByText(MOCK_CMS_INFO.shared.additionalAccessibilityInfo)
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -472,6 +472,8 @@ const SigninPasswordlessCode = ({
   } = (isSignup
     ? cmsInfo?.SignupPasswordlessCodePage
     : cmsInfo?.SigninPasswordlessCodePage) ?? {};
+  const additionalAccessibilityInfo =
+    cmsInfo?.shared.additionalAccessibilityInfo;
 
   // Heading and instruction text vary based on signup vs signin
   const subHeadingText = isSignup
@@ -563,6 +565,10 @@ const SigninPasswordlessCode = ({
           </>
         )}
       </p>
+
+      {additionalAccessibilityInfo && (
+        <p className="mt-2 text-sm">{additionalAccessibilityInfo}</p>
+      )}
 
       <FormVerifyCode
         {...{


### PR DESCRIPTION
Because:
* We have a11y text in Strapi that we display for browser services that do something unusual at the end of the flow that users should be told about, like Relay, and Smart Window in the near future. This text is missing from the passwordless OTP page and should be added.

This commit:
* Pulls this text from Strapi and renders it on the page when present, adds a Storybook state

closes FXA-13902