### PR TITLE
bug(settings): Fix issue where stale JWTs would result in errors

### DIFF
--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -146,13 +146,19 @@ export class SettingsPage extends SettingsLayout {
   }
 
   /**
+   * The MFA guard modal's heading. Use to assert the protected modal is (or is
+   * not) displayed; the locator auto-waits when passed to `expect`.
+   */
+  get mfaGuardHeading() {
+    return this.page.getByRole('heading', { name: 'Enter confirmation code' });
+  }
+
+  /**
    * Indicates that the MFA guard's modal dialog is currently displayed.
    * @returns true if the MFA modal is open
    */
   async isMfaGuardVisible() {
-    return await this.page
-      .getByRole('heading', { name: 'Enter confirmation code' })
-      .isVisible();
+    return await this.mfaGuardHeading.isVisible();
   }
 
   /**
@@ -164,9 +170,7 @@ export class SettingsPage extends SettingsLayout {
   async confirmMfaGuard(email: string) {
     const code =
       await this.target.emailClient.getVerifyAccountChangeCode(email);
-    await this.page
-      .getByRole('heading', { name: 'Enter confirmation code' })
-      .waitFor();
+    await this.mfaGuardHeading.waitFor();
     await this.page
       .getByRole('textbox', { name: 'Enter 6-digit code' })
       .fill(code);

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -71,6 +71,43 @@ test.describe('severity-1 #smoke', () => {
       credentials.password = newPassword;
     });
 
+    test('re-prompts for MFA on a subsequent change after the session token rotates', async ({
+      target,
+      pages: { page, changePassword, settings, signin },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
+      const secondPassword = testAccountTracker.generatePassword();
+      const thirdPassword = testAccountTracker.generatePassword();
+
+      // First change: satisfy the MFA guard, which caches a `password`-scope JWT.
+      await settings.password.changeButton.click();
+      await settings.confirmMfaGuard(credentials.email);
+      await changePassword.fillOutChangePassword(
+        credentials.password,
+        secondPassword
+      );
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText('Password updated');
+      credentials.password = secondPassword;
+
+      // The successful change rotates the session token, which every cached MFA
+      // JWT derives from via its `stid` claim. Those JWTs are now dead, so the
+      // next protected action must re-prompt for MFA rather than reuse them.
+      await settings.password.changeButton.click();
+      await expect(settings.mfaGuardHeading).toBeVisible();
+
+      // The recovered flow still completes once the new MFA code is confirmed.
+      await settings.confirmMfaGuard(credentials.email);
+      await changePassword.fillOutChangePassword(
+        credentials.password,
+        thirdPassword
+      );
+      await expect(settings.alertBar).toHaveText('Password updated');
+      credentials.password = thirdPassword;
+    });
+
     test('reset password via settings works', async ({
       target,
       pages: { page, changePassword, resetPassword, settings, signin },

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
@@ -131,6 +131,37 @@ describe('lib/routes/auth-schemes/mfa', () => {
     }
   });
 
+  it('increments bad_state and throws when the jwt is missing required claims', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const tokenWithoutStid = jwt.sign(
+      { sub: account.uid, scope: ['mfa:test'], iat: now, jti: uuidv4() },
+      config.mfa.jwt.secretKey,
+      {
+        algorithm: 'HS256',
+        expiresIn: config.mfa.jwt.expiresInSec,
+        audience: config.mfa.jwt.audience,
+        issuer: config.mfa.jwt.issuer,
+      }
+    );
+    request.headers.authorization = `Bearer ${tokenWithoutStid}`;
+
+    const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
+
+    try {
+      await authStrategy.authenticate(request, h);
+      throw new Error('Should have thrown an error');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(AppError);
+      const errorResponse = err.output.payload;
+      expect(errorResponse.code).toBe(401);
+      expect(errorResponse.errno).toBe(AppError.ERRNO.INVALID_MFA_TOKEN);
+      expect(errorResponse.message).toBe('Invalid or expired MFA token');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'mfa.invalid_mfa_token.bad_state'
+      );
+    }
+  });
+
   it('should not authenticate if the parent session cannot be found', async () => {
     const getCredentialsFunc = jest.fn().mockResolvedValue(null);
     const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
@@ -144,6 +175,32 @@ describe('lib/routes/auth-schemes/mfa', () => {
       expect(errorResponse.code).toBe(401);
       expect(errorResponse.errno).toBe(AppError.ERRNO.INVALID_MFA_TOKEN);
       expect(errorResponse.message).toBe('Invalid or expired MFA token');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'mfa.invalid_mfa_token.bad_stid'
+      );
+    }
+  });
+
+  it('translates a thrown invalid-token lookup (errno 110) into an MFA token error', async () => {
+    const lookupError = Object.assign(
+      new Error('The authentication token could not be found'),
+      { errno: AppError.ERRNO.INVALID_TOKEN }
+    );
+    const getCredentialsFunc = jest.fn().mockRejectedValue(lookupError);
+    const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
+
+    try {
+      await authStrategy.authenticate(request, h);
+      throw new Error('Should have thrown an error');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(AppError);
+      const errorResponse = err.output.payload;
+      expect(errorResponse.code).toBe(401);
+      expect(errorResponse.errno).toBe(AppError.ERRNO.INVALID_MFA_TOKEN);
+      expect(errorResponse.message).toBe('Invalid or expired MFA token');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'mfa.invalid_mfa_token.bad_stid'
+      );
     }
   });
 
@@ -161,6 +218,9 @@ describe('lib/routes/auth-schemes/mfa', () => {
       expect(errorResponse.code).toBe(401);
       expect(errorResponse.errno).toBe(AppError.ERRNO.INVALID_MFA_TOKEN);
       expect(errorResponse.message).toBe('Invalid or expired MFA token');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'mfa.invalid_mfa_token.bad_sub'
+      );
     }
   });
 

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
@@ -131,15 +131,22 @@ export const strategy = (
         decoded.scope == null ||
         decoded.stid == null
       ) {
+        statsd?.increment('mfa.invalid_mfa_token.bad_state');
         throw AppError.invalidMfaToken();
       }
 
-      const sessionToken = await getCredentialsFunc(decoded.stid);
-      if (!sessionToken) {
+      let sessionToken;
+      try {
+        sessionToken = await getCredentialsFunc(decoded.stid);
+      } catch (err) { }
+
+       if (!sessionToken) {
+        statsd?.increment('mfa.invalid_mfa_token.bad_stid');
         throw AppError.invalidMfaToken();
       }
 
       if (sessionToken.uid == null || sessionToken.uid !== decoded.sub) {
+        statsd?.increment('mfa.invalid_mfa_token.bad_sub');
         throw AppError.invalidMfaToken();
       }
 

--- a/packages/fxa-settings/src/lib/cache.test.ts
+++ b/packages/fxa-settings/src/lib/cache.test.ts
@@ -1,0 +1,334 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  JwtTokenCache,
+  JwtNotFoundError,
+  MfaOtpRequestCache,
+  JwtPayload,
+} from './cache';
+import { AuthUiErrors } from './auth-errors/auth-errors';
+
+// Fixed clock so `exp`/`Date.now()` comparisons are deterministic.
+const MOCK_NOW_MS = 1_700_000_000_000;
+const MOCK_NOW_SEC = MOCK_NOW_MS / 1000;
+
+// Real session tokens are fixed-length 64-hex strings, so one is never a
+// prefix of another. These distinct, equal-length values mirror that.
+const SESSION_A = 'a'.repeat(64);
+const SESSION_B = 'b'.repeat(64);
+
+/**
+ * Builds a fake JWT (`header.payload.signature`) whose middle segment is the
+ * base64-encoded `payload`. Only the payload is ever decoded by the cache, so
+ * the header and signature are placeholders.
+ */
+const makeJwt = (payload: object) =>
+  `header.${btoa(JSON.stringify(payload))}.signature`;
+
+/** A payload that satisfies `decodeTokenPayload`'s type guard. */
+const makePayload = (overrides: Partial<JwtPayload> = {}): JwtPayload => ({
+  aud: 'fxa',
+  exp: MOCK_NOW_SEC + 600,
+  iat: MOCK_NOW_SEC,
+  iss: 'accounts.firefox.com',
+  jti: 'jti-123',
+  stid: 'session-token-id',
+  sub: 'uid-123',
+  scope: ['mfa:password'],
+  ...overrides,
+});
+
+const VALID_JWT = makeJwt(makePayload());
+const EXPIRED_JWT = makeJwt(makePayload({ exp: MOCK_NOW_SEC - 1 }));
+
+describe('cache', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(MOCK_NOW_MS));
+
+    localStorage.clear();
+    (JwtTokenCache as any)._state = undefined;
+    (JwtTokenCache as any).listeners.clear();
+    (MfaOtpRequestCache as any)._state = undefined;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('JwtTokenCache', () => {
+    describe('getKey', () => {
+      it('joins the session token and scope', () => {
+        expect(JwtTokenCache.getKey(SESSION_A, 'password')).toBe(
+          `${SESSION_A}-password`
+        );
+      });
+    });
+
+    describe('setToken / getToken', () => {
+      it('stores and returns a token for a session and scope', () => {
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        expect(JwtTokenCache.getToken(SESSION_A, 'password')).toBe(VALID_JWT);
+      });
+
+      it('scopes tokens independently for the same session', () => {
+        const emailJwt = makeJwt(makePayload({ scope: ['mfa:email'] }));
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        JwtTokenCache.setToken(SESSION_A, 'email', emailJwt);
+
+        expect(JwtTokenCache.getToken(SESSION_A, 'password')).toBe(VALID_JWT);
+        expect(JwtTokenCache.getToken(SESSION_A, 'email')).toBe(emailJwt);
+      });
+
+      it('throws JwtNotFoundError when no token exists', () => {
+        expect(() => JwtTokenCache.getToken(SESSION_A, 'password')).toThrow(
+          JwtNotFoundError
+        );
+      });
+
+      it.each([
+        ['session token', '', 'password', VALID_JWT, 'Invalid sessionToken'],
+        ['scope', SESSION_A, '', VALID_JWT, 'Invalid scope'],
+        ['jwt', SESSION_A, 'password', '', 'Invalid jwt'],
+      ])(
+        'throws when the %s is missing',
+        (_label, session, scope, jwt, message) => {
+          expect(() =>
+            JwtTokenCache.setToken(session as string, scope as any, jwt as string)
+          ).toThrow(message as string);
+        }
+      );
+    });
+
+    describe('removeToken', () => {
+      it('removes a single token', () => {
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        JwtTokenCache.removeToken(SESSION_A, 'password');
+        expect(() => JwtTokenCache.getToken(SESSION_A, 'password')).toThrow(
+          JwtNotFoundError
+        );
+      });
+
+      it('leaves other scopes on the same session intact', () => {
+        const emailJwt = makeJwt(makePayload({ scope: ['mfa:email'] }));
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        JwtTokenCache.setToken(SESSION_A, 'email', emailJwt);
+
+        JwtTokenCache.removeToken(SESSION_A, 'password');
+
+        expect(JwtTokenCache.getToken(SESSION_A, 'email')).toBe(emailJwt);
+      });
+    });
+
+    describe('clearTokens', () => {
+      it('removes every scope for the given session', () => {
+        const emailJwt = makeJwt(makePayload({ scope: ['mfa:email'] }));
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        JwtTokenCache.setToken(SESSION_A, 'email', emailJwt);
+
+        JwtTokenCache.clearTokens(SESSION_A);
+
+        expect(() => JwtTokenCache.getToken(SESSION_A, 'password')).toThrow(
+          JwtNotFoundError
+        );
+        expect(() => JwtTokenCache.getToken(SESSION_A, 'email')).toThrow(
+          JwtNotFoundError
+        );
+      });
+
+      it('does not touch tokens belonging to a different session', () => {
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        JwtTokenCache.setToken(SESSION_B, 'password', VALID_JWT);
+
+        JwtTokenCache.clearTokens(SESSION_A);
+
+        expect(JwtTokenCache.getToken(SESSION_B, 'password')).toBe(VALID_JWT);
+      });
+    });
+
+    describe('hasToken', () => {
+      it('returns true for a present, unexpired token', () => {
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        expect(JwtTokenCache.hasToken(SESSION_A, 'password')).toBe(true);
+      });
+
+      it('returns false when no token is cached', () => {
+        expect(JwtTokenCache.hasToken(SESSION_A, 'password')).toBe(false);
+      });
+
+      it('returns false for an expired token', () => {
+        JwtTokenCache.setToken(SESSION_A, 'password', EXPIRED_JWT);
+        expect(JwtTokenCache.hasToken(SESSION_A, 'password')).toBe(false);
+      });
+    });
+
+    describe('isExpired', () => {
+      it('returns true when exp is in the past', () => {
+        expect(JwtTokenCache.isExpired(EXPIRED_JWT)).toBe(true);
+      });
+
+      it('returns false when exp is in the future', () => {
+        expect(JwtTokenCache.isExpired(VALID_JWT)).toBe(false);
+      });
+
+      it('returns false when the token cannot be decoded', () => {
+        expect(JwtTokenCache.isExpired('not-a-jwt')).toBe(false);
+      });
+    });
+
+    describe('decodeTokenPayload', () => {
+      it('decodes a well-formed payload', () => {
+        const payload = makePayload();
+        expect(JwtTokenCache.decodeTokenPayload(makeJwt(payload))).toEqual(
+          payload
+        );
+      });
+
+      it('returns null for a string without a payload segment', () => {
+        expect(JwtTokenCache.decodeTokenPayload('not-a-jwt')).toBeNull();
+      });
+
+      it('returns null when a required claim is missing', () => {
+        const { stid, ...withoutStid } = makePayload();
+        expect(
+          JwtTokenCache.decodeTokenPayload(makeJwt(withoutStid))
+        ).toBeNull();
+      });
+
+      it('returns null when scope is not an array', () => {
+        const badScope = makeJwt(makePayload({ scope: 'mfa:password' as any }));
+        expect(JwtTokenCache.decodeTokenPayload(badScope)).toBeNull();
+      });
+    });
+
+    describe('persistence', () => {
+      it('rehydrates cached tokens from localStorage', () => {
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+
+        // Drop the in-memory state to force a read from storage.
+        (JwtTokenCache as any)._state = undefined;
+
+        expect(JwtTokenCache.getToken(SESSION_A, 'password')).toBe(VALID_JWT);
+      });
+    });
+
+    describe('subscribe / getSnapshot', () => {
+      it('exposes the current tokens via getSnapshot', () => {
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        expect(JwtTokenCache.getSnapshot()).toEqual({
+          [`${SESSION_A}-password`]: VALID_JWT,
+        });
+      });
+
+      it('returns a new snapshot reference on mutation so consumers re-render', () => {
+        const before = JwtTokenCache.getSnapshot();
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+        expect(JwtTokenCache.getSnapshot()).not.toBe(before);
+      });
+
+      it.each([
+        ['setToken', () => JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT)],
+        [
+          'removeToken',
+          () => JwtTokenCache.removeToken(SESSION_A, 'password'),
+        ],
+        ['clearTokens', () => JwtTokenCache.clearTokens(SESSION_A)],
+      ])('notifies subscribers on %s', (_label, mutate) => {
+        const listener = jest.fn();
+        JwtTokenCache.subscribe(listener);
+
+        mutate();
+
+        expect(listener).toHaveBeenCalledTimes(1);
+      });
+
+      it('stops notifying after unsubscribe', () => {
+        const listener = jest.fn();
+        const unsubscribe = JwtTokenCache.subscribe(listener);
+
+        unsubscribe();
+        JwtTokenCache.setToken(SESSION_A, 'password', VALID_JWT);
+
+        expect(listener).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('JwtNotFoundError', () => {
+    it('mirrors the auth server invalid-MFA-token error shape', () => {
+      const error = new JwtNotFoundError();
+      expect(error.errno).toBe(AuthUiErrors.INVALID_MFA_TOKEN.errno);
+      expect(error.code).toBe(401);
+      expect(error.message).toBe('Could not locate jwt in cache.');
+    });
+  });
+
+  describe('MfaOtpRequestCache', () => {
+    describe('getKey', () => {
+      it('joins the session token and scope', () => {
+        expect(MfaOtpRequestCache.getKey(SESSION_A, 'password')).toBe(
+          `${SESSION_A}-password`
+        );
+      });
+    });
+
+    describe('set / get', () => {
+      it('records the request time for a session and scope', () => {
+        MfaOtpRequestCache.set(SESSION_A, 'password');
+        expect(MfaOtpRequestCache.get(SESSION_A, 'password')).toBe(MOCK_NOW_MS);
+      });
+
+      it('returns undefined when no request was recorded', () => {
+        expect(
+          MfaOtpRequestCache.get(SESSION_A, 'password')
+        ).toBeUndefined();
+      });
+    });
+
+    describe('remove', () => {
+      it('clears a single recorded request', () => {
+        MfaOtpRequestCache.set(SESSION_A, 'password');
+        MfaOtpRequestCache.remove(SESSION_A, 'password');
+        expect(
+          MfaOtpRequestCache.get(SESSION_A, 'password')
+        ).toBeUndefined();
+      });
+    });
+
+    describe('clear', () => {
+      it('removes every scope for the given session', () => {
+        MfaOtpRequestCache.set(SESSION_A, 'password');
+        MfaOtpRequestCache.set(SESSION_A, 'email');
+
+        MfaOtpRequestCache.clear(SESSION_A);
+
+        expect(
+          MfaOtpRequestCache.get(SESSION_A, 'password')
+        ).toBeUndefined();
+        expect(MfaOtpRequestCache.get(SESSION_A, 'email')).toBeUndefined();
+      });
+
+      it('does not touch requests belonging to a different session', () => {
+        MfaOtpRequestCache.set(SESSION_A, 'password');
+        MfaOtpRequestCache.set(SESSION_B, 'password');
+
+        MfaOtpRequestCache.clear(SESSION_A);
+
+        expect(MfaOtpRequestCache.get(SESSION_B, 'password')).toBe(MOCK_NOW_MS);
+      });
+    });
+
+    describe('persistence', () => {
+      it('rehydrates recorded requests from localStorage', () => {
+        MfaOtpRequestCache.set(SESSION_A, 'password');
+
+        // Drop the in-memory state to force a read from storage.
+        (MfaOtpRequestCache as any)._state = undefined;
+
+        expect(MfaOtpRequestCache.get(SESSION_A, 'password')).toBe(MOCK_NOW_MS);
+      });
+    });
+  });
+});

--- a/packages/fxa-settings/src/lib/mfa-guard-utils.test.ts
+++ b/packages/fxa-settings/src/lib/mfa-guard-utils.test.ts
@@ -33,8 +33,14 @@ describe('mfa-guard-utils', () => {
   });
 
   describe('isInvalidJwtError', () => {
-    it('should return true if the error is an invalid JWT error', () => {
+    it('should return true for an invalid MFA token error (errno 223)', () => {
       expect(isInvalidJwtError({ code: 401, errno: 223 })).toBe(true);
+    });
+
+    it('should return true for a generic invalid token error (errno 110)', () => {
+      // The MFA strategy resolves a JWT's parent session (stid) via
+      // db.sessionToken, which throws errno 110 when that session is gone.
+      expect(isInvalidJwtError({ code: 401, errno: 110 })).toBe(true);
     });
 
     it('should return false if the error is not an invalid JWT error', () => {

--- a/packages/fxa-settings/src/lib/mfa-guard-utils.ts
+++ b/packages/fxa-settings/src/lib/mfa-guard-utils.ts
@@ -41,5 +41,13 @@ export const clearMfaAndJwtCacheOnInvalidJwt = (
  * @returns
  */
 export const isInvalidJwtError = (e: unknown): boolean => {
-  return (e as any)?.errno === AuthUiErrors.INVALID_MFA_TOKEN.errno;
+  const errno = (e as any)?.errno;
+  return (
+    // 223 - the auth server's dedicated invalid/expired MFA token error.
+    errno === AuthUiErrors.INVALID_MFA_TOKEN.errno ||
+    // 110 - a generic invalid token. The MFA strategy resolves a JWT's parent
+    // session (stid) via db.sessionToken, which throws 110 when that session is
+    // gone (e.g. after a password change). Treat it as a stale-JWT signal too.
+    errno === AuthUiErrors.INVALID_TOKEN.errno
+  );
 };

--- a/packages/fxa-settings/src/models/Account.test.ts
+++ b/packages/fxa-settings/src/models/Account.test.ts
@@ -30,6 +30,7 @@ jest.mock('../lib/cache', () => {
       getToken: jest.fn(),
       setToken: jest.fn(),
       removeToken: jest.fn(),
+      clearTokens: jest.fn(),
       hasToken: jest.fn(),
     },
     isSigningOut: jest.fn(() => false),
@@ -60,7 +61,9 @@ describe('Account', () => {
       jest.clearAllMocks();
       mockAuthClient = {
         passwordChangeWithJWT: jest.fn(),
-        accountEmails: jest.fn().mockResolvedValue({ original: 'a@b.com', primary: 'a@b.com' })
+        accountEmails: jest
+          .fn()
+          .mockResolvedValue({ original: 'a@b.com', primary: 'a@b.com' }),
       } as any;
       account = new Account(mockAuthClient);
       Object.defineProperty(account, 'email', {
@@ -75,36 +78,27 @@ describe('Account', () => {
       });
     });
 
-    it('should transfer JWT from old session token to new session token', async () => {
+    it('clears all cached MFA tokens for the old session when the session token rotates', async () => {
       const oldToken = 'old-token';
       const newToken = 'new-token';
-      const jwt = 'mock-jwt';
 
       mockedSessionToken.mockReturnValue(oldToken);
       mockedJwtCache.hasToken.mockReturnValue(true);
-      mockedJwtCache.getToken.mockReturnValue(jwt);
-      mockedJwtCache.getSnapshot.mockReturnValue({
-        [`${oldToken}-password`]: jwt,
-      });
+      mockedJwtCache.getToken.mockReturnValue('mock-jwt');
       mockAuthClient.passwordChangeWithJWT.mockResolvedValue({
         sessionToken: newToken,
       } as any);
 
       await account.changePassword('oldPass', 'newPass');
 
-      expect(mockedJwtCache.setToken).toHaveBeenCalledWith(
-        newToken,
-        'password',
-        jwt
-      );
-      expect(mockedJwtCache.removeToken).toHaveBeenCalledWith(
-        oldToken,
-        'password'
-      );
+      // Every cached MFA JWT references the old session via its stid claim and is
+      // dead once the password change destroys that session, so drop them all.
+      expect(mockedJwtCache.clearTokens).toHaveBeenCalledWith(oldToken);
+      expect(mockedJwtCache.setToken).not.toHaveBeenCalled();
       expect(mockedSessionToken).toHaveBeenCalledWith(newToken);
     });
 
-    it('should not transfer JWT if session token unchanged', async () => {
+    it('does not clear cached MFA tokens when the session token is unchanged', async () => {
       const token = 'same-token';
 
       mockedSessionToken.mockReturnValue(token);
@@ -116,26 +110,7 @@ describe('Account', () => {
 
       await account.changePassword('oldPass', 'newPass');
 
-      expect(mockedJwtCache.setToken).not.toHaveBeenCalled();
-      expect(mockedJwtCache.removeToken).not.toHaveBeenCalled();
-    });
-
-    it('should not transfer JWT if none exists', async () => {
-      const oldToken = 'old-token';
-      const newToken = 'new-token';
-
-      mockedSessionToken.mockReturnValue(oldToken);
-      mockedJwtCache.hasToken.mockReturnValue(true);
-      mockedJwtCache.getToken.mockReturnValue('jwt');
-      mockedJwtCache.getSnapshot.mockReturnValue({}); // No JWT in snapshot to transfer
-      mockAuthClient.passwordChangeWithJWT.mockResolvedValue({
-        sessionToken: newToken,
-      } as any);
-
-      await account.changePassword('oldPass', 'newPass');
-
-      expect(mockedJwtCache.setToken).not.toHaveBeenCalled();
-      expect(mockedJwtCache.removeToken).not.toHaveBeenCalled();
+      expect(mockedJwtCache.clearTokens).not.toHaveBeenCalled();
     });
   });
 
@@ -184,7 +159,9 @@ describe('Account', () => {
   describe('createPassword', () => {
     let account: Account;
     const authClient: any = {
-      accountEmails: jest.fn().mockResolvedValue({ original: 'a@b.com', primary: 'a@b.com' }),
+      accountEmails: jest
+        .fn()
+        .mockResolvedValue({ original: 'a@b.com', primary: 'a@b.com' }),
       createPassword: jest.fn().mockResolvedValue({ passwordCreated: 123 }),
       createPasswordWithJwt: jest
         .fn()
@@ -265,7 +242,9 @@ describe('Account', () => {
       mockAuthClient = {
         account: jest.fn().mockResolvedValue(baseAccountResponse),
         attachedClients: jest.fn().mockResolvedValue(baseClientResponse),
-        accountEmails: jest.fn().mockResolvedValue({ original: 'a@b.com', primary: 'a@b.com' })
+        accountEmails: jest
+          .fn()
+          .mockResolvedValue({ original: 'a@b.com', primary: 'a@b.com' }),
       } as unknown as jest.Mocked<AuthClient>;
       (sessionToken as jest.Mock).mockReturnValue('test-token');
       account = new Account(mockAuthClient);

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -681,16 +681,18 @@ export class Account implements AccountData {
     // Use the new MFA-protected endpoint
     const jwt = this.getCachedJwtByScope('password');
 
-    const response = await this.withLoadingStatus((async () => {
-      const emails = await this.authClient.accountEmails(currentSessionToken);
-      return this.authClient.passwordChangeWithJWT(
-        jwt,
-        emails,
-        oldPassword,
-        newPassword,
-        currentSessionToken
-      )
-    })());
+    const response = await this.withLoadingStatus(
+      (async () => {
+        const emails = await this.authClient.accountEmails(currentSessionToken);
+        return this.authClient.passwordChangeWithJWT(
+          jwt,
+          emails,
+          oldPassword,
+          newPassword,
+          currentSessionToken
+        );
+      })()
+    );
 
     firefox.passwordChanged(
       this.primaryEmail.email,
@@ -701,17 +703,12 @@ export class Account implements AccountData {
       response.unwrapBKey
     );
 
-    // Transfer the JWT from the old session token to the new one
-    // to prevent MfaGuard from requesting another OTP code
+    // A password change destroys the old session token, which every cached MFA JWT
+    // derives from. Drop them all so the next sensitive action re-prompts for OTP
+    // instead of using a dead JWT, which the auth server would reject as as an
+    // invalid MFA token.
     if (currentSessionToken !== response.sessionToken) {
-      const oldJwt =
-        JwtTokenCache.getSnapshot()[
-          JwtTokenCache.getKey(currentSessionToken, 'password')
-        ];
-      if (oldJwt) {
-        JwtTokenCache.setToken(response.sessionToken, 'password', oldJwt);
-        JwtTokenCache.removeToken(currentSessionToken, 'password');
-      }
+      JwtTokenCache.clearTokens(currentSessionToken);
     }
 
     sessionToken(response.sessionToken);
@@ -725,14 +722,16 @@ export class Account implements AccountData {
   }
 
   async createPassword(newPassword: string) {
-    const passwordCreatedResult = await this.withLoadingStatus((async () => {
-      const emails = await this.authClient.accountEmails(sessionToken()!);
-      return this.authClient.createPassword(
-        sessionToken()!,
-        emails,
-        newPassword
-      )
-    })());
+    const passwordCreatedResult = await this.withLoadingStatus(
+      (async () => {
+        const emails = await this.authClient.accountEmails(sessionToken()!);
+        return this.authClient.createPassword(
+          sessionToken()!,
+          emails,
+          newPassword
+        );
+      })()
+    );
 
     updateExtendedAccountState({
       passwordCreated: passwordCreatedResult.passwordCreated,
@@ -742,14 +741,12 @@ export class Account implements AccountData {
 
   async createPasswordWithJwt(newPassword: string) {
     const jwt = this.getCachedJwtByScope('password');
-    const passwordCreatedResult = await this.withLoadingStatus((async () => {
-      const emails = await this.authClient.accountEmails(sessionToken()!);
-      return this.authClient.createPasswordWithJwt(
-        jwt,
-        emails,
-        newPassword
-      )
-    })());
+    const passwordCreatedResult = await this.withLoadingStatus(
+      (async () => {
+        const emails = await this.authClient.accountEmails(sessionToken()!);
+        return this.authClient.createPasswordWithJwt(jwt, emails, newPassword);
+      })()
+    );
 
     updateExtendedAccountState({
       passwordCreated: passwordCreatedResult.passwordCreated,
@@ -1329,18 +1326,20 @@ export class Account implements AccountData {
     replaceKey: boolean,
     useMfaJwt: boolean
   ) {
-    const reauth = await this.withLoadingStatus((async () => {
-      const emails = await this.authClient.accountEmails(sessionToken()!);
-      return this.authClient.sessionReauth(
-        sessionToken()!,
-        emails,
-        password,
-        {
-          keys: true,
-          reason: 'recovery_key',
-        }
-      )
-    })());
+    const reauth = await this.withLoadingStatus(
+      (async () => {
+        const emails = await this.authClient.accountEmails(sessionToken()!);
+        return this.authClient.sessionReauth(
+          sessionToken()!,
+          emails,
+          password,
+          {
+            keys: true,
+            reason: 'recovery_key',
+          }
+        );
+      })()
+    );
     const keys = await this.withLoadingStatus(
       this.authClient.accountKeys(reauth.keyFetchToken!, reauth.unwrapBKey!)
     );
@@ -1413,15 +1412,17 @@ export class Account implements AccountData {
   }
 
   async destroy(password: string) {
-    await this.withLoadingStatus((async () => {
-      const emails = await this.authClient.accountEmails(sessionToken()!);
-      await this.authClient.accountDestroy(
-        emails,
-        password,
-        {},
-        sessionToken()!
-      )
-    })());
+    await this.withLoadingStatus(
+      (async () => {
+        const emails = await this.authClient.accountEmails(sessionToken()!);
+        await this.authClient.accountDestroy(
+          emails,
+          password,
+          {},
+          sessionToken()!
+        );
+      })()
+    );
     firefox.accountDeleted(this.uid);
     Storage.factory('localStorage').clear();
   }
@@ -1434,7 +1435,6 @@ export class Account implements AccountData {
     kB: string;
     isFirefoxMobileClient: boolean;
   }) {
-
     const response = await this.authClient.resetPasswordWithRecoveryKey(
       opts.accountResetToken,
       // During the (unauthenticated) password reset flow `this.primaryEmail.email`


### PR DESCRIPTION
## Because:
- Upon resetting a password, we'd see lots of 401s and token invalid errors.
- Resetting the password destroys the session token that JWTs derive from, thus making auth server reject them.

## This pull request
- Ensures that invalid JWTs are cleared from cache after a password reset.
- Handles invalid token errors by clearing applicable cached JWTs.
- Makes sure that the jwt token cache is cleared after a successful password reset.

## Issue that this pull request solves

Closes: [FXA-14018](https://mozilla-hub.atlassian.net/browse/FXA-14018)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

STR underlying issue.

- Login
- Add secondary email (provide MFA code)
- Change password (provide MFA code)
- Try to swap secondary and primary email

- Observe 401. Cached jwt token with parent session that had been deleted was being used


[FXA-14018]: https://mozilla-hub.atlassian.net/browse/FXA-14018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ