### PR TITLE
fix(passkey): record prfEnabled by requesting PRF at registration

### DIFF
--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -8,6 +8,7 @@ import {
   verifyWebauthnRegistrationResponse,
   generateWebauthnAuthenticationOptions,
   verifyWebauthnAuthenticationResponse,
+  extractPrfEnabled,
 } from './webauthn-adapter';
 import { PasskeyConfig } from './passkey.config';
 import { VirtualAuthenticator } from './virtual-authenticator';
@@ -159,6 +160,50 @@ describe('generateWebauthnRegistrationOptions', () => {
       { id: credId, type: 'public-key' },
     ]);
   });
+
+  it('requests the PRF extension so authenticators report PRF support', async () => {
+    const options = await generateWebauthnRegistrationOptions(testConfig(), {
+      uid: Buffer.alloc(16, 0xbb).toString('hex'),
+      email: 'bob@example.com',
+      challenge: randomBytes(32).toString('base64url'),
+    });
+
+    // credProps is added by SimpleWebAuthn itself; we only own the PRF probe.
+    expect(options.extensions).toEqual(expect.objectContaining({ prf: {} }));
+  });
+});
+
+describe('extractPrfEnabled', () => {
+  it.each([
+    {
+      label: 'prf.enabled is true',
+      input: { prf: { enabled: true } },
+      expected: true,
+    },
+    {
+      label: 'prf.enabled is false',
+      input: { prf: { enabled: false } },
+      expected: false,
+    },
+    {
+      label: 'prf is present without enabled',
+      input: { prf: {} },
+      expected: false,
+    },
+    {
+      label: 'prf.enabled is a non-boolean truthy value',
+      input: { prf: { enabled: 'false' } },
+      expected: false,
+    },
+    { label: 'prf is absent', input: {}, expected: false },
+    {
+      label: 'client extension results are undefined',
+      input: undefined,
+      expected: false,
+    },
+  ])('returns $expected when $label', ({ input, expected }) => {
+    expect(extractPrfEnabled(input)).toBe(expected);
+  });
 });
 
 describe('verifyWebauthnRegistrationResponse', () => {
@@ -186,18 +231,48 @@ describe('verifyWebauthnRegistrationResponse', () => {
     });
 
     expect(result.verified).toBe(true);
-    if (!result.verified) throw new Error('narrowing');
 
-    expect(typeof result.data.credentialId).toBe('string');
-    expect(result.data.credentialId).toBe(cred.id.toString('base64url'));
-    expect(result.data.publicKey).toBeInstanceOf(Buffer);
-    expect(result.data.signCount).toBe(0);
-    expect(result.data.transports).toEqual(['internal']);
-    expect(typeof result.data.aaguid).toBe('string');
-    expect(result.data.aaguid).toBe('00000000-0000-0000-0000-000000000000');
-    expect(result.data.backupEligible).toBe(false);
-    expect(result.data.backupState).toBe(false);
-    expect(result.data.prfEnabled).toBe(false);
+    expect(typeof result.data?.credentialId).toBe('string');
+    expect(result.data?.credentialId).toBe(cred.id.toString('base64url'));
+    expect(result.data?.publicKey).toBeInstanceOf(Buffer);
+    expect(result.data?.signCount).toBe(0);
+    expect(result.data?.transports).toEqual(['internal']);
+    expect(typeof result.data?.aaguid).toBe('string');
+    expect(result.data?.aaguid).toBe('00000000-0000-0000-0000-000000000000');
+    expect(result.data?.backupEligible).toBe(false);
+    expect(result.data?.backupState).toBe(false);
+    // No prf in clientExtensionResults → not PRF-enabled.
+    expect(result.data?.prfEnabled).toBe(false);
+  });
+
+  it('records prfEnabled when the browser reports PRF support', async () => {
+    const cred = VirtualAuthenticator.createCredential();
+    const challenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnRegistrationOptions(config, {
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
+      email: 'test@example.com',
+      challenge,
+    });
+
+    const attestation = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: TEST_RP_ID,
+    });
+    // prf.enabled is a WebAuthn Level 3 client-extension output the browser
+    // sets; the virtual authenticator leaves clientExtensionResults empty, so
+    // attach it here. (Field absent from SimpleWebAuthn's output type.)
+    (attestation.clientExtensionResults as { prf?: { enabled: boolean } }).prf =
+      { enabled: true };
+
+    const result = await verifyWebauthnRegistrationResponse(config, {
+      response: attestation,
+      challenge,
+    });
+
+    expect(result.verified).toBe(true);
+    expect(result.data?.prfEnabled).toBe(true);
   });
 
   it('rejects a mismatched challenge', async () => {
@@ -380,9 +455,8 @@ describe('verifyWebauthnAuthenticationResponse', () => {
     });
 
     expect(result.verified).toBe(true);
-    if (!result.verified) throw new Error('narrowing');
-    expect(result.data.newSignCount).toBe(1);
-    expect(result.data.backupState).toBe(false);
+    expect(result.data?.newSignCount).toBe(1);
+    expect(result.data?.backupState).toBe(false);
   });
 
   it('tracks incrementing sign counts across assertions', async () => {

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -16,6 +16,7 @@ import type {
   PublicKeyCredentialCreationOptionsJSON,
   PublicKeyCredentialRequestOptionsJSON,
   AuthenticatorTransportFuture,
+  AuthenticationExtensionsClientInputs,
 } from '@simplewebauthn/server';
 
 import { uuidTransformer } from '@fxa/shared/db/mysql/core';
@@ -79,6 +80,9 @@ export async function generateWebauthnRegistrationOptions(
       authenticatorAttachment: config.authenticatorAttachment,
     },
     excludeCredentials: input.excludeCredentials,
+    // Probe PRF capability only (no eval) for passkey Phase 1.
+    // Cast: SimpleWebAuthn's bundled type predates PRF.
+    extensions: { prf: {} } as AuthenticationExtensionsClientInputs,
   });
 }
 
@@ -107,11 +111,12 @@ export type RegistrationVerificationResult =
   | { verified: true; data: VerifiedRegistrationData };
 
 /**
- * Extract the PRF `enabled` flag from authenticator extension results.
+ * Extract the PRF `enabled` flag from the browser's client extension results.
  */
-function extractPrfEnabled(extensions: unknown): boolean {
-  return Boolean(
-    (extensions as { prf?: { enabled?: unknown } } | undefined)?.prf?.enabled
+export function extractPrfEnabled(extensions: unknown): boolean {
+  return (
+    (extensions as { prf?: { enabled?: unknown } } | undefined)?.prf
+      ?.enabled === true
   );
 }
 
@@ -142,13 +147,8 @@ export async function verifyWebauthnRegistrationResponse(
     return { verified: false };
   }
 
-  const {
-    credential,
-    aaguid,
-    credentialDeviceType,
-    credentialBackedUp,
-    authenticatorExtensionResults,
-  } = registrationInfo;
+  const { credential, aaguid, credentialDeviceType, credentialBackedUp } =
+    registrationInfo;
 
   return {
     verified: true,
@@ -160,7 +160,7 @@ export async function verifyWebauthnRegistrationResponse(
       aaguid,
       backupEligible: credentialDeviceType === 'multiDevice',
       backupState: credentialBackedUp,
-      prfEnabled: extractPrfEnabled(authenticatorExtensionResults),
+      prfEnabled: extractPrfEnabled(input.response.clientExtensionResults),
     },
   };
 }

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -749,6 +749,16 @@ export const passkeyRoutes = (
                 credProps: isA.boolean().optional(),
                 hmacCreateSecret: isA.boolean().optional(),
                 minPinLength: isA.boolean().optional(),
+                prf: isA
+                  .object({
+                    eval: isA
+                      .object({
+                        first: isA.string().required(),
+                        second: isA.string().optional(),
+                      })
+                      .optional(),
+                  })
+                  .optional(),
               })
               .optional(),
           }),

--- a/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
@@ -192,6 +192,7 @@ describe('#integration - remote passkey registration', () => {
     );
     expect(options.challenge).toBeDefined();
     expect(options.rp).toBeDefined();
+    expect(options.extensions).toEqual(expect.objectContaining({ prf: {} }));
 
     // Step 2: simulate authenticator
     const cred = VirtualAuthenticator.createCredential();


### PR DESCRIPTION
## Because

- Passkey registration never requested the WebAuthn PRF extension, **and** `prfEnabled` was read from the authenticator's CBOR extension output (hmac-secret) rather than the browser's client extension results where `prf.enabled` actually lives. Either defect alone forced `prfEnabled = 0` for every passkey, silently dead-ending Phase 2 passwordless Sync key derivation.

## This pull request

- Requests the PRF extension (probe-only, empty `eval`) in the server-generated registration options.
- Allows `prf` through the `/passkey/registration/start` response schema so Hapi response validation doesn't reject it (would otherwise 500).
- Reads `prfEnabled` from `input.response.clientExtensionResults`.
- Exports `extractPrfEnabled` and adds coverage for the response-shape variants (`true` / `false` / missing / `undefined`) plus a registration-roundtrip assertion.

## Issue that this pull request solves

Closes: FXA-13978

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review

**Automated:** `nx test-unit accounts-passkey` (the integration spec in `passkeys.in.spec.ts` needs `yarn start infrastructure`).

**Manual (admin panel — `prfEnabled` is not surfaced in the account UI):**
1. Create an account and register one or more passkeys; using a few different authenticator types gives broader coverage.
2. In admin-panel, search the account and check the **prfEnabled** column for each passkey.
3. Expect `prfEnabled = true` for PRF-capable authenticator + browser/OS combos, `false` otherwise. Before this fix, **every** passkey reported `false` regardless of authenticator.

`prfEnabled = true` requires *both* an authenticator that supports CTAP2 `hmac-secret` and a browser/OS that implements the WebAuthn PRF extension. Rough expectations:

| Authenticator | Expected `prfEnabled` | Notes |
|---|---|---|
| Apple passkeys (iCloud Keychain) | `true` | iOS 18 / macOS 15 / Safari 18+; older Apple OS → `false` |
| Android passkeys (Google Password Manager) | `true` | Recent Android + Chrome |
| Password managers (1Password, Bitwarden, Dashlane, …) | `true` | Current versions with passkey + PRF support |
| FIDO2 security keys (YubiKey 5, recent Titan, …) | `true` | Need `hmac-secret` (e.g. YubiKey firmware ≥ 5.2.3) |
| Windows Hello (platform authenticator) | usually `false` | Windows Hello has not implemented PRF/`hmac-secret`; confirm against the Windows build under test |
| U2F / CTAP1 or older security keys | `false` | No `hmac-secret` support |
| Any authenticator on a pre-PRF browser/OS | `false` | Below the WebAuthn PRF support floors |

- **Key files:** `libs/accounts/passkey/src/lib/webauthn-adapter.ts` (request PRF + read from the right object); `packages/fxa-auth-server/lib/routes/passkeys.ts` (response-schema allowance).
- **Risky/complex:** `prfEnabled` is sourced from client-reported `clientExtensionResults` — inherent to WebAuthn (no server-verifiable source for `prf.enabled`); capability hint, not a security boundary.

## Other information

- **QA:** marked `qa-` — QA cannot validate, since `prfEnabled` state is not communicated in the account UI (admin-panel only).
- **Forward-only:** passkeys created before this fix keep `prfEnabled = 0` and need re-registration to become PRF-capable.
- **Functional tests:** unchanged — the Playwright polyfill/virtual-authenticator path doesn't inspect extension results; PRF-capable E2E coverage is a Phase 2 (FXA-12970) concern.
