### PR TITLE
fix(ci): install python3-venv before recreating glean_parser venv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,10 @@ commands:
       - run:
           name: Recreate venv with glean_parser 19
           command: |
+            # Img doesn't ship with venv; only install if missing.
+            if ! python3 -c "import ensurepip" 2>/dev/null; then
+              sudo apt-get update && sudo apt-get install -y python3-venv
+            fi
             rm -rf .venv
             python3 -m venv .venv
             .venv/bin/pip install 'glean_parser~=19.0'


### PR DESCRIPTION
Because:

 - The nightly Create FxA Image job fails at the glean_parser venv step with "ensurepip is not available". It is the only job on the stock cimg/node image, which the Node 24 bump moved to cimg/node:24.15.0 (Ubuntu 24.04 / Python 3.12), shipping python3 without the venv module.

This commit:

 - Installs python3-venv in the provision step when missing, mirroring what the CI Dockerfile already does for the custom images.

Closes: FXA-13862

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
