### PR TITLE
fix(auth-server): refund PayPal credit notes despite stale invoice mirror

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -264,7 +264,7 @@ export class StripeWebhookHandler extends StripeHandler {
       return;
     }
     const creditNote = event.data.object as Stripe.CreditNote;
-    const invoice = await this.stripeHelper.expandResource(
+    let invoice = await this.stripeHelper.expandResource(
       creditNote.invoice,
       'invoices'
     );
@@ -290,14 +290,31 @@ export class StripeWebhookHandler extends StripeHandler {
     }
 
     // We can't issue a refund if there's no paypal transaction to refund.
-    const transactionId =
+    let transactionId =
       this.stripeHelper.getInvoicePaypalTransactionId(invoice);
+
+    // Re-fetch if there's no transaction id on the invoice
+    if (!transactionId) {
+      invoice = await this.stripeHelper.getInvoiceWithDiscount(invoice.id);
+      transactionId = this.stripeHelper.getInvoicePaypalTransactionId(invoice);
+    }
+
     if (!transactionId) {
       this.log.error('handleCreditNoteEvent', {
         invoiceId: invoice.id,
         message:
           'Credit note issued on invoice without a PayPal transaction id.',
       });
+      await this.stripeHelper.updateInvoiceWithPaypalRefundReason(
+        invoice,
+        'Credit note issued on invoice without a PayPal transaction id.'
+      );
+      reportSentryError(
+        new Error(
+          `Credit note on invoice without PayPal transaction id: ${invoice.id}`
+        ),
+        request
+      );
       return;
     }
 
@@ -310,6 +327,10 @@ export class StripeWebhookHandler extends StripeHandler {
         invoiceId: invoice.id,
         message: 'Credit note exceeds invoice amount.',
       });
+      await this.stripeHelper.updateInvoiceWithPaypalRefundReason(
+        invoice,
+        'Credit note amount exceeds invoice amount; refund not issued.'
+      );
       reportSentryError(
         new Error(`Credit amount exceeds invoice: ${invoice.id}.`),
         request

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhooks.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhooks.spec.ts
@@ -1620,15 +1620,24 @@ describe('StripeWebhookHandler', () => {
         expect(sentryMod.reportSentryError).not.toHaveBeenCalled();
       });
 
-      it('doesnt issue refund without a paypal transaction to refund', async () => {
-        StripeWebhookHandlerInstance.paypalHelper = {};
+      it('tags the invoice and reports to Sentry when neither the cached nor the live invoice has a paypal transaction id', async () => {
+        const sentryMod = require('../../sentry');
+        jest.spyOn(sentryMod, 'reportSentryError').mockReturnValue({});
+        StripeWebhookHandlerInstance.paypalHelper = {
+          issueRefund: jest.fn().mockResolvedValue(undefined),
+        };
         invoice.collection_method = 'send_invoice';
         invoiceCreditNoteEvent.data.object.out_of_band_amount = 500;
         StripeWebhookHandlerInstance.stripeHelper.expandResource = jest
           .fn()
           .mockResolvedValue(invoice);
+        StripeWebhookHandlerInstance.stripeHelper.getInvoiceWithDiscount = jest
+          .fn()
+          .mockResolvedValue(invoice);
         StripeWebhookHandlerInstance.stripeHelper.getInvoicePaypalTransactionId =
           jest.fn().mockReturnValue(null);
+        StripeWebhookHandlerInstance.stripeHelper.updateInvoiceWithPaypalRefundReason =
+          jest.fn().mockResolvedValue({});
         StripeWebhookHandlerInstance.log.error = jest.fn().mockReturnValue({});
         const result = await StripeWebhookHandlerInstance.handleCreditNoteEvent(
           {},
@@ -1644,7 +1653,6 @@ describe('StripeWebhookHandler', () => {
         expect(
           StripeWebhookHandlerInstance.stripeHelper.expandResource
         ).toHaveBeenCalledTimes(1);
-        expect(StripeWebhookHandlerInstance.log.error).toHaveBeenCalledTimes(1);
         expect(StripeWebhookHandlerInstance.log.error).toHaveBeenCalledWith(
           'handleCreditNoteEvent',
           {
@@ -1655,12 +1663,62 @@ describe('StripeWebhookHandler', () => {
         );
         expect(
           StripeWebhookHandlerInstance.stripeHelper
+            .updateInvoiceWithPaypalRefundReason
+        ).toHaveBeenCalledWith(
+          invoice,
+          'Credit note issued on invoice without a PayPal transaction id.'
+        );
+        expect(sentryMod.reportSentryError).toHaveBeenCalledTimes(1);
+        expect(
+          StripeWebhookHandlerInstance.paypalHelper.issueRefund
+        ).not.toHaveBeenCalled();
+        expect(
+          StripeWebhookHandlerInstance.stripeHelper.getInvoiceWithDiscount
+        ).toHaveBeenCalledWith(invoice.id);
+        expect(
+          StripeWebhookHandlerInstance.stripeHelper
             .getInvoicePaypalTransactionId
-        ).toHaveBeenCalledTimes(1);
+        ).toHaveBeenCalledTimes(2);
         expect(
           StripeWebhookHandlerInstance.stripeHelper
             .getInvoicePaypalTransactionId
         ).toHaveBeenCalledWith(invoice);
+      });
+
+      it('tags the invoice when the credit note amount exceeds the invoice amount', async () => {
+        const sentryMod = require('../../sentry');
+        jest.spyOn(sentryMod, 'reportSentryError').mockReturnValue({});
+        StripeWebhookHandlerInstance.paypalHelper = {
+          issueRefund: jest.fn().mockResolvedValue(undefined),
+        };
+        invoice.collection_method = 'send_invoice';
+        invoice.amount_due = 500;
+        invoiceCreditNoteEvent.data.object.out_of_band_amount = 900;
+        invoiceCreditNoteEvent.data.object.customer_balance_transaction = null;
+        StripeWebhookHandlerInstance.stripeHelper.expandResource = jest
+          .fn()
+          .mockResolvedValue(invoice);
+        StripeWebhookHandlerInstance.stripeHelper.getInvoicePaypalTransactionId =
+          jest.fn().mockReturnValue('tx-1234');
+        StripeWebhookHandlerInstance.stripeHelper.updateInvoiceWithPaypalRefundReason =
+          jest.fn().mockResolvedValue({});
+        StripeWebhookHandlerInstance.log.error = jest.fn().mockReturnValue({});
+        const result = await StripeWebhookHandlerInstance.handleCreditNoteEvent(
+          {},
+          invoiceCreditNoteEvent
+        );
+        expect(result).toBeUndefined();
+        expect(
+          StripeWebhookHandlerInstance.paypalHelper.issueRefund
+        ).not.toHaveBeenCalled();
+        expect(
+          StripeWebhookHandlerInstance.stripeHelper
+            .updateInvoiceWithPaypalRefundReason
+        ).toHaveBeenCalledWith(
+          invoice,
+          'Credit note amount exceeds invoice amount; refund not issued.'
+        );
+        expect(sentryMod.reportSentryError).toHaveBeenCalledTimes(1);
       });
 
       it('logs an error if the amount doesnt match the invoice amount', async () => {
@@ -1742,6 +1800,44 @@ describe('StripeWebhookHandler', () => {
           StripeWebhookHandlerInstance.stripeHelper
             .getInvoicePaypalTransactionId
         ).toHaveBeenCalledWith(invoice);
+        expect(
+          StripeWebhookHandlerInstance.paypalHelper.issueRefund
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          StripeWebhookHandlerInstance.paypalHelper.issueRefund
+        ).toHaveBeenCalledWith(invoice, 'tx-1234', RefundType.Full, undefined);
+      });
+
+      it('re-fetches the invoice from Stripe and issues the refund when only the live invoice has the transaction id', async () => {
+        StripeWebhookHandlerInstance.paypalHelper = {
+          issueRefund: jest.fn().mockResolvedValue({}),
+        };
+        invoice.collection_method = 'send_invoice';
+        invoiceCreditNoteEvent.data.object.out_of_band_amount = 500;
+        invoice.amount_due = 500;
+        StripeWebhookHandlerInstance.stripeHelper.expandResource = jest
+          .fn()
+          .mockResolvedValue(invoice);
+        // The cached (Firestore) invoice has no transaction id, but the
+        // authoritative Stripe invoice does. See PAY-3762.
+        StripeWebhookHandlerInstance.stripeHelper.getInvoiceWithDiscount = jest
+          .fn()
+          .mockResolvedValue(invoice);
+        StripeWebhookHandlerInstance.stripeHelper.getInvoicePaypalTransactionId =
+          jest.fn().mockReturnValueOnce(null).mockReturnValue('tx-1234');
+        StripeWebhookHandlerInstance.log.error = jest.fn().mockReturnValue({});
+        const result = await StripeWebhookHandlerInstance.handleCreditNoteEvent(
+          {},
+          invoiceCreditNoteEvent
+        );
+        expect(result).toBeUndefined();
+        expect(
+          StripeWebhookHandlerInstance.stripeHelper.getInvoiceWithDiscount
+        ).toHaveBeenCalledWith(invoice.id);
+        expect(
+          StripeWebhookHandlerInstance.stripeHelper
+            .getInvoicePaypalTransactionId
+        ).toHaveBeenCalledTimes(2);
         expect(
           StripeWebhookHandlerInstance.paypalHelper.issueRefund
         ).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Because:

* A PayPal customer refunded via a Stripe credit note never received their
  payout: handleCreditNoteEvent read the invoice from the Firestore mirror,
  which lacked paypalTransactionId, so it skipped the refund while the
  subscription was still cancelled and the billing agreement removed.
* The mirror goes stale because processInvoice writes the transaction id and
  pays the invoice out of band concurrently; the resulting same-second
  invoice.updated/invoice.paid events collide on the Firestore event-time
  guard, dropping the transaction id.

This commit:

* Re-fetches the authoritative invoice from Stripe in handleCreditNoteEvent
  when the cached invoice has no transaction id, recovering already-stale
  invoices instead of silently skipping the refund.
* Persists the transaction id before paying out of band so the invoice.paid
  sync reliably captures it, preventing new stale mirrors.
* Surfaces the remaining no-transaction-id and credit-note-exceeds-invoice
  early returns via a Sentry report and a paypalRefundReason invoice tag.
* Adds unit coverage for the re-fetch recovery and neither-cached-nor-live
  paths.

Closes #PAY-3762

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
