### PR TITLE
fix(auth): restore device management for Fire TV, Lockwise, and Reality

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
@@ -8,13 +8,18 @@ const { AppError } = require('@fxa/accounts/errors');
 const joi = require('joi');
 const validators = require('../validators');
 const { BEARER_AUTH_REGEX } = validators;
+const { OAUTH_SCOPE_OLD_SYNC } = require('fxa-shared/oauth/constants');
 const encrypt = require('fxa-shared/auth/encrypt');
 const oauthDB = require('../../oauth/db');
 const client = require('../../oauth/client');
+const ScopeSet = require('fxa-shared/oauth/scopes').scopeSetHelpers;
+
+const OLD_SYNC_SCOPE = ScopeSet.fromArray([OAUTH_SCOPE_OLD_SYNC]);
 
 module.exports = function schemeRefreshTokenScheme(config, db) {
-  // Gate access to the device API by Firefox client_id. Firefox sign-ins
-  // without Sync can still register a device.
+  // A refresh token may manage devices if it carries the Sync (oldsync) scope
+  // or its client_id is allowlisted. The allowlist covers Firefox sign-ins
+  // without Sync, which have no oldsync scope to match on.
   const deviceManagementClientIds = new Set(
     (config?.oauth?.deviceManagementClientIds || []).map((id) =>
       id.toLowerCase()
@@ -46,7 +51,8 @@ module.exports = function schemeRefreshTokenScheme(config, db) {
           return h.unauthenticated(AppError.invalidToken());
         }
         const clientIdHex = refreshToken.clientId.toString('hex').toLowerCase();
-        if (!deviceManagementClientIds.has(clientIdHex)) {
+        const hasOldSyncScope = refreshToken.scope.intersects(OLD_SYNC_SCOPE);
+        if (!deviceManagementClientIds.has(clientIdHex) && !hasOldSyncScope) {
           return h.unauthenticated(AppError.invalidToken());
         }
 

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.spec.ts
@@ -182,9 +182,34 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
     });
   });
 
-  it('rejects refresh tokens from non-allowlisted client_ids', async () => {
+  it('allows a non-allowlisted client_id whose refresh token has the oldsync scope', async () => {
+    // Regression guard: a Sync client_id outside the allowlist must still
+    // authenticate via the oldsync scope, not be rejected with 401/errno-110.
     oauthDB.getRefreshToken.mockResolvedValue({
       scope: ScopeSet.fromString('https://identity.mozilla.com/apps/oldsync'),
+      userId: USER_ID,
+      clientId: Buffer.from('0123456789abcdef', 'hex'), // not in the allowlist
+    });
+
+    const scheme = schemeRefreshToken(config, db);
+    await scheme().authenticate(
+      {
+        headers: {
+          authorization:
+            'Bearer B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78',
+        },
+        app,
+      },
+      response
+    );
+
+    expect(response.unauthenticated).not.toHaveBeenCalled();
+    expect(response.authenticated).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects refresh tokens that are neither allowlisted nor oldsync-scoped', async () => {
+    oauthDB.getRefreshToken.mockResolvedValue({
+      scope: ScopeSet.fromString('profile'),
       userId: USER_ID,
       clientId: Buffer.from('0123456789abcdef', 'hex'),
     });

--- a/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.in.spec.ts
@@ -385,16 +385,16 @@ describe.each(testVersions)(
       expect(devices[1].name).toBe('first device');
     });
 
-    it('does not allow non-allowlisted clients', async () => {
-      // After FXA-13704 the refresh-token scheme rejects any client_id not in
-      // the deviceManagementClientIds allowlist before reaching the
-      // publicClient check, so this also covers the prior "non-public client"
-      // case using NON_PUBLIC_CLIENT_ID (not in the allowlist either).
+    it('does not allow non-allowlisted clients without the oldsync scope', async () => {
+      // A refresh token that is neither allowlisted nor oldsync-scoped is
+      // rejected at the gate with 401/errno-110. A non-allowlisted client that
+      // still carries the oldsync scope is allowed via the scope path (covered
+      // by the unit spec).
       const refresh = await oauthServerDb.generateRefreshToken({
         clientId: buf(NON_PUBLIC_CLIENT_ID),
         userId: buf(client.uid),
         email: client.email,
-        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+        scope: 'profile',
       });
       refreshToken = refresh.token.toString('hex');
 


### PR DESCRIPTION
## Because

- After train-338, Firefox for Fire TV, Lockwise, and Reality started getting `401 / errno-110` on `/v1/account/device*` and lost Sync (device list, Send Tab, command polling).
- The Firefox client treats `401 / errno-110` as an invalid token and re-authenticates; with the same client_id it is rejected again, so always-on Fire TV devices entered a retry loop and drove a device-error spike (since rolled back).
- Root cause: train-338 commit `db88943306` (FXA-13704) narrowed the device-management gate on the refresh-token auth scheme from "refresh token has the oldsync scope" to a five-entry client_id allowlist, dropping these Firefox products which hold the oldsync scope but were not listed.

## This pull request

- Adds the four affected client_ids (Fire TV, Lockwise ×2, Reality) to `oauth.deviceManagementClientIds` in `config/index.ts`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13944

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Notes

This could be done as a config only change in webinfra but seems slightly easier to do this?