### PR TITLE
fix(passkeys): source enter-password metrics surface from router state

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
@@ -56,8 +56,8 @@ const MOCK_LOCATION_STATE = {
 const mockSessionReauth = jest.fn();
 const mockAccountEmails = jest.fn().mockResolvedValue({
   original: MOCK_EMAIL,
-  primary: MOCK_EMAIL
-})
+  primary: MOCK_EMAIL,
+});
 const mockHandleNavigation = jest.fn();
 const mockNavigate = jest.fn();
 let mockLocationState: Record<string, unknown> | undefined = undefined;
@@ -104,7 +104,7 @@ function applyDefaultMocks(): void {
   mockOAuthDataError = null;
   mockAccountEmails.mockResolvedValue({
     original: MOCK_EMAIL,
-    primary: MOCK_EMAIL
+    primary: MOCK_EMAIL,
   });
   mockSessionReauth.mockResolvedValue({
     keyFetchToken: 'keyfetchtoken',
@@ -278,12 +278,23 @@ describe('SigninPasskeyFallback container', () => {
       fireEvent.click(getByTestId('continue-button'));
     }
 
-    it('fires success with the passkeySurface reason after sessionReauth resolves', async () => {
-      mockLocationState = {
-        ...MOCK_LOCATION_STATE,
-        passkeySurface: 'signin',
-      };
+    beforeEach(() => {
+      mockLocationState = { passkeySurface: 'signin' };
+      jest.spyOn(CacheModule, 'currentAccount').mockReturnValue({
+        uid: MOCK_UID,
+        email: MOCK_EMAIL,
+        sessionToken: MOCK_SESSION_TOKEN,
+        verified: true,
+      });
+    });
+
+    it('tags the enter-password view and success events with the router-state surface', async () => {
       const { getByTestId } = render();
+      await waitFor(() => {
+        expect(GleanMetrics.passkeyEnterPassword.view).toHaveBeenCalledWith({
+          event: { reason: 'signin' },
+        });
+      });
       submitPassword(getByTestId);
       await waitFor(() => {
         expect(GleanMetrics.passkeyEnterPassword.success).toHaveBeenCalledWith({
@@ -346,10 +357,7 @@ describe('SigninPasskeyFallback container', () => {
     ])(
       'fires passkey.auth_success with reason=%s on successful reauth (passkeySurface=%s)',
       async (surface, expectedReason) => {
-        mockLocationState = {
-          ...MOCK_LOCATION_STATE,
-          passkeySurface: surface,
-        };
+        mockLocationState = { passkeySurface: surface };
         const { getByTestId } = render();
         submitPassword(getByTestId);
         await waitFor(() => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
@@ -49,7 +49,7 @@ const SigninPasskeyFallbackContainer = ({
   const sessionToken = signinState?.sessionToken;
   const email = signinState?.email;
   const uid = signinState?.uid;
-  const passkeySurface = signinState?.passkeySurface ?? 'emailfirst';
+  const passkeySurface = location.state?.passkeySurface ?? 'emailfirst';
 
   // Mirrors Signin/container.tsx's avatar fetch: mint a profile:avatar-scoped
   // OAuth token, GET /v1/avatar from the profile server, fall back to default


### PR DESCRIPTION
## Because

- Passkey sign-ins started from the signin page were attributed to
  `emailfirst` in Glean, so the per-flow breakdown couldn't tell `signin`
  apart from email-first (FXA-13896 items 2 and 3).

## This pull request

- Reads `passkeySurface` from `location.state` instead of `signinState` in
  `SigninPasskeyFallback/container.tsx`, so `passkey_enter_password.*` and
  `passkey.auth_success` carry the real surface (`signin`) instead of
  defaulting to `emailfirst`.
- Updates the existing `passkey_enter_password` / `passkey.auth_success` tests
  to the real navigation shape (surface in router state, session from
  localStorage) so they guard the regression instead of masking it.

## Issue that this pull request solves

Closes: FXA-13896

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Flow to reach the corrected events locally (Glean pings log to the browser
console when `GLEAN_ENABLED=true`; passkeys need `FEATURE_FLAGS_PASSKEYS_ENABLED=true`
and `FEATURE_FLAGS_PASSKEY_AUTHENTICATION_ENABLED=true`):

1. Use an account that has both a passkey and a password, in a Sync flow
   (Chrome DevTools → WebAuthn → enable the virtual authenticator).
2. From the **signin** page (not email-first), click **Sign in with passkey**
   and complete the assertion → you land on the enter-password page.
3. Confirm `passkey_enter_password.view` logs `reason: "signin"` (was `emailfirst`).
4. Enter the password and continue → `passkey.auth_success` logs
   `reason: "signin_withpassword"` (was `emailfirst_withpassword`).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
