### PR TITLE
fix(passkeys): extend non-decoupled keys-required sign-in to passkey, 2FA, and recovery flows

### DIFF
--- a/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Sync passkey signin + password-fallback flow, driven through the UI via the
-// Sync OAuth URL (context=oauth_webchannel_v1, service=sync) so the auth-server
-// sets requiresPasswordForSync=true and the SPA routes to
-// /signin_passkey_fallback (the production trigger).
+// Sync passkey signin + password-fallback flow via the Sync OAuth URL.
+// Sync needs keys, so the client routes to /signin_passkey_fallback.
 
 import { expect, test } from '../../lib/fixtures/standard';
 import { FirefoxCommand } from '../../lib/channels';

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -144,7 +144,7 @@ export type SessionReauthOptions = SignInOptions;
 export type SessionReauthedAccountData = Omit<
   SignedInAccountData,
   'sessionToken'
-> & { originalEmail:string, primaryEmail:string };
+> & { originalEmail: string; primaryEmail: string };
 
 export type SessionStatus = {
   state: 'verified' | 'unverified';
@@ -261,7 +261,6 @@ export type PasskeyAuthenticationResult = {
   uid: hexstring;
   sessionToken: hexstring;
   verified: boolean;
-  requiresPasswordForSync: boolean;
   hasPassword: boolean;
 };
 
@@ -938,7 +937,7 @@ export default class AuthClient {
         options.skipCaseError = true;
         options.originalLoginEmail = email.primary;
         return this.signIn(
-          {...email, original: error.email},
+          { ...email, original: error.email },
           password,
           options,
           createHeaders(headers, options)
@@ -1690,7 +1689,7 @@ export default class AuthClient {
           sessionToken,
           {
             ...email,
-            original: error.email
+            original: error.email,
           },
           password,
           options,
@@ -1845,7 +1844,7 @@ export default class AuthClient {
         !options.skipCaseError
       ) {
         Sentry.addBreadcrumb({
-          message: 'Unexpected incorrect email case error'
+          message: 'Unexpected incorrect email case error',
         });
         options.skipCaseError = true;
 
@@ -1886,7 +1885,10 @@ export default class AuthClient {
     keyFetchToken: hexstring;
     passwordChangeToken: hexstring;
   }> {
-    const oldCredentials = await crypto.getCredentials(email.original, oldPassword);
+    const oldCredentials = await crypto.getCredentials(
+      email.original,
+      oldPassword
+    );
     try {
       const passwordData = await this.sessionPost(
         '/password/change/start',
@@ -1912,7 +1914,7 @@ export default class AuthClient {
         !options.skipCaseError
       ) {
         Sentry.addBreadcrumb({
-          message: 'Unexpected incorrect email case error'
+          message: 'Unexpected incorrect email case error',
         });
         options.skipCaseError = true;
 
@@ -2088,7 +2090,7 @@ export default class AuthClient {
       };
     }
 
-     try {
+    try {
       const accountData = await this.jwtPost(
         '/mfa/password/change',
         jwt,
@@ -2107,7 +2109,7 @@ export default class AuthClient {
         options.skipCaseError = true;
         Sentry.addBreadcrumb({
           category: 'passwordChangeJWT',
-          message: 'Unexepected incorrect email case!'
+          message: 'Unexpected incorrect email case!',
         });
         return await this.passwordChangeWithJWT(
           jwt,
@@ -3748,24 +3750,35 @@ export default class AuthClient {
    *
    * @param response `PublicKeyCredentialJSON` returned by the browser
    * @param challenge The challenge string returned by `beginPasskeyAuthentication`
-   * @param options.service Optional service identifier (e.g. `sync`). Drives
-   *   `requiresPasswordForSync` in the response.
+   * @param options.service Optional service identifier (e.g. `sync`) used
+   *   server-side to frame post-signin notifications.
+   * @param options.keysRequired When true, this login still needs Sync-scoped
+   *   keys that are obtained via a follow-up step (a password step today), so
+   *   the login is not yet complete here and the server defers its login
+   *   notifications/metrics until keys are available. The caller owns this
+   *   decision, based on the browser's keys-optional capability.
    * @param headers Optional additional headers
    */
   async completePasskeyAuthentication(
     response: PublicKeyCredentialJSON,
     challenge: string,
-    options: { service?: string; metricsContext?: MetricsContext } = {},
+    options: {
+      keysRequired: boolean;
+      service?: string;
+      metricsContext?: MetricsContext;
+    },
     headers?: Headers
   ): Promise<PasskeyAuthenticationResult> {
     const payload: {
       response: PublicKeyCredentialJSON;
       challenge: string;
+      keysRequired: boolean;
       service?: string;
       metricsContext?: MetricsContext;
     } = {
       response,
       challenge,
+      keysRequired: options.keysRequired,
       ...(options.service ? { service: options.service } : {}),
       ...(options.metricsContext
         ? { metricsContext: options.metricsContext }
@@ -3854,7 +3867,7 @@ export default class AuthClient {
       email,
       password,
     }: {
-      email: { primary:string, original:string };
+      email: { primary: string; original: string };
       password: string;
     },
     headers?: Headers
@@ -3934,7 +3947,7 @@ export default class AuthClient {
   public async accountEmails(
     sessionToken: hexstring,
     headers?: Headers
-  ): Promise<{ original: string, primary:string }> {
+  ): Promise<{ original: string; primary: string }> {
     const result = await this.sessionGet(
       '/account/emails',
       sessionToken,
@@ -3942,7 +3955,7 @@ export default class AuthClient {
     );
     return {
       original: result.originalEmail,
-      primary: result.primaryEmail
-    }
+      primary: result.primaryEmail,
+    };
   }
 }

--- a/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
@@ -101,9 +101,11 @@ const PASSKEY_AUTHENTICATION_FINISH_POST = {
       - \`response\` (object, required) — AuthenticationResponseJSON from the browser
       - \`challenge\` (string, required) — challenge from the start endpoint
       - \`service\` (string, optional) — OAuth service identifier (e.g. \`"sync"\`)
+      - \`keysRequired\` (boolean, required) — when \`true\`, this login still needs
+        Sync-scoped keys obtained via a follow-up step (a password step today), so
+        the server defers its login notifications/metrics until keys are available.
 
-      **Response:** \`uid\`, \`sessionToken\`, \`verified\`, \`requiresPasswordForSync\`,
-      \`hasPassword\`
+      **Response:** \`uid\`, \`sessionToken\`, \`verified\`, \`hasPassword\`
 
       **Security event:** \`account.passkey.authentication_success\` recorded on success.
     `,

--- a/packages/fxa-auth-server/lib/passkey-utils.spec.ts
+++ b/packages/fxa-auth-server/lib/passkey-utils.spec.ts
@@ -6,6 +6,7 @@ import {
   isPasskeyAuthenticationEnabled,
   isPasskeyFeatureEnabled,
   isPasskeyRegistrationEnabled,
+  PasskeyFlagsConfig,
 } from './passkey-utils';
 
 describe('passkey-utils', () => {
@@ -23,7 +24,8 @@ describe('passkey-utils', () => {
     });
 
     it('should throw featureNotEnabled error when config.passkeys.enabled is undefined', () => {
-      const config = { passkeys: {} };
+      // Simulate a malformed config that omits the required `enabled`.
+      const config = { passkeys: {} } as PasskeyFlagsConfig<'enabled'>;
       expect(() => isPasskeyFeatureEnabled(config)).toThrow(
         'Feature not enabled'
       );

--- a/packages/fxa-auth-server/lib/passkey-utils.ts
+++ b/packages/fxa-auth-server/lib/passkey-utils.ts
@@ -6,12 +6,23 @@ import { ConfigType } from '../config';
 import { AppError } from '@fxa/accounts/errors';
 
 /**
+ * These helpers only read the passkeys feature flags, so they accept just that
+ * slice of config — the full config is structurally compatible, and tests can
+ * pass a minimal flag object.
+ */
+export type PasskeyFlagsConfig<K extends keyof ConfigType['passkeys']> = {
+  passkeys: Pick<ConfigType['passkeys'], K>;
+};
+
+/**
  * Checks if the passkey feature is enabled.
  * @param config - The application configuration object
  * @returns true if the passkey feature is enabled and the service is available
  * @throws AppError.featureNotEnabled if the feature flag is disabled
  */
-export function isPasskeyFeatureEnabled(config: ConfigType): boolean {
+export function isPasskeyFeatureEnabled(
+  config: PasskeyFlagsConfig<'enabled'>
+): boolean {
   if (!config.passkeys.enabled) {
     throw AppError.featureNotEnabled();
   }
@@ -24,7 +35,9 @@ export function isPasskeyFeatureEnabled(config: ConfigType): boolean {
  * Management routes (list/delete/rename) use isPasskeyFeatureEnabled instead.
  * @throws AppError.featureNotEnabled if either flag is disabled
  */
-export function isPasskeyRegistrationEnabled(config: ConfigType): boolean {
+export function isPasskeyRegistrationEnabled(
+  config: PasskeyFlagsConfig<'enabled' | 'registrationEnabled'>
+): boolean {
   if (!config.passkeys.enabled || !config.passkeys.registrationEnabled) {
     throw AppError.featureNotEnabled();
   }
@@ -36,7 +49,9 @@ export function isPasskeyRegistrationEnabled(config: ConfigType): boolean {
  * Requires both the master `passkeys.enabled` flag and `passkeys.authenticationEnabled`.
  * @throws AppError.featureNotEnabled if either flag is disabled
  */
-export function isPasskeyAuthenticationEnabled(config: ConfigType): boolean {
+export function isPasskeyAuthenticationEnabled(
+  config: PasskeyFlagsConfig<'enabled' | 'authenticationEnabled'>
+): boolean {
   if (!config.passkeys.enabled || !config.passkeys.authenticationEnabled) {
     throw AppError.featureNotEnabled();
   }

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -12,6 +12,7 @@ import {
   isPasskeyAuthenticationEnabled,
 } from '../passkey-utils';
 import { passkeyRoutes, PasskeyHandler } from './passkeys';
+import { ConfigType } from '../../config';
 import { FxaMailer } from '../senders/fxa-mailer';
 import { OAuthClientInfoServiceName } from '../senders/oauth_client_info';
 
@@ -54,13 +55,15 @@ describe('passkeys routes', () => {
   const CREDENTIAL_ID_B64 =
     Buffer.from('credential-id-xyz').toString('base64url');
 
+  // Only the passkeys flags are read by these routes; cast the partial fixture
+  // to the full ConfigType the factory expects.
   const config = {
     passkeys: {
       enabled: true,
       registrationEnabled: true,
       authenticationEnabled: true,
     },
-  };
+  } as unknown as ConfigType;
 
   const mockAuthenticationOptions = {
     challenge: 'auth-challenge-xyz',
@@ -1074,6 +1077,7 @@ describe('passkeys routes', () => {
         response: { authenticatorData: 'abc' },
       },
       challenge: 'auth-challenge-xyz',
+      keysRequired: false,
     };
 
     it('verifies the response and returns session token with metadata', async () => {
@@ -1093,19 +1097,8 @@ describe('passkeys routes', () => {
         uid: UID,
         sessionToken: 'new-session-token-data',
         verified: true,
-        requiresPasswordForSync: false,
         hasPassword: true,
       });
-    });
-
-    it('sets requiresPasswordForSync true when service is sync', async () => {
-      const result = await runTest('/passkey/authentication/finish', {
-        auth: { credentials: {} },
-        app: { ua: {} },
-        payload: { ...payload, service: 'sync' },
-      });
-
-      expect(result.requiresPasswordForSync).toBe(true);
     });
 
     it('sets hasPassword false for passwordless accounts', async () => {
@@ -1397,11 +1390,11 @@ describe('passkeys routes', () => {
         );
       });
 
-      it('forces the generic "Mozilla account" email for a sync sign-in (no Firefox/Sync framing before keys)', async () => {
+      it('forces the generic "Mozilla account" email while deferring, dropping the service framing (no framing before keys)', async () => {
         await runTest('/passkey/authentication/finish', {
           auth: { credentials: {} },
           app: { ua: {} },
-          payload: { ...payload, service: 'sync' },
+          payload: { ...payload, service: 'sync', keysRequired: true },
         });
 
         expect(mockOauthClientInfoService.fetch).toHaveBeenCalledWith(
@@ -1472,7 +1465,7 @@ describe('passkeys routes', () => {
         );
       });
 
-      it('emits the account.login metrics event and flow signal for a non-sync sign-in', async () => {
+      it('emits the account.login metrics event and flow signal when keysRequired is false', async () => {
         await runTest('/passkey/authentication/finish', {
           auth: { credentials: {} },
           app: { ua: {} },
@@ -1488,7 +1481,7 @@ describe('passkeys routes', () => {
         );
       });
 
-      it('records the account.login security event for a non-sync sign-in', async () => {
+      it('records the account.login security event when keysRequired is false', async () => {
         await runTest('/passkey/authentication/finish', {
           auth: { credentials: {} },
           app: { ua: {} },
@@ -1501,11 +1494,11 @@ describe('passkeys routes', () => {
         );
       });
 
-      it('does not emit the account.login metrics event for a sync sign-in', async () => {
+      it('does not emit the account.login metrics event when keysRequired is true', async () => {
         await runTest('/passkey/authentication/finish', {
           auth: { credentials: {} },
           app: { ua: {} },
-          payload: { ...payload, service: 'sync' },
+          payload: { ...payload, keysRequired: true },
         });
 
         expect(request.emitMetricsEvent).not.toHaveBeenCalledWith(
@@ -1515,17 +1508,67 @@ describe('passkeys routes', () => {
         expect(request.setMetricsFlowCompleteSignal).not.toHaveBeenCalled();
       });
 
-      it('does not record the account.login security event for a sync sign-in', async () => {
+      it('does not record the account.login security event when keysRequired is true', async () => {
         await runTest('/passkey/authentication/finish', {
           auth: { credentials: {} },
           app: { ua: {} },
-          payload: { ...payload, service: 'sync' },
+          payload: { ...payload, keysRequired: true },
         });
 
         expect(recordSecurityEvent).not.toHaveBeenCalledWith(
           'account.login',
           expect.anything()
         );
+      });
+
+      // The client owns the defer decision (it depends on the browser's
+      // keys-optional capability); `service` does not influence it. The two
+      // tests below pair a deferring login with a non-Sync service and a
+      // non-deferring login with service=sync to prove that independence.
+      it('defers account.login and sends a generic-subject email when keysRequired is true, regardless of service', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload: {
+            ...payload,
+            service: 'vpn',
+            keysRequired: true,
+          },
+        });
+
+        expect(request.emitMetricsEvent).not.toHaveBeenCalledWith(
+          'account.login',
+          expect.anything()
+        );
+        expect(request.setMetricsFlowCompleteSignal).not.toHaveBeenCalled();
+        expect(recordSecurityEvent).not.toHaveBeenCalledWith(
+          'account.login',
+          expect.anything()
+        );
+        // New-device-login email is still sent, just with a generic subject.
+        expect(mockOauthClientInfoService.fetch).toHaveBeenCalledWith(
+          undefined
+        );
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
+        expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledWith(
+          expect.objectContaining({ clientName: 'Mozilla' })
+        );
+      });
+
+      it('emits account.login when keysRequired is false, even for service=sync', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload: {
+            ...payload,
+            service: 'sync',
+            keysRequired: false,
+          },
+        });
+
+        expect(request.emitMetricsEvent).toHaveBeenCalledWith('account.login', {
+          uid: UID,
+        });
       });
     });
   });
@@ -1651,6 +1694,7 @@ describe('passkeys routes', () => {
         ...responseOverride,
       },
       challenge,
+      keysRequired: false,
     });
 
     const regPayload = (
@@ -1676,6 +1720,18 @@ describe('passkeys routes', () => {
       it('accepts a well-formed assertion payload', () => {
         const { error } = schema.validate(authPayload());
         expect(error).toBeUndefined();
+      });
+
+      it('rejects a payload missing keysRequired', () => {
+        const withoutKeysRequired = authPayload();
+        delete (withoutKeysRequired as { keysRequired?: boolean }).keysRequired;
+        const { error } = schema.validate(withoutKeysRequired);
+        expect(error?.details).toEqual([
+          expect.objectContaining({
+            path: ['keysRequired'],
+            type: 'any.required',
+          }),
+        ]);
       });
 
       it.each([

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -401,17 +401,17 @@ export class PasskeyHandler {
    * with flags the UI needs to drive the post-login flow.
    *
    * @param request - Unauthenticated Hapi request containing `response`,
-   *   `challenge`, and optional `service` in the payload.
-   * @returns Session token, uid, and metadata including `requiresPasswordForSync`
-   *   and `hasPassword`.
+   *   `challenge`, and optional `service` / `keysRequired` in the payload.
+   * @returns Session token, uid, `verified`, and `hasPassword`.
    */
   async authenticationFinish(request: AuthRequest) {
     await this.customs.checkIpOnly(request, 'passkeyAuthFinish');
 
-    const { response, challenge, service } = request.payload as {
+    const { response, challenge, service, keysRequired } = request.payload as {
       response: AuthenticationResponseJSON;
       challenge: string;
       service?: string;
+      keysRequired: boolean;
     };
 
     let uid: string;
@@ -451,13 +451,18 @@ export class PasskeyHandler {
     // (reason: 'otp') and linked-accounts (reason: 'google'|'apple').
     this.glean.login.complete(request, { uid, reason: 'passkey' });
 
-    const requiresPasswordForSync = service === 'sync';
-
+    // A keys-requiring login (Sync, or a non-Sync Firefox service like VPN when
+    // the browser hasn't decoupled Sync) completes its key step later, at a
+    // follow-up password step. Until then the new-device-login email is still
+    // sent, but with a generic subject (no service framing, since keys aren't
+    // retrieved yet), and the account.login metric/flow-signal/security-event
+    // are deferred to that step. The client owns the keys-required decision; it
+    // depends on the browser's keys-optional capability.
     await this.sendPostSigninNotifications(
       request,
       account,
       service,
-      requiresPasswordForSync
+      keysRequired
     );
 
     const hasPassword = account.verifierSetAt > 0;
@@ -466,7 +471,6 @@ export class PasskeyHandler {
       uid,
       sessionToken: sessionToken.data,
       verified: true,
-      requiresPasswordForSync,
       hasPassword,
     };
   }
@@ -481,11 +485,12 @@ export class PasskeyHandler {
       locale?: string;
     },
     service: string | undefined,
-    requiresPasswordForSync: boolean
+    keysRequired: boolean
   ) {
-    // Drop the service for Sync so the subject stays generic — keys aren't
-    // retrieved yet, so Firefox/Sync framing would be premature.
-    const emailService = requiresPasswordForSync ? undefined : service;
+    // The new-device-login email is always sent; when keys are still required
+    // we drop the service so the subject stays generic — keys aren't retrieved
+    // yet, so service framing would be premature.
+    const emailService = keysRequired ? undefined : service;
     try {
       const geoData = request.app.geo;
       if (this.fxaMailer.canSend('newDeviceLogin')) {
@@ -540,8 +545,9 @@ export class PasskeyHandler {
         profileChanged: false,
       });
 
-      // Non-Sync only: the Sync flow's /session/reauth step already emits these.
-      if (!requiresPasswordForSync) {
+      // When keys are required the login completes at the later /session/reauth
+      // step, which emits these; skip them here to avoid double-counting.
+      if (!keysRequired) {
         await request.emitMetricsEvent('account.login', { uid: account.uid });
         request.setMetricsFlowCompleteSignal('account.login', 'login');
         await recordSecurityEvent('account.login', {
@@ -947,6 +953,9 @@ export const passkeyRoutes = (
               .required(),
             challenge: base64urlChallenge().required(),
             service: validators.service.optional(),
+            // When true, this login still needs Sync-scoped keys obtained via a
+            // follow-up step, so the server defers login notifications/metrics.
+            keysRequired: isA.boolean().required(),
             metricsContext: METRICS_CONTEXT_SCHEMA,
           }),
         },
@@ -955,7 +964,6 @@ export const passkeyRoutes = (
             uid: isA.string().required(),
             sessionToken: isA.string().required(),
             verified: isA.boolean().required(),
-            requiresPasswordForSync: isA.boolean().required(),
             hasPassword: isA.boolean().required(),
           }),
         },

--- a/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
@@ -296,14 +296,17 @@ describe('#integration - remote passkey authentication', () => {
       'POST',
       `${authClient.api.baseURL}/passkey/authentication/finish`,
       null,
-      { response: assertionResponse, challenge: startResult.challenge }
+      {
+        response: assertionResponse,
+        challenge: startResult.challenge,
+        keysRequired: false,
+      }
     );
 
     expect(finishResult.uid).toBeDefined();
     expect(finishResult.sessionToken).toBeDefined();
     expect(finishResult.verified).toBe(true);
     expect(finishResult.hasPassword).toBe(true);
-    expect(finishResult.requiresPasswordForSync).toBe(false);
   });
 
   it('POST /passkey/authentication/finish - mismatched challenge returns error', async () => {
@@ -331,6 +334,7 @@ describe('#integration - remote passkey authentication', () => {
         {
           response: assertionResponse,
           challenge: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          keysRequired: false,
         }
       );
     }).rejects.toBeDefined();
@@ -361,7 +365,11 @@ describe('#integration - remote passkey-then-password fallback via /session/reau
       'POST',
       `${authClient.api.baseURL}/passkey/authentication/finish`,
       null,
-      { response: assertionResponse, challenge: startResult.challenge }
+      {
+        response: assertionResponse,
+        challenge: startResult.challenge,
+        keysRequired: true,
+      }
     );
     return finishResult.sessionToken;
   }

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -726,7 +726,7 @@ const AuthAndAccountSetupRoutes = ({
         />
         <SigninPasskeyFallbackContainer
           path="/signin_passkey_fallback/*"
-          {...{ integration }}
+          {...{ integration, flowQueryParams }}
         />
         <SigninRecoveryChoiceContainer
           path="/signin_recovery_choice/*"
@@ -734,11 +734,21 @@ const AuthAndAccountSetupRoutes = ({
         />
         <SigninRecoveryPhoneContainer
           path="/signin_recovery_phone/*"
-          {...{ integration, setCurrentSplitLayout }}
+          {...{
+            integration,
+            setCurrentSplitLayout,
+            supportsKeysOptionalLogin:
+              useFxAStatusResult.supportsKeysOptionalLogin,
+          }}
         />
         <SigninRecoveryCodeContainer
           path="/signin_recovery_code/*"
-          {...{ integration, setCurrentSplitLayout }}
+          {...{
+            integration,
+            setCurrentSplitLayout,
+            supportsKeysOptionalLogin:
+              useFxAStatusResult.supportsKeysOptionalLogin,
+          }}
         />
         <SigninReported path="/signin_reported/*" />
         <SigninTokenCodeContainer

--- a/packages/fxa-settings/src/lib/metrics.ts
+++ b/packages/fxa-settings/src/lib/metrics.ts
@@ -516,13 +516,17 @@ export function addExperiment(choice: string, group: string) {
 }
 
 /**
- * Take a record and pick out key-values for a MetricsContext.  Note that the
- * value passed in could've been asserted to be of QueryParam type with
- * specific keys but the value is actually a record of all the URL query params.
+ * Pick out the MetricsContext key-values from URL query params. Accepts either
+ * a raw query-param record or a typed {@link QueryParams} object so callers can
+ * pass `flowQueryParams` directly. The typed shape declares a few fields as
+ * number/boolean, but at runtime every value is a string parsed from the URL,
+ * so it's read through the same string-record contract the constructor expects.
  */
 export function queryParamsToMetricsContext(
-  queryParams: Record<string, string | undefined>
+  queryParams: Record<string, string | undefined> | QueryParams
 ): Partial<MetricsContext> {
-  const context = new MetricsContext(queryParams);
+  const context = new MetricsContext(
+    queryParams as Record<string, string | undefined>
+  );
   return MetricsContext.prune(context);
 }

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -124,7 +124,6 @@ const buildArgs = (
     uid: UID,
     sessionToken: SESSION_TOKEN,
     verified: true,
-    requiresPasswordForSync: false,
     hasPassword: true,
   });
   const account = jest.fn().mockResolvedValue({
@@ -142,6 +141,7 @@ const buildArgs = (
   const integration = {
     isSync: () => false,
     isFirefoxNonSync: () => false,
+    requiresPasswordForLogin: () => false,
     getService: () => undefined,
     getClientId: () => 'service-id',
     isFirefoxMobileClient: () => false,
@@ -217,7 +217,11 @@ describe('usePasskeySignIn', () => {
     expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
       MOCK_CREDENTIAL,
       CHALLENGE,
-      { service: 'service-id', metricsContext: {} }
+      {
+        service: 'service-id',
+        keysRequired: false,
+        metricsContext: {},
+      }
     );
     expect(spies.account).toHaveBeenCalledWith(SESSION_TOKEN);
     expect(handleNavigation).toHaveBeenCalledWith({
@@ -256,6 +260,7 @@ describe('usePasskeySignIn', () => {
       integration: {
         isSync: () => true,
         isFirefoxNonSync: () => false,
+        requiresPasswordForLogin: () => false,
         getService: () => 'sync',
         getClientId: () => 'client-id-should-not-be-used',
         isFirefoxMobileClient: () => false,
@@ -273,7 +278,7 @@ describe('usePasskeySignIn', () => {
     expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
       MOCK_CREDENTIAL,
       CHALLENGE,
-      { service: 'sync', metricsContext: {} }
+      { service: 'sync', keysRequired: false, metricsContext: {} }
     );
   });
 
@@ -284,6 +289,7 @@ describe('usePasskeySignIn', () => {
       integration: {
         isSync: () => false,
         isFirefoxNonSync: () => false,
+        requiresPasswordForLogin: () => false,
         getService: () => undefined,
         getClientId: () => 'service-id',
         isFirefoxMobileClient: () => false,
@@ -301,7 +307,7 @@ describe('usePasskeySignIn', () => {
     expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
       MOCK_CREDENTIAL,
       CHALLENGE,
-      { metricsContext: {} }
+      { keysRequired: false, metricsContext: {} }
     );
     expect(storeAccountData).toHaveBeenCalled();
     expect(handleNavigation).toHaveBeenCalledWith({
@@ -332,6 +338,7 @@ describe('usePasskeySignIn', () => {
       integration: {
         isSync: () => true,
         isFirefoxNonSync: () => false,
+        requiresPasswordForLogin: () => false,
         getService: () => 'sync',
         type: IntegrationType.OAuthNative,
         data: {},
@@ -375,6 +382,7 @@ describe('usePasskeySignIn', () => {
         integration: {
           isSync: () => true,
           isFirefoxNonSync: () => false,
+          requiresPasswordForLogin: () => true,
           getService: () => 'sync',
           type: IntegrationType.OAuthNative,
           data: {},
@@ -384,7 +392,6 @@ describe('usePasskeySignIn', () => {
         uid: UID,
         sessionToken: SESSION_TOKEN,
         verified: true,
-        requiresPasswordForSync: true,
         hasPassword,
       });
 
@@ -402,6 +409,71 @@ describe('usePasskeySignIn', () => {
     }
   );
 
+  it('routes a non-Sync sign-in to set_password when requiresPasswordForLogin is true', async () => {
+    const { args, spies } = buildArgs({
+      integration: {
+        isSync: () => false,
+        isFirefoxNonSync: () => true,
+        requiresPasswordForLogin: () => true,
+        getService: () => 'vpn',
+        getClientId: () => 'service-id',
+        isFirefoxMobileClient: () => false,
+        type: IntegrationType.OAuthNative,
+        data: {},
+      } as unknown as PasskeySignInIntegration,
+    });
+    spies.completePasskeyAuthentication.mockResolvedValue({
+      uid: UID,
+      sessionToken: SESSION_TOKEN,
+      verified: true,
+      hasPassword: false,
+    });
+
+    const { result } = renderHook(() => usePasskeySignIn(args));
+    await act(async () => {
+      await result.current.onClick();
+    });
+    expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
+      MOCK_CREDENTIAL,
+      CHALLENGE,
+      expect.objectContaining({ keysRequired: true })
+    );
+    expect(spies.navigateWithQuery).toHaveBeenCalledWith(
+      '/post_verify/set_password',
+      {
+        state: {
+          passwordCreationReason: 'passkey',
+          passkeySurface: 'emailfirst',
+        },
+      }
+    );
+    expect(handleNavigation).not.toHaveBeenCalled();
+  });
+
+  it('forwards supportsKeysOptionalLogin to integration.requiresPasswordForLogin', async () => {
+    const requiresPasswordForLogin = jest.fn().mockReturnValue(false);
+    const { args } = buildArgs({
+      integration: {
+        isSync: () => false,
+        isFirefoxNonSync: () => true,
+        requiresPasswordForLogin,
+        getService: () => 'vpn',
+        getClientId: () => 'service-id',
+        isFirefoxMobileClient: () => false,
+        type: IntegrationType.OAuthNative,
+        data: {},
+      } as unknown as PasskeySignInIntegration,
+      supportsKeysOptionalLogin: true,
+    });
+
+    const { result } = renderHook(() => usePasskeySignIn(args));
+    await act(async () => {
+      await result.current.onClick();
+    });
+
+    expect(requiresPasswordForLogin).toHaveBeenCalledWith(true);
+  });
+
   it('sends service=sync in the passkey authentication request for a Sync sign-in when the service URL param is absent', async () => {
     // Mobile Firefox omits service=sync and defaults via clientId, so
     // getService() returns undefined; isSync() must still drive service=sync.
@@ -409,6 +481,7 @@ describe('usePasskeySignIn', () => {
       integration: {
         isSync: () => true,
         isFirefoxNonSync: () => false,
+        requiresPasswordForLogin: () => false,
         getService: () => undefined,
         isFirefoxMobileClient: () => false,
         type: IntegrationType.OAuthNative,
@@ -425,7 +498,7 @@ describe('usePasskeySignIn', () => {
     expect(spies.completePasskeyAuthentication).toHaveBeenCalledWith(
       MOCK_CREDENTIAL,
       CHALLENGE,
-      { service: 'sync', metricsContext: {} }
+      { service: 'sync', keysRequired: false, metricsContext: {} }
     );
   });
 
@@ -434,6 +507,8 @@ describe('usePasskeySignIn', () => {
       integration: {
         isSync: () => false,
         isFirefoxNonSync: () => true,
+        // VPN without keys: exercises the mobile navigation-skip path, not the password detour.
+        requiresPasswordForLogin: () => false,
         getService: () => 'vpn',
         getClientId: () => 'service-id',
         isFirefoxMobileClient: () => true,
@@ -497,6 +572,7 @@ describe('usePasskeySignIn', () => {
         integration: {
           isSync: () => true,
           isFirefoxNonSync: () => false,
+          requiresPasswordForLogin: () => true,
           getService: () => 'sync',
           type: IntegrationType.OAuthNative,
           data: {},
@@ -506,7 +582,6 @@ describe('usePasskeySignIn', () => {
         uid: UID,
         sessionToken: SESSION_TOKEN,
         verified: true,
-        requiresPasswordForSync: true,
         hasPassword,
       });
 
@@ -861,6 +936,7 @@ describe('usePasskeySignIn', () => {
         integration: {
           isSync: () => true,
           isFirefoxNonSync: () => false,
+          requiresPasswordForLogin: () => true,
           getService: () => 'sync',
           type: IntegrationType.OAuthNative,
           data: {},
@@ -870,7 +946,6 @@ describe('usePasskeySignIn', () => {
         uid: UID,
         sessionToken: SESSION_TOKEN,
         verified: true,
-        requiresPasswordForSync: true,
         hasPassword: true,
       });
 
@@ -941,6 +1016,7 @@ describe('usePasskeySignIn', () => {
       const integration = {
         isSync: () => false,
         isFirefoxNonSync: () => false,
+        requiresPasswordForLogin: () => false,
         getService: () => undefined,
         getClientId: () => 'service-id',
         isFirefoxMobileClient: () => false,
@@ -1029,6 +1105,7 @@ describe('usePasskeySignIn', () => {
           integration: {
             isSync: () => false,
             isFirefoxNonSync: () => false,
+            requiresPasswordForLogin: () => false,
             getService: () => undefined,
             getClientId: () => 'service-id',
             isFirefoxMobileClient: () => false,

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -168,15 +168,11 @@ const gleanEventsForSurface = (
 export type PasskeySignInIntegration = NavigationOptions['integration'];
 
 /**
- * Resolves the `service` value sent with a passkey authentication request.
- * Forces `sync` for any Sync integration; everything else uses
- * `resolveServiceOrClientId`. Why force it:
- * - The server decides per credential whether the account password is needed
- *   (phase 1: always, to derive Sync keys; phase 2: not when the passkey
- *   carries a stored key wrap) and needs `service=sync` to make that call.
- * - Mobile Firefox omits the `service=sync` URL param, so `getService()` is
- *   undefined and `resolveServiceOrClientId` would return the client id,
- *   silently skipping that decision.
+ * Resolves the `service` sent with a passkey authentication request, forcing
+ * `sync` for any Sync integration. Mobile Firefox omits the `service=sync` URL
+ * param, so `getService()` is undefined and `resolveServiceOrClientId` would
+ * otherwise resolve to the client id — losing the Sync attribution the server
+ * needs for its post-signin notifications.
  */
 export function resolvePasskeyService(
   integration: PasskeySignInIntegration
@@ -215,12 +211,8 @@ export interface UsePasskeySignInArgs {
   navigateWithQuery: ReturnType<typeof useNavigateWithQuery>;
   queryParams: string;
   surface: PasskeySignInSurface;
-  /**
-   * Whether the passkey button is rendered on this surface. Drives the
-   * `passkey.button_view` impression so it counts buttons shown, not hook
-   * mounts.
-   */
   isButtonVisible?: boolean;
+  supportsKeysOptionalLogin?: boolean;
 }
 
 export interface UsePasskeySignInResult {
@@ -238,6 +230,7 @@ export function usePasskeySignIn({
   queryParams,
   surface,
   isButtonVisible = false,
+  supportsKeysOptionalLogin,
 }: UsePasskeySignInArgs): UsePasskeySignInResult {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
@@ -336,11 +329,20 @@ export function usePasskeySignIn({
       const metricsContext = queryParamsToMetricsContext(
         searchParams(queryParams) as Record<string, string | undefined>
       );
+
+      const keysRequired = integration.requiresPasswordForLogin(
+        supportsKeysOptionalLogin
+      );
       const completion = await authClient.completePasskeyAuthentication(
         credential,
         challengeOptions.challenge,
         {
           ...(serviceForRequest ? { service: serviceForRequest } : {}),
+          // True when this login still needs Sync-scoped keys that a
+          // follow-up password step will provide. The server uses it to
+          // defer its login metrics/email framing until keys exist; the
+          // client uses the same value below to route to that step.
+          keysRequired,
           metricsContext,
         }
       );
@@ -388,8 +390,10 @@ export function usePasskeySignIn({
         hasPassword: completion.hasPassword,
       });
 
-      if (completion.requiresPasswordForSync) {
-        // Sync still needs a password to derive keys
+      if (keysRequired) {
+        // A password is needed to derive scoped keys before the browser
+        // login/OAuth messages are sent. An existing-password account re-enters
+        // its password; a passwordless account creates one.
         const fallbackPath = completion.hasPassword
           ? '/signin_passkey_fallback'
           : '/post_verify/set_password';
@@ -482,6 +486,7 @@ export function usePasskeySignIn({
     queryParams,
     setLocalizedError,
     surface,
+    supportsKeysOptionalLogin,
   ]);
 
   return { isLoading, errorBanner, onClick };

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -68,6 +68,7 @@ export const Index = ({
     queryParams: location.search,
     surface: 'emailfirst',
     isButtonVisible: showPasskeySignin,
+    supportsKeysOptionalLogin: useFxAStatusResult.supportsKeysOptionalLogin,
   });
   const handlePasskeyClick = () => {
     // Cancel any pending suggested-email auto-submit so it can't override

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
@@ -15,6 +15,8 @@ import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { MOCK_EMAIL, MOCK_SESSION_TOKEN, MOCK_UID } from '../../mocks';
 import SigninPasskeyFallbackContainer from './container';
 import GleanMetrics from '../../../lib/glean';
+import { queryParamsToMetricsContext } from '../../../lib/metrics';
+import { QueryParams } from '../../..';
 
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
@@ -52,6 +54,12 @@ const MOCK_LOCATION_STATE = {
   emailVerified: true,
   sessionVerified: true,
 };
+
+const MOCK_FLOW_QUERY_PARAMS = {
+  flowId: 'f'.repeat(64),
+  flowBeginTime: '1700000000000',
+  deviceId: 'd'.repeat(32),
+} as unknown as QueryParams;
 
 const mockSessionReauth = jest.fn();
 const mockAccountEmails = jest.fn().mockResolvedValue({
@@ -129,6 +137,7 @@ function render(integration?: Integration) {
         integration={
           (integration ?? createMockSyncIntegration()) as Integration
         }
+        flowQueryParams={MOCK_FLOW_QUERY_PARAMS}
       />
     </LocationProvider>
   );
@@ -192,7 +201,11 @@ describe('SigninPasskeyFallback container', () => {
           MOCK_SESSION_TOKEN,
           { original: MOCK_EMAIL, primary: MOCK_EMAIL },
           'pa55word',
-          { keys: true }
+          {
+            keys: true,
+            reason: 'signin',
+            metricsContext: queryParamsToMetricsContext(MOCK_FLOW_QUERY_PARAMS),
+          }
         );
       });
       expect(mockHandleNavigation).toHaveBeenCalledWith(
@@ -207,6 +220,27 @@ describe('SigninPasskeyFallback container', () => {
           }),
         })
       );
+    });
+
+    it('passes the flow metricsContext to sessionReauth so the deferred account.login is correlated', async () => {
+      const { getByTestId } = render();
+      submitPassword(getByTestId);
+
+      await waitFor(() => {
+        expect(mockSessionReauth).toHaveBeenCalledWith(
+          MOCK_SESSION_TOKEN,
+          { original: MOCK_EMAIL, primary: MOCK_EMAIL },
+          'pa55word',
+          expect.objectContaining({
+            reason: 'signin',
+            metricsContext: expect.objectContaining({
+              flowId: MOCK_FLOW_QUERY_PARAMS.flowId,
+              flowBeginTime: Number(MOCK_FLOW_QUERY_PARAMS.flowBeginTime),
+              deviceId: MOCK_FLOW_QUERY_PARAMS.deviceId,
+            }),
+          })
+        );
+      });
     });
 
     it('performs navigation to finish sign-in after reauth on desktop', async () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Integration,
   useAuthClient,
@@ -23,13 +23,19 @@ import VerificationMethods from '../../../constants/verification-methods';
 import { getSigninState, handleNavigation } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { buildPasskeyAuthSuccessReason } from '../../../lib/passkeys/signin-flow';
+import { queryParamsToMetricsContext } from '../../../lib/metrics';
+import { QueryParams } from '../../..';
 import SigninPasskeyFallback from '.';
 
 // Password step for accounts that signed in with a passkey but still need the
 // account password to unwrap Sync encryption keys.
 const SigninPasskeyFallbackContainer = ({
   integration,
-}: { integration: Integration } & RouteComponentProps) => {
+  flowQueryParams,
+}: {
+  integration: Integration;
+  flowQueryParams: QueryParams;
+} & RouteComponentProps) => {
   const authClient = useAuthClient();
   const config = useConfig();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -50,6 +56,10 @@ const SigninPasskeyFallbackContainer = ({
   const email = signinState?.email;
   const uid = signinState?.uid;
   const passkeySurface = location.state?.passkeySurface ?? 'emailfirst';
+  const metricsContext = useMemo(
+    () => queryParamsToMetricsContext(flowQueryParams),
+    [flowQueryParams]
+  );
 
   // Mirrors Signin/container.tsx's avatar fetch: mint a profile:avatar-scoped
   // OAuth token, GET /v1/avatar from the profile server, fall back to default
@@ -121,7 +131,7 @@ const SigninPasskeyFallbackContainer = ({
           sessionToken,
           emails,
           password,
-          { keys: true }
+          { keys: true, reason: 'signin', metricsContext }
         ));
       } catch (err) {
         const errno = (err as { errno?: number })?.errno;
@@ -191,6 +201,7 @@ const SigninPasskeyFallbackContainer = ({
       email,
       uid,
       passkeySurface,
+      metricsContext,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -99,6 +99,7 @@ const SigninPasswordlessCode = ({
     queryParams: location.search,
     surface: 'login_otp',
     isButtonVisible: showPasskeySignin,
+    supportsKeysOptionalLogin: useFxAStatusResult.supportsKeysOptionalLogin,
   });
 
   const [localizedErrorBannerMessage, setLocalizedErrorBannerMessage] =

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -32,11 +32,13 @@ type SigninRecoveryCodeLocationState = {
 export type SigninRecoveryCodeContainerProps = {
   integration: Integration;
   setCurrentSplitLayout?: (value: boolean) => void;
+  supportsKeysOptionalLogin?: boolean;
 };
 
 export const SigninRecoveryCodeContainer = ({
   integration,
   setCurrentSplitLayout,
+  supportsKeysOptionalLogin,
 }: SigninRecoveryCodeContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
@@ -152,6 +154,7 @@ export const SigninRecoveryCodeContainer = ({
         unwrapBKey,
         loading: sendingPhoneCode,
         setCurrentSplitLayout,
+        supportsKeysOptionalLogin,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -307,6 +307,90 @@ describe('PageSigninRecoveryCode', () => {
     });
   });
 
+  describe('passwordless redirect to set_password when keys are required', () => {
+    const keysRequiredIntegration = () => {
+      const integration = createMockSigninOAuthNativeSyncIntegration();
+      integration.requiresPasswordForLogin = () => true;
+      return integration;
+    };
+    const submitSuccess = () =>
+      jest
+        .fn()
+        .mockResolvedValue({ data: { consumeRecoveryCode: { remaining: 3 } } });
+
+    it.each([
+      ['isPasswordlessOtpSignin', 'otp'],
+      ['isSignInWithThirdPartyAuth', 'third_party_auth'],
+    ])(
+      'redirects a %s sign-in to set_password with reason %s',
+      async (marker, expectedReason) => {
+        const user = userEvent.setup();
+        const handleNavigationSpy = jest.spyOn(SigninUtils, 'handleNavigation');
+        renderWithLocalizationProvider(
+          <LocationProvider>
+            <SigninRecoveryCode
+              finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+              integration={keysRequiredIntegration()}
+              navigateToRecoveryPhone={jest.fn()}
+              signinState={{ ...mockSigninLocationState, [marker]: true }}
+              submitRecoveryCode={submitSuccess()}
+              supportsKeysOptionalLogin={false}
+            />
+          </LocationProvider>
+        );
+        await user.type(screen.getByRole('textbox'), MOCK_BACKUP_CODE);
+        await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+        await waitFor(() => {
+          expect(mockNavigateWithQuery).toHaveBeenCalledWith(
+            '/post_verify/set_password',
+            expect.objectContaining({
+              replace: true,
+              state: { passwordCreationReason: expectedReason },
+            })
+          );
+        });
+        // Web channel messages must be deferred until the password is set.
+        expect(handleNavigationSpy).not.toHaveBeenCalled();
+      }
+    );
+
+    it('continues through handleNavigation when keys are not required', async () => {
+      const user = userEvent.setup();
+      const handleNavigationSpy = jest
+        .spyOn(SigninUtils, 'handleNavigation')
+        .mockResolvedValue({ error: undefined });
+      const integration = createMockSigninOAuthNativeSyncIntegration();
+      integration.requiresPasswordForLogin = () => false;
+
+      renderWithLocalizationProvider(
+        <LocationProvider>
+          <SigninRecoveryCode
+            finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+            integration={integration}
+            navigateToRecoveryPhone={jest.fn()}
+            signinState={{
+              ...mockSigninLocationState,
+              isPasswordlessOtpSignin: true,
+            }}
+            submitRecoveryCode={submitSuccess()}
+            supportsKeysOptionalLogin={true}
+          />
+        </LocationProvider>
+      );
+      await user.type(screen.getByRole('textbox'), MOCK_BACKUP_CODE);
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(handleNavigationSpy).toHaveBeenCalled();
+      });
+      expect(mockNavigateWithQuery).not.toHaveBeenCalledWith(
+        '/post_verify/set_password',
+        expect.anything()
+      );
+    });
+  });
+
   describe('submit with error', () => {
     it('shows an error tooltip when submit without code', async () => {
       const mockSubmitRecoveryCode = jest.fn();

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -24,6 +24,7 @@ import { storeAccountData } from '../../../lib/storage-utils';
 import { handleNavigation } from '../utils';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { isBase32Crockford } from '../../../lib/utilities';
 import Banner from '../../../components/Banner';
 import { HeadingPrimary } from '../../../components/HeadingPrimary';
@@ -44,10 +45,13 @@ const SigninRecoveryCode = ({
   unwrapBKey,
   loading = false,
   setCurrentSplitLayout,
+  supportsKeysOptionalLogin,
 }: SigninRecoveryCodeProps & RouteComponentProps) => {
   useEffect(() => {
     GleanMetrics.loginBackupCode.view();
   }, []);
+
+  const navigateWithQuery = useNavigateWithQuery();
 
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
   const [bannerErrorMessage, setBannerErrorMessage] = useState<string>('');
@@ -94,6 +98,24 @@ const SigninRecoveryCode = ({
   };
 
   const onSuccessNavigate = useCallback(async () => {
+    // Passwordless sign-in needing keys must set a password;
+    // defer the browser login messages.
+    if (
+      (signinState.isPasswordlessOtpSignin ||
+        signinState.isSignInWithThirdPartyAuth) &&
+      integration.requiresPasswordForLogin(supportsKeysOptionalLogin)
+    ) {
+      navigateWithQuery('/post_verify/set_password', {
+        replace: true,
+        state: {
+          passwordCreationReason: signinState.isSignInWithThirdPartyAuth
+            ? 'third_party_auth'
+            : 'otp',
+        },
+      });
+      return;
+    }
+
     const navigationOptions = {
       email,
       signinData: {
@@ -136,6 +158,9 @@ const SigninRecoveryCode = ({
     unwrapBKey,
     ftlMsgResolver,
     authClient,
+    signinState,
+    supportsKeysOptionalLogin,
+    navigateWithQuery,
   ]);
 
   const localizedInvalidCodeError = getLocalizedErrorMessage(
@@ -163,6 +188,9 @@ const SigninRecoveryCode = ({
         // Update verification status of stored current account
         verified: true,
         sessionVerified: true,
+        // OTP sign-in is the only genuinely passwordless case; a third-party
+        // account may have a password, so leave it unset and let SetPassword verify.
+        ...(signinState.isPasswordlessOtpSignin && { hasPassword: false }),
       });
 
       setStoredSignedInStatus(true);

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -16,6 +16,7 @@ export type SigninRecoveryCodeProps = {
   lastFourPhoneDigits?: string;
   loading?: boolean;
   setCurrentSplitLayout?: (value: boolean) => void;
+  supportsKeysOptionalLogin?: boolean;
 } & SensitiveData.AuthData;
 
 export type SubmitRecoveryCode = (

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
@@ -18,6 +18,7 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 import { SigninRecoveryPhoneProps } from './interfaces';
 import { storeAccountData } from '../../../lib/storage-utils';
 import { handleNavigation } from '../utils';
+import GleanMetrics from '../../../lib/glean';
 import {
   useFinishOAuthFlowHandler,
   useOAuthKeysCheck,
@@ -229,6 +230,88 @@ describe('SigninRecoveryPhoneContainer', () => {
         expect.objectContaining({
           isSessionAALUpgrade: true,
         })
+      );
+    });
+  });
+
+  describe('passwordless redirect to set_password when keys are required', () => {
+    const keysRequiredIntegration = () => {
+      const integration =
+        createMockSigninOAuthNativeSyncIntegration() as Integration;
+      integration.requiresPasswordForLogin = () => true;
+      return integration;
+    };
+
+    it.each([
+      ['isPasswordlessOtpSignin', 'otp'],
+      ['isSignInWithThirdPartyAuth', 'third_party_auth'],
+    ])(
+      'redirects a %s sign-in to set_password with reason %s',
+      async (marker, expectedReason) => {
+        mockReachRouter('/signin_recovery_phone', {
+          signinState: { ...mockSigninLocationState, [marker]: true },
+          lastFourPhoneDigits: '1234',
+        });
+        renderSigninRecoveryPhoneContainer(keysRequiredIntegration());
+
+        await currentPageProps?.verifyCode('123456');
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.stringContaining('/post_verify/set_password'),
+          expect.objectContaining({
+            replace: true,
+            state: { passwordCreationReason: expectedReason },
+          })
+        );
+        // Web channel messages must be deferred until the password is set.
+        expect(handleNavigation).not.toHaveBeenCalled();
+      }
+    );
+
+    it('records the recovery-phone success metric before the redirect', async () => {
+      const successSpy = jest
+        .spyOn(GleanMetrics.login, 'recoveryPhoneSuccessView')
+        .mockImplementation(() => {});
+      mockReachRouter('/signin_recovery_phone', {
+        signinState: {
+          ...mockSigninLocationState,
+          isPasswordlessOtpSignin: true,
+        },
+        lastFourPhoneDigits: '1234',
+      });
+      renderSigninRecoveryPhoneContainer(keysRequiredIntegration());
+
+      await currentPageProps?.verifyCode('123456');
+
+      // Recovery succeeded even though we redirect to set_password, so the
+      // success funnel event must still fire.
+      expect(successSpy).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining('/post_verify/set_password'),
+        expect.anything()
+      );
+      successSpy.mockRestore();
+    });
+
+    it('continues through handleNavigation when keys are not required', async () => {
+      const integration =
+        createMockSigninOAuthNativeSyncIntegration() as Integration;
+      integration.requiresPasswordForLogin = () => false;
+      mockReachRouter('/signin_recovery_phone', {
+        signinState: {
+          ...mockSigninLocationState,
+          isPasswordlessOtpSignin: true,
+        },
+        lastFourPhoneDigits: '1234',
+      });
+      renderSigninRecoveryPhoneContainer(integration);
+
+      await currentPageProps?.verifyCode('123456');
+
+      expect(handleNavigation).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        expect.stringContaining('/post_verify/set_password'),
+        expect.anything()
       );
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
@@ -35,6 +35,7 @@ import { SigninLocationState } from '../interfaces';
 const SigninRecoveryPhoneContainer = ({
   integration,
   setCurrentSplitLayout,
+  supportsKeysOptionalLogin,
 }: SigninRecoveryPhoneContainerProps & RouteComponentProps) => {
   const alertBar = useAlertBar();
   const authClient = useAuthClient();
@@ -86,6 +87,10 @@ const SigninRecoveryPhoneContainer = ({
       return;
     }
 
+    const isPasswordlessSignin =
+      signinState.isPasswordlessOtpSignin ||
+      signinState.isSignInWithThirdPartyAuth;
+
     try {
       storeAccountData({
         sessionToken: signinState.sessionToken,
@@ -94,20 +99,40 @@ const SigninRecoveryPhoneContainer = ({
         // Update verification status of stored current account
         verified: true,
         sessionVerified: true,
+        // OTP sign-in is the only genuinely passwordless case; a third-party
+        // account may have a password, so leave it unset and let SetPassword verify.
+        ...(signinState.isPasswordlessOtpSignin && { hasPassword: false }),
       });
 
       setStoredSignedInStatus(true);
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      const recoveryPhoneSigninSuccessGleanMetric =
-        GleanMetrics.login.recoveryPhoneSuccessView;
+      // Recovery-phone verification succeeded; record it before any redirect so
+      // the success funnel matches the TOTP and backup-code flows.
+      GleanMetrics.login.recoveryPhoneSuccessView();
+
+      // Passwordless sign-in needing keys must set a password first;
+      // defer the success alert and browser login messages.
+      if (
+        isPasswordlessSignin &&
+        integration.requiresPasswordForLogin(supportsKeysOptionalLogin)
+      ) {
+        navigateWithQuery('/post_verify/set_password', {
+          replace: true,
+          state: {
+            passwordCreationReason: signinState.isSignInWithThirdPartyAuth
+              ? 'third_party_auth'
+              : 'otp',
+          },
+        });
+        return;
+      }
 
       alertBar.success(
         ftlMsgResolver.getMsg(
           'signin-recovery-phone-success-message',
           'Signed in successfully. Limits may apply if you use your recovery phone again.'
-        ),
-        recoveryPhoneSigninSuccessGleanMetric
+        )
       );
 
       const navigationOptions = {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/interfaces.ts
@@ -10,6 +10,7 @@ import { SigninIntegration, SigninLocationState } from '../interfaces';
 export interface SigninRecoveryPhoneContainerProps {
   integration: Integration;
   setCurrentSplitLayout?: (value: boolean) => void;
+  supportsKeysOptionalLogin?: boolean;
 }
 
 export interface SigninRecoveryPhoneLocationState extends SigninLocationState {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -444,6 +444,37 @@ describe('Sign in with TOTP code page', () => {
         );
       });
     });
+
+    it('does not record hasPassword on a third-party-auth sign-in', async () => {
+      // A third-party account may have a password, so the flow must not assert
+      // hasPassword: false here — SetPassword verifies it via accountStatus.
+      const user = userEvent.setup();
+      jest.spyOn(SigninUtils, 'handleNavigation').mockResolvedValue({
+        error: undefined,
+      });
+      const storeAccountDataSpy = jest
+        .spyOn(StorageUtils, 'storeAccountData')
+        .mockImplementation(() => {});
+      const submitTotpCode = jest.fn().mockResolvedValue({ error: undefined });
+      renderWithLocalizationProvider(
+        <Subject
+          submitTotpCode={submitTotpCode}
+          signinState={{
+            ...MOCK_TOTP_LOCATION_STATE,
+            isSignInWithThirdPartyAuth: true,
+          }}
+        />
+      );
+      await user.type(screen.getByLabelText('Enter 6-digit code'), '123456');
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(storeAccountDataSpy).toHaveBeenCalled();
+      });
+      expect(storeAccountDataSpy.mock.calls[0][0]).not.toHaveProperty(
+        'hasPassword'
+      );
+    });
   });
 
   // "keys not optional" = Firefox where Sync isn't decoupled: desktop before
@@ -519,6 +550,39 @@ describe('Sign in with TOTP code page', () => {
         '/post_verify/set_password',
         expect.anything()
       );
+    });
+
+    it('redirects a third-party-auth sign-in to set_password when keys are not optional', async () => {
+      const user = userEvent.setup();
+      const handleNavigationSpy = jest
+        .spyOn(SigninUtils, 'handleNavigation')
+        .mockResolvedValue({ error: undefined });
+      const submitTotpCode = jest.fn().mockResolvedValue({ error: undefined });
+
+      renderWithLocalizationProvider(
+        <Subject
+          integration={vpnIntegration()}
+          submitTotpCode={submitTotpCode}
+          supportsKeysOptionalLogin={false}
+          signinState={{
+            ...MOCK_TOTP_LOCATION_STATE,
+            isSignInWithThirdPartyAuth: true,
+          }}
+        />
+      );
+      await user.type(screen.getByLabelText('Enter 6-digit code'), '123456');
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await waitFor(() => {
+        expect(mockNavigateWithQuery).toHaveBeenCalledWith(
+          '/post_verify/set_password',
+          expect.objectContaining({
+            replace: true,
+            state: { passwordCreationReason: 'third_party_auth' },
+          })
+        );
+      });
+      expect(handleNavigationSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -134,6 +134,10 @@ export const SigninTotpCode = ({
         showInlineRecoveryKeySetup,
       } = signinState;
 
+      const isPasswordlessSignin =
+        signinState.isPasswordlessOtpSignin ||
+        signinState.isSignInWithThirdPartyAuth;
+
       storeAccountData({
         sessionToken,
         email,
@@ -141,23 +145,16 @@ export const SigninTotpCode = ({
         // Update verification status of stored current account
         verified: true,
         sessionVerified: true,
+        // OTP sign-in is the only genuinely passwordless case; a third-party
+        // account may have a password, so leave it unset and let SetPassword verify.
         ...(signinState.isPasswordlessOtpSignin && { hasPassword: false }),
       });
 
-      // Passwordless flow: after TOTP, redirect to set_password for key
-      // derivation. The session is now verified so /password/create (which
-      // requires verifiedSessionToken) will work. Redirect when keys are
-      // needed — Sync always, and non-Sync browser services that require keys
-      // because the browser hasn't decoupled Sync. Other non-Sync
-      // flows that don't require keys continue through handleNavigation.
-      //
-      // The inbound `isPasswordlessOtpSignin` lives on SigninLocationState;
-      // the outbound `passwordCreationReason` lives on SetPasswordLocationState.
-      // They look related but belong to different state objects on different
-      // routes — the boolean gates the redirect, the enum tags the Glean
-      // reason on the destination page.
+      // Passwordless sign-in needing keys: redirect to set_password.
+      // Other flows continue through handleNavigation.
+      // passwordCreationReason tags the Glean reason on the destination page.
       if (
-        signinState.isPasswordlessOtpSignin &&
+        isPasswordlessSignin &&
         integration.requiresPasswordForLogin(
           useFxAStatusResult.supportsKeysOptionalLogin
         )
@@ -165,7 +162,9 @@ export const SigninTotpCode = ({
         navigateWithQuery('/post_verify/set_password', {
           replace: true,
           state: {
-            passwordCreationReason: 'otp',
+            passwordCreationReason: signinState.isSignInWithThirdPartyAuth
+              ? 'third_party_auth'
+              : 'otp',
           },
         });
         return;

--- a/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
@@ -40,6 +40,7 @@ const SigninAlternativeAuthOptions = ({
   localizedSuccessBannerDescription,
   isSignedIntoFirefox = false,
   setCurrentSplitLayout,
+  supportsKeysOptionalLogin,
 }: SigninAlternativeAuthOptionsProps & RouteComponentProps) => {
   const config = useConfig();
   const authClient = useAuthClient();
@@ -61,6 +62,7 @@ const SigninAlternativeAuthOptions = ({
     queryParams: location.search,
     surface: 'alternative_auth',
     isButtonVisible: showPasskeySignin,
+    supportsKeysOptionalLogin,
   });
 
   const {

--- a/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninDecider/index.tsx
@@ -233,6 +233,8 @@ export const SigninDecider = ({
           flowQueryParams,
           isSignedIntoFirefox,
           setCurrentSplitLayout,
+          supportsKeysOptionalLogin:
+            useFxAStatusResult.supportsKeysOptionalLogin,
         }}
       />
     );

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -78,6 +78,7 @@ const Signin = ({
     queryParams: location.search,
     surface: 'login',
     isButtonVisible: showPasskeySignin,
+    supportsKeysOptionalLogin,
   });
 
   const [localizedBannerError, setLocalizedBannerError] = useState(

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -144,7 +144,9 @@ export interface SigninCachedProps extends SigninSharedProps {
   supportsKeysOptionalLogin?: boolean;
 }
 
-export type SigninAlternativeAuthOptionsProps = SigninSharedProps;
+export type SigninAlternativeAuthOptionsProps = SigninSharedProps & {
+  supportsKeysOptionalLogin?: boolean;
+};
 
 export type BeginSigninHandler = (
   email: string,


### PR DESCRIPTION
## Because

- PR #20750 (FXA-13947 / FXA-13946) fixed keyless logins for passwordless OTP and third-party-auth sign-ins to non-Sync Firefox services that request Sync-scoped keys (e.g. Android VPN) when the browser has not decoupled Sync — but it did not cover passkey sign-in, nor the remaining 2FA/recovery completion paths.
- Spotted during engineering review of #20750 (not a QA report): a passwordless account signing in with a passkey (or completing TOTP / recovery-code / recovery-phone) to such a service on a non-decoupled browser still receives a keyless login (`Sync scope granted, but keys_jwe is None`).

## This pull request

- **Passkey redirect** — drives the password-step decision from `integration.requiresPasswordForLogin(supportsKeysOptionalLogin)` (a decoupling-aware, client-side check) instead of the server's `service === 'sync'` signal. Routes a passwordless account to `/post_verify/set_password` and an existing-password account to `/signin_passkey_fallback`, deferring the `fxaLogin` / `fxaOAuthLogin` web-channel messages until keys are available.
- **2FA / recovery parity** — extends the same keys-required redirect to the other passwordless completion paths: TOTP, recovery code, and recovery phone.
- **Server cleanup** — tidies the passkey auth response and feature-flag helper types; removes the now-unused `requiresPasswordForSync` response field.
- **Notification timing** — for keys-required passkey sign-ins, defers the `account.login` metric / flow signal / security event (the new-device email is still sent, with generic framing) so the metric fires once keys are actually obtained at reauth / set-password. The client passes the decoupling-aware `requiresPasswordForLogin` to the server, and the passkey fallback reauth now passes `reason: 'signin'` + the flow `metricsContext` so the deferred metric lands correlated. `keysRequired` is a required field on `/passkey/authentication/finish` (the `service === 'sync'` fallback was removed).
- Unit tests cover all of the above; remote/functional passkey specs updated for the response change.

## Issue that this pull request solves

Closes: FXA-13979

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- #20750 is already merged to `main`; this branch is now a single squashed commit on top of `main` — review the diff directly.
- Suggested reading order: (1) passkey redirect via `requiresPasswordForLogin`, (2) 2FA/recovery parity, (3) server response/type tidy + the now-required `keysRequired` contract, (4) keys-required notification deferral.
- Risky / focus areas: the `requiresPasswordForLogin` decoupling logic and `supportsKeysOptionalLogin` fail-closed default; the notification deferral and the fallback-reauth `metricsContext` correlation.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- The fix sits behind the passkey feature flags, so this is a latent gap closed ahead of passkey GA, not a live production regression.
- Found during engineering review of #20750 (not reported by QA) — an extension of the same underlying bug.

