### PR TITLE
feat(auth-server): tag auth.strategy.used metric with route path

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.js
@@ -103,8 +103,14 @@ function strategy(kind, getCredentialsFunc, options) {
     return err;
   };
 
-  const recordUsed = () => {
-    statsd.increment('auth.strategy.used', [`scheme:bearer`, `kind:${kind}`]);
+  // `path` is the templated route (e.g. /v1/account/device), never the raw
+  // URL, so cardinality stays ~2 schemes x authed routes (~130 series total).
+  const recordUsed = (req) => {
+    statsd.increment('auth.strategy.used', [
+      `scheme:bearer`,
+      `kind:${kind}`,
+      `path:${req.route?.path ?? 'unknown'}`,
+    ]);
   };
 
   return function (server, options) {
@@ -144,7 +150,7 @@ function strategy(kind, getCredentialsFunc, options) {
           await postAuthenticate(req, token);
         }
 
-        recordUsed();
+        recordUsed(req);
         return h.authenticated({ credentials: token });
       },
       payload: async function (req, h) {

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.spec.ts
@@ -313,7 +313,7 @@ describe('lib/routes/auth-schemes/bearer-fxa-token', () => {
   describe('auth.strategy.used metric', () => {
     const authHeader = `Bearer fxs_${HEX_64}`;
 
-    it('increments {scheme=bearer, kind=<kind>} on successful auth', async () => {
+    it('increments {scheme=bearer, kind=<kind>, path=<path>} on successful auth', async () => {
       const statsd = { increment: jest.fn() };
       const authStrategy = strategy(
         'sessionToken',
@@ -321,13 +321,17 @@ describe('lib/routes/auth-schemes/bearer-fxa-token', () => {
         testOptions({ statsd })
       )(null as any, null as any);
 
-      const req = makeReq({ headers: { authorization: authHeader } });
+      const req = makeReq({
+        headers: { authorization: authHeader },
+        route: { path: '/v1/account/devices' },
+      });
       const h = makeH();
 
       await authStrategy.authenticate(req as any, h as any);
       expect(statsd.increment).toHaveBeenCalledWith('auth.strategy.used', [
         'scheme:bearer',
         'kind:sessionToken',
+        'path:/v1/account/devices',
       ]);
     });
 

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.js
@@ -97,9 +97,9 @@ function requireOptions(options) {
  *   - `throwOnFailure` — true for single-strategy routes, false for
  *     multi-strategy chains where Hapi must fall through to the next.
  *   - `statsd` + `kind` — drive the
- *     `auth.strategy.used{scheme=hawk,kind=<kind>}` metric that tracks the
- *     Hawk -> Bearer migration; required so a registration cannot silently
- *     disappear from the dashboard.
+ *     `auth.strategy.used{scheme=hawk,kind=<kind>,path=<path>}` metric that
+ *     tracks the Hawk -> Bearer migration; required so a registration cannot
+ *     silently disappear from the dashboard.
  *
  * All failure modes carry `errno=110` ("Token not found") so a final 401
  * in a multi-strategy chain matches the single-strategy response shape.
@@ -127,8 +127,14 @@ function strategy(getCredentialsFunc, options) {
     return err;
   };
 
-  const recordUsed = () => {
-    statsd.increment('auth.strategy.used', [`scheme:hawk`, `kind:${kind}`]);
+  // `path` is the templated route (e.g. /v1/account/device), never the raw
+  // URL, so cardinality stays ~2 schemes x authed routes (~130 series total).
+  const recordUsed = (req) => {
+    statsd.increment('auth.strategy.used', [
+      `scheme:hawk`,
+      `kind:${kind}`,
+      `path:${req.route?.path ?? 'unknown'}`,
+    ]);
   };
 
   return function (server, options) {
@@ -156,7 +162,7 @@ function strategy(getCredentialsFunc, options) {
             return failAuth();
           }
 
-          recordUsed();
+          recordUsed(req);
           return h.authenticated({ credentials: token });
         }
 

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.spec.ts
@@ -167,7 +167,7 @@ describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
   });
 
   describe('auth.strategy.used metric', () => {
-    it('increments {scheme=hawk, kind=<kind>} on successful auth when statsd+kind are provided', async () => {
+    it('increments {scheme=hawk, kind=<kind>, path=<path>} on successful auth when statsd+kind are provided', async () => {
       const statsd = { increment: jest.fn() };
       const getCredentialsFunc = jest
         .fn()
@@ -180,6 +180,7 @@ describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
       const request = {
         headers: { authorization: HAWK_HEADER },
         auth: { mode: 'required' },
+        route: { path: '/v1/account/devices' },
       };
       const h = { authenticated: jest.fn() };
 
@@ -187,6 +188,7 @@ describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
       expect(statsd.increment).toHaveBeenCalledWith('auth.strategy.used', [
         'scheme:hawk',
         'kind:sessionToken',
+        'path:/v1/account/devices',
       ]);
     });
 

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -418,8 +418,8 @@ async function create(
 
   const hawkFxAToken = require('./routes/auth-schemes/hawk-fxa-token');
   // Register auth strategies for all token types. These strategies support Hawk (without validation) and FxA token types.
-  // `statsd`+`kind` drive the `auth.strategy.used{scheme,kind}` metric that
-  // tracks Hawk vs Bearer traffic during the FXA-9392 migration.
+  // `statsd`+`kind` drive the `auth.strategy.used{scheme,kind,path}` metric
+  // that tracks Hawk vs Bearer traffic during the FXA-9392 migration.
   server.auth.scheme(
     'fxa-hawk-session-token',
     hawkFxAToken.strategy(makeCredentialFn(db.sessionToken.bind(db)), {


### PR DESCRIPTION
## Because

- The Hawk to Bearer token migration could not be observed per endpoint; the `auth.strategy.used` counter carried only `scheme` and `kind`, so adoption couldn't be broken down by route.

## This pull request

- Adds a templated `path` tag to `auth.strategy.used` in the Hawk and Bearer FxA-token schemes (`hawk-fxa-token.js`, `bearer-fxa-token.js`).
- Uses `req.route.path` (templated route, never the raw URL) so cardinality stays bounded at ~2 schemes × authed routes.
- Falls back to `path:unknown` when the route is unavailable.
- Updates `hawk-fxa-token.spec.ts` and `bearer-fxa-token.spec.ts` to assert the new tag.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13948

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

- Metric change only; no behavior change to authentication. Per-endpoint adoption becomes visible in StatsD/Grafana once deploy