### PR TITLE
bug(settings): Fix race in useClientInfoState

### DIFF
--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -277,7 +277,7 @@ export function useClientInfoState() {
     loading: boolean;
     error?: Error;
     data?: { clientInfo: RelierClientInfo };
-  }>({ loading: false });
+  }>({ loading: true });
 
   const urlQueryData = new UrlQueryData(new ReachRouterWindow());
   const clientId =


### PR DESCRIPTION
## Because

- There is an unlikely but possible race condition in useClientInfoState.
- Since we default to `loading:false`, and useEffect is async it's possible the state returned indicates loading is complete, even though we haven't made the call yet.

## This pull request

- Defaults to `loading:true` thus ensuring calling code really does wait for the data to load.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
