### PR TITLE
feat(auth/ui): Support cached sign-in state for Mobile when keys_optional is false

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.test.tsx
@@ -111,6 +111,76 @@ describe('SigninDecider routing', () => {
     });
   });
 
+  describe('Mobile authorization flow', () => {
+    // Mobile does not send `keys_optional` so we detect signed-in Mobile users
+    // authorizing a non-Sync service and route them to cached signin.
+
+    it('routes to cached signin for Mobile signed into Firefox + service=vpn without keys_optional', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.Vpn,
+        isSync: false,
+        isMobile: true,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        isSignedIntoFirefox: true,
+        supportsKeysOptionalLogin: false,
+      });
+
+      passwordInputNotRendered();
+      screen.getByRole('button', { name: 'Sign in' });
+    });
+
+    it('routes to cached signin for Mobile signed into Firefox + service=relay without keys_optional', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.Relay,
+        isSync: false,
+        isMobile: true,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        isSignedIntoFirefox: true,
+        supportsKeysOptionalLogin: false,
+      });
+
+      passwordInputNotRendered();
+    });
+
+    it('routes to password signin when Mobile is not signed into Firefox', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.Vpn,
+        isSync: false,
+        isMobile: true,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        isSignedIntoFirefox: false,
+        supportsKeysOptionalLogin: false,
+      });
+
+      passwordInputRendered();
+    });
+
+    it('routes to password signin for Desktop signed into Firefox + service=relay without keys_optional', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.Relay,
+        isSync: false,
+        isMobile: false,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        isSignedIntoFirefox: true,
+        supportsKeysOptionalLogin: false,
+      });
+
+      passwordInputRendered();
+    });
+  });
+
   describe('cached vs password based on integration requesting keys', () => {
     it('routes to password signin when integration wants keys and user has a password', () => {
       const integration = createMockSigninOAuthNativeSyncIntegration();

--- a/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.tsx
@@ -134,10 +134,17 @@ export const SigninDecider = ({
   // Relay browser service login launched in Firefox desktop 135, and the "keys optional"
   // capability (Sync decoupling) launched in Fx desktop 147, meaning all Relay service users
   // in those Fx versions require a password.
-  // This also covers Mobile until Sync has been decoupled.
+  // This also covers Mobile until Sync is decoupled except for the authorization state below.
   const syncNotDecoupledRequiresPassword =
     !useFxAStatusResult.supportsKeysOptionalLogin &&
     integration.wantsKeysIfPasswordEntered();
+
+  // In Firefox Android 153, Sync is not decoupled, but we need to show cached sign-in
+  // for signed-in users (e.g., signed into Sync) that are authorizing VPN.
+  const isMobileAuthorizationFlow =
+    syncNotDecoupledRequiresPassword &&
+    !!isSignedIntoFirefox &&
+    integration.isFirefoxMobileClient();
 
   // Redirect-based RPs (OAuthWeb) that request scoped keys always need a password for key
   // derivation. In practice today, we don't have RPs that need this, but we do support it.
@@ -152,7 +159,7 @@ export const SigninDecider = ({
     // The password is forced when the RP requests prompt=login
     (isOAuth && integration.wantsLogin());
 
-  // Do we have a session token, and can we defer the key fetch?
+  // Do we have a session token, and can we defer the key fetch because sync is decoupled?
   const keysOptional =
     hasCachedSession && useFxAStatusResult.supportsKeysOptionalLogin;
 
@@ -165,7 +172,11 @@ export const SigninDecider = ({
   // Passwordless users always see cached sign-in and are redirected to set a
   // password after signing in, if a password is required (e.g. for Sync).
   const showCached =
-    hasCachedSession && (!hasPassword || !passwordNeeded || keysOptional);
+    hasCachedSession &&
+    (isMobileAuthorizationFlow ||
+      !hasPassword ||
+      !passwordNeeded ||
+      keysOptional);
 
   if (showCached) {
     return (

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -183,6 +183,36 @@ export const CachedNonSyncBrowserServiceWithPasswordlessCapabilityNotSignedIntoD
     name: 'Cached > Non-Sync browser service > Browser has Sync keys optional capability > Account is not signed into Firefox Desktop',
   };
 
+export const CachedNonSyncBrowserServiceMobileAuthorizationFlow: Story = {
+  ...story({
+    sessionToken: MOCK_SESSION_TOKEN,
+    serviceName: MozServices.MozillaVPN,
+    integration: createMockSigninOAuthNativeIntegration({
+      service: OAuthNativeServices.Vpn,
+      isSync: false,
+      isMobile: true,
+    }),
+    supportsKeysOptionalLogin: false,
+    isSignedIntoFirefox: true,
+  }),
+  name: 'Cached > Non-Sync browser service > Browser does not have keys optional capability > Account is signed into Firefox Mobile',
+};
+
+export const CachedNonSyncBrowserServiceMobileNotSignedIn: Story = {
+  ...story({
+    sessionToken: MOCK_SESSION_TOKEN,
+    serviceName: MozServices.MozillaVPN,
+    integration: createMockSigninOAuthNativeIntegration({
+      service: OAuthNativeServices.Vpn,
+      isSync: false,
+      isMobile: true,
+    }),
+    supportsKeysOptionalLogin: false,
+    isSignedIntoFirefox: false,
+  }),
+  name: 'Cached > Non-Sync browser service > Browser does not have keys optional capability > Account is not signed into Firefox Mobile',
+};
+
 export const CmsNonCachedDefault: Story = {
   ...story({
     integration: createMockSigninOAuthIntegration({

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -144,7 +144,7 @@ export function createMockSigninOAuthNativeSyncIntegration({
     wantsTwoStepAuthentication: () => false,
     getCmsInfo: () => undefined,
     isFirefoxClient: () => true,
-    isFirefoxMobileClient: () => isSync && isMobile,
+    isFirefoxMobileClient: () => isMobile,
     isFirefoxDesktopClient: () => isSync && !isMobile,
     getLegalTerms: () => undefined,
   };
@@ -224,7 +224,7 @@ export function createMockSigninOAuthNativeIntegration({
     getClientId: () => MOCK_CLIENT_ID,
     getCmsInfo: () => cmsInfo,
     isFirefoxClient: () => true,
-    isFirefoxMobileClient: () => isSync && isMobile,
+    isFirefoxMobileClient: () => isMobile,
     isFirefoxDesktopClient: () => !isMobile,
     getLegalTerms: () => undefined,
   };


### PR DESCRIPTION
Because:
* We need to show cached sign-in/'authorization state' or users will have to enter their password when they've already signed into Sync and they are just opting into VPN. Mobile cannot send keys_optional: true here without causing other bugs as it's meant to signal to FxA that sync has been decoupled

This commit:
* Adds a condition for this state specifically and renders cached sign-in for it
* Adds unit tests and storybook

closes FXA-13903

---

Note, we have a functional test that covers this in `vpnIntegration` but it's disabled now with a fixme.