### PR TITLE
fix(fxa-settings): route passkey Sync sign-in to password fallback on mobile

### DIFF
--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/browser';
 import { FtlMsgResolver } from 'fxa-react/lib/utils';
 import {
   usePasskeySignIn,
+  resolvePasskeyService,
   type PasskeySignInAuthClient,
   type PasskeySignInIntegration,
 } from './signin-flow';
@@ -15,6 +16,7 @@ import { storeAccountData } from '../storage-utils';
 import { AuthUiErrors } from '../auth-errors/auth-errors';
 import GleanMetrics from '../glean';
 import { IntegrationType } from '../../models';
+import { OAuthNativeServices } from '@fxa/accounts/oauth';
 import {
   ensureCanLinkAcountOrRedirect,
   handleNavigation,
@@ -139,6 +141,7 @@ const buildArgs = (
     isFirefoxNonSync: () => false,
     getService: () => undefined,
     getClientId: () => 'service-id',
+    isFirefoxMobileClient: () => false,
     type: IntegrationType.OAuthWeb,
     data: {},
     wantsTwoStepAuthentication: () => false,
@@ -244,13 +247,14 @@ describe('usePasskeySignIn', () => {
     });
   });
 
-  it('forwards the Firefox service name (not the client id) for a Sync sign-in', async () => {
+  it('sends service=sync in the passkey authentication request for a Sync sign-in, not the client id', async () => {
     const { args, spies } = buildArgs({
       integration: {
         isSync: () => true,
         isFirefoxNonSync: () => false,
         getService: () => 'sync',
         getClientId: () => 'client-id-should-not-be-used',
+        isFirefoxMobileClient: () => false,
         type: IntegrationType.OAuthNative,
         data: {},
         wantsTwoStepAuthentication: () => false,
@@ -278,6 +282,7 @@ describe('usePasskeySignIn', () => {
         isFirefoxNonSync: () => false,
         getService: () => undefined,
         getClientId: () => 'service-id',
+        isFirefoxMobileClient: () => false,
         type: IntegrationType.Web,
         data: {},
       } as unknown as PasskeySignInIntegration,
@@ -391,6 +396,56 @@ describe('usePasskeySignIn', () => {
       expect(handleNavigation).not.toHaveBeenCalled();
     }
   );
+
+  it('sends service=sync in the passkey authentication request for a Sync sign-in when the service URL param is absent', async () => {
+    // Mobile Firefox omits service=sync and defaults via clientId, so
+    // getService() returns undefined; isSync() must still drive service=sync.
+    const { args, spies } = buildArgs({
+      integration: {
+        isSync: () => true,
+        isFirefoxNonSync: () => false,
+        getService: () => undefined,
+        isFirefoxMobileClient: () => false,
+        type: IntegrationType.OAuthNative,
+        data: {},
+      } as unknown as PasskeySignInIntegration,
+    });
+
+    const { result } = renderHook(() => usePasskeySignIn(args));
+
+    await act(async () => {
+      await result.current.onClick();
+    });
+
+    expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
+      MOCK_CREDENTIAL,
+      CHALLENGE,
+      { service: 'sync', metricsContext: {} }
+    );
+  });
+
+  it('skips navigation on Firefox mobile so Firefox finishes sign-in via WebChannel', async () => {
+    const { args } = buildArgs({
+      integration: {
+        isSync: () => false,
+        isFirefoxNonSync: () => true,
+        getService: () => 'vpn',
+        getClientId: () => 'service-id',
+        isFirefoxMobileClient: () => true,
+        type: IntegrationType.OAuthNative,
+        data: {},
+      } as unknown as PasskeySignInIntegration,
+    });
+
+    const { result } = renderHook(() => usePasskeySignIn(args));
+    await act(async () => {
+      await result.current.onClick();
+    });
+
+    expect(handleNavigation).toHaveBeenCalledWith(
+      expect.objectContaining({ performNavigation: false })
+    );
+  });
 
   // Locks the contract: each DOMException name maps to its expected FTL id
   // AND its fallback string. Drift in either lands silently otherwise.
@@ -785,6 +840,7 @@ describe('usePasskeySignIn', () => {
         isFirefoxNonSync: () => false,
         getService: () => undefined,
         getClientId: () => 'service-id',
+        isFirefoxMobileClient: () => false,
         type: IntegrationType.OAuthWeb,
         data: {},
         wantsTwoStepAuthentication: () => true,
@@ -872,6 +928,7 @@ describe('usePasskeySignIn', () => {
             isFirefoxNonSync: () => false,
             getService: () => undefined,
             getClientId: () => 'service-id',
+            isFirefoxMobileClient: () => false,
             type: IntegrationType.OAuthWeb,
             data: {},
             wantsTwoStepAuthentication: () => false,
@@ -891,5 +948,71 @@ describe('usePasskeySignIn', () => {
         })
       );
     });
+  });
+});
+
+describe('resolvePasskeyService', () => {
+  const make = (overrides: {
+    isSync?: () => boolean;
+    getService?: () => string | undefined;
+    getClientId?: () => string | undefined;
+    type?: IntegrationType;
+  }) =>
+    ({
+      isSync: () => false,
+      getService: () => undefined,
+      getClientId: () => undefined,
+      type: IntegrationType.OAuthNative,
+      ...overrides,
+    }) as unknown as PasskeySignInIntegration;
+
+  it('resolves to sync for a Sync integration when getService() is undefined', () => {
+    expect(
+      resolvePasskeyService(
+        make({ isSync: () => true, getService: () => undefined })
+      )
+    ).toBe(OAuthNativeServices.Sync);
+  });
+
+  it('resolves to sync for a Sync integration when getService() returns sync', () => {
+    expect(
+      resolvePasskeyService(
+        make({ isSync: () => true, getService: () => OAuthNativeServices.Sync })
+      )
+    ).toBe(OAuthNativeServices.Sync);
+  });
+
+  it('resolves to the Firefox service for a non-Sync Firefox service (vpn)', () => {
+    expect(
+      resolvePasskeyService(
+        make({ isSync: () => false, getService: () => OAuthNativeServices.Vpn })
+      )
+    ).toBe(OAuthNativeServices.Vpn);
+  });
+
+  it('resolves to the client id for an OAuth integration with no Firefox service', () => {
+    expect(
+      resolvePasskeyService(
+        make({
+          isSync: () => false,
+          getService: () => undefined,
+          getClientId: () => 'client-id',
+          type: IntegrationType.OAuthWeb,
+        })
+      )
+    ).toBe('client-id');
+  });
+
+  it('resolves to undefined for a non-OAuth Web integration with no Firefox service', () => {
+    expect(
+      resolvePasskeyService(
+        make({
+          isSync: () => false,
+          getService: () => undefined,
+          getClientId: () => 'client-id',
+          type: IntegrationType.Web,
+        })
+      )
+    ).toBeUndefined();
   });
 });

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -18,7 +18,7 @@ import {
   ensureCanLinkAcountOrRedirect,
   handleNavigation,
 } from '../../pages/Signin/utils';
-import { getEmailService } from '../../models/integrations/utils';
+import { resolveServiceOrClientId } from '../../models/integrations/utils';
 import { queryParamsToMetricsContext } from '../metrics';
 import { searchParams } from '../utilities';
 import {
@@ -154,6 +154,26 @@ const gleanEventsForSurface = (
  */
 export type PasskeySignInIntegration = NavigationOptions['integration'];
 
+/**
+ * Resolves the `service` value sent with a passkey authentication request.
+ * Forces `sync` for any Sync integration; everything else uses
+ * `resolveServiceOrClientId`. Why force it:
+ * - The server decides per credential whether the account password is needed
+ *   (phase 1: always, to derive Sync keys; phase 2: not when the passkey
+ *   carries a stored key wrap) and needs `service=sync` to make that call.
+ * - Mobile Firefox omits the `service=sync` URL param, so `getService()` is
+ *   undefined and `resolveServiceOrClientId` would return the client id,
+ *   silently skipping that decision.
+ */
+export function resolvePasskeyService(
+  integration: PasskeySignInIntegration
+): string | undefined {
+  if (integration.isSync()) {
+    return 'sync';
+  }
+  return resolveServiceOrClientId(integration);
+}
+
 /** Pick<> so tests can pass minimal mocks without `as any`. */
 export type PasskeySignInAuthClient = Pick<
   AuthClient,
@@ -280,7 +300,7 @@ export function usePasskeySignIn({
         throw err;
       }
 
-      const serviceForRequest = getEmailService(integration);
+      const serviceForRequest = resolvePasskeyService(integration);
       const metricsContext = queryParamsToMetricsContext(
         searchParams(queryParams) as Record<string, string | undefined>
       );
@@ -379,7 +399,9 @@ export function usePasskeySignIn({
         queryParams,
         handleFxaLogin: true,
         handleFxaOAuthLogin: true,
-        performNavigation: true,
+        // On Firefox mobile, the browser finishes sign-in via WebChannel
+        // messages; navigating the WebView away would interrupt it.
+        performNavigation: !integration.isFirefoxMobileClient(),
         isPasskeySession: true,
         accountHasTotp,
       });

--- a/packages/fxa-settings/src/models/integrations/utils.test.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.test.ts
@@ -3,7 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { OAuthNativeServices } from '@fxa/accounts/oauth';
-import { isFirefoxService } from './utils';
+import { IntegrationType } from './integration';
+import { isFirefoxService, resolveServiceOrClientId } from './utils';
+
+const makeIntegration = (
+  type: IntegrationType,
+  service: string | undefined,
+  clientId: string | undefined
+) =>
+  ({
+    type,
+    getService: () => service,
+    getClientId: () => clientId,
+  }) as Parameters<typeof resolveServiceOrClientId>[0];
 
 describe('isFirefoxService', () => {
   it('should return true for OAuthNativeServices.Sync', () => {
@@ -33,5 +45,63 @@ describe('isFirefoxService', () => {
 
   it('should return false for undefined service', () => {
     expect(isFirefoxService(undefined)).toBe(false);
+  });
+});
+
+describe('resolveServiceOrClientId', () => {
+  it('returns the service when getService() is a Firefox service (sync)', () => {
+    expect(
+      resolveServiceOrClientId(
+        makeIntegration(
+          IntegrationType.OAuthNative,
+          OAuthNativeServices.Sync,
+          'client-id'
+        )
+      )
+    ).toBe(OAuthNativeServices.Sync);
+  });
+
+  it('returns the service when getService() is a Firefox service (vpn)', () => {
+    expect(
+      resolveServiceOrClientId(
+        makeIntegration(
+          IntegrationType.OAuthNative,
+          OAuthNativeServices.Vpn,
+          'client-id'
+        )
+      )
+    ).toBe(OAuthNativeServices.Vpn);
+  });
+
+  it('returns the client id for an OAuth integration when getService() is undefined', () => {
+    expect(
+      resolveServiceOrClientId(
+        makeIntegration(IntegrationType.OAuthWeb, undefined, 'client-id')
+      )
+    ).toBe('client-id');
+  });
+
+  it('returns the client id for an OAuth integration when getService() is not a Firefox service', () => {
+    expect(
+      resolveServiceOrClientId(
+        makeIntegration(IntegrationType.OAuthWeb, 'monitor', 'client-id')
+      )
+    ).toBe('client-id');
+  });
+
+  it('returns undefined for an OAuth integration with no Firefox service and no client id', () => {
+    expect(
+      resolveServiceOrClientId(
+        makeIntegration(IntegrationType.OAuthWeb, undefined, undefined)
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for a non-OAuth integration when getService() is not a Firefox service', () => {
+    expect(
+      resolveServiceOrClientId(
+        makeIntegration(IntegrationType.Web, undefined, 'client-id')
+      )
+    ).toBeUndefined();
   });
 });

--- a/packages/fxa-settings/src/models/integrations/utils.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.ts
@@ -12,12 +12,14 @@ export function isFirefoxService(service?: string) {
 }
 
 /**
- * Resolves the `service` to send for new-device-login emails: the Firefox
- * service name when present (e.g. 'sync'), otherwise an OAuth RP's client id so
- * the server names the RP. Only for genuine OAuth integrations — a Web
- * integration's getClientId() can fall back to the first-party Settings client.
+ * Resolves the `service` value to send with a sign-in or sign-up request,
+ * mainly so the server names the right service in the new-device-login email:
+ * the Firefox service name when present (e.g. 'sync'), otherwise an OAuth RP's
+ * client id so the server names the RP. Only for genuine OAuth integrations — a
+ * Web integration's getClientId() can fall back to the first-party Settings
+ * client.
  */
-export function getEmailService(
+export function resolveServiceOrClientId(
   integration: Parameters<typeof isOAuthIntegration>[0] & {
     getService(): string | undefined;
     getClientId(): string | undefined;

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
@@ -37,6 +37,7 @@ function createMockSyncIntegration() {
     type: IntegrationType.OAuthNative,
     getService: () => MozServices.FirefoxSync,
     isSync: () => true,
+    isFirefoxMobileClient: () => false,
     requiresKeys: () => true,
     wantsKeys: () => true,
     getCmsInfo: () => undefined,
@@ -197,6 +198,32 @@ describe('SigninPasskeyFallback container', () => {
           }),
         })
       );
+    });
+
+    it('performs navigation to finish sign-in after reauth on desktop', async () => {
+      const { getByTestId } = render();
+      submitPassword(getByTestId);
+
+      await waitFor(() => {
+        expect(mockHandleNavigation).toHaveBeenCalledWith(
+          expect.objectContaining({ performNavigation: true })
+        );
+      });
+    });
+
+    it('skips navigation after reauth on Firefox mobile so Firefox finishes sign-in via WebChannel', async () => {
+      const mobileIntegration = {
+        ...createMockSyncIntegration(),
+        isFirefoxMobileClient: () => true,
+      } as unknown as Integration;
+      const { getByTestId } = render(mobileIntegration);
+      submitPassword(getByTestId);
+
+      await waitFor(() => {
+        expect(mockHandleNavigation).toHaveBeenCalledWith(
+          expect.objectContaining({ performNavigation: false })
+        );
+      });
     });
 
     it('renders an error banner when sessionReauth throws', async () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
@@ -25,6 +25,8 @@ import { SigninLocationState } from '../interfaces';
 import { buildPasskeyAuthSuccessReason } from '../../../lib/passkeys/signin-flow';
 import SigninPasskeyFallback from '.';
 
+// Password step for accounts that signed in with a passkey but still need the
+// account password to unwrap Sync encryption keys.
 const SigninPasskeyFallbackContainer = ({
   integration,
 }: { integration: Integration } & RouteComponentProps) => {
@@ -149,6 +151,10 @@ const SigninPasskeyFallbackContainer = ({
         queryParams: location.search,
         handleFxaLogin: true,
         handleFxaOAuthLogin: true,
+        // On Firefox mobile, the browser finishes Sync sign-in via WebChannel
+        // messages; navigating the WebView away would interrupt it and leave
+        // Sync paused. Desktop finishes by navigating.
+        performNavigation: !integration.isFirefoxMobileClient(),
       });
       if (navError) {
         GleanMetrics.passkeyEnterPassword.submitFrontendError({

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -59,7 +59,7 @@ import {
 } from '../../lib/sensitive-data-client';
 import { Constants } from '../../lib/constants';
 import {
-  getEmailService,
+  resolveServiceOrClientId,
   isUnsupportedContext,
 } from '../../models/integrations/utils';
 import { AuthKeyStretchUpgrade } from '../../lib/auth-key-stretch-upgrade';
@@ -463,7 +463,7 @@ const SigninContainer = ({
         }
       }
 
-      const emailService = getEmailService(integration);
+      const service = resolveServiceOrClientId(integration);
 
       const v2Enabled = keyStretchExp.queryParamModel.isV2(config);
 
@@ -489,7 +489,7 @@ const SigninContainer = ({
         verificationMethod: VerificationMethods.EMAIL_OTP,
         keys: wantsKeys,
         // See oauth_client_info in the auth-server for details on service/clientId.
-        ...(emailService ? { service: emailService } : {}),
+        ...(service ? { service } : {}),
         metricsContext: queryParamsToMetricsContext(
           flowQueryParams as ReturnType<typeof searchParams>
         ),


### PR DESCRIPTION
## Because

- On mobile Firefox (reproduced on iOS, reported on Android), signing in to Sync
  via a passkey did nothing — the browser was left in a "syncing paused" state
  with no redirect to the password fallback. This affected both standard
  (password) and passwordless accounts.
- Mobile Firefox commonly omits the `service=sync` URL param and infers Sync from
  the client ID, so `getService()` returned `undefined`, the server never set
  `requiresPasswordForSync`, and the password step required to derive Sync keys
  was silently skipped.

## This pull request

- Derives the service from `integration.isSync() ? 'sync' : integration.getService()`
  in `packages/fxa-settings/src/lib/passkeys/signin-flow.ts`, so Sync sign-ins
  reliably trigger the password fallback redirect (`/signin_passkey_fallback` for
  standard accounts, `/post_verify/set_password` for passwordless). `isSync()` is
  the same signal already trusted for the can-link check.
- Sets `performNavigation: !integration.isFirefoxMobileClient()` in
  `packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx` so
  mobile lets Firefox complete Sync via WebChannel messages instead of navigating
  the WebView away — matching the existing idiom in `SigninTokenCode`,
  `SigninTotpCode`, `SigninRecoveryCode`, and `SigninRecoveryPhone`.
- Adds regression tests covering `service=sync` when the URL param is absent, and
  mobile vs desktop navigation behaviour in the fallback container.

## Issue that this pull request solves

Closes: FXA-13911

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

STR:
- with Firefox iOS and/or Firefox for Android emulator and local fxa stack
  - create a Mozilla account
  - set up a passkey for the account
  - use the passkey to sign in to sync on Firefox iOS and/or Firefox for Android

Expectation:
- prompted to enter account password after verifying passkey
- signed into sync

Bug:
- no password prompt
- sync sign-in incomplete "syncing paused" with no recovery

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Pre-merge review completed: `/fxa-review` returned APPROVE (0 blocking issues) and
`/fxa-security-review` found no security concerns. Client-side change in
`fxa-settings`; validation via Playwright Sync passkey functional tests.
