### PR TITLE
fix(mobile): Redirect passwordless users to set_password in OAuthNative flows when Sync is not decoupled

### DIFF
--- a/packages/functional-tests/lib/query-params.ts
+++ b/packages/functional-tests/lib/query-params.ts
@@ -5,7 +5,12 @@
 // This file contains query params that don't reflect states that can be reached from 123done.
 import uaStrings from './ua-strings';
 import { FF_OAUTH_CLIENT_ID } from './channels';
-import { SYNC_SESSION_TOKEN_SCOPE, OLDSYNC_SCOPE, VPN_SCOPE } from './scopes';
+import {
+  SYNC_SESSION_TOKEN_SCOPE,
+  OLDSYNC_SCOPE,
+  VPN_SCOPE,
+  PROFILE_SCOPE,
+} from './scopes';
 
 export const oauthWebchannelV1 = new URLSearchParams({
   context: 'oauth_webchannel_v1',
@@ -85,6 +90,22 @@ export const vpnMobileOAuthQueryParams = new URLSearchParams({
   state: 'fakestate',
   automatedBrowser: 'true',
   service: 'vpn',
+});
+
+// When Sync is not decoupled on Android, signing up for VPN on Android means
+// signing up for Sync as well; all scopes are included in the request
+export const vpnSyncMobileOAuthFenixQueryParams = new URLSearchParams({
+  ...Object.fromEntries(oauthWebchannelV1.entries()),
+  client_id: 'a2270f727f45f648', // Fenix (Android)
+  code_challenge_method: 'S256',
+  code_challenge: '2oc_C4v1qHeefWAGu5LI5oDG1oX4FV_Itc148D8_oQI',
+  keys_jwk:
+    'eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6ImdUejVIWFJfa2pxSFRtMG43ZjhxcDMybVZFaHZ1cGo1dXNUV1h5TWZsb1kiLCJ5IjoiVER5TlhkalhibHZld1pWLVc5MXNDZU9fRWd0NU9WYXhpblBzOEFTQ3owZyJ9',
+  scope: `${PROFILE_SCOPE} ${OLDSYNC_SCOPE} ${VPN_SCOPE}`,
+  state: 'fakestate',
+  automatedBrowser: 'true',
+  service: 'vpn',
+  entrypoint: 'protection_panel',
 });
 
 export const syncDesktopOAuthQueryParamsNoScope = new URLSearchParams({

--- a/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from '../../lib/fixtures/standard';
 import {
   syncMobileOAuthFenixQueryParams,
   vpnMobileOAuthQueryParams,
+  vpnSyncMobileOAuthFenixQueryParams,
 } from '../../lib/query-params';
 import { PROFILE_SCOPE, VPN_SCOPE } from '../../lib/scopes';
 
@@ -53,4 +54,30 @@ test.describe('vpn integration', () => {
       });
     }
   );
+
+  test('passwordless VPN + Sync signin on Android routes to set password when Sync is not decoupled', async ({
+    target,
+    syncOAuthBrowserPages: { page, signin, signinPasswordlessCode },
+    testAccountTracker,
+  }) => {
+    const { email, password } = await testAccountTracker.signUpPasswordless();
+    await signin.goto('/authorization', vpnSyncMobileOAuthFenixQueryParams);
+    await signin.fillOutEmailFirstForm(email);
+
+    await page.waitForURL(/signin_passwordless_code/);
+    const code = await target.emailClient.getPasswordlessSigninCode(email);
+    await signinPasswordlessCode.fillOutCodeForm(code);
+
+    await page.waitForURL(/set_password/);
+    await expect(
+      page.getByRole('heading', { name: 'Create password to sync' })
+    ).toBeVisible();
+
+    await page.getByLabel('Password', { exact: true }).fill(password);
+    await page.getByLabel('Repeat password').fill(password);
+    await page.getByRole('button', { name: 'Start syncing' }).click();
+
+    await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+    await signin.checkWebChannelMessage(FirefoxCommand.Login);
+  });
 });

--- a/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
+++ b/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
@@ -1364,6 +1364,7 @@ test.describe('severity-2', () => {
       },
       testAccountTracker,
     }) => {
+      test.fixme(true, 'TODO in FXA-13647');
       // Create passwordless account and set up TOTP via API
       const { email, sessionToken } =
         await testAccountTracker.signUpPasswordless();

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -585,7 +585,11 @@ const AuthAndAccountSetupRoutes = ({
         {/* Post verify */}
         <ThirdPartyAuthCallback
           path="/post_verify/third_party_auth/callback/*"
-          {...{ flowQueryParams, integration }}
+          {...{
+            flowQueryParams,
+            integration,
+            useFxAStatusResult,
+          }}
         />
         <SetPasswordContainer
           path="/post_verify/set_password/*"
@@ -678,6 +682,7 @@ const AuthAndAccountSetupRoutes = ({
             flowQueryParams,
             isSignedIntoFirefox,
             setCurrentSplitLayout,
+            useFxAStatusResult,
           }}
         />
         <SigninPasswordlessCodeContainer
@@ -688,6 +693,7 @@ const AuthAndAccountSetupRoutes = ({
             flowQueryParams,
             isSignedIntoFirefox,
             setCurrentSplitLayout,
+            useFxAStatusResult,
           }}
         />
         <SigninContainer
@@ -741,7 +747,12 @@ const AuthAndAccountSetupRoutes = ({
         />
         <SigninTotpCodeContainer
           path="/signin_totp_code/*"
-          {...{ integration, serviceName, setCurrentSplitLayout }}
+          {...{
+            integration,
+            serviceName,
+            setCurrentSplitLayout,
+            useFxAStatusResult,
+          }}
         />
         <SigninConfirmed
           path="/signin_verified/*"

--- a/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
+++ b/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
@@ -16,6 +16,7 @@ export const FormSetupAccount = ({
   onSubmit,
   loading,
   isSync,
+  requirePasswordConfirmation,
   offeredSyncEngineConfigs,
   submitButtonGleanId,
   passwordFormType = 'signup',
@@ -45,8 +46,8 @@ export const FormSetupAccount = ({
         submitButtonGleanId,
         passwordFormType,
         cmsButton,
+        requirePasswordConfirmation,
       }}
-      requirePasswordConfirmation={isSync}
     />
   );
 };

--- a/packages/fxa-settings/src/components/FormSetupAccount/interfaces.ts
+++ b/packages/fxa-settings/src/components/FormSetupAccount/interfaces.ts
@@ -22,6 +22,7 @@ export type FormSetupAccountProps = {
   onSubmit: (e?: React.BaseSyntheticEvent) => Promise<void>;
   loading: boolean;
   isSync: boolean;
+  requirePasswordConfirmation?: boolean;
   offeredSyncEngineConfigs?: typeof syncEngineConfigs;
   submitButtonGleanId?: string;
   passwordFormType?: 'signup' | 'post-verify-set-password';

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
@@ -154,6 +154,7 @@ describe('useFxAStatus', () => {
       const integration = {
         type: IntegrationType.Web,
         isSync: () => false,
+        isFirefoxNonSync: () => false,
       };
 
       renderHook(() => useFxAStatus(integration));

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
@@ -19,7 +19,10 @@ import {
 import firefox from '../../channels/firefox';
 import { Constants } from '../../constants';
 
-type FxAStatusIntegration = Pick<Integration, 'type' | 'isSync'>;
+type FxAStatusIntegration = Pick<
+  Integration,
+  'type' | 'isSync' | 'isFirefoxNonSync'
+>;
 
 /**
  * If integration.isSync or integration is OAuthNative, sends firefox.fxaStatus to retrieve

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getSyncEngineIds, syncEngineConfigs } from '../../sync-engines';
+import type { UseFxAStatusResult } from '.';
 
 export function mockUseFxAStatus({
   offeredSyncEnginesOverride,
@@ -36,7 +37,7 @@ export function mockUseFxAStatus({
     selectedEnginesForGlean,
     supportsKeysOptionalLogin,
     supportsCanLinkAccountUid,
-  };
+  } satisfies UseFxAStatusResult;
 }
 
 export default mockUseFxAStatus;

--- a/packages/fxa-settings/src/models/integrations/integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/integration.test.ts
@@ -41,6 +41,38 @@ describe('Integration Model', function () {
     });
   });
 
+  describe('requiresPasswordForLogin', function () {
+    it('is true when keys are required (Sync), regardless of keys-optional support', () => {
+      jest.spyOn(model, 'requiresKeys').mockReturnValue(true);
+      jest.spyOn(model, 'wantsKeysIfPasswordEntered').mockReturnValue(false);
+      expect(model.requiresPasswordForLogin(true)).toBe(true);
+    });
+
+    it('is true for a non-Sync client that wants keys when keys are not optional', () => {
+      jest.spyOn(model, 'requiresKeys').mockReturnValue(false);
+      jest.spyOn(model, 'wantsKeysIfPasswordEntered').mockReturnValue(true);
+      expect(model.requiresPasswordForLogin(false)).toBe(true);
+    });
+
+    it('is false for a non-Sync client that wants keys when the browser supports keys-optional login', () => {
+      jest.spyOn(model, 'requiresKeys').mockReturnValue(false);
+      jest.spyOn(model, 'wantsKeysIfPasswordEntered').mockReturnValue(true);
+      expect(model.requiresPasswordForLogin(true)).toBe(false);
+    });
+
+    it('is false when the client does not want keys', () => {
+      jest.spyOn(model, 'requiresKeys').mockReturnValue(false);
+      jest.spyOn(model, 'wantsKeysIfPasswordEntered').mockReturnValue(false);
+      expect(model.requiresPasswordForLogin(false)).toBe(false);
+    });
+
+    it('treats an omitted keys-optional flag as "not supported"', () => {
+      jest.spyOn(model, 'requiresKeys').mockReturnValue(false);
+      jest.spyOn(model, 'wantsKeysIfPasswordEntered').mockReturnValue(true);
+      expect(model.requiresPasswordForLogin()).toBe(true);
+    });
+  });
+
   describe('isTrusted', function () {
     it('returns `true`', () => {
       expect(model.isTrusted()).toBeTruthy();

--- a/packages/fxa-settings/src/models/integrations/integration.ts
+++ b/packages/fxa-settings/src/models/integrations/integration.ts
@@ -199,6 +199,30 @@ export class GenericIntegration<
     return this.requiresKeys() || this.wantsKeysIfPasswordEntered();
   }
 
+  /**
+   * Whether a passwordless account must set a password because scoped keys
+   * must be derived and sent to the browser.
+   *
+   * - Sync always requires keys (`requiresKeys`), so a passwordless Sync sign-in
+   *   must set a password first.
+   * - A non-Sync Firefox service that wants keys (`wantsKeysIfPasswordEntered`)
+   *   only requires a password when the browser has NOT decoupled Sync. When the
+   *   browser has the "keys optional" capability set (Fx desktop 147+, TBD in mobile),
+   *   it can complete login without keys, so no password is required.
+   *
+   * When this is true (and the caller has also confirmed the account has no
+   * password), when the user has authenticated, route them to
+   * `/post_verify/set_password` and defer the fxaLogin/fxaOAuthLogin web channel
+   * messages until keys are available — otherwise the browser receives a keyless
+   * OAuth login.
+   */
+  requiresPasswordForLogin(supportsKeysOptionalLogin = false): boolean {
+    return (
+      this.requiresKeys() ||
+      (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+    );
+  }
+
   wantsLogin(): boolean {
     return false;
   }

--- a/packages/fxa-settings/src/pages/Index/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Index/interfaces.ts
@@ -30,6 +30,7 @@ export type IndexIntegration = Pick<
   | 'requiresKeys'
   | 'wantsKeys'
   | 'wantsKeysIfPasswordEntered'
+  | 'requiresPasswordForLogin'
   | 'wantsLogin'
   | 'wantsTwoStepAuthentication'
 >;

--- a/packages/fxa-settings/src/pages/Index/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Index/mocks.tsx
@@ -86,6 +86,7 @@ export function createMockIndexOAuthNativeIntegration({
     requiresKeys: () => false,
     wantsKeys: () => false,
     wantsKeysIfPasswordEntered: () => false,
+    requiresPasswordForLogin: () => false,
     wantsLogin: () => false,
     wantsTwoStepAuthentication: () => false,
     data: new OAuthIntegrationData(
@@ -116,6 +117,7 @@ export function createMockIndexWebIntegration(): IndexIntegration {
     requiresKeys: () => false,
     wantsKeys: () => false,
     wantsKeysIfPasswordEntered: () => false,
+    requiresPasswordForLogin: () => false,
     wantsLogin: () => false,
     wantsTwoStepAuthentication: () => false,
     data: new IntegrationData(

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
@@ -140,8 +140,13 @@ function applyDefaultMocks() {
   }));
 }
 
-function render(integration = mockSyncDesktopV3Integration()) {
-  const useFxAStatusResult = mockUseFxAStatus();
+function render(
+  integration = mockSyncDesktopV3Integration(),
+  {
+    supportsKeysOptionalLogin = false,
+  }: { supportsKeysOptionalLogin?: boolean } = {}
+) {
+  const useFxAStatusResult = mockUseFxAStatus({ supportsKeysOptionalLogin });
   renderWithLocalizationProvider(
     <LocationProvider>
       <SetPasswordContainer
@@ -162,6 +167,7 @@ function mockSyncDesktopV3Integration() {
     isSync: () => true,
     requiresKeys: () => true,
     wantsKeys: () => true,
+    requiresPasswordForLogin: () => true,
     data: { service: 'sync' },
     isDesktopSync: () => true,
     isFirefoxClientServiceRelay: () => false,
@@ -185,6 +191,7 @@ function mockOAuthNativeIntegration(
     isSync: () => true,
     requiresKeys: () => true,
     wantsKeys: () => true,
+    requiresPasswordForLogin: () => true,
     data: { service: 'sync' },
     isDesktopSync: () => true,
     isFirefoxClientServiceRelay: () => false,
@@ -194,6 +201,34 @@ function mockOAuthNativeIntegration(
     isFirefoxMobileClient: () => isFirefoxMobileClient,
     getCmsInfo: () => undefined,
     getWebChannelServices: mockGetWebChannelServices({ isSync: true }),
+  } as ModelsModule.Integration;
+}
+// A non-Sync Firefox client (VPN) whose scope requests keys. This tests
+// the mobile case where Sync has not been decoupled yet.
+function mockVpnOAuthNativeIntegration() {
+  return {
+    type: ModelsModule.IntegrationType.OAuthNative,
+    getService: () => 'vpn',
+    getClientId: () => undefined,
+    isSync: () => false,
+    requiresKeys: () => false,
+    wantsKeysIfPasswordEntered: () => true,
+    wantsKeys: () => true,
+    requiresPasswordForLogin(supportsKeysOptionalLogin = false) {
+      return (
+        this.requiresKeys() ||
+        (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+      );
+    },
+    data: { service: 'vpn' },
+    isDesktopSync: () => false,
+    isFirefoxClientServiceRelay: () => false,
+    isFirefoxClientServiceSmartWindow: () => false,
+    isFirefoxClientServiceVpn: () => true,
+    isFirefoxNonSync: () => true,
+    isFirefoxMobileClient: () => true,
+    getCmsInfo: () => undefined,
+    getWebChannelServices: mockGetWebChannelServices({ isSync: false }),
   } as ModelsModule.Integration;
 }
 
@@ -226,6 +261,28 @@ describe('SetPassword-container', () => {
     });
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(currentSetPasswordProps).toBeDefined();
+  });
+
+  // "keys not optional" = Firefox where Sync isn't decoupled: desktop before
+  // 147, and Mobile as of Firefox 153.
+  it('renders for the non-Sync VPN flow that needs keys when keys are not optional', async () => {
+    render(mockVpnOAuthNativeIntegration(), {
+      supportsKeysOptionalLogin: false,
+    });
+    await waitFor(() => {
+      expect(SetPasswordModule.default).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('redirects to signin for the non-Sync VPN flow when the browser supports keys-optional login', async () => {
+    render(mockVpnOAuthNativeIntegration(), {
+      supportsKeysOptionalLogin: true,
+    });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/signin', { replace: true });
+    });
+    expect(SetPasswordModule.default).not.toHaveBeenCalled();
   });
 
   it('redirects to signin when user already has a password', async () => {

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -34,6 +34,7 @@ const SetPasswordContainer = ({
     offeredSyncEngineConfigs,
     declinedSyncEngines,
     selectedEnginesForGlean,
+    supportsKeysOptionalLogin,
   },
 }: {
   integration: Integration;
@@ -214,8 +215,16 @@ const SetPasswordContainer = ({
   );
 
   // Users must be already authenticated on this page.
-  // This page is currently always for the Sync flow.
-  if (!email || !sessionToken || !uid || !integration.isSync()) {
+  // This page only applies applies to flows where a passwordless account must
+  // set a password for key derivation, including non-Sync Firefox flows that
+  // that require keys because the browser hasn't decoupled Sync (desktop before
+  // Fx 147, and Mobile presently as of Fx 153).
+  if (
+    !email ||
+    !sessionToken ||
+    !uid ||
+    !integration.requiresPasswordForLogin(supportsKeysOptionalLogin)
+  ) {
     navigateWithQuery('/signin', { replace: true });
     return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.test.tsx
@@ -43,6 +43,17 @@ describe('SetPassword page', () => {
     expect(screen.getByText('Start syncing')).toBeInTheDocument();
   });
 
+  it('renders both password inputs, including for non-Sync flows', () => {
+    renderWithLocalizationProvider(
+      <Subject
+        integration={createMockIntegration(undefined, { isSync: false })}
+      />
+    );
+
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Repeat password')).toBeInTheDocument();
+  });
+
   it('renders CMS overrides when PostVerifySetPasswordPage is set', () => {
     const cmsInfo = {
       shared: { buttonColor: '#333' },

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
@@ -156,8 +156,9 @@ export const SetPassword = ({
         }}
         loading={createPasswordLoading}
         onSubmit={handleSubmit(onSubmit)}
-        // This page is only shown during the Sync flow
-        isSync={true}
+        isSync={integration.isSync()}
+        // This form completes Sync sign up, so we want the user to confirm their new password.
+        requirePasswordConfirmation={true}
         passwordFormType="post-verify-set-password"
         cmsButton={cmsButton}
       />

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/interfaces.ts
@@ -21,7 +21,10 @@ export type CreatePasswordHandler = (
   newPassword: string
 ) => Promise<CreatePasswordHandlerError>;
 
-export type PostVerifySetPasswordIntegration = Pick<Integration, 'getCmsInfo'>;
+export type PostVerifySetPasswordIntegration = Pick<
+  Integration,
+  'getCmsInfo' | 'isSync'
+>;
 
 /**
  * How the user got to the create-password page. Determines which Glean
@@ -34,7 +37,7 @@ export interface SetPasswordProps {
   email: string;
   createPasswordHandler: CreatePasswordHandler;
   offeredSyncEngineConfigs?: typeof syncEngineConfigs;
-  integration?: PostVerifySetPasswordIntegration;
+  integration: PostVerifySetPasswordIntegration;
   passwordCreationReason?: PasswordCreationReason;
   /**
    * Glean `reason` for the funnel events, composed by the container. Defaults

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/mocks.tsx
@@ -14,17 +14,19 @@ import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { RelierCmsInfo } from '../../../models';
 
 export function createMockIntegration(
-  cmsInfo?: RelierCmsInfo
+  cmsInfo?: RelierCmsInfo,
+  { isSync = true } = {}
 ): PostVerifySetPasswordIntegration {
   return {
     getCmsInfo: () => cmsInfo,
+    isSync: () => isSync,
   };
 }
 
 export const Subject = ({
   email = MOCK_EMAIL,
   createPasswordHandler = () => Promise.resolve({ error: null }),
-  integration,
+  integration = createMockIntegration(),
   passwordCreationReason,
   gleanReason,
 }: {

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -19,6 +19,7 @@ import {
   ensureCanLinkAcountOrRedirect,
 } from '../../Signin/utils';
 import { QueryParams } from '../../../index';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { MOCK_EMAIL, MOCK_SESSION_TOKEN } from '../../mocks';
 import { LocationProvider } from '@reach/router';
 import { GenericData } from '../../../lib/model-data';
@@ -64,6 +65,7 @@ jest.mock('../../../lib/oauth/hooks', () => {
 jest.mock('../../Signin/utils', () => {
   return {
     __esModule: true,
+    ...jest.requireActual('../../Signin/utils'),
     handleNavigation: jest.fn(),
     ensureCanLinkAcountOrRedirect: jest.fn(),
   };
@@ -104,7 +106,10 @@ function mockWebIntegration({ redirectTo }: { redirectTo?: string } = {}) {
   );
 }
 
-function mockOAuthNativeIntegration({ service }: { service?: string } = {}) {
+function mockOAuthNativeIntegration({
+  service,
+  keysJwk,
+}: { service?: string; keysJwk?: string } = {}) {
   const integration = new ModelsModule.OAuthNativeIntegration(
     new GenericData({
       service,
@@ -124,27 +129,36 @@ function mockOAuthNativeIntegration({ service }: { service?: string } = {}) {
     trusted: true,
     imageUri: '',
   };
+  // Presence of a keysJwk (with scopedKeysEnabled) makes the scope request keys,
+  // so a non-Sync service like VPN reports wantsKeysIfPasswordEntered().
+  if (keysJwk !== undefined) {
+    integration.data.keysJwk = keysJwk;
+  }
   return integration;
 }
 
-function renderWith(
-  props: {
-    flowQueryParams?: QueryParams;
-    integration: ModelsModule.Integration;
-  } = {
-    flowQueryParams: {
+function renderWith(props?: {
+  flowQueryParams?: QueryParams;
+  integration: ModelsModule.Integration;
+  supportsKeysOptionalLogin?: boolean;
+}) {
+  const {
+    flowQueryParams = {
       flowId: 'bbbb',
       flowBeginTime: 1734112296874,
     },
-    integration: mockThirdPartyAuthCallbackIntegration(),
-  }
-) {
+    integration = mockThirdPartyAuthCallbackIntegration(),
+    supportsKeysOptionalLogin = false,
+  } = props ?? {};
+  const useFxAStatusResult = mockUseFxAStatus({ supportsKeysOptionalLogin });
   return renderWithLocalizationProvider(
     <LocationProvider>
       <AppContext.Provider
         value={{ ...mockAppContext(), ...createAppContext() }}
       >
-        <ThirdPartyAuthCallback {...props} />;
+        <ThirdPartyAuthCallback
+          {...{ flowQueryParams, integration, useFxAStatusResult }}
+        />
       </AppContext.Provider>
     </LocationProvider>
   );
@@ -260,6 +274,7 @@ describe('ThirdPartyAuthCallback component', () => {
         handleFxaOAuthLogin: false,
         integration: integration,
         isSignInWithThirdPartyAuth: true,
+        supportsKeysOptionalLogin: false,
         queryParams: '?',
         redirectTo: redirectTo,
         signinData: {
@@ -302,6 +317,73 @@ describe('ThirdPartyAuthCallback component', () => {
           handleFxaLogin: false,
           handleFxaOAuthLogin: false,
           isSignInWithThirdPartyAuth: true,
+        })
+      );
+    });
+  });
+
+  // "keys not optional" = Firefox where Sync isn't decoupled: desktop before
+  // 147, and Mobile as of Firefox 153.
+  it('defers handleFxaLogin and handleFxaOAuthLogin for service=vpn wanting keys when keys are not optional', async () => {
+    const integration = mockOAuthNativeIntegration({
+      service: OAuthNativeServices.Vpn,
+      keysJwk: 'mock-keys-jwk',
+    });
+    renderWith({
+      integration,
+      supportsKeysOptionalLogin: false,
+    });
+    await waitFor(() => {
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          handleFxaLogin: false,
+          handleFxaOAuthLogin: false,
+          isSignInWithThirdPartyAuth: true,
+          supportsKeysOptionalLogin: false,
+        })
+      );
+    });
+  });
+
+  it('signs in immediately for service=vpn when the browser supports keys-optional login', async () => {
+    const integration = mockOAuthNativeIntegration({
+      service: OAuthNativeServices.Vpn,
+      keysJwk: 'mock-keys-jwk',
+    });
+    renderWith({
+      integration,
+      supportsKeysOptionalLogin: true,
+    });
+    await waitFor(() => {
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          handleFxaLogin: true,
+          handleFxaOAuthLogin: true,
+          isSignInWithThirdPartyAuth: true,
+          supportsKeysOptionalLogin: true,
+        })
+      );
+    });
+  });
+
+  it('defers handleFxaLogin and handleFxaOAuthLogin for service=relay wanting keys when keys are not optional', async () => {
+    // A passwordless third-party account (created via another RP) signing into
+    // Relay on a non-decoupled browser must also set a password
+    const integration = mockOAuthNativeIntegration({
+      service: OAuthNativeServices.Relay,
+      keysJwk: 'mock-keys-jwk',
+    });
+    renderWith({
+      integration,
+      supportsKeysOptionalLogin: false,
+    });
+    await waitFor(() => {
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          handleFxaLogin: false,
+          handleFxaOAuthLogin: false,
+          isSignInWithThirdPartyAuth: true,
+          supportsKeysOptionalLogin: false,
         })
       );
     });

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -17,6 +17,7 @@ import {
   handleNavigation,
   ensureCanLinkAcountOrRedirect,
 } from '../../Signin/utils';
+import type { UseFxAStatusResult } from '../../../lib/hooks/useFxAStatus';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import {
   StoredAccountData,
@@ -43,9 +44,11 @@ type LinkedAccountData = {
 const ThirdPartyAuthCallback = ({
   integration,
   flowQueryParams,
+  useFxAStatusResult,
 }: {
   integration: Integration;
   flowQueryParams?: QueryParams;
+  useFxAStatusResult: UseFxAStatusResult;
 } & RouteComponentProps) => {
   const account = useAccount();
   const authClient = useAuthClient();
@@ -86,6 +89,12 @@ const ThirdPartyAuthCallback = ({
   const performNavigation = useCallback(
     async (linkedAccount: LinkedAccountData, needsVerification = false) => {
       const isFirefoxNonSync = integration.isFirefoxNonSync();
+      // Passwordless accounts that need keys (Sync, or a non-Sync Firefox service
+      // when Sync is not decoupled) need to defer the browser login/OAuth messages
+      // and let handleNavigation route to set_password.
+      const deferKeysUntilPasswordSet = integration.requiresPasswordForLogin(
+        useFxAStatusResult.supportsKeysOptionalLogin
+      );
 
       if (integration.isFirefoxNonSync() || integration.isSync()) {
         const ok = await ensureCanLinkAcountOrRedirect({
@@ -121,13 +130,14 @@ const ThirdPartyAuthCallback = ({
         finishOAuthFlowHandler,
         queryParams: location.search,
         isSignInWithThirdPartyAuth: true,
-        // For non‑Sync integrations we can sign in to the browser immediately because
-        // those integrations do not require keys to be available.
-        // For Sync, third‑party auth is only offered if the account is passwordless.
-        // In that case, we must defer browser login/OAuth messages until after the
-        // user sets a password and keys are available (see SetPassword/container.tsx).
-        handleFxaLogin: isFirefoxNonSync,
-        handleFxaOAuthLogin: isFirefoxNonSync,
+        supportsKeysOptionalLogin: useFxAStatusResult.supportsKeysOptionalLogin,
+        // For non‑Sync browser services where Sync has been decoupled, we can
+        // sign in to the browser immediately because those integrations do not require keys
+        // (e.g. a password entered). For passwordless accounts, we must
+        // defer browser login/OAuth messages until after the user sets a
+        // password and keys are available.
+        handleFxaLogin: isFirefoxNonSync && !deferKeysUntilPasswordSet,
+        handleFxaOAuthLogin: isFirefoxNonSync && !deferKeysUntilPasswordSet,
       };
 
       const { error: navError } = await handleNavigation(navigationOptions);
@@ -144,6 +154,7 @@ const ThirdPartyAuthCallback = ({
       navigateWithQuery,
       webRedirectCheck,
       ftlMsgResolver,
+      useFxAStatusResult.supportsKeysOptionalLogin,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.test.tsx
@@ -13,6 +13,7 @@ import SigninPasswordlessCodeContainer from './container';
 import { screen, waitFor } from '@testing-library/react';
 import { MOCK_EMAIL, MOCK_CLIENT_ID } from '../../mocks';
 import { createMockWebIntegration } from '../../../lib/integrations/mocks';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { createMockPasswordlessLocationState } from './mocks';
 
 let integration: Integration;
@@ -87,6 +88,7 @@ async function render() {
           integration,
           serviceName: 'sync',
           flowQueryParams: {},
+          useFxAStatusResult: mockUseFxAStatus(),
         }}
       />
     </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.tsx
@@ -22,6 +22,7 @@ const SigninPasswordlessCodeContainer = ({
   flowQueryParams,
   isSignedIntoFirefox,
   setCurrentSplitLayout,
+  useFxAStatusResult,
 }: SigninPasswordlessCodeContainerProps & RouteComponentProps) => {
   const navigateWithQuery = useNavigateWithQuery();
   const location = useLocation() as ReturnType<typeof useLocation> & {
@@ -123,6 +124,7 @@ const SigninPasswordlessCodeContainer = ({
         isSignup,
         isSignedIntoFirefox,
         resendCountdownSeconds: 5,
+        useFxAStatusResult,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -97,6 +97,7 @@ jest.mock('../../../lib/hooks/useNavigateWithQuery', () => ({
 let mockHandleNavigation = jest.fn().mockResolvedValue({ error: undefined });
 
 jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
   getSyncNavigate: jest.fn((search, options) => ({
     to: '/connect_another_device',
   })),
@@ -133,6 +134,7 @@ function resetMockAuthClient() {
 function render(
   props: Partial<SigninPasswordlessCodeProps> & {
     isSignup?: boolean;
+    supportsKeysOptionalLogin?: boolean;
   } = {}
 ) {
   if (!props.integration) {
@@ -573,6 +575,9 @@ describe('SigninPasswordlessCode page', () => {
 
       const integration = createMockSigninWebIntegration();
       integration.isSync = jest.fn().mockReturnValue(true);
+      // Sync requires keys, so a passwordless sign-in must set a password
+      // (passwordless TOTP accounts verify via email first).
+      integration.requiresKeys = jest.fn().mockReturnValue(true);
 
       render({ integration, isSignup: false });
       await submitCode();
@@ -677,6 +682,7 @@ describe('SigninPasswordlessCode page', () => {
 
         const integration = createMockSigninWebIntegration();
         integration.isSync = jest.fn().mockReturnValue(true);
+        integration.requiresKeys = jest.fn().mockReturnValue(true);
 
         render({ integration, isSignup: false });
         await submitCode();
@@ -710,6 +716,7 @@ describe('SigninPasswordlessCode page', () => {
 
         const integration = createMockSigninWebIntegration();
         integration.isSync = jest.fn().mockReturnValue(true);
+        integration.requiresKeys = jest.fn().mockReturnValue(true);
 
         render({ integration, isSignup: false });
         await submitCode();
@@ -730,6 +737,7 @@ describe('SigninPasswordlessCode page', () => {
 
         const integration = createMockSigninWebIntegration();
         integration.isSync = jest.fn().mockReturnValue(true);
+        integration.requiresKeys = jest.fn().mockReturnValue(true);
 
         render({ integration, isSignup: true });
         await submitCode();
@@ -750,13 +758,18 @@ describe('SigninPasswordlessCode page', () => {
         expect(mockEnsureCanLinkAcountOrRedirect).not.toHaveBeenCalled();
       });
 
-      it('redirects to set password page for Firefox non-Sync (Relay) signin flow when user accepts merge', async () => {
+      it('sends can_link_account then continues through handleNavigation for a Firefox non-Sync (Relay) signin flow that does not need keys', async () => {
         mockEnsureCanLinkAcountOrRedirect = jest.fn().mockResolvedValue(true);
 
         const integration = createMockSigninOAuthNativeIntegration({
           service: OAuthNativeServices.Relay,
           isSync: false,
         });
+        // Relay doesn't request keys, so no set_password detour — it flows
+        // through handleNavigation.
+        integration.wantsKeysIfPasswordEntered = jest
+          .fn()
+          .mockReturnValue(false);
 
         render({ integration, isSignup: false });
         await submitCode();
@@ -773,6 +786,61 @@ describe('SigninPasswordlessCode page', () => {
         await waitFor(() => {
           expect(mockHandleNavigation).toHaveBeenCalled();
         });
+      });
+
+      // "keys not optional" = Firefox where Sync isn't decoupled: desktop
+      // before 147, and Mobile as of Firefox 153.
+      it('redirects to set password for a non-Sync VPN signin that needs keys when keys are not optional', async () => {
+        mockEnsureCanLinkAcountOrRedirect = jest.fn().mockResolvedValue(true);
+
+        const integration = createMockSigninOAuthNativeIntegration({
+          service: OAuthNativeServices.Vpn,
+          isSync: false,
+        });
+
+        render({
+          integration,
+          isSignup: false,
+          supportsKeysOptionalLogin: false,
+        });
+        await submitCode();
+
+        await waitFor(() => {
+          expect(mockNavigateWithQuery).toHaveBeenCalledWith(
+            '/post_verify/set_password',
+            expect.objectContaining({
+              replace: true,
+              state: { passwordCreationReason: 'otp' },
+            })
+          );
+        });
+        // Web channel messages must be deferred — handleNavigation only runs
+        // after the password is created.
+        expect(mockHandleNavigation).not.toHaveBeenCalled();
+      });
+
+      it('continues through handleNavigation for a non-Sync VPN signin when the browser supports keys-optional login', async () => {
+        mockEnsureCanLinkAcountOrRedirect = jest.fn().mockResolvedValue(true);
+
+        const integration = createMockSigninOAuthNativeIntegration({
+          service: OAuthNativeServices.Vpn,
+          isSync: false,
+        });
+
+        render({
+          integration,
+          isSignup: false,
+          supportsKeysOptionalLogin: true,
+        });
+        await submitCode();
+
+        await waitFor(() => {
+          expect(mockHandleNavigation).toHaveBeenCalled();
+        });
+        expect(mockNavigateWithQuery).not.toHaveBeenCalledWith(
+          '/post_verify/set_password',
+          expect.anything()
+        );
       });
 
       it('with OAuth integration', async () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -68,6 +68,7 @@ const SigninPasswordlessCode = ({
   isSignup = false,
   isSignedIntoFirefox = false,
   resendCountdownSeconds = 0,
+  useFxAStatusResult,
 }: SigninPasswordlessCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const authClient = useAuthClient();
@@ -314,10 +315,17 @@ const SigninPasswordlessCode = ({
         }
       }
 
-      // Sync flows need a password to derive encryption keys (unwrapBKey).
-      // TOTP accounts must verify first since /password/create requires
-      // a verifiedSessionToken.
-      if (integration.isSync()) {
+      // Flows that need encryption keys (unwrapBKey) require a password first:
+      // Sync always, and non-Sync Firefox clients that want keys (e.g. VPN) when
+      // the browser hasn't decoupled Sync. Route to set_password without sending
+      // any web channel messages — they're sent after the password is created,
+      // once keys are available. TOTP accounts must verify first
+      // since /password/create requires a verifiedSessionToken.
+      if (
+        integration.requiresPasswordForLogin(
+          useFxAStatusResult.supportsKeysOptionalLogin
+        )
+      ) {
         const accountData = {
           uid: result.uid,
           sessionToken: result.sessionToken,

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/interfaces.ts
@@ -5,6 +5,7 @@
 import type { QueryParams } from '../../..';
 import type { HandledError } from '../../../lib/error-utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import type { UseFxAStatusResult } from '../../../lib/hooks/useFxAStatus';
 import { SigninIntegration } from '../interfaces';
 
 export interface PasswordlessLocationState {
@@ -23,6 +24,7 @@ export interface SigninPasswordlessCodeContainerProps {
   flowQueryParams: QueryParams;
   isSignedIntoFirefox?: boolean;
   setCurrentSplitLayout?: (value: boolean) => void;
+  useFxAStatusResult: UseFxAStatusResult;
 }
 
 export interface SigninPasswordlessCodeProps {
@@ -37,6 +39,7 @@ export interface SigninPasswordlessCodeProps {
   isSignup?: boolean;
   isSignedIntoFirefox?: boolean;
   resendCountdownSeconds?: number;
+  useFxAStatusResult: UseFxAStatusResult;
 }
 
 export interface PasswordlessConfirmCodeResponse {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
@@ -11,6 +11,7 @@ import {
   WebIntegration,
 } from '../../../models';
 import { SigninPasswordlessCodeProps } from './interfaces';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import SigninPasswordlessCode from '.';
 import {
   MOCK_CLIENT_ID,
@@ -93,7 +94,10 @@ export const Subject = ({
   isSignup = false,
   isSignedIntoFirefox = false,
   sendError = null,
-}: Partial<SigninPasswordlessCodeProps>) => {
+  supportsKeysOptionalLogin = false,
+}: Partial<SigninPasswordlessCodeProps> & {
+  supportsKeysOptionalLogin?: boolean;
+}) => {
   return (
     <LocationProvider>
       <SigninPasswordlessCode
@@ -106,6 +110,7 @@ export const Subject = ({
           isSignup,
           isSignedIntoFirefox,
           sendError,
+          useFxAStatusResult: mockUseFxAStatus({ supportsKeysOptionalLogin }),
         }}
       />
     </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -18,6 +18,7 @@ import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import SigninTotpCodeContainer from './container';
 import { MozServices } from '../../../lib/types';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { createMockWebIntegration } from '../SigninTokenCode/mocks';
 import {
   Integration,
@@ -121,14 +122,18 @@ const mockAuthClient = {
 function mockVerifyTotp(success: boolean = true, errorOut: boolean = false) {
   mockAuthClient.verifyTotpCode.mockReset();
   if (errorOut) {
-    mockAuthClient.verifyTotpCode.mockRejectedValue(new Error('Unexpected error'));
+    mockAuthClient.verifyTotpCode.mockRejectedValue(
+      new Error('Unexpected error')
+    );
   } else if (!success) {
     mockAuthClient.verifyTotpCode.mockResolvedValue({ success: false });
   } else {
     mockAuthClient.verifyTotpCode.mockResolvedValue({ success: true });
   }
 
-  (ModelsModule.useAuthClient as jest.Mock).mockImplementation(() => mockAuthClient);
+  (ModelsModule.useAuthClient as jest.Mock).mockImplementation(
+    () => mockAuthClient
+  );
 }
 const mockSensitiveDataClient = createMockSensitiveDataClient();
 mockSensitiveDataClient.getDataType = jest.fn();
@@ -177,6 +182,7 @@ describe('signin totp code container', () => {
           {...{
             integration,
             serviceName: MozServices.Default,
+            useFxAStatusResult: mockUseFxAStatus(),
           }}
         />
       </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -21,6 +21,7 @@ import {
   useFinishOAuthFlowHandler,
   useOAuthKeysCheck,
 } from '../../../lib/oauth/hooks';
+import type { UseFxAStatusResult } from '../../../lib/hooks/useFxAStatus';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { getHandledError, HandledError } from '../../../lib/error-utils';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
@@ -34,12 +35,14 @@ export type SigninTotpCodeContainerProps = {
   integration: Integration;
   serviceName: MozServices;
   setCurrentSplitLayout?: (value: boolean) => void;
+  useFxAStatusResult: UseFxAStatusResult;
 };
 
 export const SigninTotpCodeContainer = ({
   integration,
   serviceName,
   setCurrentSplitLayout,
+  useFxAStatusResult,
 }: SigninTotpCodeContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const session = useSession();
@@ -156,6 +159,7 @@ export const SigninTotpCodeContainer = ({
         keyFetchToken,
         unwrapBKey,
         setCurrentSplitLayout,
+        useFxAStatusResult,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -445,4 +445,80 @@ describe('Sign in with TOTP code page', () => {
       });
     });
   });
+
+  // "keys not optional" = Firefox where Sync isn't decoupled: desktop before
+  // 147, and Mobile as of Firefox 153.
+  describe('passwordless OTP redirect to set_password for non-Sync clients that need keys', () => {
+    // A non-Sync Firefox client (VPN) whose scope requests keys.
+    const vpnIntegration = () => {
+      const integration = mockOAuthNativeSigninIntegration(false);
+      integration.isFirefoxClientServiceVpn = () => true;
+      integration.wantsKeysIfPasswordEntered = () => true;
+      return integration;
+    };
+
+    it('redirects to set_password when keys are not optional', async () => {
+      const user = userEvent.setup();
+      const handleNavigationSpy = jest
+        .spyOn(SigninUtils, 'handleNavigation')
+        .mockResolvedValue({ error: undefined });
+      const submitTotpCode = jest.fn().mockResolvedValue({ error: undefined });
+
+      renderWithLocalizationProvider(
+        <Subject
+          integration={vpnIntegration()}
+          submitTotpCode={submitTotpCode}
+          supportsKeysOptionalLogin={false}
+          signinState={{
+            ...MOCK_TOTP_LOCATION_STATE,
+            isPasswordlessOtpSignin: true,
+          }}
+        />
+      );
+      await user.type(screen.getByLabelText('Enter 6-digit code'), '123456');
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(mockNavigateWithQuery).toHaveBeenCalledWith(
+          '/post_verify/set_password',
+          expect.objectContaining({
+            replace: true,
+            state: { passwordCreationReason: 'otp' },
+          })
+        );
+      });
+      // Web channel messages must be deferred until after the password is set.
+      expect(handleNavigationSpy).not.toHaveBeenCalled();
+    });
+
+    it('continues through handleNavigation when the browser supports keys-optional login', async () => {
+      const user = userEvent.setup();
+      const handleNavigationSpy = jest
+        .spyOn(SigninUtils, 'handleNavigation')
+        .mockResolvedValue({ error: undefined });
+      const submitTotpCode = jest.fn().mockResolvedValue({ error: undefined });
+
+      renderWithLocalizationProvider(
+        <Subject
+          integration={vpnIntegration()}
+          submitTotpCode={submitTotpCode}
+          supportsKeysOptionalLogin={true}
+          signinState={{
+            ...MOCK_TOTP_LOCATION_STATE,
+            isPasswordlessOtpSignin: true,
+          }}
+        />
+      );
+      await user.type(screen.getByLabelText('Enter 6-digit code'), '123456');
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(handleNavigationSpy).toHaveBeenCalled();
+      });
+      expect(mockNavigateWithQuery).not.toHaveBeenCalledWith(
+        '/post_verify/set_password',
+        expect.anything()
+      );
+    });
+  });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -15,6 +15,7 @@ import { SigninIntegration, SigninLocationState } from '../interfaces';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { handleNavigation } from '../utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import type { UseFxAStatusResult } from '../../../lib/hooks/useFxAStatus';
 import { storeAccountData } from '../../../lib/storage-utils';
 import {
   getLocalizedErrorMessage,
@@ -38,6 +39,7 @@ export type SigninTotpCodeProps = {
   submitTotpCode: (totpCode: string) => Promise<{ error?: HandledError }>;
   serviceName?: MozServices;
   setCurrentSplitLayout?: (value: boolean) => void;
+  useFxAStatusResult: UseFxAStatusResult;
 } & SensitiveData.AuthData;
 
 export const viewName = 'signin-totp-code';
@@ -51,6 +53,7 @@ export const SigninTotpCode = ({
   keyFetchToken,
   unwrapBKey,
   setCurrentSplitLayout,
+  useFxAStatusResult,
 }: SigninTotpCodeProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
@@ -135,18 +138,24 @@ export const SigninTotpCode = ({
         ...(signinState.isPasswordlessOtpSignin && { hasPassword: false }),
       });
 
-      // Passwordless Sync flow: after TOTP, redirect to set_password
-      // for key derivation. The session is now verified so
-      // /password/create (which requires verifiedSessionToken) will work.
-      // Only redirect to set_password for Sync integrations, non-Sync
-      // OAuth flows (e.g. Relay) should continue through handleNavigation.
+      // Passwordless flow: after TOTP, redirect to set_password for key
+      // derivation. The session is now verified so /password/create (which
+      // requires verifiedSessionToken) will work. Redirect when keys are
+      // needed — Sync always, and non-Sync browser services that require keys
+      // because the browser hasn't decoupled Sync. Other non-Sync
+      // flows that don't require keys continue through handleNavigation.
       //
       // The inbound `isPasswordlessOtpSignin` lives on SigninLocationState;
       // the outbound `passwordCreationReason` lives on SetPasswordLocationState.
       // They look related but belong to different state objects on different
       // routes — the boolean gates the redirect, the enum tags the Glean
       // reason on the destination page.
-      if (signinState.isPasswordlessOtpSignin && integration.isSync()) {
+      if (
+        signinState.isPasswordlessOtpSignin &&
+        integration.requiresPasswordForLogin(
+          useFxAStatusResult.supportsKeysOptionalLogin
+        )
+      ) {
         navigateWithQuery('/post_verify/set_password', {
           replace: true,
           state: {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../mocks';
 import { MozServices } from '../../../lib/types';
 import VerificationMethods from '../../../constants/verification-methods';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { SigninIntegration } from '../interfaces';
 import { GenericData } from '../../../lib/model-data';
 
@@ -29,6 +30,12 @@ export const mockWebSigninIntegration = {
   requiresKeys: () => false,
   wantsKeysIfPasswordEntered: () => false,
   wantsKeys: () => false,
+  requiresPasswordForLogin(supportsKeysOptionalLogin = false) {
+    return (
+      this.requiresKeys() ||
+      (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+    );
+  },
   isFirefoxClientServiceRelay: () => false,
   isFirefoxClientServiceSmartWindow: () => false,
   isFirefoxClientServiceVpn: () => false,
@@ -53,6 +60,12 @@ export const mockOAuthNativeSigninIntegration = (
     requiresKeys: () => false,
     wantsKeysIfPasswordEntered: () => false,
     wantsKeys: () => false,
+    requiresPasswordForLogin(supportsKeysOptionalLogin = false) {
+      return (
+        this.requiresKeys() ||
+        (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+      );
+    },
     isFirefoxClientServiceRelay: () => isRelay,
     isFirefoxClientServiceSmartWindow: () => false,
     isFirefoxClientServiceVpn: () => false,
@@ -98,7 +111,10 @@ export const Subject = ({
   serviceName = MozServices.Default,
   signinState = MOCK_TOTP_LOCATION_STATE,
   submitTotpCode = mockSubmitTotpCode,
-}: Partial<SigninTotpCodeProps>) => {
+  supportsKeysOptionalLogin = false,
+}: Partial<SigninTotpCodeProps> & {
+  supportsKeysOptionalLogin?: boolean;
+}) => {
   return (
     <LocationProvider>
       <SigninTotpCode
@@ -108,6 +124,7 @@ export const Subject = ({
           serviceName,
           signinState,
           submitTotpCode,
+          useFxAStatusResult: mockUseFxAStatus({ supportsKeysOptionalLogin }),
         }}
       />
     </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/mocks.tsx
@@ -76,6 +76,7 @@ export function createMockSigninWebSyncIntegration() {
     requiresKeys: () => true,
     wantsKeysIfPasswordEntered: () => false,
     wantsKeys: () => true,
+    requiresPasswordForLogin: () => true,
     wantsTwoStepAuthentication: () => false,
     data: new WebIntegrationData(new GenericData({})),
     isDesktopSync: () => true,

--- a/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.test.tsx
@@ -3,25 +3,53 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { LocationProvider } from '@reach/router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 
 import SigninCached from '.';
 import { AppContext } from '../../../../models';
 import { mockAppContext } from '../../../../models/mocks';
-import { createMockSigninWebIntegration } from '../../mocks';
+import {
+  createMockSigninWebIntegration,
+  createMockSigninOAuthNativeIntegration,
+} from '../../mocks';
+import { handleNavigation } from '../../utils';
 import {
   MOCK_AVATAR_NON_DEFAULT,
   MOCK_EMAIL,
   MOCK_SESSION_TOKEN,
+  MOCK_UID,
   mockFinishOAuthFlowHandler,
 } from '../../../mocks';
 import { MozServices } from '../../../../lib/types';
+import { OAuthNativeServices } from '@fxa/accounts/oauth';
+import VerificationMethods from '../../../../constants/verification-methods';
+import VerificationReasons from '../../../../constants/verification-reasons';
 
 jest.mock('../../../../lib/storage-utils', () => ({
   storeAccountData: jest.fn(),
 }));
+
+jest.mock('../../utils', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../utils'),
+  handleNavigation: jest.fn().mockResolvedValue({ error: undefined }),
+  ensureCanLinkAcountOrRedirect: jest.fn().mockResolvedValue(true),
+}));
+
+const mockCachedSigninSuccess = () =>
+  jest.fn().mockResolvedValue({
+    data: {
+      uid: MOCK_UID,
+      emailVerified: true,
+      sessionVerified: true,
+      verificationMethod: VerificationMethods.EMAIL,
+      verificationReason: VerificationReasons.SIGN_IN,
+      totpIsActive: false,
+    },
+  });
 
 const renderSigninCached = (
   props: Partial<React.ComponentProps<typeof SigninCached>> = {}
@@ -48,6 +76,10 @@ const renderSigninCached = (
   );
 
 describe('SigninCached', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders the cached signin UI without password input or third-party auth', () => {
     renderSigninCached();
 
@@ -82,5 +114,89 @@ describe('SigninCached', () => {
     expect(
       screen.queryByRole('link', { name: 'Use a different account' })
     ).not.toBeInTheDocument();
+  });
+
+  describe('on submit', () => {
+    // "keys not optional" = Firefox where Sync isn't decoupled: desktop
+    // before 147, and Mobile as of Firefox 153.
+    it('defers web channel messages and routes a passwordless VPN sign-in to set_password when keys are not optional', async () => {
+      const user = userEvent.setup();
+      renderSigninCached({
+        integration: createMockSigninOAuthNativeIntegration({
+          service: OAuthNativeServices.Vpn,
+          isSync: false,
+        }),
+        hasPassword: false,
+        hasLinkedAccount: true,
+        supportsKeysOptionalLogin: false,
+        cachedSigninHandler: mockCachedSigninSuccess(),
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      await waitFor(() => {
+        expect(handleNavigation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isSignInWithThirdPartyAuth: true,
+            handleFxaLogin: false,
+            handleFxaOAuthLogin: false,
+            supportsKeysOptionalLogin: false,
+          })
+        );
+      });
+    });
+
+    it('signs in immediately for a passwordless VPN sign-in when the browser supports keys-optional login', async () => {
+      const user = userEvent.setup();
+      renderSigninCached({
+        integration: createMockSigninOAuthNativeIntegration({
+          service: OAuthNativeServices.Vpn,
+          isSync: false,
+        }),
+        hasPassword: false,
+        hasLinkedAccount: true,
+        supportsKeysOptionalLogin: true,
+        cachedSigninHandler: mockCachedSigninSuccess(),
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      await waitFor(() => {
+        expect(handleNavigation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isSignInWithThirdPartyAuth: false,
+            handleFxaLogin: true,
+            handleFxaOAuthLogin: true,
+            supportsKeysOptionalLogin: true,
+          })
+        );
+      });
+    });
+
+    it('signs in immediately for a VPN authorization when the user already has a password (does not defer to set_password)', async () => {
+      const user = userEvent.setup();
+      renderSigninCached({
+        integration: createMockSigninOAuthNativeIntegration({
+          service: OAuthNativeServices.Vpn,
+          isSync: false,
+        }),
+        hasPassword: true,
+        isSignedIntoFirefox: true,
+        supportsKeysOptionalLogin: false,
+        cachedSigninHandler: mockCachedSigninSuccess(),
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      await waitFor(() => {
+        expect(handleNavigation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isSignInWithThirdPartyAuth: false,
+            handleFxaLogin: true,
+            handleFxaOAuthLogin: true,
+          })
+        );
+      });
+    });
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
@@ -42,6 +42,7 @@ const SigninCached = ({
   isSignedIntoFirefox = false,
   setCurrentSplitLayout,
   onSessionExpired,
+  supportsKeysOptionalLogin,
 }: SigninCachedProps & RouteComponentProps) => {
   const config = useConfig();
   const location = useLocation();
@@ -51,7 +52,12 @@ const SigninCached = ({
 
   const [signinLoading, setSigninLoading] = useState<boolean>(false);
 
-  const isSync = integration.isSync();
+  // Passwordless accounts that need keys (Sync, or a non-Sync Firefox service
+  // when Sync is not decoupled) need to defer the browser login/OAuth messages
+  // and let handleNavigation route to set_password.
+  const deferKeysUntilPasswordSet =
+    !hasPassword &&
+    integration.requiresPasswordForLogin(supportsKeysOptionalLogin);
 
   const {
     clientId,
@@ -140,19 +146,23 @@ const SigninCached = ({
             : '',
         finishOAuthFlowHandler,
         queryParams: location.search,
-        // Passwordless Sync accounts (OTP or third-party auth) need to navigate
-        // to set_password within the webview, even on mobile clients. No webchannel
-        // messages are sent (deferred until after password creation), so the webview
-        // must handle navigation internally.
+        // Passwordless accounts that need keys (Sync, or a non-Sync Firefox service
+        // when Sync is not decoupled) need to navigate to set_password within the
+        // webview, even on mobile clients. No webchannel messages are sent (deferred
+        // until after password creation), so the webview must handle navigation
+        // internally.
         performNavigation:
-          (isSync && !hasPassword) || !integration.isFirefoxMobileClient(),
+          (deferKeysUntilPasswordSet && !hasPassword) ||
+          !integration.isFirefoxMobileClient(),
         isServiceWithEmailVerification,
-        // Sync users in the cached path are passwordless (third-party auth or OTP);
-        // defer web channel messages until after password creation.
-        handleFxaLogin: !isSync,
-        handleFxaOAuthLogin: !isSync,
-        // Redirect passwordless Sync users to set_password after session verification.
-        isSignInWithThirdPartyAuth: isSync,
+        // Passwordless users in the cached path that still need keys (third-party
+        // auth or OTP) defer web channel messages until after password creation.
+        handleFxaLogin: !deferKeysUntilPasswordSet,
+        handleFxaOAuthLogin: !deferKeysUntilPasswordSet,
+        supportsKeysOptionalLogin,
+        // Redirect these passwordless users to set_password after session
+        // verification.
+        isSignInWithThirdPartyAuth: deferKeysUntilPasswordSet,
       };
       const { error: navError } = await handleNavigation(navigationOptions);
       if (navError) {
@@ -183,7 +193,8 @@ const SigninCached = ({
     navigateWithQuery,
     integration,
     finishOAuthFlowHandler,
-    isSync,
+    deferKeysUntilPasswordSet,
+    supportsKeysOptionalLogin,
     location.search,
     webRedirectCheck,
     isServiceWithEmailVerification,

--- a/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.tsx
@@ -199,6 +199,8 @@ export const SigninDecider = ({
           isSignedIntoFirefox,
           setCurrentSplitLayout,
           onSessionExpired,
+          supportsKeysOptionalLogin:
+            useFxAStatusResult.supportsKeysOptionalLogin,
         }}
       />
     );

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -31,6 +31,7 @@ export type SigninUnblockIntegration = Pick<
   | 'requiresKeys'
   | 'wantsKeysIfPasswordEntered'
   | 'wantsKeys'
+  | 'requiresPasswordForLogin'
   | 'data'
   | 'isDesktopSync'
   | 'isFirefoxClientServiceRelay'
@@ -56,6 +57,7 @@ export type SigninIntegration =
       | 'requiresKeys'
       | 'wantsKeysIfPasswordEntered'
       | 'wantsKeys'
+      | 'requiresPasswordForLogin'
       | 'data'
       | 'isDesktopSync'
       | 'isFirefoxClientServiceRelay'
@@ -81,6 +83,7 @@ export type SigninOAuthIntegration = Pick<
   | 'requiresKeys'
   | 'wantsKeysIfPasswordEntered'
   | 'wantsKeys'
+  | 'requiresPasswordForLogin'
   | 'wantsLogin'
   | 'data'
   | 'isDesktopSync'
@@ -137,6 +140,7 @@ export interface SigninCachedProps extends SigninSharedProps {
   sessionToken: hexstring;
   cachedSigninHandler: CachedSigninHandler;
   onSessionExpired: (localizedErrorMessage: string) => void;
+  supportsKeysOptionalLogin?: boolean;
 }
 
 export type SigninAlternativeAuthOptionsProps = SigninSharedProps;
@@ -260,6 +264,11 @@ export interface NavigationOptions {
   showSignupConfirmedSync?: boolean;
   syncHidePromoAfterLogin?: boolean;
   isSessionAALUpgrade?: boolean;
+  // Browser "keys optional" capability (Sync decoupled from other services,
+  // Fx desktop 147+). When false, a non-Sync Firefox client that wants keys
+  // (e.g. Android VPN) must set a password before keys can be derived. Used together
+  // with `requiresPasswordForLogin` to decide the set_password redirect.
+  supportsKeysOptionalLogin?: boolean;
   handleFxaLogin?: boolean;
   handleFxaOAuthLogin?: boolean;
   syncEngines?: {

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -99,6 +99,12 @@ export function createMockSigninWebIntegration({
     requiresKeys: () => false,
     wantsKeysIfPasswordEntered: () => false,
     wantsKeys: () => false,
+    requiresPasswordForLogin(supportsKeysOptionalLogin = false) {
+      return (
+        this.requiresKeys() ||
+        (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+      );
+    },
     data: new IntegrationData(new GenericData({})),
     isDesktopSync: () => false,
     isFirefoxClientServiceRelay: () => false,
@@ -131,6 +137,12 @@ export function createMockSigninOAuthNativeSyncIntegration({
     requiresKeys: () => isSync,
     wantsKeysIfPasswordEntered: () => !isSync,
     wantsKeys: () => true,
+    requiresPasswordForLogin(supportsKeysOptionalLogin = false) {
+      return (
+        this.requiresKeys() ||
+        (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+      );
+    },
     getService: () => MozServices.FirefoxSync,
     getClientId: () => MOCK_CLIENT_ID,
     data: new IntegrationData(new GenericData({})),
@@ -169,6 +181,12 @@ export function createMockSigninOAuthIntegration({
     requiresKeys: () => false,
     wantsKeysIfPasswordEntered: () => false,
     wantsKeys: () => false,
+    requiresPasswordForLogin(supportsKeysOptionalLogin = false) {
+      return (
+        this.requiresKeys() ||
+        (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+      );
+    },
     wantsLogin: () => false,
     wantsTwoStepAuthentication: () => false,
     isDesktopSync: () => isSync,
@@ -207,6 +225,12 @@ export function createMockSigninOAuthNativeIntegration({
     requiresKeys: () => isSync,
     wantsKeysIfPasswordEntered: () => isRelay || isSmartWindow || isVpn,
     wantsKeys: () => true,
+    requiresPasswordForLogin(supportsKeysOptionalLogin = false) {
+      return (
+        this.requiresKeys() ||
+        (!supportsKeysOptionalLogin && this.wantsKeysIfPasswordEntered())
+      );
+    },
     wantsLogin: () => false,
     wantsTwoStepAuthentication: () => false,
     isDesktopSync: () => isSync && !isMobile,

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -353,13 +353,17 @@ describe('Signin utils', () => {
     });
 
     describe('third party auth with non-Sync services', () => {
-      it('sends fxaOAuthLogin and navigates to settings', async () => {
+      it('sends fxaOAuthLogin and navigates to settings when the service does not need keys', async () => {
         const fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');
+        const integration = createMockSigninOAuthNativeIntegration({
+          isSync: false,
+          service: OAuthNativeServices.Relay,
+        });
+        // A non-Sync service that doesn't request keys (no keysJwk) signs in
+        // directly — no password needed, so no set_password detour.
+        integration.wantsKeysIfPasswordEntered = () => false;
         const navigationOptions = createBaseNavigationOptions({
-          integration: createMockSigninOAuthNativeIntegration({
-            isSync: false,
-            service: OAuthNativeServices.Relay,
-          }),
+          integration,
           isSignInWithThirdPartyAuth: true,
           performNavigation: true,
           handleFxaOAuthLogin: true,
@@ -387,6 +391,65 @@ describe('Signin utils', () => {
             isSync: false,
             service: OAuthNativeServices.Vpn,
           }),
+          performNavigation: true,
+          handleFxaOAuthLogin: true,
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(fxaOAuthLoginSpy).toHaveBeenCalled();
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/post_verify/service_welcome',
+          {
+            state: { origin: 'signin' },
+            replace: true,
+          }
+        );
+      });
+
+      // "keys not optional" = Firefox where Sync isn't decoupled: desktop
+      // before 147, and Mobile as of Firefox 153.
+      it('routes service=vpn third-party auth to set_password when keys are not optional', async () => {
+        const fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');
+        const navigationOptions = createBaseNavigationOptions({
+          integration: createMockSigninOAuthNativeIntegration({
+            isSync: false,
+            service: OAuthNativeServices.Vpn,
+          }),
+          isSignInWithThirdPartyAuth: true,
+          supportsKeysOptionalLogin: false,
+          performNavigation: true,
+          handleFxaOAuthLogin: false,
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        // The OAuth login must be deferred until after the password is set,
+        // otherwise the browser receives keyless keys_jwe.
+        expect(fxaOAuthLoginSpy).not.toHaveBeenCalled();
+        expect(navigateSpy).toHaveBeenCalledWith(
+          expect.stringContaining('/post_verify/set_password'),
+          expect.objectContaining({
+            state: expect.objectContaining({
+              passwordCreationReason: 'third_party_auth',
+            }),
+            replace: true,
+          })
+        );
+      });
+
+      // keys-optional login = Sync decoupled (Firefox desktop 147+).
+      it('routes service=vpn third-party auth to service_welcome when the browser supports keys-optional login', async () => {
+        const fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');
+        const navigationOptions = createBaseNavigationOptions({
+          integration: createMockSigninOAuthNativeIntegration({
+            isSync: false,
+            service: OAuthNativeServices.Vpn,
+          }),
+          isSignInWithThirdPartyAuth: true,
+          supportsKeysOptionalLogin: true,
           performNavigation: true,
           handleFxaOAuthLogin: true,
         });

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -552,9 +552,16 @@ const getOAuthNavigationTarget = async (
 ): Promise<NavigationTarget | NavigationTargetError> => {
   const locationState = createSigninLocationState(navigationOptions);
 
+  // Passwordless (third-party-auth) sign-ins that need keys must set a password
+  // first. For Sync this is always the case; for non-Sync Firefox clients that
+  // want keys it only applies when the browser hasn't decoupled Sync.
+  // Returning here, before `finishOAuthFlowHandler` runs, ensures no keyless
+  // `oauthData` is produced and no premature fxaOAuthLogin fires.
   if (
     navigationOptions.isSignInWithThirdPartyAuth &&
-    navigationOptions.integration.isSync()
+    navigationOptions.integration.requiresPasswordForLogin(
+      navigationOptions.supportsKeysOptionalLogin
+    )
   ) {
     const syncNav = getSyncNavigate(navigationOptions.queryParams, {
       showInlineRecoveryKeySetup: locationState.showInlineRecoveryKeySetup,


### PR DESCRIPTION
## Because

* We do not account for the 'sync not decoupled' case when passwordless users (both passwordless OTP and third party auth) try to sign up for VPN

## This pull request

* Redirects these users to set_password so we can derive Sync key material (required if Sync is not decoupled)
* Applies this across all passwordless entry points (third-party-auth callback, cached sign-in, OTP, and post-TOTP) via a shared `requiresPasswordToDeriveKeys` check, rather than only Sync
* Defers the fxaLogin/fxaOAuthLogin web channel messages until after the password is set, so the browser receives keys instead of a keyless login
* Skips the password when the browser supports keys-optional login (decoupled Sync)

## Issue that this pull request solves

closes FXA-13947
closes FXA-13946

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.