### PR TITLE
WIP: DO NOT MERGE - fix(fxa-settings): passkey registration failures on iOS and Windows Hello

### DIFF
--- a/packages/functional-tests/lib/passkeyPolyfill.ts
+++ b/packages/functional-tests/lib/passkeyPolyfill.ts
@@ -44,7 +44,7 @@ const WEBAUTHN_DOM_EXCEPTION_NAMES = [
   'UnknownError',
 ];
 
-type Mode = 'pending' | 'success' | 'cancel' | 'corrupt';
+type Mode = 'pending' | 'success' | 'cancel' | 'corrupt' | 'prf-unsupported';
 type Trigger = () => Promise<void>;
 type PostCheck = () => Promise<void>;
 
@@ -54,6 +54,7 @@ type CreationOptions = {
   challenge: string;
   rp?: { id?: string };
   allowCredentials?: Array<{ id: string }>;
+  extensions?: { prf?: unknown };
 };
 type RequestOptions = {
   challenge: string;
@@ -141,6 +142,30 @@ export class PasskeyPolyfill {
   }
 
   /**
+   * Simulate a platform authenticator that can't provision PRF (e.g. Windows
+   * Hello without the PRF platform update): the first `create()` (with the PRF
+   * probe) rejects with `UnknownError`, and the app's retry without PRF
+   * succeeds. The trigger drives the initial ceremony, the on-page retry
+   * assertion, and the "Try again" click; resolves once the retry mints a
+   * credential. See `handleCreate` for the PRF-conditional rejection.
+   */
+  async prfFallback(trigger: Trigger) {
+    const credentialAdded = new Promise<void>((resolve) => {
+      this.onCredentialAdded = resolve;
+    });
+
+    const previous = this.mode;
+    this.mode = 'prf-unsupported';
+    try {
+      await trigger();
+      await credentialAdded;
+    } finally {
+      this.onCredentialAdded = undefined;
+      this.mode = previous;
+    }
+  }
+
+  /**
    * Simulate a successful assertion ceremony (sign-in). Unlike {@link success},
    * does not wait for a new credential to be added — assertions reuse existing
    * credentials minted by prior `success()` calls. The trigger is responsible
@@ -216,6 +241,16 @@ export class PasskeyPolyfill {
   ): Promise<RegistrationResponseJSON> {
     await this.waitForReleasableMode();
 
+    // Simulate a platform authenticator that can't provision PRF: reject the
+    // ceremony when the PRF probe is present so the app falls back, but mint a
+    // credential once it retries without PRF.
+    if (this.mode === 'prf-unsupported' && options.extensions?.prf) {
+      throw makeDomExceptionLike(
+        'UnknownError',
+        'The operation failed for an unknown transient reason.'
+      );
+    }
+
     const cred = VirtualAuthenticator.createCredential();
     this.credentials.push(cred);
 
@@ -284,12 +319,15 @@ export class PasskeyPolyfill {
 }
 
 /**
- * Playwright serialises thrown Errors, so a plain `new Error()` from Node
- * loses its `name`. Build an Error with `name` set explicitly so the browser
- * shim can re-raise it as a DOMException with the correct type.
+ * Conveys a DOMException name across the Playwright exposeFunction boundary.
+ * A custom Error `name` does not reliably survive serialisation (only `message`
+ * does), so encode the name as a `"Name: message"` prefix that the browser shim
+ * parses back out — `err.name` is still set as a best effort. Without this, a
+ * non-default name like `UnknownError` would be lost and the shim would fall
+ * back to `NotAllowedError`, mis-categorising the failure.
  */
 function makeDomExceptionLike(name: string, message: string) {
-  const err = new Error(message);
+  const err = new Error(`${name}: ${message}`);
   err.name = name;
   return err;
 }
@@ -315,14 +353,44 @@ const BROWSER_POLYFILL = `(() => {
     if (window.__fxaPasskeyPolyfillInstalled) return;
     window.__fxaPasskeyPolyfillInstalled = true;
 
+    // Decode an unpadded base64url string to an ArrayBuffer. The Node-side
+    // VirtualAuthenticator returns base64url fields, but toCredentialJSON now
+    // reads the binary getters (rawId, response.*) directly instead of calling
+    // toJSON(), so the fake credential must expose real ArrayBuffers — exactly
+    // like a native PublicKeyCredential.
+    function b64urlToBuffer(s) {
+      const base64 = s.replace(/-/g, '+').replace(/_/g, '/');
+      const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+      const binary = atob(padded);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      return bytes.buffer;
+    }
+
+    function buildResponse(r) {
+      const response = {};
+      if (r.clientDataJSON)
+        response.clientDataJSON = b64urlToBuffer(r.clientDataJSON);
+      if (r.attestationObject) {
+        response.attestationObject = b64urlToBuffer(r.attestationObject);
+        response.getTransports = () => r.transports || [];
+      }
+      if (r.authenticatorData)
+        response.authenticatorData = b64urlToBuffer(r.authenticatorData);
+      if (r.signature) response.signature = b64urlToBuffer(r.signature);
+      if (r.userHandle) response.userHandle = b64urlToBuffer(r.userHandle);
+      return response;
+    }
+
     class FakePublicKeyCredential {
       constructor(json) {
         this._json = json;
         this.id = json.id;
-        this.rawId = null;
+        this.rawId = b64urlToBuffer(json.rawId || json.id);
         this.type = 'public-key';
         this.authenticatorAttachment = json.authenticatorAttachment;
-        this.response = null;
+        this.response = buildResponse(json.response || {});
+        this._clientExtensionResults = json.clientExtensionResults || {};
       }
       static isUserVerifyingPlatformAuthenticatorAvailable() {
         return Promise.resolve(true);
@@ -332,6 +400,7 @@ const BROWSER_POLYFILL = `(() => {
       }
       static parseCreationOptionsFromJSON(o) { return o; }
       static parseRequestOptionsFromJSON(o) { return o; }
+      getClientExtensionResults() { return this._clientExtensionResults; }
       toJSON() { return this._json; }
     }
 
@@ -367,13 +436,20 @@ const BROWSER_POLYFILL = `(() => {
         return await fn(options, window.location.origin);
       } catch (err) {
         // exposeFunction serialises Errors; rebuild a DOMException so the
-        // fxa-settings webauthn-errors handler categorises correctly.
-        const incoming = err && err.name;
-        const errName =
-          incoming && WEBAUTHN_ERROR_NAMES.indexOf(incoming) !== -1
-            ? incoming
-            : 'NotAllowedError';
-        const msg = (err && err.message) || 'WebAuthn operation failed';
+        // fxa-settings webauthn-errors handler categorises correctly. The
+        // custom Error name may not survive serialisation, so recover it from
+        // the "Name: message" prefix the Node side encodes (see
+        // makeDomExceptionLike), falling back to NotAllowedError.
+        const raw = (err && err.message) || 'WebAuthn operation failed';
+        const prefix = /^([A-Za-z]+Error): /.exec(raw);
+        let errName = err && err.name;
+        if (!errName || WEBAUTHN_ERROR_NAMES.indexOf(errName) === -1) {
+          errName =
+            prefix && WEBAUTHN_ERROR_NAMES.indexOf(prefix[1]) !== -1
+              ? prefix[1]
+              : 'NotAllowedError';
+        }
+        const msg = prefix ? raw.slice(prefix[0].length) : raw;
         throw new DOMException(msg, errName);
       }
     }

--- a/packages/functional-tests/pages/settings/passkey.ts
+++ b/packages/functional-tests/pages/settings/passkey.ts
@@ -26,6 +26,17 @@ export class SettingsPasskeyAddPage extends PasskeyPage {
     return this.page.getByTestId('passkey-add-cancel');
   }
 
+  // On-page error shown when the authenticator rejects the PRF probe. It's
+  // rendered in an error Banner (body text, not a heading). Matched by regex so
+  // the source needn't carry the curly apostrophe in the copy.
+  get incompleteMessage() {
+    return this.page.getByText(/Passkey setup didn.t complete/);
+  }
+
+  get tryAgainButton() {
+    return this.page.getByTestId('passkey-add-retry');
+  }
+
   /**
    * Happy-path passkey registration. Assumes the user is signed in and the
    * settings page is loaded. Installs the WebAuthn polyfill (idempotent),

--- a/packages/functional-tests/tests/settings/passkey.spec.ts
+++ b/packages/functional-tests/tests/settings/passkey.spec.ts
@@ -66,6 +66,46 @@ test.describe('severity-1 #smoke', () => {
       expect(credentials).toHaveLength(1);
     });
 
+    test('retries without PRF when the authenticator rejects the PRF probe', async ({
+      target,
+      pages: { page, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      const { email } = await signInAccount(
+        target,
+        page,
+        settings,
+        signin,
+        testAccountTracker
+      );
+
+      await settings.goto();
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.passkey.status).toHaveText('Not set');
+
+      await settingsPasskeyAdd.initPasskeys(page);
+
+      // prf-unsupported mode rejects the first (with-PRF) create() with
+      // UnknownError — the way Windows Hello does without the PRF platform
+      // update — then mints a credential on the retry without PRF.
+      await settingsPasskeyAdd.passkeyAuth.prfFallback(async () => {
+        await settings.passkey.createButton.click();
+        await settings.confirmMfaGuard(email);
+        // The page stays on the add view and offers a retry rather than
+        // bouncing back to settings.
+        await expect(settingsPasskeyAdd.incompleteMessage).toBeVisible();
+        await settingsPasskeyAdd.tryAgainButton.click();
+      });
+
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText('Passkey created');
+      await expect(settings.passkey.status).toHaveText('Enabled');
+      await expect(settings.passkey.subRow).toBeVisible();
+
+      const credentials = settingsPasskeyAdd.passkeyAuth.getCredentials();
+      expect(credentials).toHaveLength(1);
+    });
+
     test('cancels passkey registration', async ({
       target,
       pages: { page, settings, settingsPasskeyAdd, signin },

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/en.ftl
@@ -4,6 +4,15 @@ page-passkey-add-creating-heading = Creating passkey…
 page-passkey-add-follow-prompts = Follow the prompts on your device.
 page-passkey-add-cancel = Cancel
 
+## On-page error shown when the authenticator can't provision the PRF extension
+## (e.g. Windows Hello without the PRF platform update). The user can retry
+## without it; a passkey created this way still works for sign-in.
+
+page-passkey-add-incomplete = Passkey setup didn’t complete.
+# Short body shown below the error banner, above the "Try again" button.
+page-passkey-add-incomplete-body = Your device didn’t accept the request. Let’s try again.
+page-passkey-add-try-again = Try again
+
 ## Success / Error messages (shown in alert bar after returning to settings)
 
 page-passkey-add-success = Passkey created

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -101,6 +101,11 @@ const mockCreationOptions = {
   pubKeyCredParams: [{ alg: -7, type: 'public-key' as const }],
 };
 
+const mockCreationOptionsWithPrf = {
+  ...mockCreationOptions,
+  extensions: { prf: {} },
+};
+
 const mockCredential = {
   id: 'Y3JlZA',
   rawId: 'Y3JlZA',
@@ -292,6 +297,102 @@ describe('PagePasskeyAdd', () => {
     expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
       replace: true,
     });
+  });
+
+  it('stays on the add page with a Try again button when the PRF probe is rejected', async () => {
+    mockBeginPasskeyRegistration.mockResolvedValue(mockCreationOptionsWithPrf);
+    mockCreateCredential.mockRejectedValue(
+      new DOMException('operation failed', 'UnknownError')
+    );
+
+    renderPage();
+
+    await expect(
+      screen.findByRole('button', { name: 'Try again' })
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText(/passkey setup didn.t complete/i)).toBeVisible();
+    // No auto-retry: the initial ceremony is the only create() until the user acts.
+    expect(mockCreateCredential).toHaveBeenCalledTimes(1);
+    expect(
+      GleanMetrics.accountPref.passkeyCreateSubmitFrontendError
+    ).toHaveBeenCalledWith({ event: { reason: 'prf_unsupported' } });
+    // We stay on the page rather than bouncing to settings.
+    expect(mockNavigateWithQuery).not.toHaveBeenCalled();
+    expect(mockHandleWebAuthnError).not.toHaveBeenCalled();
+  });
+
+  it('completes registration without PRF when Try again succeeds', async () => {
+    mockBeginPasskeyRegistration.mockResolvedValue(mockCreationOptionsWithPrf);
+    // First (with-PRF) attempt rejected; the retry (PRF stripped) succeeds via
+    // the default mockResolvedValue from beforeEach.
+    mockCreateCredential.mockRejectedValueOnce(
+      new DOMException('operation failed', 'UnknownError')
+    );
+
+    renderPage();
+    const retryButton = await screen.findByRole('button', {
+      name: 'Try again',
+    });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mockAlertSuccess).toHaveBeenCalledWith('Passkey created');
+    });
+    expect(mockCreateCredential).toHaveBeenCalledTimes(2);
+    // First call requested PRF; the retry stripped it.
+    expect(mockCreateCredential.mock.calls[0][0].extensions?.prf).toEqual({});
+    expect(
+      mockCreateCredential.mock.calls[1][0].extensions?.prf
+    ).toBeUndefined();
+    expect(mockCompletePasskeyRegistration).toHaveBeenCalled();
+    // Initial ceremony view + the retry view.
+    expect(GleanMetrics.accountPref.passkeyCreateView).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns to settings with the help message when Try again also fails', async () => {
+    mockBeginPasskeyRegistration.mockResolvedValue(mockCreationOptionsWithPrf);
+    const unknownError = new DOMException('operation failed', 'UnknownError');
+    mockCreateCredential.mockRejectedValue(unknownError); // both attempts fail
+
+    renderPage();
+    const retryButton = await screen.findByRole('button', {
+      name: 'Try again',
+    });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mockAlertError).toHaveBeenCalledWith(
+        'mock-could-not-complete-message'
+      );
+    });
+    expect(mockCreateCredential).toHaveBeenCalledTimes(2);
+    expect(
+      GleanMetrics.accountPref.passkeyCreateSubmitFrontendError
+    ).toHaveBeenCalledWith({ event: { reason: 'prf_retry_failed' } });
+    expect(mockCaptureException).toHaveBeenCalledWith(unknownError);
+    expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
+      replace: true,
+    });
+  });
+
+  it('does not retry without PRF when the rejected options never requested it', async () => {
+    // mockCreationOptions (the default) has no PRF extension, so an UnknownError
+    // is categorised normally rather than triggering a strip-and-retry.
+    const unknownError = new DOMException('operation failed', 'UnknownError');
+    mockCreateCredential.mockRejectedValue(unknownError);
+    mockHandleWebAuthnError.mockReturnValue({
+      category: WebAuthnErrorCategory.Unexpected,
+      errorType: WebAuthnErrorType.Unknown,
+      ftlId: 'passkey-registration-error-unexpected',
+      fallbackText: 'Passkey setup failed. Try again or choose another method.',
+      logToSentry: true,
+    });
+
+    renderPage();
+    await waitFor(() => {
+      expect(mockHandleWebAuthnError).toHaveBeenCalled();
+    });
+    expect(mockCreateCredential).toHaveBeenCalledTimes(1);
   });
 
   it('shows the cancel/timeout banner and navigates to settings on TimeoutError', async () => {

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import * as Sentry from '@sentry/browser';
 
@@ -18,13 +18,20 @@ import {
 import {
   createCredential,
   isWebAuthnLevel3Supported,
+  type PublicKeyCredentialCreationOptionsJSON,
+  type PublicKeyCredentialJSON,
 } from '../../../lib/passkeys/webauthn';
+import {
+  isRetriableWithoutPrf,
+  stripPrfExtension,
+} from '../../../lib/passkeys/prf-fallback';
 import {
   handleWebAuthnError,
   WebAuthnErrorType,
 } from '../../../lib/passkeys/webauthn-errors';
 import { MfaGuard, useMfaErrorHandler } from '../MfaGuard';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { Banner } from '../../Banner';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import GleanMetrics from '../../../lib/glean';
 import {
@@ -78,6 +85,19 @@ export const PagePasskeyAdd = () => {
   const wasCanceled = useRef(false);
   const abortController = useRef<AbortController | null>(null);
 
+  // When a platform authenticator rejects the PRF probe (e.g. Windows Hello
+  // without the PRF platform update) we stay on this page and offer a retry
+  // instead of bouncing to settings. The cached registration lets "Try again"
+  // call createCredential immediately — preserving the click's user activation
+  // — rather than re-fetching options first.
+  const [showPrfRetry, setShowPrfRetry] = useState(false);
+  const prfRetry = useRef<{
+    jwt: string;
+    creationOptions: PublicKeyCredentialCreationOptionsJSON;
+    challenge: string;
+  } | null>(null);
+  const retryInFlight = useRef(false);
+
   const navigateToSettings = useCallback(() => {
     navigateWithQuery(SETTINGS_PATH + '#security', { replace: true });
   }, [navigateWithQuery]);
@@ -92,6 +112,66 @@ export const PagePasskeyAdd = () => {
     alertBar.error(passkeyCanceledOrTimedOutMessage());
     navigateToSettings();
   }, [alertBar, navigateToSettings]);
+
+  // Shared success tail for both the initial ceremony and the no-PRF retry.
+  const finishRegistration = useCallback(
+    async (
+      jwt: string,
+      credential: PublicKeyCredentialJSON,
+      challenge: string
+    ) => {
+      await authClient.completePasskeyRegistration(jwt, credential, challenge);
+      await account.refresh('passkeys');
+      if (!isMounted.current || wasCanceled.current) return;
+      GleanMetrics.accountPref.passkeyCreateSuccessView();
+      alertBar.success(
+        ftlMsgResolver.getMsg('page-passkey-add-success', 'Passkey created')
+      );
+      navigateToSettings();
+    },
+    [account, authClient, alertBar, ftlMsgResolver, navigateToSettings]
+  );
+
+  // "Try again" after a PRF-probe rejection: retry without PRF. The click is a
+  // fresh user activation, so createCredential runs before any other await to
+  // keep that activation valid for the browser prompt.
+  const handlePrfRetry = useCallback(async () => {
+    const cached = prfRetry.current;
+    if (retryInFlight.current || !cached) return;
+    retryInFlight.current = true;
+    setShowPrfRetry(false);
+    GleanMetrics.accountPref.passkeyCreateView();
+
+    const controller = new AbortController();
+    abortController.current = controller;
+    try {
+      const credential = await createCredential(
+        stripPrfExtension(cached.creationOptions),
+        undefined,
+        controller.signal
+      );
+      if (!isMounted.current || wasCanceled.current) return;
+      await finishRegistration(cached.jwt, credential, cached.challenge);
+    } catch (error) {
+      if (!isMounted.current || wasCanceled.current) return;
+      if (handleMfaError(error)) return;
+      // The no-PRF retry failed too — return to settings with the generic
+      // help-link message. Skip Sentry for user cancellations.
+      const isUserCancel =
+        error instanceof DOMException &&
+        (error.name === 'NotAllowedError' || error.name === 'AbortError');
+      if (!isUserCancel) {
+        Sentry.captureException(error);
+      }
+      GleanMetrics.accountPref.passkeyCreateSubmitFrontendError({
+        event: { reason: 'prf_retry_failed' },
+      });
+      alertBar.error(passkeyCouldNotCompleteMessage());
+      navigateToSettings();
+    } finally {
+      retryInFlight.current = false;
+    }
+  }, [alertBar, finishRegistration, handleMfaError, navigateToSettings]);
 
   useEffect(() => {
     isMounted.current = true;
@@ -129,12 +209,34 @@ export const PagePasskeyAdd = () => {
 
         if (!isMounted.current || wasCanceled.current) return;
 
-        // Step 2: Browser WebAuthn prompt
-        const credential = await createCredential(
-          creationOptions,
-          undefined,
-          controller.signal
-        );
+        // Step 2: Browser WebAuthn prompt.
+        let credential: PublicKeyCredentialJSON;
+        try {
+          credential = await createCredential(
+            creationOptions,
+            undefined,
+            controller.signal
+          );
+        } catch (createError) {
+          // Some platform authenticators (e.g. Windows Hello without the PRF
+          // platform update) reject the whole ceremony — before any prompt —
+          // when PRF is requested. PRF only powers Phase-2 passwordless Sync,
+          // so stay on the page and offer a retry without it instead of
+          // failing registration outright.
+          if (
+            isRetriableWithoutPrf(createError) &&
+            creationOptions.extensions?.prf
+          ) {
+            if (!isMounted.current || wasCanceled.current) return;
+            prfRetry.current = { jwt, creationOptions, challenge };
+            GleanMetrics.accountPref.passkeyCreateSubmitFrontendError({
+              event: { reason: 'prf_unsupported' },
+            });
+            setShowPrfRetry(true);
+            return;
+          }
+          throw createError;
+        }
 
         // After the WebAuthn prompt resolves we're past the abortable window;
         // if the user has clicked Cancel by this point, skip the server call
@@ -142,21 +244,7 @@ export const PagePasskeyAdd = () => {
         if (!isMounted.current || wasCanceled.current) return;
 
         // Step 3: Complete registration with server
-        await authClient.completePasskeyRegistration(
-          jwt,
-          credential,
-          challenge
-        );
-        await account.refresh('passkeys');
-
-        if (!isMounted.current || wasCanceled.current) return;
-
-        // Success
-        GleanMetrics.accountPref.passkeyCreateSuccessView();
-        alertBar.success(
-          ftlMsgResolver.getMsg('page-passkey-add-success', 'Passkey created')
-        );
-        navigateToSettings();
+        await finishRegistration(jwt, credential, challenge);
       } catch (error) {
         // handleCancel already showed the cancellation banner and navigated;
         // suppress the AbortError side effects so they don't double-fire.
@@ -254,6 +342,7 @@ export const PagePasskeyAdd = () => {
     ftlMsgResolver,
     handleMfaError,
     navigateToSettings,
+    finishRegistration,
   ]);
 
   return (
@@ -261,25 +350,64 @@ export const PagePasskeyAdd = () => {
       className="max-w-lg mx-auto mt-6 p-10 tablet:my-10 flex flex-col items-center bg-white dark:bg-grey-700 shadow tablet:rounded-xl border border-transparent text-center"
       data-testid="page-passkey-add"
     >
-      <LoadingSpinner className="flex justify-center mb-6" />
-      <FtlMsg id="page-passkey-add-creating-heading">
-        <h2 className="text-xl font-bold mb-2">Creating passkey…</h2>
-      </FtlMsg>
-      <FtlMsg id="page-passkey-add-follow-prompts">
-        <p className="text-grey-400 dark:text-grey-200 mb-6">
-          Follow the prompts on your device.
-        </p>
-      </FtlMsg>
-      <FtlMsg id="page-passkey-add-cancel">
-        <button
-          onClick={handleCancel}
-          className="link-blue text-sm"
-          data-testid="passkey-add-cancel"
-          data-glean-id="account_pref_passkey_create_cancel"
-        >
-          Cancel
-        </button>
-      </FtlMsg>
+      {showPrfRetry ? (
+        <div className="w-full">
+          <Banner
+            type="error"
+            content={{
+              localizedHeading: ftlMsgResolver.getMsg(
+                'page-passkey-add-incomplete',
+                'Passkey setup didn’t complete.'
+              ),
+            }}
+          />
+          <FtlMsg id="page-passkey-add-incomplete-body">
+            <p className="text-sm text-grey-500 dark:text-grey-200 mb-6">
+              Your device didn’t accept the request. Let’s try again.
+            </p>
+          </FtlMsg>
+          <FtlMsg id="page-passkey-add-try-again">
+            <button
+              onClick={handlePrfRetry}
+              className="cta-primary cta-xl w-full"
+              data-testid="passkey-add-retry"
+            >
+              Try again
+            </button>
+          </FtlMsg>
+          <FtlMsg id="page-passkey-add-cancel">
+            <button
+              onClick={handleCancel}
+              className="link-blue text-sm mt-4"
+              data-testid="passkey-add-cancel"
+            >
+              Cancel
+            </button>
+          </FtlMsg>
+        </div>
+      ) : (
+        <>
+          <LoadingSpinner className="flex justify-center mb-6" />
+          <FtlMsg id="page-passkey-add-creating-heading">
+            <h2 className="text-xl font-bold mb-2">Creating passkey…</h2>
+          </FtlMsg>
+          <FtlMsg id="page-passkey-add-follow-prompts">
+            <p className="text-grey-400 dark:text-grey-200 mb-6">
+              Follow the prompts on your device.
+            </p>
+          </FtlMsg>
+          <FtlMsg id="page-passkey-add-cancel">
+            <button
+              onClick={handleCancel}
+              className="link-blue text-sm"
+              data-testid="passkey-add-cancel"
+              data-glean-id="account_pref_passkey_create_cancel"
+            >
+              Cancel
+            </button>
+          </FtlMsg>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/fxa-settings/src/lib/passkeys/prf-fallback.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/prf-fallback.test.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { isRetriableWithoutPrf, stripPrfExtension } from './prf-fallback';
+import type { PublicKeyCredentialCreationOptionsJSON } from './webauthn';
+
+const baseOptions: PublicKeyCredentialCreationOptionsJSON = {
+  rp: { name: 'Mozilla Accounts', id: 'accounts.firefox.com' },
+  user: {
+    id: 'dXNlci1pZA',
+    name: 'test@example.com',
+    displayName: 'test@example.com',
+  },
+  challenge: 'Y2hhbGxlbmdl',
+  pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+};
+
+describe('isRetriableWithoutPrf', () => {
+  // Retriable: "unexpected" ceremony failures — the class a browser produces
+  // when it chokes on the optional PRF probe rather than ignoring it.
+  it.each(['UnknownError', 'OperationError', 'DataError', 'EncodingError'])(
+    'returns true for a %s DOMException (unexpected ceremony failure)',
+    (name) => {
+      expect(isRetriableWithoutPrf(new DOMException('failed', name))).toBe(
+        true
+      );
+    }
+  );
+
+  it('returns true for an unrecognized DOMException name', () => {
+    expect(isRetriableWithoutPrf(new DOMException('weird', 'WeirdError'))).toBe(
+      true
+    );
+  });
+
+  // Not retriable: user-action errors must never trigger a silent re-prompt.
+  it.each(['NotAllowedError', 'AbortError', 'TimeoutError'])(
+    'returns false for a %s DOMException (user action)',
+    (name) => {
+      expect(isRetriableWithoutPrf(new DOMException('cancel', name))).toBe(
+        false
+      );
+    }
+  );
+
+  // Not retriable: device/platform errors dropping PRF won't fix, and which
+  // have better specific messages.
+  it.each(['NotSupportedError', 'SecurityError', 'InvalidStateError'])(
+    'returns false for a %s DOMException (device/platform)',
+    (name) => {
+      expect(isRetriableWithoutPrf(new DOMException('nope', name))).toBe(false);
+    }
+  );
+
+  it('returns false for a non-DOMException error (e.g. password-manager plain Error)', () => {
+    expect(isRetriableWithoutPrf(new TypeError('boom'))).toBe(false);
+    expect(isRetriableWithoutPrf(new Error('cancelled'))).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isRetriableWithoutPrf(null)).toBe(false);
+  });
+});
+
+describe('stripPrfExtension', () => {
+  it('drops the extensions object when prf was the only extension', () => {
+    const result = stripPrfExtension({
+      ...baseOptions,
+      extensions: { prf: {} },
+    });
+    expect(result.extensions).toBeUndefined();
+  });
+
+  it('removes prf but preserves other extensions', () => {
+    const result = stripPrfExtension({
+      ...baseOptions,
+      extensions: { credProps: true, prf: { eval: { first: 'c2FsdA' } } },
+    });
+    expect(result.extensions).toEqual({ credProps: true });
+  });
+
+  it('returns the same object reference when there is no prf extension', () => {
+    const options = { ...baseOptions, extensions: { credProps: true } };
+    expect(stripPrfExtension(options)).toBe(options);
+  });
+
+  it('returns the same object reference when there are no extensions', () => {
+    expect(stripPrfExtension(baseOptions)).toBe(baseOptions);
+  });
+
+  it('does not mutate the input options', () => {
+    const options = { ...baseOptions, extensions: { prf: {} } };
+    stripPrfExtension(options);
+    expect(options.extensions).toEqual({ prf: {} });
+  });
+});

--- a/packages/fxa-settings/src/lib/passkeys/prf-fallback.ts
+++ b/packages/fxa-settings/src/lib/passkeys/prf-fallback.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { PublicKeyCredentialCreationOptionsJSON } from './webauthn';
+import {
+  categorizeWebAuthnError,
+  WebAuthnErrorCategory,
+} from './webauthn-errors';
+
+/**
+ * True when a registration ceremony failed in a way that requesting the
+ * optional PRF extension could have caused — i.e. it's worth retrying without
+ * PRF.
+ *
+ * PRF is best-effort: a spec-compliant browser ignores it when it can't honour
+ * it, so a ceremony that fails *because* PRF was requested is a browser/OS bug
+ * with no proper error to report — it surfaces as an "unexpected" DOMException
+ * (Windows Hello throws `UnknownError`; other stacks could throw
+ * `OperationError`, `DataError`, an unrecognized name, etc.). Rather than
+ * hardcode one name, reuse the shared categorizer and match its `Unexpected`
+ * bucket.
+ *
+ * Deliberately excluded:
+ *  - `UserAction` (NotAllowed/Abort/Timeout) — user cancelled; never re-prompt.
+ *  - non-`DOMException` (TypeError, password-manager plain-Error cancels) — the
+ *    categorizer's default is `Unexpected`, so the instanceof guard keeps those
+ *    out.
+ *  - `DevicePlatform` (Security/InvalidState/NotReadable/NotSupported) — rp
+ *    mismatch / duplicate / I/O, which dropping PRF won't fix and which have
+ *    better specific messages.
+ */
+export function isRetriableWithoutPrf(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    categorizeWebAuthnError(error, 'registration').category ===
+      WebAuthnErrorCategory.Unexpected
+  );
+}
+
+/**
+ * Returns the creation options with the PRF extension removed, preserving any
+ * other extensions. Used to retry registration without PRF when an
+ * authenticator rejects the PRF probe. Returns the original object unchanged
+ * (same reference) when there is no PRF extension to strip.
+ */
+export function stripPrfExtension(
+  options: PublicKeyCredentialCreationOptionsJSON
+): PublicKeyCredentialCreationOptionsJSON {
+  if (!options.extensions?.prf) {
+    return options;
+  }
+  const remainingExtensions = { ...options.extensions };
+  delete remainingExtensions.prf;
+  return {
+    ...options,
+    extensions:
+      Object.keys(remainingExtensions).length > 0
+        ? remainingExtensions
+        : undefined,
+  };
+}

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.test.ts
@@ -7,22 +7,34 @@ import {
   getCredential,
   isWebAuthnLevel3Supported,
   PublicKeyCredentialCreationOptionsJSON,
-  PublicKeyCredentialJSON,
   PublicKeyCredentialRequestOptionsJSON,
 } from './webauthn';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
-const mockCredentialJSON: PublicKeyCredentialJSON = {
-  id: 'bW9jay1pZA',
-  rawId: 'bW9jay1yYXctaWQ',
-  type: 'public-key',
-  response: {
-    clientDataJSON: 'bW9jay1jbGllbnQtZGF0YQ',
-    attestationObject: 'bW9jay1hdHRlc3RhdGlvbg',
-  },
-  clientExtensionResults: {},
+// Human-readable source bytes for the credential's binary fields. The browser
+// returns these as ArrayBuffers; toCredentialJSON base64url-encodes them.
+const SRC = {
+  rawId: 'raw-id',
+  clientDataJSON: 'client-data',
+  attestationObject: 'attestation-object',
+  authenticatorData: 'auth-data',
+  signature: 'signature',
+  userHandle: 'user-handle',
 };
+
+// credential.id is already a base64url string in the WebAuthn API; it passes
+// through unchanged (it is not re-encoded from rawId).
+const CRED_ID = 'mock-credential-id';
+
+const enc = new TextEncoder();
+const toBuf = (s: string): ArrayBuffer => enc.encode(s).buffer as ArrayBuffer;
+
+// Reference base64url encoder built on Node's Buffer — deliberately a different
+// implementation from production's btoa-based encoder, so equality assertions
+// cross-check rather than tautologically mirror the code under test.
+const b64url = (s: string): string =>
+  Buffer.from(s, 'utf8').toString('base64url');
 
 const mockCreationOptions: PublicKeyCredentialCreationOptionsJSON = {
   rp: { name: 'Mozilla Accounts', id: 'accounts.firefox.com' },
@@ -45,7 +57,6 @@ const mockRequestOptions: PublicKeyCredentialRequestOptionsJSON = {
 function setupMockPKC(
   overrides: Record<string, unknown> = {}
 ): Record<string, jest.Mock> {
-  // Use a class so that mockCredential instances pass `instanceof PublicKeyCredential`.
   class MockPublicKeyCredential {}
   const statics = {
     parseCreationOptionsFromJSON: jest.fn().mockReturnValue({}),
@@ -57,24 +68,82 @@ function setupMockPKC(
   return statics as Record<string, jest.Mock>;
 }
 
-function setupMockCredentials(result: PublicKeyCredentialJSON): {
+type MockCredential = Record<string, unknown> & { toJSON: jest.Mock };
+
+/**
+ * Builds a credential mock mirroring what the browser returns: binary fields as
+ * ArrayBuffers, an L2 getter for extension results, and a `toJSON` spy that the
+ * code under test must NOT call (that native call is what crashes WebKit).
+ */
+function makeAttestationCredential(
+  overrides: {
+    clientExtensionResults?: Record<string, unknown>;
+    authenticatorAttachment?: string;
+    transports?: string[];
+    omitGetTransports?: boolean;
+  } = {}
+): MockCredential {
+  const response: Record<string, unknown> = {
+    clientDataJSON: toBuf(SRC.clientDataJSON),
+    attestationObject: toBuf(SRC.attestationObject),
+  };
+  if (!overrides.omitGetTransports) {
+    response.getTransports = jest
+      .fn()
+      .mockReturnValue(overrides.transports ?? ['internal']);
+  }
+  return {
+    id: CRED_ID,
+    rawId: toBuf(SRC.rawId),
+    type: 'public-key',
+    ...(overrides.authenticatorAttachment
+      ? { authenticatorAttachment: overrides.authenticatorAttachment }
+      : {}),
+    response,
+    getClientExtensionResults: jest
+      .fn()
+      .mockReturnValue(overrides.clientExtensionResults ?? {}),
+    toJSON: jest.fn(),
+  };
+}
+
+function makeAssertionCredential(
+  overrides: {
+    clientExtensionResults?: Record<string, unknown>;
+    omitUserHandle?: boolean;
+  } = {}
+): MockCredential {
+  const response: Record<string, unknown> = {
+    clientDataJSON: toBuf(SRC.clientDataJSON),
+    authenticatorData: toBuf(SRC.authenticatorData),
+    signature: toBuf(SRC.signature),
+  };
+  if (!overrides.omitUserHandle) {
+    response.userHandle = toBuf(SRC.userHandle);
+  }
+  return {
+    id: CRED_ID,
+    rawId: toBuf(SRC.rawId),
+    type: 'public-key',
+    response,
+    getClientExtensionResults: jest
+      .fn()
+      .mockReturnValue(overrides.clientExtensionResults ?? {}),
+    toJSON: jest.fn(),
+  };
+}
+
+function wireCredentials(credential: unknown): {
   mockCreate: jest.Mock;
   mockGet: jest.Mock;
 } {
-  // Create an instance of the mock class so `instanceof PublicKeyCredential` passes.
-  const MockPKC = (global as any).PublicKeyCredential as { prototype: object };
-  const mockCredential = Object.create(MockPKC.prototype);
-  mockCredential.toJSON = jest.fn().mockReturnValue(result);
-
-  const mockCreate = jest.fn().mockResolvedValue(mockCredential);
-  const mockGet = jest.fn().mockResolvedValue(mockCredential);
-
+  const mockCreate = jest.fn().mockResolvedValue(credential);
+  const mockGet = jest.fn().mockResolvedValue(credential);
   Object.defineProperty(global.navigator, 'credentials', {
     value: { create: mockCreate, get: mockGet },
     configurable: true,
     writable: true,
   });
-
   return { mockCreate, mockGet };
 }
 
@@ -113,11 +182,13 @@ describe('isWebAuthnLevel3Supported', () => {
 describe('createCredential', () => {
   let mockPKC: Record<string, jest.Mock>;
   let mockCreate: jest.Mock;
+  let credential: MockCredential;
 
   beforeEach(() => {
     jest.useFakeTimers();
     mockPKC = setupMockPKC();
-    ({ mockCreate } = setupMockCredentials(mockCredentialJSON));
+    credential = makeAttestationCredential();
+    ({ mockCreate } = wireCredentials(credential));
   });
 
   afterEach(() => {
@@ -125,9 +196,91 @@ describe('createCredential', () => {
     (global as any).PublicKeyCredential = undefined;
   });
 
-  it('resolves with credential JSON on success', async () => {
+  it('serializes the attestation response to JSON', async () => {
     const result = await createCredential(mockCreationOptions);
-    expect(result).toEqual(mockCredentialJSON);
+    expect(result).toEqual({
+      id: CRED_ID,
+      rawId: b64url(SRC.rawId),
+      type: 'public-key',
+      response: {
+        clientDataJSON: b64url(SRC.clientDataJSON),
+        attestationObject: b64url(SRC.attestationObject),
+        transports: ['internal'],
+      },
+      clientExtensionResults: {},
+    });
+  });
+
+  it('does not call the native credential.toJSON()', async () => {
+    // The native toJSON() is what crashes WebKit < 26.5.1 when a prf output is
+    // present; serialization must go through the L2 getters instead.
+    await createCredential(mockCreationOptions);
+    expect(credential.toJSON).not.toHaveBeenCalled();
+  });
+
+  it('records the PRF enabled flag from getClientExtensionResults()', async () => {
+    credential = makeAttestationCredential({
+      clientExtensionResults: { prf: { enabled: true } },
+    });
+    ({ mockCreate } = wireCredentials(credential));
+    const result = await createCredential(mockCreationOptions);
+    expect(result.clientExtensionResults).toEqual({ prf: { enabled: true } });
+  });
+
+  it('omits transports when the authenticator exposes no getTransports()', async () => {
+    credential = makeAttestationCredential({ omitGetTransports: true });
+    ({ mockCreate } = wireCredentials(credential));
+    const result = await createCredential(mockCreationOptions);
+    expect(result.response).toEqual({
+      clientDataJSON: b64url(SRC.clientDataJSON),
+      attestationObject: b64url(SRC.attestationObject),
+    });
+  });
+
+  it('includes authenticatorAttachment when the browser reports it', async () => {
+    credential = makeAttestationCredential({
+      authenticatorAttachment: 'platform',
+    });
+    ({ mockCreate } = wireCredentials(credential));
+    const result = await createCredential(mockCreationOptions);
+    expect(result.authenticatorAttachment).toBe('platform');
+  });
+
+  it('omits authenticatorAttachment when the browser does not report it', async () => {
+    const result = await createCredential(mockCreationOptions);
+    expect(result).not.toHaveProperty('authenticatorAttachment');
+  });
+
+  it('serializes a 1Password-style plain object without calling its toJSON', async () => {
+    // 1Password returns a plain object (not a PublicKeyCredential) whose native
+    // toJSON throws; manual serialization sidesteps it entirely.
+    const plain = makeAttestationCredential();
+    ({ mockCreate } = wireCredentials(plain));
+    const result = await createCredential(mockCreationOptions);
+    expect(result.id).toBe(CRED_ID);
+    expect(plain.toJSON).not.toHaveBeenCalled();
+  });
+
+  it('throws UnknownError when create resolves null', async () => {
+    mockCreate.mockResolvedValue(null);
+    await expect(createCredential(mockCreationOptions)).rejects.toMatchObject({
+      name: 'UnknownError',
+      message: expect.stringContaining('returned null'),
+    });
+  });
+
+  it('throws UnknownError when the response is neither attestation nor assertion', async () => {
+    mockCreate.mockResolvedValue({
+      id: CRED_ID,
+      rawId: toBuf(SRC.rawId),
+      type: 'public-key',
+      response: {},
+      getClientExtensionResults: () => ({}),
+    });
+    await expect(createCredential(mockCreationOptions)).rejects.toMatchObject({
+      name: 'UnknownError',
+      message: expect.stringContaining('unrecognized authenticator response'),
+    });
   });
 
   it('passes parsed options and AbortSignal to navigator.credentials.create', async () => {
@@ -225,43 +378,18 @@ describe('createCredential', () => {
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
-
-  it('resolves via duck-typed toJSON() when credential is a plain object (e.g. 1Password)', async () => {
-    // 1Password returns a plain object that mimics PublicKeyCredential
-    // but is not an actual instance of the class.
-    const proxyCredential = {
-      id: mockCredentialJSON.id,
-      rawId: new ArrayBuffer(8),
-      type: 'public-key',
-      authenticatorAttachment: 'platform',
-      response: {},
-      getClientExtensionResults: jest.fn().mockReturnValue({}),
-      toJSON: jest.fn().mockReturnValue(mockCredentialJSON),
-    };
-    mockCreate.mockResolvedValue(proxyCredential);
-
-    const result = await createCredential(mockCreationOptions);
-    expect(result).toEqual(mockCredentialJSON);
-    expect(proxyCredential.toJSON).toHaveBeenCalled();
-  });
-
-  it('throws when credential lacks toJSON()', async () => {
-    mockCreate.mockResolvedValue({ id: 'no-toJSON', type: 'public-key' });
-    await expect(createCredential(mockCreationOptions)).rejects.toMatchObject({
-      name: 'UnknownError',
-      message: expect.stringContaining('without toJSON()'),
-    });
-  });
 });
 
 describe('getCredential', () => {
   let mockPKC: Record<string, jest.Mock>;
   let mockGet: jest.Mock;
+  let credential: MockCredential;
 
   beforeEach(() => {
     jest.useFakeTimers();
     mockPKC = setupMockPKC();
-    ({ mockGet } = setupMockCredentials(mockCredentialJSON));
+    credential = makeAssertionCredential();
+    ({ mockGet } = wireCredentials(credential));
   });
 
   afterEach(() => {
@@ -269,9 +397,42 @@ describe('getCredential', () => {
     (global as any).PublicKeyCredential = undefined;
   });
 
-  it('resolves with credential JSON on success', async () => {
+  it('serializes the assertion response to JSON', async () => {
     const result = await getCredential(mockRequestOptions);
-    expect(result).toEqual(mockCredentialJSON);
+    expect(result).toEqual({
+      id: CRED_ID,
+      rawId: b64url(SRC.rawId),
+      type: 'public-key',
+      response: {
+        clientDataJSON: b64url(SRC.clientDataJSON),
+        authenticatorData: b64url(SRC.authenticatorData),
+        signature: b64url(SRC.signature),
+        userHandle: b64url(SRC.userHandle),
+      },
+      clientExtensionResults: {},
+    });
+  });
+
+  it('does not call the native credential.toJSON()', async () => {
+    // The assertion path serializes a prf output during Phase-2 sign-in; the
+    // native toJSON() would crash WebKit < 26.5.1 there too.
+    await getCredential(mockRequestOptions);
+    expect(credential.toJSON).not.toHaveBeenCalled();
+  });
+
+  it('omits userHandle when the authenticator does not return one', async () => {
+    credential = makeAssertionCredential({ omitUserHandle: true });
+    ({ mockGet } = wireCredentials(credential));
+    const result = await getCredential(mockRequestOptions);
+    expect(result.response).not.toHaveProperty('userHandle');
+  });
+
+  it('throws UnknownError when get resolves null', async () => {
+    mockGet.mockResolvedValue(null);
+    await expect(getCredential(mockRequestOptions)).rejects.toMatchObject({
+      name: 'UnknownError',
+      message: expect.stringContaining('returned null'),
+    });
   });
 
   it('passes parsed options and AbortSignal to navigator.credentials.get', async () => {
@@ -324,30 +485,5 @@ describe('getCredential', () => {
     await expect(getCredential(mockRequestOptions)).rejects.toBeDefined();
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
-  });
-
-  it('resolves via duck-typed toJSON() when credential is a plain object (e.g. 1Password)', async () => {
-    const proxyCredential = {
-      id: mockCredentialJSON.id,
-      rawId: new ArrayBuffer(8),
-      type: 'public-key',
-      authenticatorAttachment: 'platform',
-      response: {},
-      getClientExtensionResults: jest.fn().mockReturnValue({}),
-      toJSON: jest.fn().mockReturnValue(mockCredentialJSON),
-    };
-    mockGet.mockResolvedValue(proxyCredential);
-
-    const result = await getCredential(mockRequestOptions);
-    expect(result).toEqual(mockCredentialJSON);
-    expect(proxyCredential.toJSON).toHaveBeenCalled();
-  });
-
-  it('throws when credential lacks toJSON()', async () => {
-    mockGet.mockResolvedValue({ id: 'no-toJSON', type: 'public-key' });
-    await expect(getCredential(mockRequestOptions)).rejects.toMatchObject({
-      name: 'UnknownError',
-      message: expect.stringContaining('without toJSON()'),
-    });
   });
 });

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.ts
@@ -73,7 +73,8 @@ export interface PublicKeyCredentialRequestOptionsJSON {
 }
 
 // ─── Credential response types ───────────────────────────────────────────────
-// Shapes produced by PublicKeyCredential.toJSON(), sent to the backend.
+// JSON shapes sent to the backend, built by manual serialization in
+// toCredentialJSON (see the note there on why we avoid the native toJSON()).
 
 export interface AuthenticatorAttestationResponseJSON {
   clientDataJSON: Base64URLString;
@@ -117,12 +118,6 @@ type PublicKeyCredentialLevel3 = typeof PublicKeyCredential & {
   ): PublicKeyCredentialRequestOptions;
 };
 
-declare global {
-  interface PublicKeyCredential {
-    toJSON(): PublicKeyCredentialJSON;
-  }
-}
-
 // ─── Feature detection ───────────────────────────────────────────────────────
 
 /**
@@ -130,10 +125,10 @@ declare global {
  * (parseCreationOptionsFromJSON, parseRequestOptionsFromJSON) on the
  * PublicKeyCredential constructor.
  *
- * We require Level 3 rather than falling back to Level 2 as a deliberate
- * scope decision. The JSON helpers eliminate all manual base64url ↔
- * ArrayBuffer conversion; supporting Level 2 would add ~30–50 lines of
- * encoding code for no functional gain on modern browsers. PRF (used for
+ * We gate on the Level 3 parse helpers (request side) as a deliberate scope
+ * decision — they eliminate manual base64url → ArrayBuffer decoding of the
+ * options. The response side is serialized by hand regardless (see
+ * toCredentialJSON), so this gate concerns only the request path. PRF (used for
  * passwordless Sync key derivation) is also a Level 3 extension, though PRF
  * is optional — non-PRF passkeys work for basic authentication regardless,
  * so the Level 3 gate is purely about code simplicity, not a hard PRF
@@ -151,15 +146,10 @@ declare global {
  * No authenticator (YubiKey, Face ID, Windows Hello, etc.) is excluded —
  * Level 3 is a browser API concern, not an authenticator capability.
  *
- * If product decides to support older Safari / iOS 16, the wrappers below
- * need a Level 2 fallback that manually encodes/decodes binary fields. At
- * that point, adopting a library such as @simplewebauthn/browser is worth
- * considering — it handles both Level 2 and Level 3 paths, the 1Password
- * plain-object fallback, and conditional UI, avoiding further bespoke
- * encoding code.
- *
- * toJSON() on the credential instance is not explicitly checked; it always
- * ships alongside the static parse helpers in practice.
+ * To also support browsers that lack the parse helpers (older Safari / iOS),
+ * the request side would need a manual parse path too — the response side is
+ * already manual. Adopting @simplewebauthn/browser, which handles both
+ * directions plus the 1Password plain-object case, is worth considering then.
  */
 export function isWebAuthnLevel3Supported(): boolean {
   if (typeof window === 'undefined') {
@@ -176,28 +166,76 @@ export function isWebAuthnLevel3Supported(): boolean {
 
 // ─── Credential extraction ──────────────────────────────────────────────────
 
-/** Type guard for objects that can serialize to credential JSON. */
-function hasToJSON(
-  value: unknown
-): value is { toJSON: () => PublicKeyCredentialJSON } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'toJSON' in value &&
-    typeof value.toJSON === 'function'
+/**
+ * Encodes a binary credential field to unpadded base64url. Chunked so large
+ * buffers (e.g. attestationObject) don't overflow String.fromCharCode's
+ * argument list.
+ */
+function bufferToBase64url(buffer: ArrayBuffer | ArrayBufferView): string {
+  // ArrayBuffer.isView, not `instanceof ArrayBuffer`: the latter is unreliable
+  // across realms (iframes, workers), which would silently read zero bytes.
+  const bytes = ArrayBuffer.isView(buffer)
+    ? new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+    : new Uint8Array(buffer);
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/** Serializes an attestation or assertion response, base64url-encoding binary fields. */
+function serializeResponse(
+  response: AuthenticatorResponse,
+  operation: string
+): AuthenticatorResponseJSON {
+  if ('attestationObject' in response) {
+    const attestation = response as AuthenticatorAttestationResponse;
+    return {
+      clientDataJSON: bufferToBase64url(attestation.clientDataJSON),
+      attestationObject: bufferToBase64url(attestation.attestationObject),
+      // getTransports() is optional per spec; some authenticators omit it.
+      ...(typeof attestation.getTransports === 'function'
+        ? { transports: attestation.getTransports() }
+        : {}),
+    };
+  }
+  if ('signature' in response) {
+    const assertion = response as AuthenticatorAssertionResponse;
+    return {
+      clientDataJSON: bufferToBase64url(assertion.clientDataJSON),
+      authenticatorData: bufferToBase64url(assertion.authenticatorData),
+      signature: bufferToBase64url(assertion.signature),
+      ...(assertion.userHandle
+        ? { userHandle: bufferToBase64url(assertion.userHandle) }
+        : {}),
+    };
+  }
+  throw new DOMException(
+    `${operation} returned an unrecognized authenticator response`,
+    'UnknownError'
   );
 }
 
 /**
- * Extracts `PublicKeyCredentialJSON` from a browser credential result.
+ * Builds `PublicKeyCredentialJSON` from a browser credential by hand, reading
+ * the long-standing Level 2 getters instead of the native
+ * `PublicKeyCredential.toJSON()`.
  *
- * Prefers duck-typing (`toJSON()`) over `instanceof PublicKeyCredential`
- * because password managers (e.g. 1Password) may return a plain object
- * that has all the right fields but is not a real `PublicKeyCredential`.
+ * Why not toJSON(): WebKit before 26.5.1 crashes the WebContent renderer
+ * inside its native extension-output serializer when a `prf` output is present
+ * — an uncatchable process trap, not a JS exception, so no try/catch can
+ * recover it. The Level 2 getters (rawId, response.*, getClientExtensionResults)
+ * predate that serializer and avoid the broken code path entirely.
  *
- * No client-side shape validation of the `toJSON()` return value —
- * `@simplewebauthn/server:verifyRegistrationResponse` performs strict
- * WebAuthn spec validation server-side and rejects malformed data.
+ * Duck-typed (no `instanceof PublicKeyCredential`) so password managers that
+ * return a plain object with the same fields (e.g. 1Password) serialize too.
+ * No client-side shape validation — the server (`@simplewebauthn/server`)
+ * validates strictly and rejects malformed data.
  */
 function toCredentialJSON(
   rawCredential: Credential | null,
@@ -206,13 +244,20 @@ function toCredentialJSON(
   if (!rawCredential) {
     throw new DOMException(`${operation} returned null`, 'UnknownError');
   }
-  if (hasToJSON(rawCredential)) {
-    return rawCredential.toJSON();
-  }
-  throw new DOMException(
-    `${operation} returned a credential without toJSON()`,
-    'UnknownError'
-  );
+  const credential = rawCredential as PublicKeyCredential;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: 'public-key',
+    ...(credential.authenticatorAttachment
+      ? { authenticatorAttachment: credential.authenticatorAttachment }
+      : {}),
+    response: serializeResponse(credential.response, operation),
+    clientExtensionResults:
+      typeof credential.getClientExtensionResults === 'function'
+        ? (credential.getClientExtensionResults() as Record<string, unknown>)
+        : {},
+  };
 }
 
 // ─── Wrapper functions ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Because

- On Firefox, creating a passkey fails: on iOS the WebContent renderer crashes and the setup prompt loops; on desktop with Windows Hello it errors out and can't complete. (FXA-13991)
- Both stem from requesting the WebAuthn PRF extension during registration — iOS WebKit before 26.5.1 crashes serializing the PRF result, and Windows Hello without the PRF platform update rejects the ceremony before any prompt. PRF only powers Phase-2 passwordless Sync, so neither should block a user from creating a passkey.

## This pull request

- Serializes the credential by hand in `toCredentialJSON` (`packages/fxa-settings/src/lib/passkeys/webauthn.ts`) using the WebAuthn Level 2 getters instead of the native `PublicKeyCredential.toJSON()` that crashes the WebKit renderer when a PRF output is present (verified on an iOS 26.2 device).
- When a registration `create()` fails in a way the optional PRF probe could have caused, keeps the user on the add page with an error banner and a "Try again" action (`packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx`) instead of returning to settings; the retry strips the PRF extension and reuses the cached options, producing a working passkey without it.
- Adds `isRetriableWithoutPrf` and `stripPrfExtension` (`packages/fxa-settings/src/lib/passkeys/prf-fallback.ts`), which reuse the shared WebAuthn error categorizer so any "unexpected" ceremony failure is handled, with unit tests.
- Records Glean `prf_unsupported` and `prf_retry_failed` reasons, and adds a functional test (a new `prf-unsupported` polyfill mode in `packages/functional-tests/lib/passkeyPolyfill.ts`) that drives the reject → on-page retry → success flow.

## Issue that this pull request solves

Closes: FXA-13991

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `webauthn.ts` (manual L2 serialization), `PagePasskeyAdd/index.tsx` (on-page retry flow), `prf-fallback.ts` (retry predicate).
- Suggested review order: `webauthn.ts` → `prf-fallback.ts` → `PagePasskeyAdd/index.tsx` → functional test.
- Risky or complex parts: the manual credential serialization must round-trip byte-exact for server verification; the retry depends on the manual click providing fresh user activation (the consumed-activation reason the auto-retry was dropped).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
