### PR TITLE
fix(customs): remove flaky check_reputation integration test

### DIFF
--- a/packages/fxa-customs-server/test/remote/check_reputation_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_reputation_tests.js
@@ -33,18 +33,6 @@ config.reputationService = {
   timeout: 25,
 };
 
-// We use a restify based test reputation client to query the reputation server stub
-// in here for testing purposes, but also instantiate an instance of the actual reputation
-// client to verify some of the behavior in the module.
-var repJSClientConfig = {
-  serviceUrl: config.reputationService.baseUrl,
-  id: 'root',
-  key: 'toor',
-  timeout: 25,
-};
-var ipr = require('../../lib/ipReputationClient');
-var repJSClient = new ipr(repJSClientConfig);
-
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
@@ -76,37 +64,6 @@ ENDPOINTS.forEach((endpoint) => {
       t.notOk(err, 'no errors were returned');
       t.end();
     });
-  });
-
-  test('query reputation stub directly using ip-reputation-js-client', (t) => {
-    return reputationClient
-      .getAsync('/heartbeat')
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'clears reputation for TEST_IP');
-        return repJSClient.remove(TEST_IP);
-      })
-      .then(() => {
-        return repJSClient.get(TEST_IP);
-      })
-      .then(function (response) {
-        t.equal(
-          response.statusCode,
-          404,
-          'reputation value for TEST_IP not found'
-        );
-        var f =
-          response &&
-          response.timingPhases &&
-          response.timingPhases.total &&
-          typeof response.timingPhases.total === 'number' &&
-          response.timingPhases.total > 0.0;
-        t.equal(f, true, 'response contains timing data');
-        t.end();
-      })
-      .catch(function (err) {
-        t.fail(err);
-        t.end();
-      });
   });
 
   test(`does not block ${endpoint} for IP with nonexistent reputation`, (t) => {


### PR DESCRIPTION
## Because

- `test/remote/check_reputation_tests.js` intermittently failed in the nightly Integration Test. The flaky subtest (`query reputation stub directly using ip-reputation-js-client`) asserted `timingPhases.total > 0`, but the client computes that total from integer-millisecond `Date.now()` deltas, so a sub-millisecond localhost round-trip produced a `0ms` total and failed the assertion.
- `fxa-customs-server` is no longer in active use, so the subtest isn't worth stabilizing.

## This pull request

- Removes the flaky direct-client subtest and its now-unused `repJSClient` setup from `check_reputation_tests.js`. No source or other tests are touched.

## Issue that this pull request solves

Closes: FXA-13959

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Scoped deliberately small: only the flaky subtest is removed. The `ipReputationClient.js` source and the rest of the customs-server remain untouched for a future cleanup, since the service is no longer in active use.
