### PR TITLE
fix(ci): build apps before functional tests start them

### DIFF
--- a/packages/functional-tests/scripts/start-services.sh
+++ b/packages/functional-tests/scripts/start-services.sh
@@ -11,7 +11,24 @@ mkdir -p ~/.pm2/logs
 mkdir -p artifacts/tests
 chmod +x node_modules/@nestjs/cli/bin/nest.js
 
-# Make sure we have built the latest
+# Build the apps before starting them. `start` no longer depends on `build`
+# (#20688), and a cached `build` does not recreate gitignored outputs (e.g.
+# email-renderer's public/locales, content-server's app/dist bundle), so
+# services would otherwise crash or hang on missing artifacts at boot. Force a
+# fresh build here so the started services have everything they need.
+NODE_OPTIONS="--max-old-space-size=7168" NODE_ENV=test npx nx run-many \
+    -t build \
+    --skip-nx-cache \
+    --parallel=2 \
+    -p \
+    123done \
+    fxa-admin-panel \
+    fxa-admin-server \
+    fxa-auth-server \
+    fxa-content-server \
+    fxa-profile-server \
+    fxa-settings
+
 NODE_OPTIONS="--max-old-space-size=7168" NODE_ENV=test npx nx run-many \
     -t start \
     --parallel=2 \


### PR DESCRIPTION
## Because

- Functional-test CI has failed on branches built from `main` since PR #20688
  (merged 2026-06-17), which dropped `build` from the `start` target's
  dependencies.
- The functional-tests job (`start-services.sh` → `nx run-many -t start`) no
  longer rebuilds, and a cached upstream `build` does **not** recreate gitignored
  outputs (nx doesn't track them as outputs). So the started services boot
  without artifacts they need:
  - **fxa-auth-server** crashes at boot on the missing `@fxa/accounts/email-renderer`
    `public/locales` (`Invalid ftl translations basePath`);
  - **fxa-content-server** hangs on its missing `app/dist` webpack bundle
    (`check:url .../app.bundle.js` never returns 200).
- The heartbeat/URL checks never pass, so every Playwright test fails with
  connection-refused.

## This pull request

- Builds the started apps with `nx run-many -t build --skip-nx-cache` in
  `start-services.sh` **before** `-t start`, regenerating the gitignored outputs
  a cached build skips — the same work the `start` → `build` chain did before
  #20688. No rebuild is added to `start`, so #20688's fast local-start path is
  preserved.
- `start-services.sh` is CI-only (sole caller: the functional-tests job), so the
  change is scoped to CI. Local `yarn start` / `start mza` already build via
  `pm2-all.sh` before starting and were never affected.

## Closes:

Closes: FXA-14006

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Single step added to `packages/functional-tests/scripts/start-services.sh`.
- Validated incrementally: an l10n-only first cut fixed auth-server's boot crash
  but content-server then hung on its missing bundle — confirming this is a
  class of "gitignored build output not regenerated" issues, hence building the
  apps rather than regenerating one artifact.
- Full regression analysis in FXA-14006.

## Screenshots (Optional)

N/A

## Other information (Optional)

- Environmental/CI fix; unblocks functional tests for all PRs built after #20688.
- Alternatives considered & rejected: persisting the gitignored dirs to the CI
  workspace (a cached upstream build never creates them, so nothing to persist);
  re-adding `build` to the `start` target (wider impact, re-slows `start`,
  fights #20688's intent).
- Trade-off: the cache-skipped build adds a few minutes to the "Start services"
  step; tune (timeout bump or narrower `--skip-nx-cache`) if it proves tight.
