### PR TITLE
fix(settings): skip redundant set-password account-status check

### DIFF
--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
@@ -5,6 +5,7 @@
 import * as ModelsModule from '../../../models';
 import * as CacheModule from '../../../lib/cache';
 import * as SetPasswordModule from '.';
+import { StoredAccountData } from '../../../lib/storage-utils';
 
 import AuthClient from 'fxa-auth-client/browser';
 import {
@@ -106,7 +107,7 @@ function mockModelsModule() {
 }
 // Call this when testing local storage
 function mockCurrentAccount(
-  storedAccount = {
+  storedAccount: StoredAccountData = {
     uid: MOCK_UID,
     sessionToken: MOCK_SESSION_TOKEN,
     email: MOCK_EMAIL,
@@ -236,6 +237,52 @@ describe('SetPassword-container', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/signin', { replace: true });
     });
     expect(SetPasswordModule.default).not.toHaveBeenCalled();
+  });
+
+  describe('password state gating', () => {
+    it('skips the check and renders when stored state is passwordless', async () => {
+      mockCurrentAccount({ ...MOCK_STORED_ACCOUNT, hasPassword: false });
+      render();
+      await waitFor(() => {
+        expect(SetPasswordModule.default).toHaveBeenCalled();
+      });
+      expect(mockAuthClient.accountStatus).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('skips the check and redirects to signin when stored state has a password', async () => {
+      mockCurrentAccount({ ...MOCK_STORED_ACCOUNT, hasPassword: true });
+      render();
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/signin', { replace: true });
+      });
+      expect(mockAuthClient.accountStatus).not.toHaveBeenCalled();
+      expect(SetPasswordModule.default).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the accountStatus check when stored state is unknown', async () => {
+      mockCurrentAccount({ ...MOCK_STORED_ACCOUNT, hasPassword: undefined });
+      render();
+      await waitFor(() => {
+        expect(SetPasswordModule.default).toHaveBeenCalled();
+      });
+      expect(mockAuthClient.accountStatus).toHaveBeenCalledWith(
+        undefined,
+        MOCK_SESSION_TOKEN
+      );
+    });
+
+    it('treats a failed fallback check as no password and renders', async () => {
+      mockCurrentAccount({ ...MOCK_STORED_ACCOUNT, hasPassword: undefined });
+      mockAuthClient.accountStatus = jest
+        .fn()
+        .mockRejectedValue(new Error('network failure'));
+      render();
+      await waitFor(() => {
+        expect(SetPasswordModule.default).toHaveBeenCalled();
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
   describe('calling createPassword', () => {

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -67,45 +67,33 @@ const SetPasswordContainer = ({
     flowQueryParams as unknown as Record<string, string>
   );
 
+  // Trust the stored password state; fall back to a one-time accountStatus
+  // check only when it's unknown (e.g. third-party sign-in, stale/direct hit).
+  const knownHasPassword = storedLocalAccount?.hasPassword;
+  const passwordStateKnown = knownHasPassword !== undefined;
+
   const [passwordStatus, setPasswordStatus] = useState<{
     isLoading: boolean;
     hasPassword: boolean;
   }>({
-    isLoading: true,
-    hasPassword: false,
+    isLoading: !passwordStateKnown,
+    hasPassword: knownHasPassword ?? false,
   });
-  const didRunPasswordStatusCheckRef = useRef(false);
+  const didCheckRef = useRef(false);
   useEffect(() => {
-    if (didRunPasswordStatusCheckRef.current) return;
-    didRunPasswordStatusCheckRef.current = true;
-    const checkPasswordStatus = async () => {
-      if (sessionToken) {
-        try {
-          const status = await authClient.accountStatus(
-            undefined,
-            sessionToken
-          );
-          setPasswordStatus({
-            isLoading: false,
-            hasPassword: !!status.hasPassword,
-          });
-        } catch (error) {
-          // TODO? Might need to retry.
-          // Request to create a PW won't go through if they already have one.
-          setPasswordStatus({
-            isLoading: false,
-            hasPassword: false,
-          });
-        }
-      } else {
+    if (passwordStateKnown || !sessionToken || didCheckRef.current) return;
+    didCheckRef.current = true;
+    authClient
+      .accountStatus(undefined, sessionToken)
+      .then((status) =>
         setPasswordStatus({
           isLoading: false,
-          hasPassword: false,
-        });
-      }
-    };
-    checkPasswordStatus();
-  }, [authClient, sessionToken]);
+          hasPassword: !!status.hasPassword,
+        })
+      )
+      // On failure, treat as no password; the server rejects if one exists.
+      .catch(() => setPasswordStatus({ isLoading: false, hasPassword: false }));
+  }, [authClient, sessionToken, passwordStateKnown]);
 
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,
@@ -234,10 +222,7 @@ const SetPasswordContainer = ({
     return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
-  // User already has a password, redirect to signin.
-  // This can happen when a user signs into the browser with third party
-  // oauth and they try to use Sync or Send Tab later, but keys are missing.
-  // Firefox will send users to this page to set a password and receive keys.
+  // Already has a password (re-entry): sign in instead.
   if (passwordStatus.hasPassword) {
     navigateWithQuery('/signin', { replace: true });
     return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -258,6 +258,7 @@ const SigninPasswordlessCode = ({
         // Update verification status of stored current account
         verified: isSessionVerified,
         sessionVerified: isSessionVerified,
+        hasPassword: false,
       });
 
       const navigationOptions = {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -37,6 +37,7 @@ import { navigate } from '@reach/router';
 import { OAUTH_ERRORS } from '../../../lib/oauth';
 import userEvent from '@testing-library/user-event';
 import * as SigninUtils from '../utils';
+import * as StorageUtils from '../../../lib/storage-utils';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -411,6 +412,36 @@ describe('Sign in with TOTP code page', () => {
           screen.getByText('Sorry, there was a problem signing you out')
         ).toBeInTheDocument();
         expect(mockNavigateWithQuery).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('recording password state for set-password', () => {
+    it('records hasPassword: false on a passwordless OTP sign-in', async () => {
+      const user = userEvent.setup();
+      jest.spyOn(SigninUtils, 'handleNavigation').mockResolvedValue({
+        error: undefined,
+      });
+      const storeAccountDataSpy = jest
+        .spyOn(StorageUtils, 'storeAccountData')
+        .mockImplementation(() => {});
+      const submitTotpCode = jest.fn().mockResolvedValue({ error: undefined });
+      renderWithLocalizationProvider(
+        <Subject
+          submitTotpCode={submitTotpCode}
+          signinState={{
+            ...MOCK_TOTP_LOCATION_STATE,
+            isPasswordlessOtpSignin: true,
+          }}
+        />
+      );
+      await user.type(screen.getByLabelText('Enter 6-digit code'), '123456');
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(storeAccountDataSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ hasPassword: false })
+        );
       });
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -132,6 +132,7 @@ export const SigninTotpCode = ({
         // Update verification status of stored current account
         verified: true,
         sessionVerified: true,
+        ...(signinState.isPasswordlessOtpSignin && { hasPassword: false }),
       });
 
       // Passwordless Sync flow: after TOTP, redirect to set_password

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -16,6 +16,7 @@ import {
   createMockSigninOAuthNativeSyncIntegration,
   createMockSigninOAuthNativeIntegration,
   createMockSigninOAuthIntegration,
+  createMockSigninWebIntegration,
 } from './mocks';
 import {
   handleNavigation,
@@ -135,6 +136,47 @@ describe('Signin utils', () => {
       expect(navigateSpy).toHaveBeenCalledWith('/settings');
       expect(hardNavigateSpy).not.toHaveBeenCalled();
       expect(fxaLoginSpy).not.toHaveBeenCalled();
+    });
+
+    it('replaces history on a set-password completion so Back cannot return to it', async () => {
+      const navigationOptions = createBaseNavigationOptions({
+        integration: {
+          ...createMockSigninWebIntegration(),
+          isSync: () => true,
+        },
+        queryParams: '?service=sync',
+        showSignupConfirmedSync: true,
+        origin: 'post-verify-set-password',
+        performNavigation: true,
+        handleFxaLogin: true,
+      });
+
+      await handleNavigation(navigationOptions);
+
+      expect(navigateSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/signup_confirmed_sync'),
+        expect.objectContaining({ replace: true })
+      );
+    });
+
+    it('does not replace history for a Sync sign-in that is not a set-password completion', async () => {
+      const navigationOptions = createBaseNavigationOptions({
+        integration: {
+          ...createMockSigninWebIntegration(),
+          isSync: () => true,
+        },
+        queryParams: '?service=sync',
+        showSignupConfirmedSync: true,
+        performNavigation: true,
+        handleFxaLogin: true,
+      });
+
+      await handleNavigation(navigationOptions);
+
+      expect(navigateSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/signup_confirmed_sync'),
+        expect.objectContaining({ replace: false })
+      );
     });
 
     describe('unverified session navigation', () => {

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -355,7 +355,12 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
     if (navigationOptions.performNavigation !== false) {
       const { to, locationState, shouldHardNavigate } =
         await getNonOAuthNavigationTarget(navigationOptions);
-      performNavigation({ to, locationState, shouldHardNavigate });
+      performNavigation({
+        to,
+        locationState,
+        shouldHardNavigate,
+        replace: navigationOptions.origin === 'post-verify-set-password',
+      });
     }
     return { error: undefined };
   }


### PR DESCRIPTION
## Because

- The post-verify set-password page blocked first paint on a blocking `accountStatus` round-trip, which intermittently exceeded the stage smoke test's 10s assertion and flaked `passkeySetPassword.spec.ts`.
- Every in-app flow that routes to this page (passkey, OTP, third-party) does so only for passwordless accounts, so re-deriving the password state with a network call is redundant.

## This pull request

- Gates the `accountStatus` check on router state in `packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx`: when the page is reached via a forward flow (`location.state.passwordCreationReason` is set), it paints immediately without the round-trip.
- Keeps the check for stateless arrivals (refresh / direct URL / back), where a password may already exist and a redirect to `/signin` is still wanted.
- Simplifies the check effect to a flat `then`/`catch`, resolves the stale retry TODO, and corrects the inaccurate "third-party may have a password" comment.
- Adds container tests covering the gating: skip when state-routed, run on stateless arrival, and fail open when the check errors.

## Issue that this pull request solves

Closes: FXA-13937

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Known pre-existing limitation (out of scope): on a stateless arrival where the `accountStatus` check itself fails *and* the account already has a password, the page falls through to the form and `/password/create` rejects server-side with a "password already set" banner instead of redirecting to `/signin`. This requires a rare triple-coincidence and is a candidate for a follow-up.
