### PR TITLE
chore(fxa-auth-client): Remove manual sentry error capture in auth-client

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -520,17 +520,6 @@ export default class AuthClient {
             errno: result.errno,
           },
         });
-        Sentry.captureMessage(
-          `Auth client encoutered known error response during a request`,
-          {
-            tags: {
-              path,
-              method: requestOptions.method || '',
-              errno: result.errno,
-              code: result.code,
-            },
-          }
-        );
         throw result;
       }
       if (!response.ok) {
@@ -547,17 +536,6 @@ export default class AuthClient {
             errno: result.errno,
           },
         });
-        // We want to monitor spikes in non-ok responses.
-        Sentry.captureMessage(
-          `Auth client encoutered non-ok response during a request`,
-          {
-            tags: {
-              path: path,
-              method: requestOptions.method || '',
-              status: response.status,
-            },
-          }
-        );
         throw new AuthClientError(
           'Unknown error',
           result,
@@ -578,19 +556,6 @@ export default class AuthClient {
             enc_path: btoa(path),
           },
         });
-        // One more check for unexpected errors that wouldn't have been caught by the above two check.
-        Sentry.captureMessage(
-          `Auth client encoutered unexpected error during request`,
-          {
-            tags: {
-              path: path,
-              method: requestOptions.method || '',
-            },
-            extra: {
-              message: e instanceof Error ? e.message : 'unknown error',
-            },
-          }
-        );
       }
       await this.errorHandler(e);
     }
@@ -2088,7 +2053,7 @@ export default class AuthClient {
       };
     }
 
-     try {
+    try {
       const accountData = await this.jwtPost(
         '/mfa/password/change',
         jwt,

--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -92,7 +92,7 @@ describe('lib/client', () => {
     });
   });
 
-  describe('Sentry error capturing in request()', () => {
+  describe('request() error handling', () => {
     let httpClient: AuthClient;
     let originalFetch: typeof globalThis.fetch;
     let originalCaptureMessage: (...args: any[]) => any;
@@ -123,152 +123,45 @@ describe('lib/client', () => {
       SentryModule.captureMessage = originalCaptureMessage;
     });
 
-    it('does not call captureMessage on a successful response', async () => {
+    it('does not manually capture a successful response to Sentry', async () => {
       globalThis.fetch = async () =>
         new Response('{"exists":true}', { status: 200 });
       await httpClient.accountStatus('0123456789abcdef');
       assert.equal(capturedMessages.length, 0);
     });
 
-    describe('known errno response', () => {
-      beforeEach(() => {
-        globalThis.fetch = async () =>
-          new Response(
-            JSON.stringify({
-              errno: 102,
-              code: 400,
-              message: 'Unknown account',
-            }),
-            { status: 400 }
-          );
-      });
-
-      it('calls captureMessage with the known-error message', async () => {
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        assert.equal(capturedMessages.length, 1);
-        assert.ok(
-          capturedMessages[0].message.includes('known error response'),
-          `expected "known error response" in "${capturedMessages[0].message}"`
+    it('does not manually capture a known errno response to Sentry', async () => {
+      globalThis.fetch = async () =>
+        new Response(
+          JSON.stringify({
+            errno: 102,
+            code: 400,
+            message: 'Unknown account',
+          }),
+          { status: 400 }
         );
-      });
-
-      it('tags the capture with path, method, errno, and code', async () => {
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        const { tags } = capturedMessages[0].context;
-        assert.ok(
-          (tags.path as string).includes('/account/status'),
-          `expected path to include /account/status, got "${tags.path}"`
-        );
-        assert.equal(typeof tags.method, 'string');
-        assert.equal(tags.errno, 102);
-        assert.equal(tags.code, 400);
-      });
-
-      it('does not call captureMessage a second time from the catch block', async () => {
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        assert.equal(capturedMessages.length, 1);
-      });
+      try {
+        await httpClient.accountStatus('0123456789abcdef');
+      } catch {}
+      assert.equal(capturedMessages.length, 0);
     });
 
-    describe('non-ok response without errno', () => {
-      beforeEach(() => {
-        globalThis.fetch = async () => new Response('{}', { status: 500 });
-      });
-
-      it('calls captureMessage with the non-ok message', async () => {
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        assert.equal(capturedMessages.length, 1);
-        assert.ok(
-          capturedMessages[0].message.includes('non-ok response'),
-          `expected "non-ok response" in "${capturedMessages[0].message}"`
-        );
-      });
-
-      it('tags the capture with path, method, and HTTP status', async () => {
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        const { tags } = capturedMessages[0].context;
-        assert.ok(
-          (tags.path as string).includes('/account/status'),
-          `expected path to include /account/status, got "${tags.path}"`
-        );
-        assert.equal(typeof tags.method, 'string');
-        assert.equal(tags.status, 500);
-      });
-
-      it('does not call captureMessage a second time from the catch block', async () => {
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        assert.equal(capturedMessages.length, 1);
-      });
+    it('does not manually capture a non-ok response to Sentry', async () => {
+      globalThis.fetch = async () => new Response('{}', { status: 500 });
+      try {
+        await httpClient.accountStatus('0123456789abcdef');
+      } catch {}
+      assert.equal(capturedMessages.length, 0);
     });
 
-    describe('unexpected error (fetch throws)', () => {
-      it('calls captureMessage with the unexpected-error message when fetch throws an Error', async () => {
-        globalThis.fetch = async () => {
-          throw new Error('Network failure');
-        };
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        assert.equal(capturedMessages.length, 1);
-        assert.ok(
-          capturedMessages[0].message.includes('unexpected error'),
-          `expected "unexpected error" in "${capturedMessages[0].message}"`
-        );
-      });
-
-      it('includes the error message in extra when fetch throws an Error', async () => {
-        globalThis.fetch = async () => {
-          throw new Error('Network failure');
-        };
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        assert.equal(
-          capturedMessages[0].context.extra.message,
-          'Network failure'
-        );
-      });
-
-      it('uses "unknown error" in extra when fetch throws a non-Error value', async () => {
-        globalThis.fetch = async () => {
-          // eslint-disable-next-line @typescript-eslint/no-throw-literal
-          throw 'plain string error';
-        };
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        assert.equal(
-          capturedMessages[0].context.extra.message,
-          'unknown error'
-        );
-      });
-
-      it('tags the capture with path and method', async () => {
-        globalThis.fetch = async () => {
-          throw new Error('timeout');
-        };
-        try {
-          await httpClient.accountStatus('0123456789abcdef');
-        } catch {}
-        const { tags } = capturedMessages[0].context;
-        assert.ok(
-          (tags.path as string).includes('/account/status'),
-          `expected path to include /account/status, got "${tags.path}"`
-        );
-        assert.equal(typeof tags.method, 'string');
-      });
+    it('does not manually capture an unexpected error to Sentry', async () => {
+      globalThis.fetch = async () => {
+        throw new Error('Network failure');
+      };
+      try {
+        await httpClient.accountStatus('0123456789abcdef');
+      } catch {}
+      assert.equal(capturedMessages.length, 0);
     });
 
     describe('WAF-blocked response (406/429 with non-JSON body)', () => {


### PR DESCRIPTION
## Because

- We have enough data to see the types of errors that were occurring
- This was producing a fairly high error capture count in Sentry

## This pull request

- Removes the manual sentry error capture being used for debuggging.
- Leaves the bread crumbs in place, so we have some visibility in the event of a downstream error.

## Issue that this pull request solves

Closes: FXA-13965

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
