### PR TITLE
fix(functional-test): Update signup button to not use CMS managed string

### DIFF
--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -20,7 +20,9 @@ export class SignupPage extends BaseLayout {
   }
 
   get submitButton() {
-    return this.page.getByRole('button', { name: 'Sign up or sign in' });
+    return this.page
+      .getByRole('button')
+      .and(this.page.locator('button[type="submit"]'));
   }
 
   get signupFormHeading() {


### PR DESCRIPTION
Because:
 - The signup submit button locator uses a string that is CMS managed and it can fail if that changes

This Commit:
 - Changes the locator to remove the name paramater, keeps the getByRole for implicit ARIA checks, then `.and` to ensure we only get the submit button

Closes: FXA-13915

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
