### PR TITLE
feat(fxa-settings): hide passkeys row for sync users

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
@@ -7,6 +7,7 @@ import Security from '.';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 import { MOCK_EMAIL } from '../../../pages/mocks';
+import { getDefault } from '../../../lib/config';
 
 describe('Security', () => {
   it('renders "fresh load" <Security/> with correct content', async () => {
@@ -60,6 +61,78 @@ describe('Security', () => {
 
     const result = await screen.findAllByText('Enabled');
     expect(result).toHaveLength(2);
+  });
+
+  describe('Passkeys row sync backstop (FXA-13997)', () => {
+    const configWithPasskeys = {
+      ...getDefault(),
+      featureFlags: { ...getDefault().featureFlags, passkeysEnabled: true },
+    };
+
+    const buildAccount = ({
+      estimatedSyncDeviceCount,
+      passkeys,
+    }: {
+      estimatedSyncDeviceCount?: number;
+      passkeys: Account['passkeys'];
+    }) =>
+      ({
+        primaryEmail: { email: MOCK_EMAIL },
+        emails: [],
+        passwordCreated: 123456789,
+        hasPassword: true,
+        recoveryKey: { exists: false, estimatedSyncDeviceCount },
+        totp: { exists: false },
+        backupCodes: { hasBackupCodes: false, count: 0 },
+        passkeys,
+      }) as unknown as Account;
+
+    const renderSecurity = (account: Account) =>
+      renderWithRouter(
+        <AppContext.Provider
+          value={mockAppContext({ account, config: configWithPasskeys })}
+        >
+          <Security />
+        </AppContext.Provider>
+      );
+
+    it('shows the passkeys row when the user has no estimated sync devices', async () => {
+      renderSecurity(
+        buildAccount({ estimatedSyncDeviceCount: 0, passkeys: [] })
+      );
+      expect(await screen.findByText('Passkeys')).toBeInTheDocument();
+    });
+
+    it('shows the passkeys row when estimatedSyncDeviceCount is absent', async () => {
+      renderSecurity(
+        buildAccount({ estimatedSyncDeviceCount: undefined, passkeys: [] })
+      );
+      expect(await screen.findByText('Passkeys')).toBeInTheDocument();
+    });
+
+    it('hides the passkeys row when the user has sync activity and no passkeys', async () => {
+      renderSecurity(
+        buildAccount({ estimatedSyncDeviceCount: 1, passkeys: [] })
+      );
+      await screen.findByText('Account recovery key');
+      expect(screen.queryByText('Passkeys')).not.toBeInTheDocument();
+    });
+
+    it('keeps the passkeys row when the user has sync activity but already has a passkey', async () => {
+      renderSecurity(
+        buildAccount({
+          estimatedSyncDeviceCount: 2,
+          passkeys: [
+            {
+              credentialId: 'cred-1',
+              name: 'My passkey',
+              createdAt: 123456789,
+            },
+          ] as unknown as Account['passkeys'],
+        })
+      );
+      expect(await screen.findByText('Passkeys')).toBeInTheDocument();
+    });
   });
 
   describe('Password row', () => {

--- a/packages/fxa-settings/src/components/Settings/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.tsx
@@ -39,8 +39,13 @@ const PwdDate = ({ passwordCreated }: { passwordCreated: number }) => {
 };
 
 export const Security = forwardRef<HTMLDivElement>((_, ref) => {
-  const { passwordCreated, hasPassword } = useAccount();
+  const { passwordCreated, hasPassword, passkeys, recoveryKey } = useAccount();
   const config = useConfig();
+
+  // Hide the passkeys row from likely-Sync users who haven't added a
+  // passkey yet, so they don't add one pre-PRF and have to re-add it later.
+  const hidePasskeysForSync =
+    (recoveryKey.estimatedSyncDeviceCount ?? 0) > 0 && passkeys.length === 0;
   const { l10n } = useLocalization();
   const localizedNotSet = l10n.getString('security-not-set', null, 'Not set');
 
@@ -88,7 +93,7 @@ export const Security = forwardRef<HTMLDivElement>((_, ref) => {
           </UnitRow>
         </Localized>
 
-        {config.featureFlags?.passkeysEnabled && (
+        {config.featureFlags?.passkeysEnabled && !hidePasskeysForSync && (
           <>
             <hr className="unit-row-hr" />
             <UnitRowPasskey />


### PR DESCRIPTION
## Because

- As a backstop for the passkeys phase 1 rollout, users who appear to use Sync
  should not add a passkey before PRF support lands, or they would later need to
  remove and re-add it.

## This pull request

- Adds a `hidePasskeysForSync` gate in
  `packages/fxa-settings/src/components/Settings/Security/index.tsx` that hides
  the passkeys row when `estimatedSyncDeviceCount > 0` and the user has no
  passkeys yet. Existing passkey holders keep the row so they can still manage
  and delete their passkeys.
- Adds tests in
  `packages/fxa-settings/src/components/Settings/Security/index.test.tsx`
  covering the row shown (no sync devices, absent count), hidden (sync activity,
  no passkeys), and kept (sync activity with an existing passkey) cases.

## Issue that this pull request solves

Closes: FXA-13997

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.