### PR TITLE
fix(passkeys): send new-device login email and notifications on passkey sign-in

### DIFF
--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -17,6 +17,7 @@ import { SettingsPage } from '../../pages/settings';
 import { SettingsPasskeyAddPage } from '../../pages/settings/passkey';
 import { SigninPage } from '../../pages/signin';
 import { enableTotpOnAccount } from '../../lib/pairing-helpers';
+import { EmailType } from '../../lib/email';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('passkey sign-in', () => {
@@ -35,7 +36,7 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, settings, settingsPasskeyAdd, signin },
       testAccountTracker,
     }) => {
-      await setUpAccountWithPasskey({
+      const { email } = await setUpAccountWithPasskey({
         target,
         page,
         settings,
@@ -44,6 +45,8 @@ test.describe('severity-1 #smoke', () => {
         testAccountTracker,
       });
       await clearSession(page);
+      // Isolate the sign-in email from setup emails.
+      await target.emailClient.clear(email);
       await page.goto(target.contentServerUrl);
 
       await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
@@ -52,6 +55,14 @@ test.describe('severity-1 #smoke', () => {
       });
 
       await expect(settings.settingsHeading).toBeVisible();
+
+      const newDeviceLogin = await target.emailClient.waitForEmail(
+        email,
+        EmailType.newDeviceLogin
+      );
+      expect(newDeviceLogin.subject).toMatch(
+        /new sign-in to your mozilla account/i
+      );
     });
 
     test('signs in with a registered passkey from /signin after submitting an email', async ({

--- a/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
@@ -12,6 +12,7 @@ import { FirefoxCommand } from '../../lib/channels';
 import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
 import { enableTotpOnAccount } from '../../lib/pairing-helpers';
 import { OLDSYNC_SCOPE } from '../../lib/scopes';
+import { EmailType } from '../../lib/email';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Sync passkey signin with password fallback', () => {
@@ -55,6 +56,8 @@ test.describe('severity-1 #smoke', () => {
 
       // The polyfill credential survives signOut via page.addInitScript.
       await settings.signOut();
+      // Isolate the sign-in email from setup emails.
+      await target.emailClient.clear(email);
 
       // Returning user picks passkey; service=sync routes to the fallback.
       await signin.goto('/authorization', syncDesktopOAuthQueryParams);
@@ -75,6 +78,14 @@ test.describe('severity-1 #smoke', () => {
       await signin.checkWebChannelMessageScope(
         FirefoxCommand.OAuthLogin,
         OLDSYNC_SCOPE
+      );
+
+      const newDeviceLogin = await target.emailClient.waitForEmail(
+        email,
+        EmailType.newDeviceLogin
+      );
+      expect(newDeviceLogin.subject).toMatch(
+        /new sign-in to your mozilla account/i
       );
     });
 

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -3607,17 +3607,21 @@ export default class AuthClient {
   async completePasskeyAuthentication(
     response: PublicKeyCredentialJSON,
     challenge: string,
-    options: { service?: string } = {},
+    options: { service?: string; metricsContext?: MetricsContext } = {},
     headers?: Headers
   ): Promise<PasskeyAuthenticationResult> {
     const payload: {
       response: PublicKeyCredentialJSON;
       challenge: string;
       service?: string;
+      metricsContext?: MetricsContext;
     } = {
       response,
       challenge,
       ...(options.service ? { service: options.service } : {}),
+      ...(options.metricsContext
+        ? { metricsContext: options.metricsContext }
+        : {}),
     };
 
     return this.request(

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -242,7 +242,15 @@ module.exports = function (
   const mfa = mfaRoutes(customs, db, log, mailer, statsd, config);
 
   const { passkeyRoutes } = require('./passkeys');
-  const passkeys = passkeyRoutes(customs, db, config, statsd, glean, log);
+  const passkeys = passkeyRoutes(
+    customs,
+    db,
+    config,
+    statsd,
+    glean,
+    log,
+    mailer
+  );
 
   const { passwordlessRoutes } = require('./passwordless');
   const passwordless = passwordlessRoutes(

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../passkey-utils';
 import { passkeyRoutes, PasskeyHandler } from './passkeys';
 import { FxaMailer } from '../senders/fxa-mailer';
+import { OAuthClientInfoServiceName } from '../senders/oauth_client_info';
 
 jest.mock('./utils/security-event', () => ({
   recordSecurityEvent: jest.fn(),
@@ -42,7 +43,9 @@ describe('passkeys routes', () => {
     route: any,
     request: any,
     mockPasskeyService: any,
-    mockFxaMailer: any;
+    mockFxaMailer: any,
+    mailer: any,
+    mockOauthClientInfoService: any;
 
   const UID = 'f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6';
   const SESSION_TOKEN_ID = 'session-token-456';
@@ -97,12 +100,20 @@ describe('passkeys routes', () => {
     requestOptions: any,
     method = 'POST'
   ) {
-    routes = passkeyRoutes(customs, db, config, statsd, glean, log);
+    routes = passkeyRoutes(customs, db, config, statsd, glean, log, mailer);
     route = routes.find((r) => r.path === routePath && r.method === method);
     request = {
+      headers: { 'user-agent': 'test-agent' },
       ...requestOptions,
+      app: {
+        acceptLanguage: 'en',
+        clientAddress: '127.0.0.1',
+        geo: { location: { country: 'United States', countryCode: 'US' } },
+        ...requestOptions.app,
+      },
     };
     request.emitMetricsEvent = jest.fn(() => Promise.resolve({}));
+    request.setMetricsFlowCompleteSignal = jest.fn();
     return await route.handler(request);
   }
 
@@ -110,6 +121,8 @@ describe('passkeys routes', () => {
     log = {
       begin: jest.fn(),
       error: jest.fn(),
+      trace: jest.fn(),
+      notifyAttachedServices: jest.fn().mockResolvedValue(undefined),
     };
     customs = {
       checkAuthenticated: jest.fn(),
@@ -130,16 +143,20 @@ describe('passkeys routes', () => {
     };
     db = {
       account: jest.fn().mockResolvedValue({
+        uid: UID,
         email: TEST_EMAIL,
         emailCode: 'emailcode123',
         emailVerified: true,
         verifierSetAt: 1234567890,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
+        emails: [{ email: TEST_EMAIL, isPrimary: true, isVerified: true }],
       }),
       createPasskeyVerifiedSessionToken: jest.fn().mockResolvedValue({
         id: 'new-session-token-id',
         data: 'new-session-token-data',
       }),
       securityEvent: jest.fn().mockResolvedValue(undefined),
+      sessions: jest.fn().mockResolvedValue([{ id: 'session-1' }]),
     };
 
     mockPasskeyService = {
@@ -165,10 +182,20 @@ describe('passkeys routes', () => {
       canSend: jest.fn().mockReturnValue(true),
       sendPostAddPasskeyEmail: jest.fn().mockResolvedValue(undefined),
       sendPostRemovePasskeyEmail: jest.fn().mockResolvedValue(undefined),
+      sendNewDeviceLoginEmail: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mailer = {
+      sendNewDeviceLoginEmail: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockOauthClientInfoService = {
+      fetch: jest.fn().mockResolvedValue({ name: 'Mozilla' }),
     };
 
     Container.set(PasskeyService, mockPasskeyService);
     Container.set(FxaMailer, mockFxaMailer);
+    Container.set(OAuthClientInfoServiceName, mockOauthClientInfoService);
   });
 
   afterEach(() => {
@@ -1067,10 +1094,13 @@ describe('passkeys routes', () => {
 
     it('sets hasPassword false for passwordless accounts', async () => {
       db.account.mockResolvedValueOnce({
+        uid: UID,
         email: TEST_EMAIL,
         emailCode: 'emailcode123',
         emailVerified: true,
         verifierSetAt: 0,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
+        emails: [{ email: TEST_EMAIL, isPrimary: true, isVerified: true }],
       });
 
       const result = await runTest('/passkey/authentication/finish', {
@@ -1280,6 +1310,178 @@ describe('passkeys routes', () => {
         })
       ).rejects.toBe(customsError);
     });
+
+    describe('post sign-in notifications', () => {
+      it('sends a generic "Mozilla account" email for a non-OAuth sign-in (no service)', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        });
+
+        expect(mockOauthClientInfoService.fetch).toHaveBeenCalledWith(
+          undefined
+        );
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledWith(
+          expect.objectContaining({
+            clientName: 'Mozilla',
+            showBannerWarning: false,
+          })
+        );
+        expect(mailer.sendNewDeviceLoginEmail).not.toHaveBeenCalled();
+      });
+
+      it('shows the relying-party name for a non-sync OAuth sign-in', async () => {
+        mockOauthClientInfoService.fetch.mockResolvedValue({
+          name: 'Firefox Monitor',
+        });
+
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload: { ...payload, service: 'dcdb5ae7add825d2' },
+        });
+
+        expect(mockOauthClientInfoService.fetch).toHaveBeenCalledWith(
+          'dcdb5ae7add825d2'
+        );
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledWith(
+          expect.objectContaining({ clientName: 'Firefox Monitor' })
+        );
+      });
+
+      it('forces the generic "Mozilla account" email for a sync sign-in (no Firefox/Sync framing before keys)', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload: { ...payload, service: 'sync' },
+        });
+
+        expect(mockOauthClientInfoService.fetch).toHaveBeenCalledWith(
+          undefined
+        );
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledWith(
+          expect.objectContaining({ clientName: 'Mozilla' })
+        );
+      });
+
+      it('falls back to the legacy mailer when fxaMailer cannot send newDeviceLogin', async () => {
+        mockFxaMailer.canSend.mockReturnValue(false);
+
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        });
+
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).not.toHaveBeenCalled();
+        expect(mailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
+        expect(mailer.sendNewDeviceLoginEmail).toHaveBeenCalledWith(
+          [{ email: TEST_EMAIL, isPrimary: true, isVerified: true }],
+          expect.objectContaining({ uid: UID }),
+          expect.objectContaining({ uid: UID })
+        );
+      });
+
+      it('does not reject the sign-in when the email send fails', async () => {
+        mockFxaMailer.sendNewDeviceLoginEmail.mockRejectedValue(
+          new Error('smtp down')
+        );
+
+        const result = await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        });
+
+        expect(result.uid).toBe(UID);
+        expect(log.trace).toHaveBeenCalledWith(
+          'passkeys.authenticationFinish.sendNewDeviceLoginEmail.error',
+          { error: expect.any(Error) }
+        );
+        expect(log.notifyAttachedServices).toHaveBeenCalledTimes(1);
+      });
+
+      it('notifies attached services of the login', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        });
+
+        expect(log.notifyAttachedServices).toHaveBeenCalledWith(
+          'login',
+          expect.anything(),
+          {
+            country: 'United States',
+            countryCode: 'US',
+            deviceCount: 1,
+            email: TEST_EMAIL,
+            service: undefined,
+            uid: UID,
+            userAgent: 'test-agent',
+          }
+        );
+      });
+
+      it('emits the account.login metrics event and flow signal for a non-sync sign-in', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        });
+
+        expect(request.emitMetricsEvent).toHaveBeenCalledWith('account.login', {
+          uid: UID,
+        });
+        expect(request.setMetricsFlowCompleteSignal).toHaveBeenCalledWith(
+          'account.login',
+          'login'
+        );
+      });
+
+      it('records the account.login security event for a non-sync sign-in', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        });
+
+        expect(recordSecurityEvent).toHaveBeenCalledWith(
+          'account.login',
+          expect.objectContaining({ account: { uid: UID } })
+        );
+      });
+
+      it('does not emit the account.login metrics event for a sync sign-in', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload: { ...payload, service: 'sync' },
+        });
+
+        expect(request.emitMetricsEvent).not.toHaveBeenCalledWith(
+          'account.login',
+          expect.anything()
+        );
+        expect(request.setMetricsFlowCompleteSignal).not.toHaveBeenCalled();
+      });
+
+      it('does not record the account.login security event for a sync sign-in', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload: { ...payload, service: 'sync' },
+        });
+
+        expect(recordSecurityEvent).not.toHaveBeenCalledWith(
+          'account.login',
+          expect.anything()
+        );
+      });
+    });
   });
 
   describe('PasskeyHandler.createPasskeySessionToken', () => {
@@ -1314,7 +1516,9 @@ describe('passkeys routes', () => {
         log,
         mockFxaMailer,
         statsd,
-        glean
+        glean,
+        mailer,
+        mockOauthClientInfoService
       );
     });
 

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -5,8 +5,10 @@
 import * as isA from 'joi';
 import { Container } from 'typedi';
 import { PasskeyService } from '@fxa/accounts/passkey';
-import { AuthRequest } from '../types';
+import { AuthClientInfoService, AuthRequest } from '../types';
 import { recordSecurityEvent } from './utils/security-event';
+import { notifyAttachedServicesForAccountSession } from './utils/account';
+import { schema as METRICS_CONTEXT_SCHEMA } from '../metrics/context';
 import { ConfigType } from '../../config';
 import {
   isPasskeyFeatureEnabled,
@@ -22,6 +24,7 @@ import {
 } from '@simplewebauthn/server';
 import { FxaMailer } from '../senders/fxa-mailer';
 import { FxaMailerFormat } from '../senders/fxa-mailer-format';
+import { OAuthClientInfoServiceName } from '../senders/oauth_client_info';
 import { reportSentryError } from '../sentry';
 
 /** Subset of the Customs service used by passkey routes. */
@@ -47,11 +50,16 @@ interface Customs {
 interface DB {
   /** Fetches the account record for the given UID. */
   account(uid: string): Promise<{
+    uid: string;
     email: string;
     emailCode: string;
     emailVerified: boolean;
     verifierSetAt: number;
+    locale?: string;
+    primaryEmail: { email: string; isVerified: boolean };
+    emails: Array<{ email: string; isPrimary: boolean; isVerified: boolean }>;
   }>;
+  sessions(uid: string): Promise<unknown[]>;
   /** Creates a passkey session token, pre-verified as AAL2 at creation time. */
   createPasskeyVerifiedSessionToken(options: {
     uid: string;
@@ -88,7 +96,9 @@ export class PasskeyHandler {
     private readonly log: any,
     private readonly fxaMailer: FxaMailer,
     private readonly statsd: any,
-    private readonly glean: GleanMetricsType
+    private readonly glean: GleanMetricsType,
+    private readonly mailer: any,
+    private readonly oauthClientInfoService: AuthClientInfoService
   ) {}
 
   /**
@@ -428,6 +438,14 @@ export class PasskeyHandler {
     this.glean.login.complete(request, { uid, reason: 'passkey' });
 
     const requiresPasswordForSync = service === 'sync';
+
+    await this.sendPostSigninNotifications(
+      request,
+      account,
+      service,
+      requiresPasswordForSync
+    );
+
     const hasPassword = account.verifierSetAt > 0;
 
     return {
@@ -437,6 +455,93 @@ export class PasskeyHandler {
       requiresPasswordForSync,
       hasPassword,
     };
+  }
+
+  async sendPostSigninNotifications(
+    request: AuthRequest,
+    account: {
+      uid: string;
+      email: string;
+      emails: any[];
+      primaryEmail: { email: string };
+      locale?: string;
+    },
+    service: string | undefined,
+    requiresPasswordForSync: boolean
+  ) {
+    // Drop the service for Sync so the subject stays generic — keys aren't
+    // retrieved yet, so Firefox/Sync framing would be premature.
+    const emailService = requiresPasswordForSync ? undefined : service;
+    try {
+      const geoData = request.app.geo;
+      if (this.fxaMailer.canSend('newDeviceLogin')) {
+        const clientInfo =
+          await this.oauthClientInfoService.fetch(emailService);
+        await this.fxaMailer.sendNewDeviceLoginEmail({
+          ...FxaMailerFormat.account(account),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.sync(false),
+          clientName: clientInfo.name,
+          showBannerWarning: false,
+        });
+      } else {
+        await this.mailer.sendNewDeviceLoginEmail(account.emails, account, {
+          acceptLanguage: request.app.acceptLanguage,
+          ip: request.app.clientAddress,
+          location: geoData.location,
+          service: emailService,
+          timeZone: geoData.timeZone,
+          uaBrowser: request.app.ua.browser,
+          uaBrowserVersion: request.app.ua.browserVersion,
+          uaOS: request.app.ua.os,
+          uaOSVersion: request.app.ua.osVersion,
+          uaDeviceType: request.app.ua.deviceType,
+          uid: account.uid,
+        });
+      }
+    } catch (err) {
+      this.log.trace(
+        'passkeys.authenticationFinish.sendNewDeviceLoginEmail.error',
+        { error: err }
+      );
+    }
+
+    try {
+      const deviceCount = (await this.db.sessions(account.uid)).length;
+      await notifyAttachedServicesForAccountSession({
+        log: this.log,
+        request,
+        account: {
+          uid: account.uid,
+          email: account.primaryEmail.email,
+          locale: account.locale,
+        },
+        service,
+        deviceCount,
+        isNewAccount: false,
+        emailVerified: true,
+        profileChanged: false,
+      });
+
+      // Non-Sync only: the Sync flow's /session/reauth step already emits these.
+      if (!requiresPasswordForSync) {
+        await request.emitMetricsEvent('account.login', { uid: account.uid });
+        request.setMetricsFlowCompleteSignal('account.login', 'login');
+        await recordSecurityEvent('account.login', {
+          db: this.db,
+          request,
+          account: { uid: account.uid },
+        });
+      }
+    } catch (err) {
+      this.log.trace(
+        'passkeys.authenticationFinish.postSigninNotifications.error',
+        { error: err }
+      );
+    }
   }
 
   /**
@@ -498,7 +603,8 @@ export const passkeyRoutes = (
   config: ConfigType,
   statsd: any,
   glean: GleanMetricsType,
-  log: any
+  log: any,
+  mailer: any
 ) => {
   // Passkey route flag hierarchy:
   //   passkeys.enabled (master switch)  — gates management routes (list/delete/rename)
@@ -516,6 +622,9 @@ export const passkeyRoutes = (
     );
   }
   const fxaMailer = Container.get(FxaMailer);
+  const oauthClientInfoService = Container.get<AuthClientInfoService>(
+    OAuthClientInfoServiceName
+  );
   const handler = new PasskeyHandler(
     service,
     db,
@@ -523,7 +632,9 @@ export const passkeyRoutes = (
     log,
     fxaMailer,
     statsd,
-    glean
+    glean,
+    mailer,
+    oauthClientInfoService
   );
 
   return [
@@ -796,6 +907,7 @@ export const passkeyRoutes = (
               .regex(/^[A-Za-z0-9_-]+$/)
               .required(),
             service: validators.service.optional(),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
           }),
         },
         response: {

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -119,7 +119,9 @@ export interface AuthLogger extends Logger {
 }
 
 export interface AuthClientInfoService {
-  fetch(service: string): Promise<{
+  // `service` is optional: when absent (or falsy) the service resolves the
+  // generic "Mozilla" client, used for sign-ins that aren't tied to a client.
+  fetch(service?: string): Promise<{
     name: string;
   }>;
 }

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -137,7 +137,8 @@ const buildArgs = (
   const integration = {
     isSync: () => false,
     isFirefoxNonSync: () => false,
-    getService: () => 'service-id',
+    getService: () => undefined,
+    getClientId: () => 'service-id',
     type: IntegrationType.OAuthWeb,
     data: {},
     wantsTwoStepAuthentication: () => false,
@@ -210,7 +211,7 @@ describe('usePasskeySignIn', () => {
     expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
       MOCK_CREDENTIAL,
       CHALLENGE,
-      { service: 'service-id' }
+      { service: 'service-id', metricsContext: {} }
     );
     expect(spies.account).toHaveBeenCalledWith(SESSION_TOKEN);
     expect(handleNavigation).toHaveBeenCalledWith({
@@ -243,6 +244,31 @@ describe('usePasskeySignIn', () => {
     });
   });
 
+  it('forwards the Firefox service name (not the client id) for a Sync sign-in', async () => {
+    const { args, spies } = buildArgs({
+      integration: {
+        isSync: () => true,
+        isFirefoxNonSync: () => false,
+        getService: () => 'sync',
+        getClientId: () => 'client-id-should-not-be-used',
+        type: IntegrationType.OAuthNative,
+        data: {},
+        wantsTwoStepAuthentication: () => false,
+      } as unknown as PasskeySignInIntegration,
+    });
+
+    const { result } = renderHook(() => usePasskeySignIn(args));
+    await act(async () => {
+      await result.current.onClick();
+    });
+
+    expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
+      MOCK_CREDENTIAL,
+      CHALLENGE,
+      { service: 'sync', metricsContext: {} }
+    );
+  });
+
   it('routes non-OAuth Web integrations through handleNavigation', async () => {
     // Soft-navigate to /settings happens inside handleNavigation (same path
     // as password sign-in). hardNavigate would cause a cached-signin flash.
@@ -250,7 +276,8 @@ describe('usePasskeySignIn', () => {
       integration: {
         isSync: () => false,
         isFirefoxNonSync: () => false,
-        getService: () => 'service-id',
+        getService: () => undefined,
+        getClientId: () => 'service-id',
         type: IntegrationType.Web,
         data: {},
       } as unknown as PasskeySignInIntegration,
@@ -262,6 +289,11 @@ describe('usePasskeySignIn', () => {
       await result.current.onClick();
     });
 
+    expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
+      MOCK_CREDENTIAL,
+      CHALLENGE,
+      { metricsContext: {} }
+    );
     expect(storeAccountData).toHaveBeenCalled();
     expect(handleNavigation).toHaveBeenCalledWith({
       email: EMAIL,
@@ -751,7 +783,8 @@ describe('usePasskeySignIn', () => {
       const integration = {
         isSync: () => false,
         isFirefoxNonSync: () => false,
-        getService: () => 'service-id',
+        getService: () => undefined,
+        getClientId: () => 'service-id',
         type: IntegrationType.OAuthWeb,
         data: {},
         wantsTwoStepAuthentication: () => true,
@@ -837,7 +870,8 @@ describe('usePasskeySignIn', () => {
           integration: {
             isSync: () => false,
             isFirefoxNonSync: () => false,
-            getService: () => 'service-id',
+            getService: () => undefined,
+            getClientId: () => 'service-id',
             type: IntegrationType.OAuthWeb,
             data: {},
             wantsTwoStepAuthentication: () => false,

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -18,6 +18,9 @@ import {
   ensureCanLinkAcountOrRedirect,
   handleNavigation,
 } from '../../pages/Signin/utils';
+import { getEmailService } from '../../models/integrations/utils';
+import { queryParamsToMetricsContext } from '../metrics';
+import { searchParams } from '../utilities';
 import {
   getCredential,
   handleWebAuthnError,
@@ -277,11 +280,17 @@ export function usePasskeySignIn({
         throw err;
       }
 
-      const service = integration.getService();
+      const serviceForRequest = getEmailService(integration);
+      const metricsContext = queryParamsToMetricsContext(
+        searchParams(queryParams) as Record<string, string | undefined>
+      );
       const completion = await authClient.completePasskeyAuthentication(
         credential,
         challengeOptions.challenge,
-        service ? { service } : {}
+        {
+          ...(serviceForRequest ? { service: serviceForRequest } : {}),
+          metricsContext,
+        }
       );
 
       gleanEvents.submitSuccess();

--- a/packages/fxa-settings/src/models/integrations/utils.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.ts
@@ -3,11 +3,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { OAuthNativeServices } from '@fxa/accounts/oauth';
+import { isOAuthIntegration } from './oauth-native-integration';
 
 const oauthNativeServices = new Set<string>(Object.values(OAuthNativeServices));
 
 export function isFirefoxService(service?: string) {
   return !!service && oauthNativeServices.has(service);
+}
+
+/**
+ * Resolves the `service` to send for new-device-login emails: the Firefox
+ * service name when present (e.g. 'sync'), otherwise an OAuth RP's client id so
+ * the server names the RP. Only for genuine OAuth integrations — a Web
+ * integration's getClientId() can fall back to the first-party Settings client.
+ */
+export function getEmailService(
+  integration: Parameters<typeof isOAuthIntegration>[0] & {
+    getService(): string | undefined;
+    getClientId(): string | undefined;
+  }
+): string | undefined {
+  const service = integration.getService();
+  if (isFirefoxService(service)) {
+    return service;
+  }
+  return isOAuthIntegration(integration)
+    ? integration.getClientId()
+    : undefined;
 }
 
 const NO_LONGER_SUPPORTED_CONTEXTS = new Set([

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -685,6 +685,24 @@ describe('signin container', () => {
       });
     });
 
+    it('does not forward a Web integration fallback clientId as the email service', async () => {
+      integration = new WebIntegration(
+        new GenericData({ service: MozServices.Default }),
+        { clientIdFallback: 'fallback-client-id' }
+      );
+      expect(integration.getClientId()).toEqual('fallback-client-id');
+
+      render();
+      await waitFor(() => expect(currentSigninProps).toBeDefined());
+      await act(async () => {
+        await currentSigninProps?.beginSigninHandler(MOCK_EMAIL, MOCK_PASSWORD);
+      });
+
+      const options = (mockAuthClient.signInWithAuthPW as jest.Mock).mock
+        .calls[0]?.[2];
+      expect(options?.service).toBeUndefined();
+    });
+
     describe('showInlineRecoveryKeySetup', () => {
       beforeEach(() => {
         mockSyncDesktopV3Integration();

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -59,7 +59,7 @@ import {
 } from '../../lib/sensitive-data-client';
 import { Constants } from '../../lib/constants';
 import {
-  isFirefoxService,
+  getEmailService,
   isUnsupportedContext,
 } from '../../models/integrations/utils';
 import { AuthKeyStretchUpgrade } from '../../lib/auth-key-stretch-upgrade';
@@ -463,8 +463,7 @@ const SigninContainer = ({
         }
       }
 
-      const service = integration.getService();
-      const clientId = integration.getClientId();
+      const emailService = getEmailService(integration);
 
       const v2Enabled = keyStretchExp.queryParamModel.isV2(config);
 
@@ -489,10 +488,8 @@ const SigninContainer = ({
       const options = {
         verificationMethod: VerificationMethods.EMAIL_OTP,
         keys: wantsKeys,
-        // See oauth_client_info in the auth-server for details on service/clientId
-        // Sending up the clientId when the user is not signing in to the browser
-        // is used to show the correct service name in emails
-        ...(isFirefoxService(service) ? { service } : { service: clientId }),
+        // See oauth_client_info in the auth-server for details on service/clientId.
+        ...(emailService ? { service: emailService } : {}),
         metricsContext: queryParamsToMetricsContext(
           flowQueryParams as ReturnType<typeof searchParams>
         ),


### PR DESCRIPTION
## Because

- Signing in with a passkey sent no "New sign-in to your Mozilla account" email — for synced or non-synced accounts — even though password sign-in does, leaving users without the new-sign-in security notification.
- We set out to fix that missing email, and while implementing it found several related notification/email misalignments on the passkey path worth correcting in the same change: it also skipped the attached-services notification, login metrics, and security event; its email lacked the relying-party name and flow metrics context; and a shared, pre-existing regression was mislabeling direct Settings sign-ins (password sign-in included).

## This pull request

- Sends the new-device-login email and `notifyAttachedServices('login')` on passkey `authenticationFinish` (both sync and non-sync), reusing the shared `notifyAttachedServicesForAccountSession` helper.
- Emits the `account.login` metrics event, flow-complete signal, and security event for non-sync sign-ins; Sync skips these because `/session/reauth` already emits them downstream (avoids double-counting).
- Names the relying party in the email for OAuth sign-ins (the client forwards the clientId) and uses the generic "New sign-in to your Mozilla account" for non-OAuth and Sync sign-ins.
- Forwards the flow `metricsContext` through `/passkey/authentication/finish` so the sign-in and its email are attributed to the flow.
- Fixes a shared, pre-existing regression (~Feb 2026, from the passwordless-OTP `clientIdFallback`): a non-OAuth Web integration's `getClientId()` falls back to the first-party Settings client, which was sent as the email `service` and mislabeled direct Settings sign-ins as "New sign-in to Firefox Accounts Settings". Now gated on `isOAuthIntegration` in **both** the passkey (`packages/fxa-settings/src/lib/passkeys/signin-flow.ts`) and **password** (`packages/fxa-settings/src/pages/Signin/container.tsx`) sign-in paths, so direct Settings sign-ins read "Mozilla account" for both.
- Wires the legacy mailer + `oauthClientInfoService` into the passkey routes (`packages/fxa-auth-server/lib/routes/passkeys.ts`).

## Issue that this pull request solves

Closes: FXA-13905

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `passkeys.ts` (`sendPostSigninNotifications` — the sync vs non-sync split); the `isOAuthIntegration` clientId gate in `signin-flow.ts` and `Signin/container.tsx`.
- Suggested review order: `passkeys.ts` → `signin-flow.ts` → `container.tsx` → tests.
- Risky or complex parts: the sync vs non-sync split (avoids double-emitting `account.login` at `/session/reauth`); the shared clientId-forwarding gate intentionally touches the password path.

## Screenshots (Optional)

N/A — no user-visible change (sign-in routing/notification logic only; no UI or FTL copy changed).

## Other information (Optional)

- Pre-merge review: `/fxa-review` run — APPROVE (0 critical/high).
- The Web-integration subject fix is a shared, pre-existing regression that also corrects the **password** sign-in path — flagging in case the team wants it tracked under its own ticket.
- Tests: auth-server `passkeys.spec` (66), settings `signin-flow` (40) + `Signin` container (50), plus functional email-subject assertions (non-OAuth + two-step Sync). All green; functional `passkeyAuth` + `signin` suites green.
