### PR TITLE
fix(UI): Add short delay before auto focus on email first

### DIFF
--- a/packages/fxa-settings/src/pages/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.test.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { createMockIndexOAuthNativeIntegration, Subject } from './mocks';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
@@ -250,6 +250,32 @@ describe('Index page', () => {
       expect(
         screen.getByRole('button', { name: 'Sign up or sign in' })
       ).toHaveAttribute('data-glean-id', 'email_first_submit');
+    });
+  });
+
+  describe('email input auto-focus', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('does not focus the email input until the defer timeout elapses', () => {
+      renderWithLocalizationProvider(<Subject />);
+
+      expect(screen.getByLabelText('Enter your email')).not.toHaveFocus();
+    });
+
+    it('focuses the email input after the defer timeout elapses', () => {
+      renderWithLocalizationProvider(<Subject />);
+
+      act(() => {
+        jest.advanceTimersByTime(10);
+      });
+
+      expect(screen.getByLabelText('Enter your email')).toHaveFocus();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -79,9 +79,20 @@ export const Index = ({
   const legalTerms = integration.getLegalTerms();
 
   const emailEngageEventEmitted = useRef(false);
+  const emailInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     GleanMetrics.emailFirst.view();
+  }, []);
+
+  // Defer auto-focus once. If the container redirects an already-signed-in user
+  // away, intermittently the browser's email autocomplete dropdown can be shown on
+  // the next page, presumably from a redirect mid-render. See FXA-14009
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      emailInputRef.current?.focus();
+    }, 10);
+    return () => clearTimeout(timer);
   }, []);
 
   const onSubmit = async ({ email }: IndexFormData) => {
@@ -198,7 +209,7 @@ export const Index = ({
             inputMode="email"
             label="Enter your email"
             inputRef={register()}
-            autoFocus
+            inputRefDOM={emailInputRef}
             errorText={tooltipErrorMessage}
             onChange={handleInputChange}
             autoCapitalize="off"


### PR DESCRIPTION
Because:
* Users are sometimes seeing what seems to be an orphaned dropdown email list

This commit:
* Adds a very short settimeout on autofocus of that input, to prevent the dropdown being orphaned if the input unmounts mid-render

closes FXA-14009

---

I tested this locally and it still autofocuses as expected, and notice no perceptible delay.

0ms might work here just to move off the syncronous `autoFocus`, but `10ms` felt fine just to get past the render. `50ms` or `100ms` would probably be fine as well but `100ms` especially seems like it could be at least slightly perceptible but if you have an opinion on a different value I'm all ears, 10ms seems fine to me.