### PR TITLE
fix(functional): scope CMS logo locator to avoid PromoQrMobile collision

### DIFF
--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -41,7 +41,11 @@ test.describe('severity-1 #smoke', () => {
       }
 
       if (logoUrl) {
-        const logo = page.getByRole('img', { name: logoAlt, exact: true });
+        // A Firefox-branded mobile promo (PromoQrMobile) renders a second img
+        // with the same alt text, so scope to the CMS logo by its src.
+        const logo = page
+          .getByRole('img', { name: logoAlt, exact: true })
+          .and(page.locator(`[src="${logoUrl}"]`));
         await expect(logo).toBeVisible();
         await expect(logo).toHaveAttribute('src', logoUrl);
       }

--- a/packages/functional-tests/tests/cms/cms.spec.ts
+++ b/packages/functional-tests/tests/cms/cms.spec.ts
@@ -40,7 +40,11 @@ test.describe('severity-1 #smoke', () => {
       }
 
       if (logoUrl) {
-        const logo = page.getByRole('img', { name: logoAlt, exact: true });
+        // A Firefox-branded mobile promo (PromoQrMobile) renders a second img
+        // with the same alt text, so scope to the CMS logo by its src.
+        const logo = page
+          .getByRole('img', { name: logoAlt, exact: true })
+          .and(page.locator(`[src="${logoUrl}"]`));
         await expect(logo).toBeVisible();
         await expect(logo).toHaveAttribute('src', logoUrl);
       }


### PR DESCRIPTION
## Because

- The `PromoQrMobile` promo renders a second `<img alt="Firefox logo">` (in a `complementary` landmark) on the Sync signin/signup screens.
- `assertCmsCustomization`'s logo locator (`getByRole('img', { name: 'Firefox logo', exact: true })`) then matched two elements, throwing a Playwright strict-mode violation before any assertion ran.
- This broke four CMS #smoke tests on stage: signup, signin, signin login confirmation, and 2FA TOTP sign-in (all with Sync). Only Sync variants failed; 123Done uses a unique logo alt.

## This pull request

- Scopes the logo locator with `.and(page.locator('[src="${logoUrl}"]'))` so it targets only the CMS header logo (CDN `src`), not the promo's bundled `ff-logo.svg`.
- Applies the identical fix in `cms.spec.ts` and `cms-2fa.spec.ts` (the helper is duplicated across both).

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14008

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test** (runs against stage; requires a WAF bypass token):

cd packages/functional-tests
CI_WAF_TOKEN='<token>' yarn playwright test --project=stage
  tests/cms/cms.spec.ts tests/cms/cms-2fa.spec.ts -g "with Sync|TOTP - Sync"

Expected: all 4 pass. Verified on stage (the 2FA test needs the SMS/redis gate enabled to run).

**Note:** These specs skip locally — the local auth-server returns an empty CMS config (`/cms/config` → `{}`), so there are no customizations to assert without a Strapi dev instance.