### PR TITLE
feat(settings): Show Kit mobile install QR code on desktop sync flow

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -206,6 +206,7 @@ describe('metrics', () => {
     });
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: jest.fn(),
+      isDesktopSync: jest.fn(),
       isFirefoxClientServiceRelay: jest.fn(),
       getServiceName: jest.fn(),
       getClientId: jest.fn(),
@@ -253,6 +254,7 @@ describe('glean', () => {
     });
     const mockIntegration = {
       isSync: jest.fn(),
+      isDesktopSync: jest.fn(),
       isFirefoxClientServiceRelay: jest.fn(),
       getServiceName: jest.fn(),
       getClientId: jest.fn(),
@@ -329,6 +331,7 @@ describe('loading spinner states', () => {
     });
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: jest.fn().mockReturnValueOnce(true),
+      isDesktopSync: jest.fn(),
       isFirefoxClientServiceRelay: jest.fn().mockReturnValueOnce(false),
       getCmsInfo: jest.fn(),
       getLegalTerms: jest.fn(),
@@ -371,6 +374,7 @@ describe('AuthAndAccountSetupRoutes', () => {
     const mockIntegration = {
       getServiceName: () => MozServices.FirefoxSync,
       isSync: () => true,
+      isDesktopSync: () => false,
       type: IntegrationType.OAuthNative,
       data: {},
       isFirefoxClientServiceRelay: () => false,
@@ -421,6 +425,7 @@ describe('SettingsRoutes', () => {
     });
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => false,
+      isDesktopSync: () => false,
       isFirefoxClientServiceRelay: jest.fn().mockReturnValueOnce(false),
       getServiceName: jest.fn(),
       getCmsInfo: jest.fn(),
@@ -469,6 +474,7 @@ describe('SettingsRoutes', () => {
     (currentAccount as jest.Mock).mockReturnValue(null);
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => false,
+      isDesktopSync: () => false,
       isFirefoxClientServiceRelay: () => false,
       getCmsInfo: jest.fn(),
       getLegalTerms: jest.fn(),
@@ -504,6 +510,7 @@ describe('SettingsRoutes', () => {
   it('redirects to sign out of sync warning', async () => {
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => true,
+      isDesktopSync: () => false,
       isFirefoxClientServiceRelay: () => false,
       getCmsInfo: jest.fn(),
       getLegalTerms: jest.fn(),
@@ -552,6 +559,7 @@ describe('SettingsRoutes', () => {
 
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => true,
+      isDesktopSync: () => false,
       isFirefoxClientServiceRelay: () => false,
       isFirefoxDesktopClient: () => true,
       getCmsInfo: jest.fn(),
@@ -672,6 +680,7 @@ describe('Integration serviceName error handling', () => {
     const mockOAuthIntegration = {
       type: IntegrationType.OAuthWeb,
       isSync: jest.fn().mockReturnValue(false),
+      isDesktopSync: jest.fn().mockReturnValue(false),
       isFirefoxClientServiceRelay: jest.fn().mockReturnValue(false),
       getServiceName: jest.fn().mockImplementation(() => {
         throw mockError;
@@ -713,6 +722,7 @@ describe('Integration serviceName error handling', () => {
       type: IntegrationType.OAuthWeb,
       clientInfoLoadFailed: true,
       isSync: jest.fn().mockReturnValue(false),
+      isDesktopSync: jest.fn().mockReturnValue(false),
       isFirefoxClientServiceRelay: jest.fn().mockReturnValue(false),
       checkClientInfo: jest.fn().mockImplementation(() => {
         throw mockError;
@@ -744,6 +754,7 @@ describe('Integration serviceName error handling', () => {
     const mockNonOAuthIntegration = {
       type: IntegrationType.Web,
       isSync: jest.fn().mockReturnValue(false),
+      isDesktopSync: jest.fn().mockReturnValue(false),
       isFirefoxClientServiceRelay: jest.fn().mockReturnValue(false),
       getServiceName: jest.fn().mockImplementation(() => {
         throw mockError;
@@ -780,6 +791,7 @@ describe('Integration serviceName error handling', () => {
     const mockOAuthNativeIntegration = {
       type: IntegrationType.OAuthNative,
       isSync: jest.fn().mockReturnValue(false),
+      isDesktopSync: jest.fn().mockReturnValue(false),
       isFirefoxClientServiceRelay: jest.fn().mockReturnValue(false),
       getServiceName: jest.fn().mockImplementation(() => {
         throw mockError;

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -526,7 +526,7 @@ const AuthAndAccountSetupRoutes = ({
 
   const useFxAStatusResult = useFxAStatus(integration);
   const defaultCmsState = useDefaultCmsState({
-    enabled: isWebIntegration(integration),
+    enabled: isWebIntegration(integration) || integration.isDesktopSync(),
   });
   try {
     // Handle getServiceName() errors that occur when OAuth scope validation fails.

--- a/packages/fxa-settings/src/components/PromoQrMobile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PromoQrMobile/index.stories.tsx
@@ -24,7 +24,9 @@ export const Default = () => {
 
   return (
     <LocationProvider {...{ history }}>
-      <PromoQrMobile integration={{ type: IntegrationType.Web }} />
+      <PromoQrMobile
+        integration={{ type: IntegrationType.Web, isDesktopSync: () => false }}
+      />
     </LocationProvider>
   );
 };
@@ -38,7 +40,24 @@ export const WithCardAppLayout = () => {
         <h1 className="card-header">Sign in</h1>
         <p className="mt-2">Continue to account settings</p>
       </AppLayout>
-      <PromoQrMobile integration={{ type: IntegrationType.Web }} />
+      <PromoQrMobile
+        integration={{ type: IntegrationType.Web, isDesktopSync: () => false }}
+      />
+    </LocationProvider>
+  );
+};
+
+export const DesktopSync = () => {
+  const history = createHistory(createMemorySource('/'));
+
+  return (
+    <LocationProvider {...{ history }}>
+      <PromoQrMobile
+        integration={{
+          type: IntegrationType.OAuthNative,
+          isDesktopSync: () => true,
+        }}
+      />
     </LocationProvider>
   );
 };

--- a/packages/fxa-settings/src/components/PromoQrMobile/index.test.tsx
+++ b/packages/fxa-settings/src/components/PromoQrMobile/index.test.tsx
@@ -27,8 +27,11 @@ beforeAll(() => {
   });
 });
 
-function createIntegration(type: IntegrationType): PromoQrMobileIntegration {
-  return { type };
+function createIntegration(
+  type: IntegrationType,
+  isDesktopSync = false
+): PromoQrMobileIntegration {
+  return { type, isDesktopSync: () => isDesktopSync };
 }
 
 function renderAtRoute(
@@ -53,12 +56,17 @@ describe('PromoQrMobile', () => {
       expect(screen.getByRole('complementary')).toBeInTheDocument();
     });
 
+    it('renders for desktop sync integrations', () => {
+      renderAtRoute('/', createIntegration(IntegrationType.OAuthNative, true));
+      expect(screen.getByRole('complementary')).toBeInTheDocument();
+    });
+
     it('does not render for OAuth integrations', () => {
       renderAtRoute('/', createIntegration(IntegrationType.OAuthWeb));
       expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
     });
 
-    it('does not render for Sync integrations', () => {
+    it('does not render for non-sync OAuth native integrations', () => {
       renderAtRoute('/', createIntegration(IntegrationType.OAuthNative));
       expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
     });
@@ -107,13 +115,19 @@ describe('PromoQrMobile', () => {
       expect(GleanMetrics.promoQrMobile.view).toHaveBeenCalledTimes(1);
     });
 
+    it('fires the view event once on desktop for desktop sync integrations', () => {
+      mockMatchMedia.mockReturnValue({ matches: true });
+      renderAtRoute('/', createIntegration(IntegrationType.OAuthNative, true));
+      expect(GleanMetrics.promoQrMobile.view).toHaveBeenCalledTimes(1);
+    });
+
     it('does not fire the view event on mobile viewports', () => {
       mockMatchMedia.mockReturnValue({ matches: false });
       renderAtRoute('/', webIntegration);
       expect(GleanMetrics.promoQrMobile.view).not.toHaveBeenCalled();
     });
 
-    it('does not fire when integration is not web', () => {
+    it('does not fire for OAuth web integrations', () => {
       mockMatchMedia.mockReturnValue({ matches: true });
       renderAtRoute('/', createIntegration(IntegrationType.OAuthWeb));
       expect(GleanMetrics.promoQrMobile.view).not.toHaveBeenCalled();

--- a/packages/fxa-settings/src/components/PromoQrMobile/index.tsx
+++ b/packages/fxa-settings/src/components/PromoQrMobile/index.tsx
@@ -11,7 +11,10 @@ import { Integration, isWebIntegration } from '../../models/integrations';
 import GleanMetrics from '../../lib/glean';
 import { isValidCmsUrl } from '../../lib/utilities';
 
-export type PromoQrMobileIntegration = Pick<Integration, 'type'>;
+export type PromoQrMobileIntegration = Pick<
+  Integration,
+  'type' | 'isDesktopSync'
+>;
 
 // Must match the `desktop` breakpoint in packages/fxa-react/configs/tailwind.js.
 // This is a little fragile, but we're doing it to fire a Glean event only at
@@ -43,7 +46,8 @@ export const PromoQrMobile = ({
   const hasLoggedView = useRef(false);
 
   const visible =
-    isWebIntegration(integration) && shouldShowPromo(location.pathname);
+    (isWebIntegration(integration) || integration.isDesktopSync()) &&
+    shouldShowPromo(location.pathname);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Because

- The Kit mobile install QR code was previously only shown on settings-only (web) sign-in and sign-up flows.
- Desktop sync users should be able to scan the same code to install the Firefox mobile app.

## This pull request

- Renders the `PromoQrMobile` QR code for desktop sync integrations (gated on `integration.isDesktopSync()`) in addition to web integrations, in `packages/fxa-settings/src/components/PromoQrMobile/index.tsx`.
- Widens the `PromoQrMobileIntegration` type to include `isDesktopSync`, reusing the same QR asset and Strapi/CMS override path the web flow already uses.
- Updates the component's tests and story to cover the desktop sync case.

## Issue that this pull request solves

Closes: FXA-13966

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
