### PR TITLE
bug(shared): Treat duplicate email bounce inserts as idempotent

### DIFF
--- a/packages/fxa-shared/db/models/auth/email-bounce.ts
+++ b/packages/fxa-shared/db/models/auth/email-bounce.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { EmailType } from '.';
-import { convertError } from '../../mysql';
+import { convertError, MysqlErrors } from '../../mysql';
 import { BaseAuthModel, Proc } from './base-auth';
 import * as Sentry from '@sentry/node';
 
@@ -70,6 +70,10 @@ export class EmailBounce extends BaseAuthModel {
         (diagnosticCode ?? '').substring(0, 255)
       );
     } catch (e: any) {
+      // SQS delivered the same bounce twice; the row exists, so this is a no-op.
+      if (e?.errno === MysqlErrors.ER_DUP_ENTRY) {
+        return;
+      }
       Sentry.captureException(e);
       throw convertError(e);
     }


### PR DESCRIPTION
Because:
 - Duplicate SES bounce notifications (SQS is at-least-once delivery) collide on the emailBounces (email, createdAt) primary key, causing false errors to report to Sentry

This commit:
 - Swallows `ER_DUP_ENTRY` in EmailBounce.create since the row already exists.

Closes: FXA-13898

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
