### PR TITLE
fix(payments-next): PaidInvoiceOnFailedCartError: Paid invoice found on failed cart

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -190,6 +190,13 @@ export class CartProcessingConflictError extends CartError {
   }
 }
 
+export class ConcurrentCartCheckoutError extends CartError {
+  constructor(cartId: string, cause?: Error) {
+    super('Concurrent checkout detected for cart', { cartId }, cause);
+    this.name = 'ConcurrentCartCheckoutError';
+  }
+}
+
 export class CartStateProcessingError extends CartError {
   constructor(message: string, cartId: string, cause: Error) {
     super(message, { cartId }, cause);

--- a/libs/payments/cart/src/lib/cart.manager.in.spec.ts
+++ b/libs/payments/cart/src/lib/cart.manager.in.spec.ts
@@ -28,6 +28,7 @@ import {
   UpdateProcessingCartFactory,
 } from './cart.factories';
 import { CartManager } from './cart.manager';
+import { setCartProcessing } from './cart.repository';
 import { ResultCart } from './cart.types';
 import { type StatsD } from '@fxa/shared/metrics/statsd';
 import { LoggerService } from '@nestjs/common';
@@ -378,6 +379,8 @@ describe('CartManager', () => {
     const STALE_PROCESSING_UID = '77777777777777777777777777777777';
     const CONCURRENT_UID = '88888888888888888888888888888888';
     const TERMINAL_SIBLING_UID = '99999999999999999999999999999999';
+    const SELF_CONCURRENT_UID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const SELF_PROCESSING_UID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
     async function seedAccount(db: AccountDatabase, uidHex: string) {
       await db
@@ -555,6 +558,48 @@ describe('CartManager', () => {
         (cart) => cart.state === CartState.PROCESSING
       ).length;
       expect(processingCount).toEqual(1);
+    });
+
+    it('fails when the same cart is already processing', async () => {
+      await seedAccount(db, SELF_PROCESSING_UID);
+      const cart = await cartManager.createCart(
+        SetupCartFactory({ uid: SELF_PROCESSING_UID })
+      );
+
+      await directUpdate(
+        db,
+        { state: CartState.PROCESSING, updatedAt: Date.now() },
+        cart.id
+      );
+
+      await expect(
+        setCartProcessing(
+          db,
+          Buffer.from(cart.id, 'hex'),
+          Buffer.from(SELF_PROCESSING_UID, 'hex'),
+          cart.version
+        )
+      ).rejects.toBeInstanceOf(CartProcessingConflictError);
+    });
+
+    it('allows only one of two concurrent checkouts for the same cart to enter processing', async () => {
+      await seedAccount(db, SELF_CONCURRENT_UID);
+      const cart = await cartManager.createCart(
+        SetupCartFactory({ uid: SELF_CONCURRENT_UID })
+      );
+
+      const results = await Promise.allSettled([
+        cartManager.setProcessingCart(cart.id),
+        cartManager.setProcessingCart(cart.id),
+      ]);
+
+      const fulfillments = results.filter((r) => r.status === 'fulfilled');
+      const rejections = results.filter((r) => r.status === 'rejected');
+      expect(fulfillments).toHaveLength(1);
+      expect(rejections).toHaveLength(1);
+
+      const updated = await cartManager.fetchCartById(cart.id);
+      expect(updated.state).toEqual(CartState.PROCESSING);
     });
   });
 

--- a/libs/payments/cart/src/lib/cart.repository.ts
+++ b/libs/payments/cart/src/lib/cart.repository.ts
@@ -124,6 +124,21 @@ export async function setCartProcessing(
             conflictingCart.id.toString('hex')
           );
         }
+
+        const cartIsProcessing = carts.find(
+          (cart) =>
+            cart.id.equals(cartId) &&
+            cart.state === CartState.PROCESSING &&
+            cart.updatedAt > now - CART_PROCESSING_STALE_TIMEOUT_MS
+        );
+
+        if (cartIsProcessing) {
+          throw new CartProcessingConflictError(
+            cartId.toString('hex'),
+            uid.toString('hex'),
+            cartId.toString('hex')
+          );
+        }
       }
 
       const updatedRows = await trx

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -110,7 +110,11 @@ import {
   CartSetupInvalidPromoCodeError,
   CartRestartInvalidPromoCodeError,
   SetupCartAccountNotFoundError,
+  ConcurrentCartCheckoutError,
+  CartProcessingConflictError,
+  UpdatePayPalProcessingCartError,
 } from './cart.error';
+import { CART_PROCESSING_STALE_TIMEOUT_MS } from './cart.repository';
 import { CurrencyManager } from '@fxa/payments/currency';
 import {
   LocationConfig,
@@ -1400,9 +1404,10 @@ describe('CartService', () => {
     const mockRequestArgs = CommonMetricsFactory();
 
     it('accepts payment with Paypal', async () => {
-      const mockCart = ResultCartFactory();
+      const mockCart = ResultCartFactory({ state: CartState.START });
       const mockToken = faker.string.uuid();
 
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
       jest
         .spyOn(cartManager, 'fetchAndValidateCartVersion')
         .mockResolvedValue(mockCart);
@@ -1430,9 +1435,10 @@ describe('CartService', () => {
     });
 
     it('reject with CartStateProcessingError if cart could not be set to processing', async () => {
-      const mockCart = ResultCartFactory();
+      const mockCart = ResultCartFactory({ state: CartState.START });
       const mockToken = faker.string.uuid();
 
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
       jest
         .spyOn(cartManager, 'fetchAndValidateCartVersion')
         .mockRejectedValue(new Error('test'));
@@ -1452,6 +1458,137 @@ describe('CartService', () => {
 
       expect(checkoutService.payWithPaypal).not.toHaveBeenCalled();
       expect(cartManager.finishErrorCart).toHaveBeenCalled();
+    });
+
+    it('rejects with ConcurrentCartCheckoutError when the cart is already actively processing', async () => {
+      const mockCart = ResultCartFactory({
+        state: CartState.PROCESSING,
+        updatedAt: Date.now(),
+      });
+      const mockToken = faker.string.uuid();
+
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+      const setProcessingSpy = jest
+        .spyOn(cartManager, 'setProcessingCart')
+        .mockResolvedValue();
+      jest.spyOn(checkoutService, 'payWithPaypal').mockResolvedValue();
+      const finishErrorSpy = jest
+        .spyOn(cartManager, 'finishErrorCart')
+        .mockResolvedValue();
+
+      await expect(
+        cartService.checkoutCartWithPaypal(
+          mockCart.id,
+          mockCart.version,
+          mockAttributionData,
+          mockRequestArgs,
+          mockCart.uid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(ConcurrentCartCheckoutError);
+
+      expect(setProcessingSpy).not.toHaveBeenCalled();
+      expect(checkoutService.payWithPaypal).not.toHaveBeenCalled();
+      expect(finishErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects with ConcurrentCartCheckoutError without finalizing when the claim hits a CartProcessingConflictError', async () => {
+      const mockCart = ResultCartFactory({ state: CartState.START });
+      const mockToken = faker.string.uuid();
+
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+      jest
+        .spyOn(cartManager, 'fetchAndValidateCartVersion')
+        .mockResolvedValue(mockCart);
+      jest
+        .spyOn(cartManager, 'setProcessingCart')
+        .mockRejectedValue(
+          new CartProcessingConflictError(
+            mockCart.id,
+            mockCart.uid ?? faker.string.uuid(),
+            faker.string.uuid()
+          )
+        );
+      jest.spyOn(checkoutService, 'payWithPaypal').mockResolvedValue();
+      const finishErrorSpy = jest
+        .spyOn(cartManager, 'finishErrorCart')
+        .mockResolvedValue();
+
+      await expect(
+        cartService.checkoutCartWithPaypal(
+          mockCart.id,
+          mockCart.version,
+          mockAttributionData,
+          mockRequestArgs,
+          mockCart.uid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(ConcurrentCartCheckoutError);
+
+      expect(finishErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects with ConcurrentCartCheckoutError without finalizing when the claim fails but the cart is still processing', async () => {
+      const startCart = ResultCartFactory({ state: CartState.START });
+      const processingCart = ResultCartFactory({
+        id: startCart.id,
+        state: CartState.PROCESSING,
+        updatedAt: Date.now(),
+      });
+      const mockToken = faker.string.uuid();
+
+      jest
+        .spyOn(cartManager, 'fetchCartById')
+        .mockResolvedValueOnce(startCart)
+        .mockResolvedValue(processingCart);
+      jest
+        .spyOn(cartManager, 'fetchAndValidateCartVersion')
+        .mockRejectedValue(new CartVersionMismatchError(startCart.id));
+      jest.spyOn(checkoutService, 'payWithPaypal').mockResolvedValue();
+      const finishErrorSpy = jest
+        .spyOn(cartManager, 'finishErrorCart')
+        .mockResolvedValue();
+
+      await expect(
+        cartService.checkoutCartWithPaypal(
+          startCart.id,
+          startCart.version,
+          mockAttributionData,
+          mockRequestArgs,
+          startCart.uid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(ConcurrentCartCheckoutError);
+
+      expect(finishErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('finalizes with UpdatePayPalProcessingCartError when the claim fails and the cart is not processing', async () => {
+      const mockCart = ResultCartFactory({ state: CartState.START });
+      const mockToken = faker.string.uuid();
+
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+      jest
+        .spyOn(cartManager, 'fetchAndValidateCartVersion')
+        .mockRejectedValue(new CartVersionMismatchError(mockCart.id));
+      jest.spyOn(checkoutService, 'payWithPaypal').mockResolvedValue();
+      const finishErrorSpy = jest
+        .spyOn(cartManager, 'finishErrorCart')
+        .mockResolvedValue();
+
+      await expect(
+        cartService.checkoutCartWithPaypal(
+          mockCart.id,
+          mockCart.version,
+          mockAttributionData,
+          mockRequestArgs,
+          mockCart.uid,
+          mockToken
+        )
+      ).rejects.toBeInstanceOf(UpdatePayPalProcessingCartError);
+
+      expect(checkoutService.payWithPaypal).not.toHaveBeenCalled();
+      expect(finishErrorSpy).toHaveBeenCalled();
     });
   });
 
@@ -1529,9 +1666,10 @@ describe('CartService', () => {
 
   describe('finalizeCartWithError', () => {
     it('calls cartManager.finishErrorCart', async () => {
-      const mockCart = ResultCartFactory();
+      const mockCart = ResultCartFactory({ state: CartState.START });
       const mockErrorCart = FinishErrorCartFactory();
 
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
       jest.spyOn(cartManager, 'finishErrorCart').mockResolvedValue();
 
       await cartService.finalizeCartWithError(
@@ -1540,6 +1678,48 @@ describe('CartService', () => {
       );
 
       expect(cartManager.finishErrorCart).toHaveBeenCalledWith(mockCart.id, {
+        errorReasonId: mockErrorCart.errorReasonId,
+      });
+    });
+
+    it('does not finalize a cart that is actively processing', async () => {
+      const mockCart = ResultCartFactory({
+        state: CartState.PROCESSING,
+        updatedAt: Date.now(),
+      });
+      const mockErrorCart = FinishErrorCartFactory();
+
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+      const finishErrorSpy = jest
+        .spyOn(cartManager, 'finishErrorCart')
+        .mockResolvedValue();
+
+      await cartService.finalizeCartWithError(
+        mockCart.id,
+        mockErrorCart.errorReasonId
+      );
+
+      expect(finishErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('finalizes a cart whose processing has exceeded the stale timeout', async () => {
+      const mockCart = ResultCartFactory({
+        state: CartState.PROCESSING,
+        updatedAt: Date.now() - CART_PROCESSING_STALE_TIMEOUT_MS - 1000,
+      });
+      const mockErrorCart = FinishErrorCartFactory();
+
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+      const finishErrorSpy = jest
+        .spyOn(cartManager, 'finishErrorCart')
+        .mockResolvedValue();
+
+      await cartService.finalizeCartWithError(
+        mockCart.id,
+        mockErrorCart.errorReasonId
+      );
+
+      expect(finishErrorSpy).toHaveBeenCalledWith(mockCart.id, {
         errorReasonId: mockErrorCart.errorReasonId,
       });
     });

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -78,6 +78,8 @@ import {
   InvalidPromoCodeCartError,
   CartVersionMismatchError,
   CartInvalidStateForActionError,
+  CartProcessingConflictError,
+  ConcurrentCartCheckoutError,
   GetCartMissingTaxAddressError,
   GetCartFromPriceMissingError,
   GetCartCustomerMissingError,
@@ -94,6 +96,9 @@ import {
   CartSubscriptionDeletionFailedError,
 } from './cart.error';
 import { CartManager } from './cart.manager';
+import {
+  CART_PROCESSING_STALE_TIMEOUT_MS
+} from './cart.repository';
 import type {
   CartDTO,
   FromPrice,
@@ -142,6 +147,10 @@ const IGNORED_EXPECTED_ERRORS_STATSD = new Set([
   'PromotionCodeNotFoundError',
   'CouponErrorInvalidCode',
 ]);
+
+const isCartActivelyProcessing = (cart: ResultCart): boolean =>
+  cart.state === CartState.PROCESSING &&
+  cart.updatedAt > Date.now() - CART_PROCESSING_STALE_TIMEOUT_MS;
 
 @Injectable()
 export class CartService {
@@ -223,6 +232,9 @@ export class CartService {
         await this.cartManager.finishErrorCart(cartId, {
           errorReasonId,
         });
+
+        // TODO: uncomment to test, remove after testing
+        //await new Promise((r) => setTimeout(r, 8_000));
 
         const cart = await this.cartManager.fetchCartById(cartId);
         const store = this.asyncLocalStorage.getStore();
@@ -374,6 +386,21 @@ export class CartService {
 
       throw error;
     }
+  }
+
+  private async isOwnedByAnotherCheckout(
+    cartId: string,
+    error: unknown
+  ): Promise<boolean> {
+    if (error instanceof CartProcessingConflictError) {
+      return true;
+    }
+
+    const current = await this.cartManager
+      .fetchCartById(cartId)
+      .catch(() => null);
+
+    return !!current && isCartActivelyProcessing(current);
   }
 
   @SanitizeExceptions()
@@ -722,48 +749,59 @@ export class CartService {
         },
       });
     };
-    return this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
-      let updatedCart: ResultCart | null = null;
-      try {
-        //Ensure that the cart version matches the value passed in from FE
-        await this.cartManager.fetchAndValidateCartVersion(cartId, version);
-
-        await this.cartManager.setProcessingCart(cartId);
-
-        // Ensure we have a positive lock on the processing cart
-        updatedCart = await this.cartManager.fetchAndValidateCartVersion(
-          cartId,
-          version + 1
-        );
-      } catch (error) {
-        throw new UpdatePayPalProcessingCartError(cartId, error);
-      }
-
-      this.asyncLocalStorage.run(
-        { checkout: { subscriptionId: undefined } },
-        () => {
-          // Intentionally non-blocking
-          this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
-            await this.checkoutService.payWithPaypal(
-              updatedCart,
-              attribution,
-              requestArgs,
-              sessionUid,
-              token
-            );
-          }).catch((error) => {
-            handleException({
-              error,
-              className: 'CartService',
-              methodName: 'checkoutCartWithPaypal',
-              allowlist: [],
-              logger: this.log as Logger,
-              statsd: this.statsd,
-            });
-          });
+    return this.wrapWithCartCatch(
+      cartId,
+      { onCheckoutFail, errorAllowList: [ConcurrentCartCheckoutError] },
+      async () => {
+        const existing = await this.cartManager.fetchCartById(cartId);
+        if (isCartActivelyProcessing(existing)) {
+          throw new ConcurrentCartCheckoutError(cartId);
         }
-      );
-    });
+
+        let updatedCart: ResultCart | null = null;
+        try {
+          //Ensure that the cart version matches the value passed in from FE
+          await this.cartManager.fetchAndValidateCartVersion(cartId, version);
+
+          await this.cartManager.setProcessingCart(cartId);
+
+          // Ensure we have a positive lock on the processing cart
+          updatedCart = await this.cartManager.fetchAndValidateCartVersion(
+            cartId,
+            version + 1
+          );
+        } catch (error) {
+          if (await this.isOwnedByAnotherCheckout(cartId, error)) {
+            throw new ConcurrentCartCheckoutError(cartId, error);
+          }
+          throw new UpdatePayPalProcessingCartError(cartId, error);
+        }
+
+        this.asyncLocalStorage.run(
+          { checkout: { subscriptionId: undefined } },
+          () => {
+            // Intentionally non-blocking
+            this.wrapWithCartCatch(cartId, { onCheckoutFail }, async () => {
+              await this.checkoutService.payWithPaypal(
+                updatedCart,
+                attribution,
+                requestArgs,
+                sessionUid,
+                token
+              );
+            }).catch((error) => {
+              handleException({
+                error,
+                className: 'CartService',
+                methodName: 'checkoutCartWithPaypal',
+                allowlist: [],
+                logger: this.log as Logger,
+                statsd: this.statsd,
+              });
+            });
+          }
+        );
+      });
   }
 
   @SanitizeExceptions()
@@ -816,6 +854,8 @@ export class CartService {
 
   /**
    * Update a cart in the database by ID or with an existing cart reference
+   * Do not fail a cart that another request is actively processing, since
+   * we may have already charged the customer.
    * **Note**: This method is currently a placeholder. The arguments will likely change, and the internal implementation is far from complete.
    */
   @SanitizeExceptions()
@@ -823,6 +863,11 @@ export class CartService {
     cartId: string,
     errorReasonId: CartErrorReasonId | string
   ): Promise<void> {
+    const cart = await this.cartManager.fetchCartById(cartId);
+    if (isCartActivelyProcessing(cart)) {
+      return;
+    }
+
     try {
       await this.cartManager.finishErrorCart(cartId, {
         errorReasonId,

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -352,6 +352,10 @@ export class CheckoutService {
       });
     }
 
+    // TODO: uncomment to test, remove after testing
+    //console.log('postPaySteps: about to finish cart, sleeping, START TAB 2')
+    //await new Promise((r) => setTimeout(r, 5_000));
+
     await this.cartManager.finishCart(cart.id, version, {});
 
     if (args.isCancelInterstitialOffer && args.requestArgs) {


### PR DESCRIPTION
## Because

* When a customer checks out with PayPal in tab 1 and then sends a second request from tab 2 while the first cart is almost done processing, they end up charged by the first tab while the second tab's stale cart version throws and transitions the cart into FAIL for both tabs. The customer sees the error page, tries to subscribe again, and finds they are already subscribed to the product.

## This pull request

* Checks if the cart is already processing, and, if it is, prevents a second request from failing a cart that another request is actively processing, so the owning request finishes rather than both tabs erroring out.

## Issue that this pull request solves

Closes #[PAY-3664](https://mozilla-hub.atlassian.net/browse/PAY-3664)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally. 
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review

STRs and screen recordings:
Using the current console logs and timeouts (I'll remove them before merging):
1. Make an account, go to checkout, call this Tab 1.
2. Open new tab (Tab 2), copy Tab 1's url (make sure cart IDs are the same).
3. Open PayPal popups + log in to PayPal on both tabs at the same time.
4. On Tab 1, proceed to checkout with PayPal, wait until you see the log "postPaySteps: about to finish cart, sleeping, START TAB 2"
5. Quickly proceed to pay with PayPal in Tab 2.
6. When both tabs fail, notice that a subscription was made.
What happens: Tab 1 charges --> Tab 2 arrives with stale cart version --> Tab 2 puts cart in FAIL --> Tab 1's finishCart fails → both tabs see an error, but the customer is subscribed.
Video attached:

https://github.com/user-attachments/assets/29332632-5d35-486a-be0f-97f975328629


After the fix, instead of both tabs failing in step 6, they succeed:

https://github.com/user-attachments/assets/33ad9331-87eb-43a0-b3ce-72d956e9c399


- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3664]: https://mozilla-hub.atlassian.net/browse/PAY-3664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ