### PR TITLE
fix(auth-server): record account.create event for passwordless OTP signups

### DIFF
--- a/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
@@ -1218,18 +1218,69 @@ describe('passwordless security events', () => {
     route = getRoute(routes, '/account/passwordless/confirm_code', 'POST');
 
     return runTest(route, mockRequest, () => {
-      // Should record two events: registration_complete and otp_verified
-      expect(mockRecordSecurityEvent).toHaveBeenCalledTimes(2);
+      // Should record three events: account.create (so the generic
+      // account-creation metric fires for OTP signups too), then
+      // registration_complete and otp_verified.
+      expect(mockRecordSecurityEvent).toHaveBeenCalledTimes(3);
       expect(mockRecordSecurityEvent).toHaveBeenNthCalledWith(
         1,
-        'account.passwordless_registration_complete',
-        expect.anything()
+        'account.create',
+        expect.objectContaining({ account: { uid } })
       );
       expect(mockRecordSecurityEvent).toHaveBeenNthCalledWith(
         2,
-        'account.passwordless_login_otp_verified',
-        expect.anything()
+        'account.passwordless_registration_complete',
+        expect.objectContaining({ account: { uid } })
       );
+      expect(mockRecordSecurityEvent).toHaveBeenNthCalledWith(
+        3,
+        'account.passwordless_login_otp_verified',
+        expect.objectContaining({ account: { uid } })
+      );
+    });
+  });
+
+  it('should not record account.create when confirming OTP for an existing account', () => {
+    // Existing account: accountRecord resolves, so isNewAccount is false and
+    // the account.create event must not fire (it would double-count the
+    // metric on every passwordless sign-in).
+    mockDB.createSessionToken = jest.fn(() =>
+      Promise.resolve({
+        data: 'sessiontoken123',
+        emailVerified: true,
+        tokenVerified: true,
+        lastAuthAt: () => 1234567890,
+      })
+    );
+
+    mockRequest.payload.code = '123456';
+
+    routes = makeRoutes({
+      log: mockLog,
+      db: mockDB,
+      customs: mockCustoms,
+      recordSecurityEvent: mockRecordSecurityEvent,
+      config: {
+        passwordlessOtp: {
+          enabled: true,
+          ttl: 300,
+          digits: 6,
+          allowedClientServices: {
+            'test-client-id': { allowedServices: ['*'] },
+          },
+        },
+      },
+    });
+    route = getRoute(routes, '/account/passwordless/confirm_code', 'POST');
+
+    return runTest(route, mockRequest, () => {
+      const recordedEvents = mockRecordSecurityEvent.mock.calls.map(
+        ([name]: [string]) => name
+      );
+      expect(recordedEvents).not.toContain('account.create');
+      expect(recordedEvents).toEqual([
+        'account.passwordless_login_otp_verified',
+      ]);
     });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/passwordless.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.ts
@@ -295,6 +295,14 @@ class PasswordlessHandler {
         reason: 'otp',
       });
 
+      // This path bypasses the createAccount handler which normally records
+      // the event. We still need the event, so we also call it here for passwordless.
+      await recordSecurityEvent('account.create', {
+        db: this.db,
+        request,
+        account: { uid: account.uid },
+      });
+
       await recordSecurityEvent('account.passwordless_registration_complete', {
         db: this.db,
         request,


### PR DESCRIPTION
## Because

- The `account.create` SecurityEvent metric flatlined for `vpn` when it moved to OTP registration, which bypasses the password signup path that records it.

## This pull request

- Records `account.create` in the passwordless `confirm_code` handler, gated on `isNewAccount`, mirroring `AccountHandler.createAccount`.
- Adds test coverage for the new event firing on signup and not on sign-in.

## Issue that this pull request solves

Closes: FXA-13901

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Acceptance criterion is a production-dashboard check (auth-server panel-180 showing results for `5882386c6d801776 vpn`), verifiable after deploy.
