### PR TITLE
refactor(auth): only report accountActivity failures to Sentry

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/account-activity.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/account-activity.spec.ts
@@ -4,15 +4,16 @@
 
 import fxaShared from 'fxa-shared';
 
-import { recordActivity } from './account-activity';
-import { reportSentryError } from '../sentry';
+import * as Sentry from '@sentry/node';
 
-jest.mock('../sentry', () => ({
-  reportSentryError: jest.fn(),
+import { recordActivity } from './account-activity';
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
 }));
 
-const mockReportSentryError = reportSentryError as jest.MockedFunction<
-  typeof reportSentryError
+const mockCaptureException = Sentry.captureException as jest.MockedFunction<
+  typeof Sentry.captureException
 >;
 
 const ScopeSet = (fxaShared as any).oauth.scopes;
@@ -117,7 +118,7 @@ describe('recordActivity', () => {
     );
   });
 
-  it('reports missing scopes to Sentry, statsd, and the log while still recording', async () => {
+  it('reports missing scopes to statsd and the log while still recording', async () => {
     const deps = makeDeps();
     deps.oauthDB.recordAccountActivity.mockResolvedValueOnce({
       missingScopes: [SCOPE_RELAY],
@@ -149,14 +150,9 @@ describe('recordActivity', () => {
         missingScopes: [SCOPE_RELAY],
       }
     );
-    expect(mockReportSentryError).toHaveBeenCalledTimes(1);
-    const [reportedError] = mockReportSentryError.mock.calls[0];
-    expect(reportedError).toBeInstanceOf(Error);
-    expect(reportedError.message).toContain(SCOPE_RELAY);
-    expect(reportedError.message).toContain(CLIENT_ID_HEX);
   });
 
-  it('does not report missing scopes when every scope resolved', async () => {
+  it('does not record or warn on missing scopes when every scope resolved', async () => {
     const deps = makeDeps();
     deps.oauthDB.recordAccountActivity.mockResolvedValueOnce({
       missingScopes: [],
@@ -171,11 +167,11 @@ describe('recordActivity', () => {
       now: NOW,
     });
 
-    expect(mockReportSentryError).not.toHaveBeenCalled();
     expect(deps.statsd.increment).not.toHaveBeenCalledWith(
       'accountActivity.missing_scopes',
       expect.anything()
     );
+    expect(deps.log.warn).not.toHaveBeenCalled();
   });
 
   it('swallows DB rejection and emits write_failed instead of recorded', async () => {
@@ -200,14 +196,31 @@ describe('recordActivity', () => {
       'accountActivity.write_failed',
       { clientId: CLIENT_ID_HEX, grantType: 'refresh_token' }
     );
-    expect(deps.log.warn).toHaveBeenCalledWith(
-      'accountActivity.write_failed',
-      expect.objectContaining({
-        clientId: CLIENT_ID_HEX,
-        grantType: 'refresh_token',
-        error: 'connection lost',
-      })
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    const [reportedError] = mockCaptureException.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect((reportedError as Error).message).toBe('connection lost');
+  });
+
+  it('tags the Sentry report with clientId, grantType, and scopes for debugging', async () => {
+    const deps = makeDeps();
+    deps.oauthDB.recordAccountActivity.mockRejectedValueOnce(
+      new Error('connection lost')
     );
+
+    await recordActivity(deps, {
+      userId: USER_ID,
+      clientId: CLIENT_ID,
+      scopeSet: ScopeSet.fromArray([SCOPE_OLDSYNC, SCOPE_RELAY]),
+      throttleMs: THROTTLE_MS,
+      grantType: 'refresh_token',
+      now: NOW,
+    });
+
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { clientId: CLIENT_ID_HEX, grantType: 'refresh_token' },
+      extra: { scopes: expect.arrayContaining([SCOPE_OLDSYNC, SCOPE_RELAY]) },
+    });
   });
 
   it('filters out empty/non-string scope values defensively', async () => {

--- a/packages/fxa-auth-server/lib/oauth/account-activity.ts
+++ b/packages/fxa-auth-server/lib/oauth/account-activity.ts
@@ -9,10 +9,9 @@
 // the clientId column (JOIN clients.name for the human-readable name) and the
 // scope via scopeId (JOIN scopes.scope).
 
+import * as Sentry from '@sentry/node';
 import { StatsD } from 'hot-shots';
 import { Logger } from 'mozlog';
-
-import { reportSentryError } from '../sentry';
 
 export interface ScopeSetLike {
   getScopeValues(): Iterable<string>;
@@ -66,12 +65,14 @@ function extractScopes(scopeSet: ScopeSetLike | null | undefined): string[] {
  * single OAuth grant.
  *
  * Never throws. Never blocks the response. On DB failure, increments
- * `accountActivity.write_failed` and logs a warning; the grant still succeeds.
+ * `accountActivity.write_failed` and reports to Sentry; the grant still
+ * succeeds.
  *
  * When some requested scopes are not in the scopes table, the scopes that do
- * resolve are still written, and the missing ones are reported to Sentry plus
- * `accountActivity.missing_scopes` so the scopes table can be reconciled via
- * the admin panel.
+ * resolve are still written, and the missing ones are counted via
+ * `accountActivity.missing_scopes` plus a warning log naming them (the metric
+ * can't tag scope names) so the scopes table can be reconciled via the admin
+ * panel.
  *
  * Returns the awaited Promise so tests can assert on completion; the OAuth
  * grant path does not await it.
@@ -118,20 +119,15 @@ export async function recordActivity(
         grantType,
         missingScopes,
       });
-      reportSentryError(
-        new Error(
-          `accountActivity: scope(s) missing from scopes table, activity not recorded for them: ${missingScopes.join(
-            ', '
-          )} (clientId=${clientIdHex}, grantType=${grantType || 'unknown'})`
-        )
-      );
     }
   } catch (err) {
     statsd?.increment('accountActivity.write_failed', metricTags);
-    log?.warn('accountActivity.write_failed', {
-      clientId: clientIdHex,
-      grantType,
-      error: err instanceof Error ? err.message : String(err),
-    });
+    Sentry.captureException(
+      err instanceof Error ? err : new Error(String(err)),
+      {
+        tags: { clientId: clientIdHex, grantType: grantType || 'unknown' },
+        extra: { scopes },
+      }
+    );
   }
 }


### PR DESCRIPTION
## Because

- The accountActivity missing-scopes path reported to Sentry on every OAuth grant with an unresolved scope. That signal is already captured by the `accountActivity.missing_scopes` statsd metric and a warning log, so the Sentry report was pure redundancy and added noise.

## This pull request

- Removes the Sentry report from the missing-scopes path, keeping the warning log and the `accountActivity.missing_scopes` statsd metric.
- Reports to Sentry only when the accountActivity write itself fails (the catch path), where it's genuinely actionable.
- Updates the spec to cover the new Sentry behavior.

## Issue that this pull request solves

Closes: (n/a)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/lib/oauth/account-activity.ts`
- Risky or complex parts: none — fire-and-forget path, no behavior change to grants.