### PR TITLE
fix(fxa-settings): prevent CJK button labels breaking one character per line

### DIFF
--- a/packages/fxa-react/styles/ctas.css
+++ b/packages/fxa-react/styles/ctas.css
@@ -55,7 +55,8 @@
   /* Max-height is a likely temp "hack" for .spinner until it's converted to TW */
   /* font-color is also a hack until all buttons are TWified */
   .cta-xl {
-    @apply flex-1 font-bold text-base p-4 rounded-md;
+    /* grow without shrinking — prevents CJK labels breaking one character per line */
+    @apply grow shrink-0 basis-0 font-bold text-base p-4 rounded-md;
   }
 
   .cta-caution {
@@ -200,5 +201,23 @@
         border-color: color-mix(in srgb, var(--cta-border) 90%, black);
       }
     }
+  }
+}
+
+@layer utilities {
+  /*
+   * Flex children default to flex-shrink: 1, which squeezes CJK button labels
+   * to one character per line in settings rows and modals. Higher specificity
+   * than the flex-1 utility ensures shrink-0 wins when both are present.
+   */
+  button.cta-neutral,
+  a.cta-neutral,
+  button.cta-primary,
+  a.cta-primary,
+  button.cta-caution,
+  a.cta-caution,
+  button.cta-primary-cms,
+  a.cta-primary-cms {
+    @apply shrink-0 whitespace-nowrap;
   }
 }

--- a/packages/fxa-react/styles/ctas.css
+++ b/packages/fxa-react/styles/ctas.css
@@ -206,9 +206,10 @@
 
 @layer utilities {
   /*
-   * Flex children default to flex-shrink: 1, which squeezes CJK button labels
-   * to one character per line in settings rows and modals. Higher specificity
-   * than the flex-1 utility ensures shrink-0 wins when both are present.
+   * Flex children default to flex-shrink: 1, which squeezes CJK labels to one
+   * character per line. keep-all stops CJK from breaking between characters
+   * without nowrap, so long Latin strings can still wrap on spaces.
+   * Higher specificity than flex-1 keeps shrink-0 when both are present.
    */
   button.cta-neutral,
   a.cta-neutral,
@@ -218,6 +219,6 @@
   a.cta-caution,
   button.cta-primary-cms,
   a.cta-primary-cms {
-    @apply shrink-0 whitespace-nowrap;
+    @apply shrink-0 break-keep;
   }
 }

--- a/packages/fxa-settings/src/components/Settings/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.tsx
@@ -98,7 +98,7 @@ export const Modal = ({
               {children}
 
               {hasButtons && (
-                <div className="flex justify-center mx-auto mt-6 max-w-64">
+                <div className="flex flex-wrap justify-center mx-auto mt-6 max-w-64">
                   {hasCancelButton && (
                     <FtlMsg id="modal-cancel-button">
                       <button

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -441,7 +441,7 @@ const PasskeyDeleteModal = ({
           using a different way.
         </p>
       </FtlMsg>
-      <div className="flex justify-center mx-2 mt-6">
+      <div className="flex flex-wrap justify-center mx-2 mt-6">
         <FtlMsg id="passkey-delete-modal-cancel-button">
           <button
             className="cta-neutral mx-2 flex-1 cta-xl"

--- a/packages/fxa-settings/src/styles/unit-row.css
+++ b/packages/fxa-settings/src/styles/unit-row.css
@@ -15,6 +15,11 @@
 
   &-actions {
     @apply w-full items-baseline mt-2;
+
+    a[class*='cta-'],
+    button[class*='cta-'] {
+      @apply shrink-0 whitespace-nowrap;
+    }
   }
 
   &-hr {

--- a/packages/fxa-settings/src/styles/unit-row.css
+++ b/packages/fxa-settings/src/styles/unit-row.css
@@ -18,7 +18,7 @@
 
     a[class*='cta-'],
     button[class*='cta-'] {
-      @apply shrink-0 whitespace-nowrap;
+      @apply shrink-0 break-keep;
     }
   }
 


### PR DESCRIPTION
## Because

- Settings page CTA buttons shrink in flex layouts, causing Japanese, Chinese, and Korean labels to stack one character per line (#18683).
- Modal button containers used `gap-2` alongside child `mx-2` margins, doubling horizontal spacing and causing premature wrapping (Copilot review feedback).

## This pull request

- Apply `shrink-0` and `whitespace-nowrap` to shared CTA styles (with specificity high enough to override `flex-1` on modal buttons).
- Prevent CTA buttons/links inside unit-row actions from shrinking and wrapping.
- Allow paired modal/sub-row action buttons to wrap as a group when horizontal space is limited.
- Remove `gap-2` from modal button containers; rely on existing child `mx-2` margins for spacing.

## Issue that this pull request solves

Closes: #18683

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate). — N/A: change targets CJK line-breaking in LTR button labels; no RTL layout changes.
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-react/styles/ctas.css`, `packages/fxa-settings/src/styles/unit-row.css`, `Modal/index.tsx`, `SubRow/index.tsx`
- Suggested review order: shared CTA CSS → unit-row CSS → modal/sub-row JSX
- Risky or complex parts: ensure English/German button layouts still work on mobile and landscape widths

## Test plan

- [ ] Set browser language to Japanese (or Chinese/Korean) and open the account settings page.
- [ ] Confirm row action buttons (Add, Change, Disable, etc.) render on a single line.
- [ ] Open a settings modal with Cancel/Confirm and verify the Cancel label does not break one character per line.
- [ ] Spot-check English/German locales to ensure buttons still layout correctly on mobile and landscape widths.