### PR TITLE
fix(payments-next): Update Cancel Subscription and Resubscribe links in subscription email footer

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.spec.ts
@@ -4515,6 +4515,7 @@ describe('StripeHelper', () => {
       const expected: any = {
         uid,
         email,
+        subscriptionId: 'sub_GyHjvuW3xOeaZS',
         cardType: 'visa',
         creditAppliedInCents: 0,
         lastFour: '5309',
@@ -4556,6 +4557,7 @@ describe('StripeHelper', () => {
 
       const expectedDiscount_foreverCoupon: any = {
         ...expected,
+        subscriptionId: 'sub_1KEJVVBVqmGyQTMakN6U7sPU',
         invoiceAmountDueInCents: 450,
         invoiceNumber: '3432720C-0001',
         invoiceTotalInCents: 450,
@@ -5039,6 +5041,7 @@ describe('StripeHelper', () => {
     const expectedBaseUpdateDetails: any = {
       uid,
       email,
+      subscriptionId: eventCustomerSubscriptionUpdated.data.object.id,
       planId,
       productId,
       productIdNew: productId,
@@ -5587,6 +5590,7 @@ describe('StripeHelper', () => {
         updateType: SUBSCRIPTION_UPDATE_TYPES.REACTIVATION,
         email,
         uid,
+        subscriptionId: eventCustomerSubscriptionUpdated.data.object.id,
         productId,
         planId,
         planConfig: {},
@@ -5844,6 +5848,7 @@ describe('StripeHelper', () => {
           updateType: SUBSCRIPTION_UPDATE_TYPES.CANCELLATION,
           email,
           uid,
+          subscriptionId: subscription.id,
           productId,
           planId,
           planConfig: {},
@@ -5878,6 +5883,7 @@ describe('StripeHelper', () => {
           updateType: SUBSCRIPTION_UPDATE_TYPES.CANCELLATION,
           email,
           uid,
+          subscriptionId: subscription.id,
           productId,
           planId,
           planConfig: {},
@@ -5915,6 +5921,7 @@ describe('StripeHelper', () => {
           updateType: SUBSCRIPTION_UPDATE_TYPES.CANCELLATION,
           email,
           uid,
+          subscriptionId: subscription.id,
           productId,
           planId,
           planConfig: {},

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -105,6 +105,7 @@ export const SUBSCRIPTION_UPDATE_TYPES = {
 };
 
 export type FormattedSubscriptionForEmail = {
+  subscriptionId: string;
   productId: string;
   productName: string;
   planId: string;
@@ -2046,6 +2047,10 @@ export class StripeHelper extends StripeHelperBase {
     return {
       uid,
       email,
+      subscriptionId:
+        typeof invoice.subscription === 'string'
+          ? invoice.subscription
+          : invoice.subscription?.id,
       cardType,
       lastFour,
       payment_provider,
@@ -2116,6 +2121,7 @@ export class StripeHelper extends StripeHelperBase {
     const planSuccessActionButtonURL = successActionButtonURL || '';
 
     return {
+      subscriptionId: subscription.id,
       productId,
       productName,
       planId,
@@ -2389,6 +2395,7 @@ export class StripeHelper extends StripeHelperBase {
     const baseDetails = {
       uid,
       email,
+      subscriptionId: subscription.id,
       planId: planIdNew,
       productId: productIdNew,
       productIdNew,
@@ -2504,6 +2511,7 @@ export class StripeHelper extends StripeHelperBase {
       updateType: SUBSCRIPTION_UPDATE_TYPES.CANCELLATION,
       email,
       uid,
+      subscriptionId: subscription.id,
       productId,
       planId,
       planEmailIconURL,
@@ -2560,6 +2568,7 @@ export class StripeHelper extends StripeHelperBase {
       updateType: SUBSCRIPTION_UPDATE_TYPES.REACTIVATION,
       email,
       uid,
+      subscriptionId: subscription.id,
       productId,
       planId,
       planEmailIconURL,

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -4185,8 +4185,25 @@ module.exports = function (log, config, bounces, statsd) {
         'subscription-privacy'
       )
     );
+
+    const subscriptionId =
+      message.subscriptionId ??
+      message.subscription?.subscriptionId ??
+      (message.subscriptions?.length === 1
+        ? message.subscriptions[0]?.subscriptionId
+        : undefined);
+    const subscriptionPageUrl = (path) => {
+      if (!subscriptionId) {
+        return this.subscriptionSettingsUrl;
+      }
+      const base = this.subscriptionSettingsUrl.endsWith('/')
+        ? this.subscriptionSettingsUrl
+        : `${this.subscriptionSettingsUrl}/`;
+      return new URL(`subscriptions/${subscriptionId}/${path}`, base).href;
+    };
+
     links.cancelSubscriptionUrl = this._generateUTMLink(
-      this.subscriptionSettingsUrl,
+      subscriptionPageUrl('cancel'),
       { ...query, email, uid },
       templateName,
       'cancel-subscription'
@@ -4198,7 +4215,7 @@ module.exports = function (log, config, bounces, statsd) {
       'manage-subscription'
     );
     links.reactivateSubscriptionUrl = this._generateUTMLink(
-      this.subscriptionSettingsUrl,
+      subscriptionPageUrl('stay-subscribed'),
       { ...query, email, uid },
       templateName,
       'reactivate-subscription'


### PR DESCRIPTION
## Because

* Currently, the “Cancel subscription” or “Resubscribe” links in the footer of subscription emails navigate the customer to their Subscription Management page.

## This pull request

* Updates the emails to have the links go to the appropriate cancel or stay-subscribed pages.
* Does not update storybooks, because it needs a hard-coded sub id which creates an invalid URL.

## Issue that this pull request solves

Closes #[PAY-3441](https://mozilla-hub.atlassian.net/browse/PAY-3441)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)


https://github.com/user-attachments/assets/e4cead61-69d1-4cb8-8e50-bdfd5b7f42f7



## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3441]: https://mozilla-hub.atlassian.net/browse/PAY-3441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ