### PR TITLE
fix(passkeys): feature-flag PRF extension request at registration

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.challenge.manager.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.challenge.manager.in.spec.ts
@@ -56,6 +56,7 @@ beforeAll(async () => {
     allowedOrigins: ['http://localhost'],
     maxPasskeysPerUser: 10,
     challengeTimeout: 1000 * 60 * 5,
+    requestPrfAtRegistration: false,
   });
 
   const moduleRef = await buildTestModule(redis, config, mockLogger);
@@ -145,6 +146,7 @@ describe('PasskeyChallengeManager (integration)', () => {
         allowedOrigins: ['http://localhost'],
         maxPasskeysPerUser: 10,
         challengeTimeout: 1000,
+        requestPrfAtRegistration: false,
       });
 
       const moduleRef = await buildTestModule(redis, shortConfig, mockLogger);

--- a/libs/accounts/passkey/src/lib/passkey.challenge.manager.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.challenge.manager.spec.ts
@@ -35,6 +35,7 @@ function makeConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
     maxPasskeysPerUser: 6,
     residentKey: 'required',
     rpId: 'accounts.firefox.com',
+    requestPrfAtRegistration: false,
     ...overrides,
   });
 

--- a/libs/accounts/passkey/src/lib/passkey.config.ts
+++ b/libs/accounts/passkey/src/lib/passkey.config.ts
@@ -97,6 +97,14 @@ export class PasskeyConfig {
   public authenticatorAttachment?: AuthenticatorAttachment | undefined;
 
   /**
+   * Whether to request the WebAuthn PRF extension at registration.
+   * Off by default: requesting PRF unconditionally can regress passkey creation
+   * on some OS/browser combinations.
+   */
+  @IsBoolean()
+  public requestPrfAtRegistration!: boolean;
+
+  /**
    * Creates a new PasskeyConfig instance by copying all fields from the
    * provided options object.
    *
@@ -108,6 +116,7 @@ export class PasskeyConfig {
     this.challengeTimeout = opts.challengeTimeout;
     this.enabled = opts.enabled;
     this.maxPasskeysPerUser = opts.maxPasskeysPerUser;
+    this.requestPrfAtRegistration = opts.requestPrfAtRegistration;
     this.residentKey = opts.residentKey;
     this.rpId = opts.rpId;
   }

--- a/libs/accounts/passkey/src/lib/passkey.manager.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.in.spec.ts
@@ -34,6 +34,7 @@ describe('PasskeyManager (Integration)', () => {
     allowedOrigins: ['https://accounts.example.com'],
     maxPasskeysPerUser: 2,
     challengeTimeout: 30_000,
+    requestPrfAtRegistration: false,
   });
 
   const mockMetrics = {

--- a/libs/accounts/passkey/src/lib/passkey.manager.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.spec.ts
@@ -41,6 +41,7 @@ const mockConfig = new PasskeyConfig({
   rpId: 'accounts.example.com',
   challengeTimeout: CHALLENGE_TIMEOUT_MS,
   maxPasskeysPerUser: MOCK_MAX_PASSKEYS_PER_USER,
+  requestPrfAtRegistration: false,
 });
 
 const mockMetrics = {

--- a/libs/accounts/passkey/src/lib/passkey.provider.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.provider.spec.ts
@@ -24,6 +24,7 @@ const VALID_RAW_CONFIG: RawPasskeyConfig = {
   challengeTimeout: 30_000,
   residentKey: 'required',
   authenticatorAttachment: '',
+  requestPrfAtRegistration: false,
 };
 
 function buildModule(rawPasskeys: unknown) {

--- a/libs/accounts/passkey/src/lib/passkey.provider.ts
+++ b/libs/accounts/passkey/src/lib/passkey.provider.ts
@@ -30,6 +30,7 @@ export type RawPasskeyConfig = {
   residentKey: ResidentKeyRequirement;
   /** Empty string is treated as "no preference" and normalized to `undefined`. */
   authenticatorAttachment: AuthenticatorAttachment | '';
+  requestPrfAtRegistration: boolean;
 };
 
 /**

--- a/libs/accounts/passkey/src/lib/passkey.service.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.spec.ts
@@ -112,6 +112,7 @@ describe('PasskeyService', () => {
     maxPasskeysPerUser: 10,
     challengeTimeout: 30_000,
     residentKey: 'required',
+    requestPrfAtRegistration: false,
   });
 
   beforeEach(async () => {

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -24,6 +24,7 @@ function testConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
     residentKey: 'preferred',
     maxPasskeysPerUser: 10,
     challengeTimeout: 30_000,
+    requestPrfAtRegistration: false,
     ...overrides,
   });
 }
@@ -161,15 +162,32 @@ describe('generateWebauthnRegistrationOptions', () => {
     ]);
   });
 
-  it('requests the PRF extension so authenticators report PRF support', async () => {
-    const options = await generateWebauthnRegistrationOptions(testConfig(), {
-      uid: Buffer.alloc(16, 0xbb).toString('hex'),
-      email: 'bob@example.com',
-      challenge: randomBytes(32).toString('base64url'),
-    });
+  it('requests the PRF extension when requestPrfAtRegistration is enabled', async () => {
+    const options = await generateWebauthnRegistrationOptions(
+      testConfig({ requestPrfAtRegistration: true }),
+      {
+        uid: Buffer.alloc(16, 0xbb).toString('hex'),
+        email: 'bob@example.com',
+        challenge: randomBytes(32).toString('base64url'),
+      }
+    );
 
     // credProps is added by SimpleWebAuthn itself; we only own the PRF probe.
     expect(options.extensions).toEqual(expect.objectContaining({ prf: {} }));
+  });
+
+  it('omits the PRF extension when requestPrfAtRegistration is disabled', async () => {
+    const options = await generateWebauthnRegistrationOptions(
+      testConfig({ requestPrfAtRegistration: false }),
+      {
+        uid: Buffer.alloc(16, 0xbb).toString('hex'),
+        email: 'bob@example.com',
+        challenge: randomBytes(32).toString('base64url'),
+      }
+    );
+
+    // SimpleWebAuthn still sets credProps; we only assert our PRF probe is absent.
+    expect(options.extensions).not.toHaveProperty('prf');
   });
 });
 

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -80,9 +80,13 @@ export async function generateWebauthnRegistrationOptions(
       authenticatorAttachment: config.authenticatorAttachment,
     },
     excludeCredentials: input.excludeCredentials,
-    // Probe PRF capability only (no eval) for passkey Phase 1.
+    // Probe PRF capability only (no eval).
+    // Requesting PRF may cause regressions on some OS/browser
+    // combinations (FXA-13991), so this is feature-flagged.
     // Cast: SimpleWebAuthn's bundled type predates PRF.
-    extensions: { prf: {} } as AuthenticationExtensionsClientInputs,
+    ...(config.requestPrfAtRegistration
+      ? { extensions: { prf: {} } as AuthenticationExtensionsClientInputs }
+      : {}),
   });
 }
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2702,6 +2702,12 @@ const convictConf = convict({
       env: 'PASSKEYS__AUTHENTICATOR_ATTACHMENT',
       format: ['platform', 'cross-platform', ''],
     },
+    requestPrfAtRegistration: {
+      default: false,
+      doc: 'Request the WebAuthn PRF extension at passkey registration.',
+      env: 'PASSKEYS__REQUEST_PRF_AT_REGISTRATION',
+      format: Boolean,
+    },
   },
   twilio: {
     credentialMode: {

--- a/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
@@ -25,6 +25,7 @@ let redis: Redis | undefined;
 let db: Awaited<ReturnType<typeof setupAccountDatabase>> | undefined;
 let passkeyRpId: string;
 let passkeyOrigin: string;
+let passkeyRequestPrf: boolean;
 
 beforeAll(async () => {
   redis = new Redis({ host: 'localhost' });
@@ -41,6 +42,7 @@ beforeAll(async () => {
   const passkeyConfig = new PasskeyConfig(config.passkeys as PasskeyConfig);
   passkeyRpId = passkeyConfig.rpId;
   passkeyOrigin = passkeyConfig.allowedOrigins[0];
+  passkeyRequestPrf = passkeyConfig.requestPrfAtRegistration;
 
   const passkeyManager = new PasskeyManager(
     db,
@@ -192,7 +194,12 @@ describe('#integration - remote passkey registration', () => {
     );
     expect(options.challenge).toBeDefined();
     expect(options.rp).toBeDefined();
-    expect(options.extensions).toEqual(expect.objectContaining({ prf: {} }));
+    // The server requests the PRF probe only when the flag is enabled.
+    if (passkeyRequestPrf) {
+      expect(options.extensions).toEqual(expect.objectContaining({ prf: {} }));
+    } else {
+      expect(options.extensions?.prf).toBeUndefined();
+    }
 
     // Step 2: simulate authenticator
     const cred = VirtualAuthenticator.createCredential();


### PR DESCRIPTION
## Because

- Requesting the WebAuthn PRF extension unconditionally at passkey registration
  regressed passkey creation on some OS/browser combinations (FXA-13991),
  introduced by FXA-13978.

## This pull request

- Adds a `passkeys.requestPrfAtRegistration` convict flag (env
  `PASSKEYS__REQUEST_PRF_AT_REGISTRATION`, default `false`) in
  `packages/fxa-auth-server/config/index.ts`, plumbed through `PasskeyConfig` and
  `RawPasskeyConfig` in `libs/accounts/passkey/src/lib/passkey.config.ts` and
  `passkey.provider.ts`.
- Gates the PRF extension request in `generateWebauthnRegistrationOptions`
  (`libs/accounts/passkey/src/lib/webauthn-adapter.ts`) on the flag; `extensions`
  is omitted entirely when off.
- Leaves the existing `prfEnabled` client-extension read and the registration
  response-schema passthrough untouched.
- Splits the adapter test into flag-on/flag-off cases and adds
  `requestPrfAtRegistration` to the affected `PasskeyConfig` fixtures.

## Issue that this pull request solves

Closes: FXA-14011

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `webauthn-adapter.ts` (the gate) and the new flag in `config/index.ts`.
- Suggested review order: convict flag → `PasskeyConfig`/`RawPasskeyConfig` → adapter gate → tests.
- Risky or complex parts: confirm the default-off path omits the `prf` probe while SimpleWebAuthn's `credProps` is still emitted; AAL2 invariants (`userVerification: 'required'`) are untouched.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Backend-only. Flag is **default off**; re-enabling is config-only via webservices-infra (`PASSKEYS__REQUEST_PRF_AT_REGISTRATION=true`), no code change needed to flip.
- Pre-merge review: `/fxa-review` run on the commit — APPROVE, 0 blocking findings.
- Related: regression **FXA-13991**; introduced by **FXA-13978**.
