### PR TITLE
fix(passkeys): always require user verification in WebAuthn ceremonies

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.config.ts
+++ b/libs/accounts/passkey/src/lib/passkey.config.ts
@@ -17,7 +17,6 @@ import {
 import type {
   AuthenticatorAttachment,
   ResidentKeyRequirement,
-  UserVerificationRequirement,
 } from '@simplewebauthn/server';
 
 /**
@@ -75,16 +74,6 @@ export class PasskeyConfig {
   public challengeTimeout!: number;
 
   /**
-   * User verification requirement for WebAuthn.
-   * - 'required': User verification must occur (e.g., biometric, PIN)
-   * - 'preferred': User verification preferred but not required
-   * - 'discouraged': User verification should not occur
-   * @example 'required'
-   */
-  @IsIn(['required', 'preferred', 'discouraged'])
-  public userVerification?: UserVerificationRequirement;
-
-  /**
    * Resident key (discoverable credential) requirement.
    * - 'required': Credential must be discoverable (stored on authenticator).
    *   Must be set to 'required' for the passwordless / usernameless sign-in
@@ -121,6 +110,5 @@ export class PasskeyConfig {
     this.maxPasskeysPerUser = opts.maxPasskeysPerUser;
     this.residentKey = opts.residentKey;
     this.rpId = opts.rpId;
-    this.userVerification = opts.userVerification;
   }
 }

--- a/libs/accounts/passkey/src/lib/passkey.provider.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.provider.spec.ts
@@ -22,7 +22,6 @@ const VALID_RAW_CONFIG: RawPasskeyConfig = {
   allowedOrigins: ['https://accounts.firefox.com'],
   maxPasskeysPerUser: 10,
   challengeTimeout: 30_000,
-  userVerification: 'required',
   residentKey: 'required',
   authenticatorAttachment: '',
 };
@@ -102,7 +101,6 @@ describe('PasskeyConfigProvider', () => {
       expect(config!.allowedOrigins).toEqual(['https://accounts.firefox.com']);
       expect(config!.challengeTimeout).toBe(30_000);
       expect(config!.maxPasskeysPerUser).toBe(10);
-      expect(config!.userVerification).toBe('required');
       expect(config!.residentKey).toBe('required');
     });
 

--- a/libs/accounts/passkey/src/lib/passkey.provider.ts
+++ b/libs/accounts/passkey/src/lib/passkey.provider.ts
@@ -11,7 +11,6 @@ import { validateSync } from 'class-validator';
 import type {
   AuthenticatorAttachment,
   ResidentKeyRequirement,
-  UserVerificationRequirement,
 } from '@simplewebauthn/server';
 
 /**
@@ -28,7 +27,6 @@ export type RawPasskeyConfig = {
   allowedOrigins: string[];
   challengeTimeout: number;
   maxPasskeysPerUser: number;
-  userVerification: UserVerificationRequirement;
   residentKey: ResidentKeyRequirement;
   /** Empty string is treated as "no preference" and normalized to `undefined`. */
   authenticatorAttachment: AuthenticatorAttachment | '';

--- a/libs/accounts/passkey/src/lib/passkey.service.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.spec.ts
@@ -111,7 +111,6 @@ describe('PasskeyService', () => {
     allowedOrigins: ['https://accounts.firefox.com'],
     maxPasskeysPerUser: 10,
     challengeTimeout: 30_000,
-    userVerification: 'required',
     residentKey: 'required',
   });
 

--- a/libs/accounts/passkey/src/lib/virtual-authenticator.ts
+++ b/libs/accounts/passkey/src/lib/virtual-authenticator.ts
@@ -89,10 +89,11 @@ export class VirtualAuthenticator {
     return { id: randomBytes(32), privateKey, publicKey, signCount: 0 };
   }
 
-  /** Build a valid "none"-format attestation response for registration. */
+  /** Build a "none"-format attestation response; pass `userVerified: false` to clear the UV flag (default true). */
   static createAttestationResponse(
     cred: VirtualCredential,
-    input: { challenge: string; origin: string; rpId: string }
+    input: { challenge: string; origin: string; rpId: string },
+    opts: { userVerified?: boolean } = {}
   ): RegistrationResponseJSON {
     const jwk = cred.publicKey.export({ format: 'jwk' });
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -109,7 +110,8 @@ export class VirtualAuthenticator {
     ]);
 
     const rpIdHash = createHash('sha256').update(input.rpId).digest();
-    const flags = Buffer.from([0x45]); // UP + UV + AT
+    const uvFlag = opts.userVerified === false ? 0x00 : 0x04;
+    const flags = Buffer.from([0x41 | uvFlag]); // UP + AT (+ UV unless suppressed)
     const signCountBuf = Buffer.alloc(4);
     const credIdLen = Buffer.alloc(2);
     credIdLen.writeUInt16BE(cred.id.length, 0);
@@ -152,15 +154,17 @@ export class VirtualAuthenticator {
     };
   }
 
-  /** Build a valid signed assertion response for authentication. */
+  /** Build a signed assertion response; pass `userVerified: false` to clear the UV flag (default true). */
   static createAssertionResponse(
     cred: VirtualCredential,
-    input: { challenge: string; origin: string; rpId: string }
+    input: { challenge: string; origin: string; rpId: string },
+    opts: { userVerified?: boolean } = {}
   ): AuthenticationResponseJSON {
     cred.signCount++;
 
     const rpIdHash = createHash('sha256').update(input.rpId).digest();
-    const flags = Buffer.from([0x05]); // UP + UV
+    const uvFlag = opts.userVerified === false ? 0x00 : 0x04;
+    const flags = Buffer.from([0x01 | uvFlag]); // UP (+ UV unless suppressed)
     const signCountBuf = Buffer.alloc(4);
     signCountBuf.writeUInt32BE(cred.signCount, 0);
 

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -20,7 +20,6 @@ function testConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
     enabled: true,
     rpId: TEST_RP_ID,
     allowedOrigins: [TEST_ORIGIN],
-    userVerification: 'required',
     residentKey: 'preferred',
     maxPasskeysPerUser: 10,
     challengeTimeout: 30_000,
@@ -89,7 +88,6 @@ describe('generateWebauthnRegistrationOptions', () => {
     const options = await generateWebauthnRegistrationOptions(
       testConfig({
         residentKey: 'required',
-        userVerification: 'required',
         authenticatorAttachment: 'platform',
       }),
       {
@@ -274,6 +272,30 @@ describe('verifyWebauthnRegistrationResponse', () => {
       })
     ).rejects.toThrow();
   });
+
+  it('rejects an attestation without user verification', async () => {
+    const cred = VirtualAuthenticator.createCredential();
+    const challenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnRegistrationOptions(config, {
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
+      email: 'test@example.com',
+      challenge,
+    });
+
+    const attestation = VirtualAuthenticator.createAttestationResponse(
+      cred,
+      { challenge: options.challenge, origin: TEST_ORIGIN, rpId: TEST_RP_ID },
+      { userVerified: false }
+    );
+
+    await expect(
+      verifyWebauthnRegistrationResponse(config, {
+        response: attestation,
+        challenge,
+      })
+    ).rejects.toThrow(/user could not be verified/i);
+  });
 });
 
 describe('generateWebauthnAuthenticationOptions', () => {
@@ -290,17 +312,22 @@ describe('generateWebauthnAuthenticationOptions', () => {
     expect(options.challenge).toBe(challenge);
   });
 
-  it('sets rpId and userVerification from config', async () => {
-    const options = await generateWebauthnAuthenticationOptions(
-      testConfig({ userVerification: 'discouraged' }),
-      {
-        challenge: randomBytes(32).toString('base64url'),
-        allowCredentials: [],
-      }
-    );
+  it('sets rpId from config', async () => {
+    const options = await generateWebauthnAuthenticationOptions(testConfig(), {
+      challenge: randomBytes(32).toString('base64url'),
+      allowCredentials: [],
+    });
 
     expect(options.rpId).toBe(TEST_RP_ID);
-    expect(options.userVerification).toBe('discouraged');
+  });
+
+  it('always sets userVerification to required in generated options', async () => {
+    const options = await generateWebauthnAuthenticationOptions(testConfig(), {
+      challenge: randomBytes(32).toString('base64url'),
+      allowCredentials: [],
+    });
+
+    expect(options.userVerification).toBe('required');
   });
 
   it('omits allowCredentials for discoverable flow (empty input)', async () => {
@@ -521,5 +548,31 @@ describe('verifyWebauthnAuthenticationResponse', () => {
         signCount: stored.signCount,
       })
     ).rejects.toThrow();
+  });
+
+  it('rejects an assertion without user verification', async () => {
+    const { cred, stored } = await registerCredential(config);
+    const challenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge,
+      allowCredentials: [stored.credentialId],
+    });
+
+    const assertion = VirtualAuthenticator.createAssertionResponse(
+      cred,
+      { challenge: options.challenge, origin: TEST_ORIGIN, rpId: TEST_RP_ID },
+      { userVerified: false }
+    );
+
+    await expect(
+      verifyWebauthnAuthenticationResponse(config, {
+        response: assertion,
+        challenge,
+        credentialId: stored.credentialId,
+        publicKey: stored.publicKey,
+        signCount: stored.signCount,
+      })
+    ).rejects.toThrow(/user could not be verified/i);
   });
 });

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -74,7 +74,8 @@ export async function generateWebauthnRegistrationOptions(
     challenge: Buffer.from(input.challenge, 'base64url'),
     authenticatorSelection: {
       residentKey: config.residentKey,
-      userVerification: config.userVerification,
+      // AAL2 invariant — UV always required, not configurable.
+      userVerification: 'required',
       authenticatorAttachment: config.authenticatorAttachment,
     },
     excludeCredentials: input.excludeCredentials,
@@ -133,6 +134,8 @@ export async function verifyWebauthnRegistrationResponse(
     expectedChallenge: input.challenge,
     expectedOrigin: config.allowedOrigins,
     expectedRPID: config.rpId,
+    // Library defaults this to false; UV must be enforced for the AAL2 claim.
+    requireUserVerification: true,
   });
 
   if (!verified) {
@@ -164,7 +167,7 @@ export async function verifyWebauthnRegistrationResponse(
 
 /**
  * Per-request inputs for generating WebAuthn authentication options.
- * `rpID` and `userVerification` are supplied by PasskeyConfig.
+ * `rpID` is supplied by PasskeyConfig; `userVerification` is always 'required'.
  */
 export interface AuthenticationOptionsInput {
   /** Challenge from ChallengeManager. */
@@ -189,7 +192,8 @@ export async function generateWebauthnAuthenticationOptions(
 ): Promise<PublicKeyCredentialRequestOptionsJSON> {
   return generateAuthenticationOptions({
     rpID: config.rpId,
-    userVerification: config.userVerification,
+    // AAL2 invariant — UV always required, not configurable.
+    userVerification: 'required',
     // See comment in generateRegistrationOptions — same base64url roundtrip fix.
     challenge: Buffer.from(input.challenge, 'base64url'),
     allowCredentials:
@@ -260,6 +264,8 @@ export async function verifyWebauthnAuthenticationResponse(
     expectedOrigin: config.allowedOrigins,
     expectedRPID: config.rpId,
     credential,
+    // Library defaults this to false; UV must be enforced for the AAL2 claim.
+    requireUserVerification: true,
   });
 
   if (!verified) {

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2705,12 +2705,6 @@ const convictConf = convict({
       env: 'PASSKEYS__MAX_PASSKEYS_PER_USER',
       format: Number,
     },
-    userVerification: {
-      default: 'required',
-      doc: 'WebAuthn user-verification requirement for ceremonies. One of "required", "preferred", or "discouraged". May be relaxed to "preferred" depending on UX requirements.',
-      env: 'PASSKEYS__USER_VERIFICATION',
-      format: ['required', 'preferred', 'discouraged'],
-    },
     residentKey: {
       default: 'required',
       doc: 'WebAuthn resident-key (discoverable credential) requirement. One of "required", "preferred", or "discouraged". Discoverable credential flow won\'t work if not set to "required".',

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -600,10 +600,7 @@ export const passkeyRoutes = (
                   .string()
                   .valid('discouraged', 'preferred', 'required')
                   .optional(),
-                userVerification: isA
-                  .string()
-                  .valid('discouraged', 'preferred', 'required')
-                  .optional(),
+                userVerification: isA.string().valid('required').required(),
               })
               .optional(),
             hints: isA
@@ -754,10 +751,7 @@ export const passkeyRoutes = (
             challenge: isA.string().required(),
             allowCredentials: isA.array().items(isA.object()).optional(),
             timeout: isA.number().optional(),
-            userVerification: isA
-              .string()
-              .valid('discouraged', 'preferred', 'required')
-              .optional(),
+            userVerification: isA.string().valid('required').required(),
             rpId: isA.string().optional(),
             hints: isA
               .array()


### PR DESCRIPTION
## Because

- Passkey sign-in mints an AAL2 session token and bypasses TOTP, so user
  verification must always occur. The server's `@simplewebauthn/server` verify
  calls omitted `requireUserVerification` (which defaults to `false`), so a
  WebAuthn response with the user-verified flag cleared was accepted — granting
  an AAL2 session to a present-but-unverified user.
- User verification was also a configurable knob that could be relaxed to
  `'preferred'`/`'discouraged'`, weakening the guarantee. This must be fixed
  before the Phase 1 production rollout.

## This pull request

- Hardcodes `requireUserVerification: true` on both
  `verifyWebauthnRegistrationResponse` and `verifyWebauthnAuthenticationResponse`,
  and `userVerification: 'required'` on both option-generation functions in
  `libs/accounts/passkey/src/lib/webauthn-adapter.ts`.
- Removes the `userVerification` config knob entirely — from `PasskeyConfig`,
  `RawPasskeyConfig`, and the convict `PASSKEYS__USER_VERIFICATION` setting in
  `packages/fxa-auth-server/config/index.ts` — so user verification can no
  longer be relaxed.
- Narrows the route response schemas in
  `packages/fxa-auth-server/lib/routes/passkeys.ts` to `valid('required')`,
  dropping the now-unreachable `'preferred'`/`'discouraged'` values.
- Adds an optional `userVerified` flag to the test `VirtualAuthenticator` and
  regression tests asserting a UV-unset response is rejected for both ceremonies.

## Issue that this pull request solves

Closes: FXA-13941

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `webauthn-adapter.ts` (the enforcement — both `requireUserVerification: true` and the `'required'` options); the knob removal across `passkey.config.ts`, `passkey.provider.ts`, and `config/index.ts`.
- Suggested review order: adapter → config removal → `virtual-authenticator.ts` UV-flag bit math → the new negative tests.
- Risky or complex parts: the authenticator-data flags byte in `virtual-authenticator.ts` (UV bit clearing) underpins the regression tests.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- webservices-infra should drop the `PASSKEYS__USER_VERIFICATION` env var if it is set in any stage/prod config. With the convict key removed it is now inert (convict ignores an env var with no matching schema key, so there is no runtime break), but it should be cleaned up so it doesn't linger as a dead variable.
