### PR TITLE
feat(settings): update pairing QR links to new mzl.la shortlinks

### DIFF
--- a/packages/fxa-settings/src/lib/constants.ts
+++ b/packages/fxa-settings/src/lib/constants.ts
@@ -133,11 +133,10 @@ export const Constants = {
     'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=android&fallback=https://play.google.com/store/apps/details?id=org.mozilla.firefox',
 
   // Generic pairing download QR target (Mozilla shortlink).
-  DOWNLOAD_LINK_PAIRING_QR_DEFAULT: 'https://mzl.la/3NDxAIS',
+  DOWNLOAD_LINK_PAIRING_QR_DEFAULT: 'https://mzl.la/4vbFJda',
 
-  // Send-tab QR target; no adgroup/fallback so Adjust routes by the scanning device's OS.
-  DOWNLOAD_LINK_PAIRING_QR_SEND_TAB:
-    'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s',
+  // Send-tab QR target (Mozilla shortlink).
+  DOWNLOAD_LINK_PAIRING_QR_SEND_TAB: 'https://mzl.la/4vr1mWU',
 
   MOZ_ORG_SYNC_GET_STARTED_LINK:
     'https://www.mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started', //eslint-disable-line max-len

--- a/packages/fxa-settings/src/lib/utilities.test.ts
+++ b/packages/fxa-settings/src/lib/utilities.test.ts
@@ -19,6 +19,7 @@ import {
   toGenericOSName,
 } from './utilities';
 import { SEND_TAB_ENTRYPOINTS } from '../constants';
+import { Constants } from './constants';
 
 describe('deepMerge', () => {
   it('recursively merges multiple objects', () => {
@@ -398,23 +399,17 @@ describe('isSendTabEntrypoint', () => {
 });
 
 describe('buildPairingDownloadUrl', () => {
-  const DEFAULT_URL = 'https://mzl.la/3NDxAIS';
+  const DEFAULT_URL = Constants.DOWNLOAD_LINK_PAIRING_QR_DEFAULT;
+  const SEND_TAB_URL = Constants.DOWNLOAD_LINK_PAIRING_QR_SEND_TAB;
 
-  it('points send-tab entrypoints at the Adjust tracker so installs are attributable', () => {
-    const url = new URL(buildPairingDownloadUrl('send-tab-toolbar-icon'));
-    expect(url.host).toBe('app.adjust.com');
+  it('returns the send-tab Mozilla download link for a send-tab entrypoint', () => {
+    expect(buildPairingDownloadUrl('send-tab-toolbar-icon')).toBe(SEND_TAB_URL);
   });
 
-  it('sets campaign=send-tab for every send-tab entrypoint', () => {
+  it('returns the send-tab link for every send-tab entrypoint', () => {
     for (const entrypoint of SEND_TAB_ENTRYPOINTS) {
-      const url = new URL(buildPairingDownloadUrl(entrypoint));
-      expect(url.searchParams.get('campaign')).toBe('send-tab');
+      expect(buildPairingDownloadUrl(entrypoint)).toBe(SEND_TAB_URL);
     }
-  });
-
-  it('records the specific entrypoint as the creative for per-entrypoint attribution', () => {
-    const url = new URL(buildPairingDownloadUrl('send-tab-account-menu'));
-    expect(url.searchParams.get('creative')).toBe('send-tab-account-menu');
   });
 
   it('returns the generic Mozilla download link for a non-send-tab entrypoint', () => {

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -7,7 +7,6 @@ import { AttachedClient } from '../models/Account';
 import { navigate, NavigateFn, NavigateOptions } from '@reach/router';
 import { SEND_TAB_ENTRYPOINTS } from '../constants';
 import { Constants } from './constants';
-import { interpolate } from './error-utils';
 
 // Various utilities that don't fit in a standalone lib
 
@@ -299,13 +298,9 @@ export function isSendTabEntrypoint(
   return !!entrypoint && SEND_TAB_ENTRYPOINTS.has(entrypoint);
 }
 
-/** URL for the pairing QR: an attributable Adjust link for send-tab, else the generic Mozilla link. */
+/** URL for the pairing QR: the send-tab Mozilla shortlink for send-tab entrypoints, else the generic Mozilla shortlink. */
 export function buildPairingDownloadUrl(entrypoint?: string | null): string {
-  if (!isSendTabEntrypoint(entrypoint)) {
-    return Constants.DOWNLOAD_LINK_PAIRING_QR_DEFAULT;
-  }
-  return interpolate(Constants.DOWNLOAD_LINK_PAIRING_QR_SEND_TAB, {
-    campaign: 'send-tab',
-    creative: entrypoint,
-  });
+  return isSendTabEntrypoint(entrypoint)
+    ? Constants.DOWNLOAD_LINK_PAIRING_QR_SEND_TAB
+    : Constants.DOWNLOAD_LINK_PAIRING_QR_DEFAULT;
 }

--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -232,19 +232,17 @@ describe('Pair', () => {
       ).toBeInTheDocument();
     });
 
-    it('encodes a send-tab campaign in the QR for a send-tab entrypoint', async () => {
+    it('encodes the send-tab Mozilla download link in the QR for a send-tab entrypoint', async () => {
       await renderAndNavigateToDownload({ integration: sendTabIntegration });
-      const url = new URL(
-        screen.getByTestId('pair-qr').getAttribute('data-value')!
+      expect(screen.getByTestId('pair-qr').getAttribute('data-value')).toBe(
+        'https://mzl.la/4vr1mWU'
       );
-      expect(url.searchParams.get('campaign')).toBe('send-tab');
-      expect(url.searchParams.get('creative')).toBe('send-tab-toolbar-icon');
     });
 
     it('encodes the generic Mozilla download link for a non-send-tab entrypoint', async () => {
       await renderAndNavigateToDownload({ integration: webIntegration });
       expect(screen.getByTestId('pair-qr').getAttribute('data-value')).toBe(
-        'https://mzl.la/3NDxAIS'
+        'https://mzl.la/4vbFJda'
       );
     });
 


### PR DESCRIPTION
## Because

- The send-tab pairing QR pointed at a raw Adjust tracker URL instead of the canonical Mozilla shortlink
- The default pairing QR shortlink needed updating to its new target
- After the link swap, `buildPairingDownloadUrl` was left interpolating campaign/creative params into a URL with no placeholders — dead, misleading code

## This pull request

- Updates `DOWNLOAD_LINK_PAIRING_QR_SEND_TAB` to `https://mzl.la/4vr1mWU` and `DOWNLOAD_LINK_PAIRING_QR_DEFAULT` to `https://mzl.la/4vbFJda` in `constants.ts`
- Simplifies `buildPairingDownloadUrl` in `utilities.ts` to return the constant directly, removes the now-no-op `interpolate` call and its orphaned import, and corrects the stale JSDoc
- Updates `utilities.test.ts` to assert against `Constants` (instead of duplicated literals) so a constant change is caught
- Updates the QR-encoding assertions in `Pair/Index/index.test.tsx` to the new shortlinks

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13981

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:**
1. Open Firefox → Settings → start a "connect another device" flow that renders the pairing QR
2. Scan the generic QR → resolves to `https://mzl.la/4vbFJda`
3. Trigger the flow from a Firefox "Send Tab" entrypoint and scan → resolves to `https://mzl.la/4vr1mWU`