### PR TITLE
chore(auth): Add scope to account-activity statsd metrics

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/account-activity.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/account-activity.spec.ts
@@ -142,6 +142,10 @@ describe('recordActivity', () => {
       'accountActivity.missing_scopes',
       { clientId: CLIENT_ID_HEX, grantType: 'fxa-credentials' }
     );
+    expect(deps.statsd.increment).toHaveBeenCalledWith(
+      'accountActivity.missing_scope',
+      { scope: SCOPE_RELAY }
+    );
     expect(deps.log.warn).toHaveBeenCalledWith(
       'accountActivity.missing_scopes',
       {
@@ -150,6 +154,38 @@ describe('recordActivity', () => {
         missingScopes: [SCOPE_RELAY],
       }
     );
+  });
+
+  it('reports missing_scopes once per grant but missing_scope once per scope', async () => {
+    const deps = makeDeps();
+    deps.oauthDB.recordAccountActivity.mockResolvedValueOnce({
+      missingScopes: [SCOPE_RELAY, SCOPE_OLDSYNC],
+    });
+
+    await recordActivity(deps, {
+      userId: USER_ID,
+      clientId: CLIENT_ID,
+      scopeSet: ScopeSet.fromArray([SCOPE_OLDSYNC, SCOPE_RELAY]),
+      throttleMs: THROTTLE_MS,
+      grantType: 'fxa-credentials',
+      now: NOW,
+    });
+
+    const callsTo = (metric: string) =>
+      deps.statsd.increment.mock.calls.filter(([m]) => m === metric);
+
+    // Per-grant event fires once regardless of how many scopes are missing.
+    expect(callsTo('accountActivity.missing_scopes')).toEqual([
+      [
+        'accountActivity.missing_scopes',
+        { clientId: CLIENT_ID_HEX, grantType: 'fxa-credentials' },
+      ],
+    ]);
+    // Per-scope event fires once for each missing scope.
+    expect(callsTo('accountActivity.missing_scope')).toEqual([
+      ['accountActivity.missing_scope', { scope: SCOPE_RELAY }],
+      ['accountActivity.missing_scope', { scope: SCOPE_OLDSYNC }],
+    ]);
   });
 
   it('does not record or warn on missing scopes when every scope resolved', async () => {

--- a/packages/fxa-auth-server/lib/oauth/account-activity.ts
+++ b/packages/fxa-auth-server/lib/oauth/account-activity.ts
@@ -68,11 +68,9 @@ function extractScopes(scopeSet: ScopeSetLike | null | undefined): string[] {
  * `accountActivity.write_failed` and reports to Sentry; the grant still
  * succeeds.
  *
- * When some requested scopes are not in the scopes table, the scopes that do
- * resolve are still written, and the missing ones are counted via
- * `accountActivity.missing_scopes` plus a warning log naming them (the metric
- * can't tag scope names) so the scopes table can be reconciled via the admin
- * panel.
+ * Scopes missing from the scopes table are skipped (resolved ones still write)
+ * and counted via `accountActivity.missing_scopes` {clientId, grantType} and
+ * `accountActivity.missing_scope` {scope}, plus a warning log naming them.
  *
  * Returns the awaited Promise so tests can assert on completion; the OAuth
  * grant path does not await it.
@@ -113,7 +111,12 @@ export async function recordActivity(
     statsd?.increment('accountActivity.recorded', metricTags);
 
     if (missingScopes && missingScopes.length > 0) {
+      // Split metrics keep cardinality additive, not multiplicative: one
+      // per-grant event by {clientId, grantType}, one per-scope event by {scope}.
       statsd?.increment('accountActivity.missing_scopes', metricTags);
+      for (const scope of missingScopes) {
+        statsd?.increment('accountActivity.missing_scope', { scope });
+      }
       log?.warn('accountActivity.missing_scopes', {
         clientId: clientIdHex,
         grantType,


### PR DESCRIPTION
Because:
 - We removed the sentry error capture for missing scopes, and in doing so lost visibility into what scopes we're missing

This commit:
 - Adds a missing scope statsd metric so we can see what scopes we're missing a record for on granted tokens

Closes: FXA-14026

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
