### PR TITLE
test(functional): upgrade Playwright and fix Sync tests for keys_optional

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -51,3 +51,50 @@ For example, to run the `test-many` job:
 circleci config process .circleci/config.yml > .circleci/local.yml
 circleci local execute -c .circleci/local.yml --job test-many
 ```
+
+## Updating the CI images (Playwright / dependency bumps)
+
+Most jobs run in pre-built images published to Docker Hub as
+`mozilla/fxa-circleci:ci-<target>-vN` (`ci-builder`, `ci-test-runner`,
+`ci-functional-test-runner`). They are defined in
+[`../_dev/docker/ci/Dockerfile`](../_dev/docker/ci/Dockerfile) and built/pushed
+by the `deploy_ci_images` workflow (`deploy-fxa-ci-images` job →
+`create-fxa-ci-images`).
+
+The functional-test image bakes the Playwright browsers at build time in the
+`playwright-install` stage (`npx playwright install firefox chromium webkit`),
+so the browser versions are pinned to whatever `@playwright/test` resolves to in
+`yarn.lock` **when the image was built**. Bumping Playwright therefore needs a
+new image — otherwise functional tests fail at launch with
+`Executable doesn't exist at .../firefox-<n>`.
+
+### When the images rebuild
+
+`rebuild-check` (in `config.yml`) rebuilds when either the pipeline parameter
+`force-deploy-fxa-ci-images` is `true`, or the last commit changed `yarn.lock`
+(`git diff HEAD~1 HEAD -- yarn.lock`). The `deploy_ci_images` workflow only runs
+on the `main` and `update-ci-image` branches, plus nightly. The project builds
+pull requests, not arbitrary branch pushes, so pushing `update-ci-image` by
+itself does **not** start a build — trigger it explicitly (below).
+
+### The `-vN` tag
+
+Every image reference in `config.yml` shares one version suffix (`-vN`). Bump it
+on **all** references (the `image:` lines, the build `-t` line, and the
+`docker push` lines) when an image change must not affect in-flight branches —
+e.g. a Playwright upgrade that needs different browsers, or a base-image change
+(the Node 24 upgrade introduced `-v9`). Other branches keep the old tag until
+they adopt the bump; merging to `main` makes it the default.
+
+### Steps to ship a new image (e.g. a Playwright upgrade)
+
+1. Bump `@playwright/test` in `packages/functional-tests/package.json` and run
+   `yarn install` so `yarn.lock` updates.
+2. Bump every `-vN` reference in `config.yml` to `-v(N+1)`.
+3. Publish the new image **before** your PR's functional tests run, by pushing
+   the branch content to `update-ci-image` and triggering a pipeline for it (via
+   the CircleCI UI/API with `force-deploy-fxa-ci-images=true`). The
+   `create-fxa-ci-images` job rebuilds all three targets — re-running
+   `npx playwright install` for the new browsers — and pushes the `-v(N+1)` tags.
+4. Re-run your PR's functional tests; they now pull the new image.
+5. Once the new tag is published, the `update-ci-image` branch can be deleted.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ executors:
   # step, and the saving the initial a workspace state.
   build-executor:
     docker:
-      - image: mozilla/fxa-circleci:ci-builder-v9
+      - image: mozilla/fxa-circleci:ci-builder-v10
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
@@ -99,7 +99,7 @@ executors:
         default: medium
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-test-runner-v9
+      - image: mozilla/fxa-circleci:ci-test-runner-v10
     environment:
       NODE_ENV: development
       FIRESTORE_EMULATOR_HOST: localhost:9090
@@ -115,7 +115,7 @@ executors:
         default: large
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-test-runner-v9
+      - image: mozilla/fxa-circleci:ci-test-runner-v10
       - image: cimg/mysql:8.0
         command: --default-authentication-plugin=mysql_native_password
       - image: jdlk7/firestore-emulator
@@ -138,7 +138,7 @@ executors:
         default: xlarge
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-functional-test-runner-v9
+      - image: mozilla/fxa-circleci:ci-functional-test-runner-v10
       - image: redis
       - image: pafortin/goaws
       - image: cimg/mysql:8.0
@@ -193,7 +193,7 @@ executors:
         default: xlarge
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-functional-test-runner-v9
+      - image: mozilla/fxa-circleci:ci-functional-test-runner-v10
     environment:
       NODE_ENV: development
       CUSTOMS_SERVER_URL: none
@@ -522,7 +522,7 @@ commands:
             docker build . \
                 -f ./project/_dev/docker/ci/Dockerfile \
                 --target << parameters.target >> \
-                -t mozilla/fxa-circleci:ci-<< parameters.target >>-v9
+                -t mozilla/fxa-circleci:ci-<< parameters.target >>-v10
 
   create-fxa-ci-images:
     # Build CI images. Images are built on top of each other. Each is optimized for a specific task.
@@ -551,10 +551,10 @@ commands:
           name: Push CI Images and Extract Yarn Cache
           command: |
             docker login -u $DOCKER_USER_fxa_circleci -p $DOCKER_PASS_fxa_circleci
-            .circleci/docker-copy-cache.sh mozilla/fxa-circleci:ci-builder-v9
-            docker push mozilla/fxa-circleci:ci-test-runner-v9
-            docker push mozilla/fxa-circleci:ci-functional-test-runner-v9
-            docker push mozilla/fxa-circleci:ci-builder-v9
+            .circleci/docker-copy-cache.sh mozilla/fxa-circleci:ci-builder-v10
+            docker push mozilla/fxa-circleci:ci-test-runner-v10
+            docker push mozilla/fxa-circleci:ci-functional-test-runner-v10
+            docker push mozilla/fxa-circleci:ci-builder-v10
             wait
 
   upload_to_gcs:

--- a/packages/functional-tests/lib/sync-helpers.ts
+++ b/packages/functional-tests/lib/sync-helpers.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Page } from '@playwright/test';
+import { BaseTarget } from './targets/base';
+
+/**
+ * Start a desktop Sync sign-in/up via `/pair` so Firefox drives the
+ * fxa_status/OAuth handshake. A hardcoded fx_desktop_v3 URL no longer completes
+ * it on FF147+ (keys_optional), so the browser must drive it.
+ *
+ * @param query optional query string appended to the entry URL.
+ */
+export async function gotoSyncSession(
+  page: Page,
+  target: BaseTarget,
+  query?: string
+): Promise<void> {
+  const url = `${target.contentServerUrl}/pair${query ? `?${query}` : ''}`;
+  await page.goto(url);
+}

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "@playwright/test": "1.44.1",
+    "@playwright/test": "1.61.1",
     "@types/eslint": "^8",
     "@types/pdf-parse": "^1.1.4",
     "@types/upng-js": "^2",

--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -208,33 +208,58 @@ export abstract class BaseLayout {
    */
 
   async respondToWebChannelMessage(webChannelMessage: FirefoxCommandResponse) {
+    await this.installWebChannelResponder(webChannelMessage, { once: true });
+  }
+
+  /**
+   * Like {@link respondToWebChannelMessage}, but keeps replying instead of
+   * detaching after the first, for commands re-dispatched (e.g. fxa_status).
+   */
+  async respondToWebChannelMessageAlways(
+    webChannelMessage: FirefoxCommandResponse
+  ) {
+    await this.installWebChannelResponder(webChannelMessage, { once: false });
+  }
+
+  /**
+   * Page init script replying to each `WebChannelMessageToChrome` with a
+   * matching `WebChannelMessageToContent`; detaches after one reply when `once`.
+   *
+   * Each call adds its own init-script listener, so calling this twice for the
+   * same command before a navigation registers duplicate listeners that both
+   * reply. Install one responder per command per page.
+   */
+  private async installWebChannelResponder(
+    webChannelMessage: FirefoxCommandResponse,
+    { once }: { once: boolean }
+  ) {
     const expectedCommand = webChannelMessage.message.command;
     const response = webChannelMessage.message.data;
 
     await this.page.addInitScript(
-      ({ expectedCommand, response }) => {
+      ({ expectedCommand, response, once }) => {
         function listener(e: CustomEvent) {
           const detail = JSON.parse(e.detail);
           const command = detail.message.command;
           const messageId = detail.message.messageId;
 
-          if (command === expectedCommand) {
+          if (command !== expectedCommand) {
+            return;
+          }
+
+          if (once) {
             // @ts-ignore
             window.removeEventListener('WebChannelMessageToChrome', listener);
+          }
 
-            const event = new CustomEvent('WebChannelMessageToContent', {
+          window.dispatchEvent(
+            new CustomEvent('WebChannelMessageToContent', {
               detail: {
                 id: 'account_updates',
-                message: {
-                  command,
-                  data: response,
-                  messageId,
-                },
+                message: { command, data: response, messageId },
               },
-            });
-
-            window.dispatchEvent(event);
-          }
+            })
+          );
         }
 
         function startListening() {
@@ -242,15 +267,14 @@ export abstract class BaseLayout {
             // @ts-ignore
             window.addEventListener('WebChannelMessageToChrome', listener);
           } catch (e) {
-            // problem adding the listener, window may not be
-            // ready, try again.
+            // window may not be ready yet; try again.
             setTimeout(startListening, 0);
           }
         }
 
         startListening();
       },
-      { expectedCommand, response }
+      { expectedCommand, response, once }
     );
   }
 

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -49,13 +49,19 @@ export class RelierPage extends BaseLayout {
     ]);
   }
 
+  /**
+   * Wait for the settled /oauth page, not the intermediate /authorization
+   * redirect a loose `${contentServerUrl}/**` glob would resolve on too early.
+   */
+  private waitForOauthPage() {
+    return this.page.waitForURL((url) => /^\/oauth(\/|$)/.test(url.pathname));
+  }
+
   async clickEmailFirst() {
     await expect(this.relierHeading).toBeVisible();
 
     await this.page.getByRole('button', { name: 'Email first' }).click();
-    // We need to add a `waitUntil` option here because the page gets redirected from
-    // /authorization to /oauth before the page is fully loaded.
-    return this.page.waitForURL(`${this.target.contentServerUrl}/**`);
+    return this.waitForOauthPage();
   }
 
   async clickSignIn() {
@@ -113,12 +119,12 @@ export class RelierPage extends BaseLayout {
 
   async clickRequire2FA() {
     await this.page.getByText('Sign In (Require AAL2 Session)').click();
-    return this.page.waitForURL(`${this.target.contentServerUrl}/**`);
+    return this.waitForOauthPage();
   }
 
   async clickRequireProfileAAL2() {
     await this.page.getByText('Sign In (Require Profile AAL2)').click();
-    return this.page.waitForURL(`${this.target.contentServerUrl}/**`);
+    return this.waitForOauthPage();
   }
 
   async hasAccountAAL2Badge() {

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -120,14 +120,25 @@ export class TotpPage extends SettingsLayout {
   async setUp2faAppWithQrCode(credentials: Credentials): Promise<string> {
     await expect(this.twoStepAuthenticationHeading).toBeVisible();
     await expect(this.setup2faAppHeading).toBeVisible();
+    await expect(this.step1QRCode).toBeVisible();
 
-    const png = await this.step1QRCode.screenshot();
-    const img = UPNG.decode(png);
-    const { data } = jsQR(
-      new Uint8ClampedArray(UPNG.toRGBA8(img)[0]),
-      img.width,
-      img.height
-    ) || { data: null };
+    // Retry the screenshot+decode: in the change-2FA flow the canvas can repaint
+    // with the new secret a beat after the heading appears, so a single early
+    // screenshot may capture a blank QR.
+    let data: string | null = null;
+    await expect(async () => {
+      const png = await this.step1QRCode.screenshot();
+      const img = UPNG.decode(png);
+      data = (
+        jsQR(
+          new Uint8ClampedArray(UPNG.toRGBA8(img)[0]),
+          img.width,
+          img.height
+        ) || { data: null }
+      ).data;
+      expect(data).not.toBeNull();
+    }).toPass({ timeout: 10000 });
+
     if (data === null) {
       throw new Error('No QR code found');
     }

--- a/packages/functional-tests/pages/signin.ts
+++ b/packages/functional-tests/pages/signin.ts
@@ -149,9 +149,12 @@ export class SigninPage extends PasskeyPage {
   }
 
   async fillOutEmailFirstForm(email: string) {
-    // Ensure the page is ready after a hard navigation.
     await expect(this.emailTextbox).toBeVisible();
-    await this.emailTextbox.fill(email);
+    // l10n re-mount can drop onChange (button stays disabled); retry until it enables.
+    await expect(async () => {
+      await this.emailTextbox.fill(email);
+      await expect(this.emailFirstSubmitButton).toBeEnabled();
+    }).toPass({ timeout: 15000 });
     await this.emailFirstSubmitButton.click();
   }
 

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -45,8 +45,8 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
   // Fail the build on CI if you accidentally left test.only in the source code.
   forbidOnly: CI,
 
-  // Retry on CI only.
-  retries: CI ? 1 : 0,
+  // Retry once, locally and on CI, to absorb rare parallel-worker flakes.
+  retries: 1,
 
   // Total allowable time spent for the test function, fixtures, beforeEach and afterEach hooks. Defaults to 30 seconds.
   timeout: 60000, // 1 minute

--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../lib/fixtures/standard';
-import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
+import { enableTotpOnAccount } from '../../lib/pairing-helpers';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 import { getTotpCode } from '../../lib/totp';
 
 const ENTRYPOINT_123Done = 'purple';
@@ -509,78 +510,31 @@ test.describe('severity-1 #smoke', () => {
 
     test('enable 2FA and signin with TOTP - Sync', async ({
       target,
-      syncOAuthBrowserPages: { page, signin, settings, totp, signinTotpCode },
+      syncOAuthBrowserPages: {
+        page,
+        signin,
+        signinTotpCode,
+        connectAnotherDevice,
+      },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
 
-      // First, sign in and enable 2FA
-      syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-
-      await assertCmsCustomization(page, {
-        headline: 'Continue to your Mozilla account',
-        description:
-          'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Sign up or sign in',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      let submitButton = page.getByRole('button', {
-        name: 'Sign up or sign in',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter your password',
-        description: 'for your Mozilla account',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Sign in',
-      });
-      await page.getByTestId('input-field').fill(credentials.password);
-
-      submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
-      await submitButton.click();
-
-      await page.waitForURL(/pair/);
-
-      await page.getByRole('link', { name: 'Not now' }).click();
-
-      // Verify successful login and go to settings
-      await expect(page).toHaveURL(/settings/);
-      await settings.goto();
-
-      // Enable 2FA
-      await expect(settings.totp.status).toHaveText('Disabled');
-      await settings.totp.addButton.click();
-      await settings.confirmMfaGuard(credentials.email);
-
-      // Set up 2FA with QR code and backup codes
-      const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
-
-      await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toContainText(
-        'Two-step authentication has been enabled'
+      // Enroll TOTP out-of-band so one sign-in hits signin_totp_code (a second
+      // /pair can't re-sign-in: the signed-in browser shows pairing).
+      const secret = await enableTotpOnAccount(
+        target.authClient,
+        credentials.sessionToken
       );
-      await expect(settings.totp.status).toHaveText('Enabled');
+      // Record the secret so account cleanup can elevate AAL to delete it.
+      credentials.secret = secret;
 
-      // Sign out
-      await settings.signOut();
-
-      // Sign in again with 2FA
-      syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      // Real /pair handshake, then re-enter with the Sync CMS entrypoint for branding.
+      await gotoSyncSession(page, target);
+      await page.waitForURL(/action=email/, { timeout: 15000 });
+      const syncSigninUrl = new URL(page.url());
+      syncSigninUrl.searchParams.set('entrypoint', ENTRYPOINT_SYNC);
+      await page.goto(syncSigninUrl.toString());
 
       await assertCmsCustomization(page, {
         headline: 'Continue to your Mozilla account',
@@ -593,14 +547,7 @@ test.describe('severity-1 #smoke', () => {
         buttonText: 'Sign up or sign in',
       });
 
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      submitButton = page.getByRole('button', {
-        name: 'Sign up or sign in',
-        exact: true,
-      });
-      await submitButton.click();
+      await signin.fillOutEmailFirstForm(credentials.email);
 
       await assertCmsCustomization(page, {
         headline: 'Enter your password',
@@ -611,10 +558,7 @@ test.describe('severity-1 #smoke', () => {
         buttonColor: '#FF630B',
         buttonText: 'Sign in',
       });
-      await page.getByTestId('input-field').fill(credentials.password);
-
-      submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
-      await submitButton.click();
+      await signin.fillOutPasswordForm(credentials.password);
 
       // Should now be on TOTP code page
       await expect(page).toHaveURL(/signin_totp_code/);
@@ -629,13 +573,11 @@ test.describe('severity-1 #smoke', () => {
       const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
-      await page.waitForURL(/pair/);
-
-      await page.getByRole('link', { name: 'Not now' }).click();
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+      await connectAnotherDevice.clickNotNowPair();
 
       // Verify successful login
-      await expect(page).toHaveURL(/settings/);
-      await expect(settings.settingsHeading).toBeVisible();
+      await page.waitForURL(/settings/);
     });
   });
 });

--- a/packages/functional-tests/tests/cms/cms.spec.ts
+++ b/packages/functional-tests/tests/cms/cms.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../lib/fixtures/standard';
-import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 import { Page } from '@playwright/test';
 
 const ENTRYPOINT_123Done = 'purple';
@@ -254,13 +254,17 @@ test.describe('severity-1 #smoke', () => {
 
       test('signup with Sync', async ({
         target,
-        syncOAuthBrowserPages: { page, signup },
+        syncOAuthBrowserPages: { page, signin },
         testAccountTracker,
       }) => {
         const credentials = testAccountTracker.generateAccountDetails();
 
-        syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-        await signup.goto('/authorization', syncDesktopOAuthQueryParams);
+        // Real /pair handshake, then re-enter with the Sync CMS entrypoint for branding.
+        await gotoSyncSession(page, target);
+        await page.waitForURL(/action=email/, { timeout: 15000 });
+        const syncSigninUrl = new URL(page.url());
+        syncSigninUrl.searchParams.set('entrypoint', ENTRYPOINT_SYNC);
+        await page.goto(syncSigninUrl.toString());
 
         await assertCmsCustomization(page, {
           headline: 'Continue to your Mozilla account',
@@ -273,14 +277,7 @@ test.describe('severity-1 #smoke', () => {
           buttonText: 'Sign up or sign in',
         });
 
-        await page
-          .getByRole('textbox', { name: 'Email' })
-          .fill(credentials.email);
-        let submitButton = page.getByRole('button', {
-          name: 'Sign up or sign in',
-          exact: true,
-        });
-        await submitButton.click();
+        await signin.fillOutEmailFirstForm(credentials.email);
 
         await assertCmsCustomization(page, {
           headline: 'Create a password',
@@ -298,7 +295,7 @@ test.describe('severity-1 #smoke', () => {
         await page
           .getByTestId('verify-password-input-field')
           .fill(credentials.password);
-        submitButton = page.getByRole('button', {
+        let submitButton = page.getByRole('button', {
           name: 'Create account',
           exact: true,
         });
@@ -334,14 +331,18 @@ test.describe('severity-1 #smoke', () => {
       });
 
       test('signin with Sync', async ({
-        syncOAuthBrowserPages: { page, signin },
+        target,
+        syncOAuthBrowserPages: { page, signin, connectAnotherDevice },
         testAccountTracker,
       }) => {
         const credentials = await testAccountTracker.signUp();
 
-        // Navigate to the CMS entrypoint
-        syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-        await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+        // Real /pair handshake, then re-enter with the Sync CMS entrypoint for branding.
+        await gotoSyncSession(page, target);
+        await page.waitForURL(/action=email/, { timeout: 15000 });
+        const syncSigninUrl = new URL(page.url());
+        syncSigninUrl.searchParams.set('entrypoint', ENTRYPOINT_SYNC);
+        await page.goto(syncSigninUrl.toString());
 
         await assertCmsCustomization(page, {
           headline: 'Continue to your Mozilla account',
@@ -354,14 +355,7 @@ test.describe('severity-1 #smoke', () => {
           buttonText: 'Sign up or sign in',
         });
 
-        await page
-          .getByRole('textbox', { name: 'Email' })
-          .fill(credentials.email);
-        let submitButton = page.getByRole('button', {
-          name: 'Sign up or sign in',
-          exact: true,
-        });
-        await submitButton.click();
+        await signin.fillOutEmailFirstForm(credentials.email);
 
         await assertCmsCustomization(page, {
           headline: 'Enter your password',
@@ -372,29 +366,32 @@ test.describe('severity-1 #smoke', () => {
           buttonColor: '#FF630B',
           buttonText: 'Sign in',
         });
-        await page.getByTestId('input-field').fill(credentials.password);
+        await signin.fillOutPasswordForm(credentials.password);
 
-        submitButton = page.getByRole('button', {
-          name: 'Sign in',
-          exact: true,
-        });
-        await submitButton.click();
-
-        await page.waitForURL(/pair/);
-
-        await page.getByRole('link', { name: 'Not now' }).click();
+        await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+        await connectAnotherDevice.clickNotNowPair();
+        await page.waitForURL(/settings/);
       });
 
       test('signin login confirmation with Sync', async ({
         target,
-        syncOAuthBrowserPages: { page, signin, relier },
+        syncOAuthBrowserPages: {
+          page,
+          signin,
+          signinTokenCode,
+          connectAnotherDevice,
+        },
         testAccountTracker,
       }) => {
         const credentials = await testAccountTracker.signUpSync();
 
-        // Navigate to the CMS entrypoint
-        syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-        await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+        // Real /pair handshake redirects to sync sign-in; re-enter with the Sync
+        // CMS entrypoint for branding.
+        await gotoSyncSession(page, target);
+        await page.waitForURL(/action=email/, { timeout: 15000 });
+        const syncSigninUrl = new URL(page.url());
+        syncSigninUrl.searchParams.set('entrypoint', ENTRYPOINT_SYNC);
+        await page.goto(syncSigninUrl.toString());
 
         await assertCmsCustomization(page, {
           headline: 'Continue to your Mozilla account',
@@ -407,14 +404,7 @@ test.describe('severity-1 #smoke', () => {
           buttonText: 'Sign up or sign in',
         });
 
-        await page
-          .getByRole('textbox', { name: 'Email' })
-          .fill(credentials.email);
-        let submitButton = page.getByRole('button', {
-          name: 'Sign up or sign in',
-          exact: true,
-        });
-        await submitButton.click();
+        await signin.fillOutEmailFirstForm(credentials.email);
 
         await page.waitForURL(/signin/);
 
@@ -427,13 +417,7 @@ test.describe('severity-1 #smoke', () => {
           buttonColor: '#FF630B',
           buttonText: 'Sign in',
         });
-        await page.getByTestId('input-field').fill(credentials.password);
-
-        submitButton = page.getByRole('button', {
-          name: 'Sign in',
-          exact: true,
-        });
-        await submitButton.click();
+        await signin.fillOutPasswordForm(credentials.password);
 
         await page.waitForURL(/signin_token_code/);
 
@@ -449,16 +433,11 @@ test.describe('severity-1 #smoke', () => {
         const code = await target.emailClient.getVerifyLoginCode(
           credentials.email
         );
-        await page.getByLabel('Enter 6-digit code').fill(code);
-        submitButton = page.getByRole('button', {
-          name: 'Confirm',
-          exact: true,
-        });
-        await submitButton.click();
+        await signinTokenCode.fillOutCodeForm(code);
 
-        await page.waitForURL(/pair/);
-
-        await page.getByRole('link', { name: 'Not now', exact: true }).click();
+        await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+        await connectAnotherDevice.clickNotNowPair();
+        await page.waitForURL(/settings/);
       });
     });
   });

--- a/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
@@ -4,6 +4,7 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 import { SettingsPage } from '../../pages/settings';
 import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
 import { SigninPage } from '../../pages/signin';
@@ -21,9 +22,9 @@ test.describe('severity-2 #smoke', () => {
 
   for (const { signinVersion } of TestCases) {
     test(`signs up as v1, sign in within token code, signs  as v${signinVersion.version}`, async ({
-      page,
       target,
-      pages: {
+      syncOAuthBrowserPages: {
+        page,
         settings,
         signin,
         connectAnotherDevice,
@@ -31,11 +32,10 @@ test.describe('severity-2 #smoke', () => {
         signinTokenCode,
       },
       testAccountTracker,
-    }, {}) => {
+    }) => {
       const { email, password } = await testAccountTracker.signUpSync();
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&${signinVersion.query}`
-      );
+      // The stretch param still selects the key-stretching version on signin.
+      await gotoSyncSession(page, target, signinVersion.query);
       await signin.fillOutEmailFirstForm(email);
       await signin.fillOutPasswordForm(password);
 

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
@@ -4,6 +4,7 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 import { getTotpCode } from '../../lib/totp';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 
 test.describe('recovery key promo', () => {
   test.describe('inline', () => {
@@ -126,9 +127,7 @@ test.describe('recovery key promo', () => {
     }) => {
       const credentials = await testAccountTracker.signUpSync();
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
@@ -215,9 +214,7 @@ test.describe('recovery key promo', () => {
     }) => {
       const credentials = await testAccountTracker.signUp();
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
 
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
@@ -241,11 +238,10 @@ test.describe('recovery key promo', () => {
       // Attempting to navigate back to the inline recovery key page,
       // it should redirect to the connect another device page since they user
       // clicked "do it later"
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
-      await signin.fillOutEmailFirstForm(credentials.email);
-      await signin.fillOutPasswordForm(credentials.password);
+      // The browser session persists, so returning to the sync flow lands
+      // directly on connect-another-device without re-prompting for sign-in.
+      await gotoSyncSession(page, target);
+      await page.waitForURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
   });

--- a/packages/functional-tests/tests/misc/relayIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/relayIntegration.spec.ts
@@ -32,10 +32,9 @@ test.describe('relay integration', () => {
     ).toBeVisible();
 
     await signup.passwordTextbox.fill(password);
-    // keys_optional can't be sent in Firefox tests yet (FXA-13647), so this
-    // key-deriving desktop signup requires a password and renders the
+    // Firefox 147+ sends the keys_optional capability, so this non-Sync
+    // service completes login without keys and renders no password
     // confirmation field.
-    await signup.verifyPasswordTextbox.fill(password);
     await signup.createAccountButton.click();
 
     await page.waitForURL(/confirm_signup_code/);

--- a/packages/functional-tests/tests/misc/smartWindowIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/smartWindowIntegration.spec.ts
@@ -28,10 +28,9 @@ test.describe('smart window integration', () => {
     await page.waitForURL(/signup/);
 
     await signup.passwordTextbox.fill(password);
-    // keys_optional can't be sent in Firefox tests yet (FXA-13647), so this
-    // key-deriving desktop signup requires a password and renders the
+    // Firefox 147+ sends the keys_optional capability, so this non-Sync
+    // service completes login without keys and renders no password
     // confirmation field.
-    await signup.verifyPasswordTextbox.fill(password);
     await signup.createAccountButton.click();
 
     await page.waitForURL(/confirm_signup_code/);

--- a/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand } from '../../lib/channels';
+import {
+  FirefoxCommand,
+  FF_OAUTH_CLIENT_ID,
+  FxAStatusResponse,
+} from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import {
   syncMobileOAuthFenixQueryParams,
@@ -57,10 +61,24 @@ test.describe('vpn integration', () => {
 
   test('passwordless VPN + Sync signin on Android routes to set password when Sync is not decoupled', async ({
     target,
-    syncOAuthBrowserPages: { page, signin, signinPasswordlessCode },
+    pages: { page, signin, signinPasswordlessCode },
     testAccountTracker,
   }) => {
     const { email, password } = await testAccountTracker.signUpPasswordless();
+    // Android (Fenix) has no keys_optional (Sync not decoupled), so signin needs
+    // a password and routes to /set_password; fxa_status repeats, so answer all.
+    const syncNotDecoupledStatus: FxAStatusResponse = {
+      id: 'account_updates',
+      message: {
+        command: FirefoxCommand.FxAStatus,
+        data: {
+          signedInUser: null,
+          clientId: FF_OAUTH_CLIENT_ID,
+          capabilities: { engines: [], pairing: false, multiService: false },
+        },
+      },
+    };
+    await signin.respondToWebChannelMessageAlways(syncNotDecoupledStatus);
     await signin.goto('/authorization', vpnSyncMobileOAuthFenixQueryParams);
     await signin.fillOutEmailFirstForm(email);
 

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { FirefoxCommand } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
-import {
-  smartWindowDesktopOAuthQueryParams,
-  syncDesktopOAuthQueryParams,
-} from '../../lib/query-params';
+import { smartWindowDesktopOAuthQueryParams } from '../../lib/query-params';
+import { OLDSYNC_SCOPE } from '../../lib/scopes';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('signin with OAuth after Sync', () => {
@@ -30,9 +30,7 @@ test.describe('severity-1 #smoke', () => {
       const { email, password } = testAccountTracker.generateAccountDetails();
       const syncCredentials = await testAccountTracker.signUpSync();
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&force_passwordless=false`
-      );
+      await gotoSyncSession(page, target);
       await signin.fillOutEmailFirstForm(syncCredentials.email);
       await signin.fillOutPasswordForm(syncCredentials.password);
       await expect(page).toHaveURL(/signin_token_code/);
@@ -101,9 +99,9 @@ test.describe('severity-1 #smoke', () => {
       expect(await relier.isLoggedIn()).toBe(true);
     });
 
-    // After SyncOAuth signin and a localStorage wipe, OAuth-native flows
-    // should still suggest the browser user instead of the email-first form.
-    test('SmartWindow respects browser-signed-in user after SyncOAuth, localStorage cleared', async ({
+    // Sign in to Sync, then complete a SmartWindow OAuth sign-in for that browser
+    // user; the WebChannel oauth_login assertion proves it's actually delivered.
+    test('signin to Sync then SmartWindow delivers a real oauth login', async ({
       target,
       syncOAuthBrowserPages: {
         page,
@@ -115,8 +113,8 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       const syncCredentials = await testAccountTracker.signUpSync();
 
-      // Real SyncOAuth signin so Firefox stores the user via fxaccounts:login.
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      // Sign in to Sync so Firefox stores the user via fxaccounts:login.
+      await gotoSyncSession(page, target);
       await signin.fillOutEmailFirstForm(syncCredentials.email);
       await signin.fillOutPasswordForm(syncCredentials.password);
       await page.waitForURL(/signin_token_code/);
@@ -132,52 +130,18 @@ test.describe('severity-1 #smoke', () => {
         sessionStorage.clear();
       });
 
+      // SmartWindow recognizes the browser user and offers a cached sign-in.
       await signin.goto('/authorization', smartWindowDesktopOAuthQueryParams);
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.cachedSigninHeading).toBeVisible();
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
-      await expect(signin.emailFirstHeading).not.toBeVisible();
-    });
+      await signin.signInButton.click();
 
-    // Same scenario, taken end-to-end through token-code to /settings.
-    test('SmartWindow cached signin completes token verification', async ({
-      target,
-      syncOAuthBrowserPages: {
-        page,
-        signin,
-        signinTokenCode,
-        connectAnotherDevice,
-      },
-      testAccountTracker,
-    }) => {
-      const syncCredentials = await testAccountTracker.signUpSync();
-
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-      await signin.fillOutEmailFirstForm(syncCredentials.email);
-      await signin.fillOutPasswordForm(syncCredentials.password);
-      await page.waitForURL(/signin_token_code/);
-      let code = await target.emailClient.getVerifyLoginCode(
-        syncCredentials.email
+      // The browser is only truly signed in if fxa_oauth_login is delivered
+      // with the requested scope.
+      await signin.checkWebChannelMessageScope(
+        FirefoxCommand.OAuthLogin,
+        OLDSYNC_SCOPE
       );
-      await signinTokenCode.fillOutCodeForm(code);
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      await page.context().clearCookies();
-      await page.evaluate(() => {
-        localStorage.clear();
-        sessionStorage.clear();
-      });
-
-      await signin.goto('/authorization', smartWindowDesktopOAuthQueryParams);
-      await expect(signin.passwordFormHeading).toBeVisible();
-      await expect(page.getByText(syncCredentials.email)).toBeVisible();
-      await expect(signin.emailFirstHeading).not.toBeVisible();
-
-      await signin.fillOutPasswordForm(syncCredentials.password);
-      await page.waitForURL(/signin_token_code/);
-      code = await target.emailClient.getVerifyLoginCode(syncCredentials.email);
-      await signinTokenCode.fillOutCodeForm(code);
-
-      await page.waitForURL(/settings/);
     });
   });
 
@@ -208,9 +172,7 @@ test.describe('severity-1 #smoke', () => {
 
       expect(await relier.isLoggedIn()).toBe(true);
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&`
-      );
+      await gotoSyncSession(page, target);
 
       await expect(signin.passwordFormHeading).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();

--- a/packages/functional-tests/tests/pairing/pairChoice.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairChoice.spec.ts
@@ -9,9 +9,20 @@ test.describe('severity-2 #smoke', () => {
   test.describe('Pair entry flow', () => {
     test('direct /pair dispatches fxa_status and oauth_flow_begin and reveals the choice screen', async ({
       target,
-      syncOAuthBrowserPages: { page, settings },
+      syncOAuthBrowserPages: { page, settings, signin, signinTokenCode },
+      testAccountTracker,
     }) => {
+      // /pair requires a signed-in browser to reveal the choice screen; a fresh
+      // browser is redirected to sign-in first.
+      const credentials = await testAccountTracker.signUpSync();
       await page.goto(`${target.contentServerUrl}/pair`);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await page.waitForURL(/signin_token_code/);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await signinTokenCode.fillOutCodeForm(code);
 
       // testid avoids the Localized/label text-content quirk that confuses
       // getByLabel/getByRole here.
@@ -24,9 +35,19 @@ test.describe('severity-2 #smoke', () => {
 
     test('Continue advances to the download view when no mobile is selected', async ({
       target,
-      syncOAuthBrowserPages: { page },
+      syncOAuthBrowserPages: { page, signin, signinTokenCode },
+      testAccountTracker,
     }) => {
+      const credentials = await testAccountTracker.signUpSync();
       await page.goto(`${target.contentServerUrl}/pair`);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await page.waitForURL(/signin_token_code/);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await signinTokenCode.fillOutCodeForm(code);
+
       // Click the label so React's onChange fires; the radio is hidden behind
       // it, and check() on the input itself fails actionability.
       await page.locator('label[for="needs-mobile"]').click();

--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -553,7 +553,7 @@ test.describe('severity-1 #smoke', () => {
       );
     });
 
-    test('forces /inline_totp_setup when password sign-in on a passkey-only account hits an AAL2 RP', async ({
+    test('forces /inline_totp_setup when password sign-in on an account with a passkey enrolled hits an AAL2 RP', async ({
       target,
       pages: { page, relier, settings, settingsPasskeyAdd, signin },
       testAccountTracker,
@@ -598,6 +598,7 @@ test.describe('severity-1 #smoke', () => {
       await page.goto(`${target.relierUrl}/api/prompt_login`);
       await signin.fillOutEmailFirstForm(email);
       await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passkeySigninButton).toBeVisible();
       await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
         await signin.passkeySigninButton.click();
         await page.waitForURL((url) => url.href.startsWith(target.relierUrl));

--- a/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkeyPasswordFallback.spec.ts
@@ -2,15 +2,86 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Sync passkey signin + password-fallback flow via the Sync OAuth URL.
-// Sync needs keys, so the client routes to /signin_passkey_fallback.
+// Sync passkey signin via the real /pair handshake: the passkey can't derive
+// Sync keys, so Sync routes to /signin_passkey_fallback for the password.
 
-import { expect, test } from '../../lib/fixtures/standard';
+import { Page, expect, test } from '../../lib/fixtures/standard';
 import { FirefoxCommand } from '../../lib/channels';
-import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
 import { enableTotpOnAccount } from '../../lib/pairing-helpers';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 import { OLDSYNC_SCOPE } from '../../lib/scopes';
 import { EmailType } from '../../lib/email';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { SettingsPage } from '../../pages/settings';
+import { SettingsPasskeyAddPage } from '../../pages/settings/passkey';
+import { SigninPage } from '../../pages/signin';
+
+/** Create an account and register a passkey on it (non-sync settings flow). */
+async function setUpAccountWithPasskey({
+  target,
+  page,
+  settings,
+  settingsPasskeyAdd,
+  signin,
+  testAccountTracker,
+}: {
+  target: BaseTarget;
+  page: Page;
+  settings: SettingsPage;
+  settingsPasskeyAdd: SettingsPasskeyAddPage;
+  signin: SigninPage;
+  testAccountTracker: TestAccountTracker;
+}): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(target.contentServerUrl);
+  await signin.fillOutEmailFirstForm(credentials.email);
+  await signin.fillOutPasswordForm(credentials.password);
+  await page.waitForURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
+  await settingsPasskeyAdd.registerNewPasskey(settings, credentials.email);
+  await expect(settings.passkey.status).toHaveText('Enabled');
+  return credentials;
+}
+
+/**
+ * Drive a returning Sync passkey sign-in into /signin_passkey_fallback (the
+ * passkey can't derive Sync keys). Left submitted for the caller to assert.
+ */
+async function reachPasskeyFallback(
+  target: BaseTarget,
+  page: Page,
+  signin: SigninPage,
+  settingsPasskeyAdd: SettingsPasskeyAddPage,
+  email: string
+): Promise<void> {
+  await gotoSyncSession(page, target);
+  await page.waitForURL(/action=email/, { timeout: 15000 });
+  await signin.fillOutEmailFirstForm(email);
+  await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+    await signin.passkeySigninButton.click();
+    await page.waitForURL(/signin_passkey_fallback/);
+  });
+  await expect(page.getByTestId('passkey-fallback-email')).toHaveText(email);
+}
+
+async function passkeyFallbackSignIn(
+  target: BaseTarget,
+  page: Page,
+  signin: SigninPage,
+  settingsPasskeyAdd: SettingsPasskeyAddPage,
+  creds: { email: string; password: string }
+): Promise<void> {
+  await reachPasskeyFallback(
+    target,
+    page,
+    signin,
+    settingsPasskeyAdd,
+    creds.email
+  );
+  await page.getByTestId('password-input-field').fill(creds.password);
+  await page.getByTestId('continue-button').click();
+}
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Sync passkey signin with password fallback', () => {
@@ -26,52 +97,25 @@ test.describe('severity-1 #smoke', () => {
 
     test('full flow: passkey sign-in into Sync routes through /signin_passkey_fallback', async ({
       target,
-      syncOAuthBrowserPages: {
-        page,
-        signin,
-        signinTokenCode,
-        settings,
-        settingsPasskeyAdd,
-        connectAnotherDevice,
-      },
+      syncOAuthBrowserPages: { page, signin, settings, settingsPasskeyAdd },
       testAccountTracker,
     }) => {
-      const { email, password } = await testAccountTracker.signUpSync();
-
-      // Initial Sync OAuth password sign-in so we can register a passkey.
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-      await signin.fillOutEmailFirstForm(email);
-      await signin.fillOutPasswordForm(password);
-      await page.waitForURL(/signin_token_code/);
-      const tokenCode = await target.emailClient.getVerifyLoginCode(email);
-      await signinTokenCode.fillOutCodeForm(tokenCode);
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      await settings.goto();
-      await expect(settings.passkey.status).toHaveText('Not set');
-      await settingsPasskeyAdd.registerNewPasskey(settings, email);
-      await expect(settings.passkey.status).toHaveText('Enabled');
-
-      // The polyfill credential survives signOut via page.addInitScript.
-      await settings.signOut();
-      // Isolate the sign-in email from setup emails.
-      await target.emailClient.clear(email);
-
-      // Returning user picks passkey; service=sync routes to the fallback.
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-      await signin.fillOutEmailFirstForm(email);
-      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
-        await signin.passkeySigninButton.click();
-        await page.waitForURL(/signin_passkey_fallback/);
+      const { email, password } = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
       });
 
-      await expect(page.getByTestId('passkey-fallback-email')).toHaveText(
-        email
-      );
+      await settings.signOut();
+      await target.emailClient.clear(email);
 
-      // Password gate derives the Sync keys and emits fxaccounts:oauth_login.
-      await page.getByTestId('password-input-field').fill(password);
-      await page.getByTestId('continue-button').click();
+      await passkeyFallbackSignIn(target, page, signin, settingsPasskeyAdd, {
+        email,
+        password,
+      });
 
       await signin.checkWebChannelMessageScope(
         FirefoxCommand.OAuthLogin,
@@ -89,90 +133,63 @@ test.describe('severity-1 #smoke', () => {
 
     test('shows an error banner when the password is wrong', async ({
       target,
-      syncOAuthBrowserPages: {
-        page,
-        signin,
-        signinTokenCode,
-        settings,
-        settingsPasskeyAdd,
-        connectAnotherDevice,
-      },
+      syncOAuthBrowserPages: { page, signin, settings, settingsPasskeyAdd },
       testAccountTracker,
     }) => {
-      const { email, password } = await testAccountTracker.signUpSync();
-
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-      await signin.fillOutEmailFirstForm(email);
-      await signin.fillOutPasswordForm(password);
-      await page.waitForURL(/signin_token_code/);
-      const tokenCode = await target.emailClient.getVerifyLoginCode(email);
-      await signinTokenCode.fillOutCodeForm(tokenCode);
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      await settings.goto();
-      await settingsPasskeyAdd.registerNewPasskey(settings, email);
-      await expect(settings.passkey.status).toHaveText('Enabled');
-
-      await settings.signOut();
-
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-      await signin.fillOutEmailFirstForm(email);
-      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
-        await signin.passkeySigninButton.click();
-        await page.waitForURL(/signin_passkey_fallback/);
+      const { email } = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
       });
 
+      await settings.signOut();
+      await target.emailClient.clear(email);
+
+      await reachPasskeyFallback(
+        target,
+        page,
+        signin,
+        settingsPasskeyAdd,
+        email
+      );
       await page
         .getByTestId('password-input-field')
         .fill('definitely-the-wrong-password');
       await page.getByTestId('continue-button').click();
 
-      await expect(page.getByText(/password/i).first()).toBeVisible();
+      await expect(page.getByText('Incorrect password')).toBeVisible();
     });
 
     test('skips /signin_totp_code through the passkey fallback for a TOTP-enrolled Sync account', async ({
       target,
-      syncOAuthBrowserPages: {
-        page,
-        signin,
-        signinTokenCode,
-        settings,
-        settingsPasskeyAdd,
-        connectAnotherDevice,
-      },
+      syncOAuthBrowserPages: { page, signin, settings, settingsPasskeyAdd },
       testAccountTracker,
     }) => {
       // Passkey assertion is AAL2; the fallback only derives the Sync keys.
-      const credentials = await testAccountTracker.signUpSync();
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
       const { email, password } = credentials;
-
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-      await signin.fillOutEmailFirstForm(email);
-      await signin.fillOutPasswordForm(password);
-      await page.waitForURL(/signin_token_code/);
-      const tokenCode = await target.emailClient.getVerifyLoginCode(email);
-      await signinTokenCode.fillOutCodeForm(tokenCode);
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      await settings.goto();
-      await settingsPasskeyAdd.registerNewPasskey(settings, email);
-      await expect(settings.passkey.status).toHaveText('Enabled');
       credentials.secret = await enableTotpOnAccount(
         target.authClient,
         credentials.sessionToken
       );
 
       await settings.signOut();
+      await target.emailClient.clear(email);
 
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-      await signin.fillOutEmailFirstForm(email);
-      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
-        await signin.passkeySigninButton.click();
-        await page.waitForURL(/signin_passkey_fallback/);
+      await passkeyFallbackSignIn(target, page, signin, settingsPasskeyAdd, {
+        email,
+        password,
       });
-
-      await page.getByTestId('password-input-field').fill(password);
-      await page.getByTestId('continue-button').click();
 
       await signin.checkWebChannelMessageScope(
         FirefoxCommand.OAuthLogin,

--- a/packages/functional-tests/tests/passkeyAuth/passkeySetPassword.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkeySetPassword.spec.ts
@@ -6,7 +6,7 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 import { FirefoxCommand } from '../../lib/channels';
-import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 import { enableTotpOnAccount } from '../../lib/pairing-helpers';
 import { OLDSYNC_SCOPE } from '../../lib/scopes';
 import { getTotpCode } from '../../lib/totp';
@@ -50,7 +50,9 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.signOut();
 
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      // Real /pair handshake so Firefox derives real Sync keys.
+      await gotoSyncSession(page, target);
+      await page.waitForURL(/action=email/, { timeout: 15000 });
       await signin.fillOutEmailFirstForm(email);
       await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
         await signin.passkeySigninButton.click();
@@ -107,7 +109,9 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.passkey.status).toHaveText('Enabled');
       await settings.signOut();
 
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      // Real /pair handshake so Firefox derives real Sync keys.
+      await gotoSyncSession(page, target);
+      await page.waitForURL(/action=email/, { timeout: 15000 });
       await signin.fillOutEmailFirstForm(email);
       await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
         await signin.passkeySigninButton.click();

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -5,6 +5,7 @@
 import { FirefoxCommand } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('signup react', () => {
@@ -85,7 +86,9 @@ test.describe('severity-1 #smoke', () => {
       const { email, password } =
         testAccountTracker.generateSignupAccountDetails();
 
-      await signup.goto('/authorization', syncDesktopOAuthQueryParams);
+      // Real /pair handshake so Firefox derives real Sync keys.
+      await gotoSyncSession(page, target);
+      await page.waitForURL(/action=email/, { timeout: 15000 });
 
       await signup.fillOutEmailForm(email);
 
@@ -107,7 +110,7 @@ test.describe('severity-1 #smoke', () => {
 
     test('signup oauth webchannel with Sync desktop and send-tab entrypoint skips signup_confirmed_sync', async ({
       target,
-      syncOAuthBrowserPages: { confirmSignupCode, page, signup },
+      syncOAuthBrowserPages: { confirmSignupCode, page, signup, signin },
       testAccountTracker,
     }) => {
       const { email, password } =
@@ -129,10 +132,11 @@ test.describe('severity-1 #smoke', () => {
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
 
-      await expect(page).toHaveURL(/pair/);
-      await expect(
-        page.getByText('Account created. You’re now syncing.')
-      ).toBeVisible();
+      // FF147+: the send-tab signup skips signup_confirmed_sync and chains into
+      // an OAuth re-auth to derive Sync keys, landing on /pair once complete.
+      await signin.fillOutPasswordForm(password);
+      await page.waitForURL(/pair/);
+      await expect(page.getByText('Signed in successfully!')).toBeVisible();
       await signup.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
     });
   });

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -4,10 +4,8 @@
 
 import { FirefoxCommand, LinkAccountResponse } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
-import {
-  syncDesktopOAuthQueryParams,
-  syncDesktopV3QueryParams,
-} from '../../lib/query-params';
+import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 
 const eventDetailLinkAccount: LinkAccountResponse = {
   id: 'account_updates',
@@ -88,7 +86,9 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       const { email, password } =
         testAccountTracker.generateSignupAccountDetails();
-      await signup.goto('/', syncDesktopV3QueryParams);
+      // Initiate via /pair so the real Firefox drives the sync handshake; a new
+      // email at the email-first form routes into signup.
+      await gotoSyncSession(page, target);
 
       await signup.fillOutEmailForm(email);
 

--- a/packages/functional-tests/tests/settings/avatar.spec.ts
+++ b/packages/functional-tests/tests/settings/avatar.spec.ts
@@ -73,9 +73,10 @@ test.describe('severity-1 #smoke', () => {
       /avatar/
     );
 
-    // Refresh to simulate returning to the page later, which causes the
-    // avatar ID to be lost (the /v1/profile endpoint doesn't return it)
-    await page.reload();
+    // Refresh to drop the avatar ID (/v1/profile omits it). waitUntil 'commit'
+    // since the heading assertion below gates readiness, avoiding a hang when a
+    // background request stalls the `load` event.
+    await page.reload({ waitUntil: 'commit' });
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.avatar.photo).not.toHaveAttribute('src', /avatar/);
 

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -12,7 +12,7 @@ import { SigninRecoveryPhonePage } from '../../pages/signinRecoveryPhone';
 import { SigninTotpCodePage } from '../../pages/signinTotpCode';
 import { RecoveryPhoneSetupPage } from '../../pages/settings/recoveryPhone';
 import { FirefoxCommand } from '../../lib/channels';
-import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 import { getTotpCode } from '../../lib/totp';
 
 test.describe('severity-1 #smoke', () => {
@@ -272,7 +272,9 @@ test.describe('severity-1 #smoke', () => {
       await settings.signOut();
       await page.waitForURL(/\//);
 
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      // Real /pair handshake so Firefox derives real Sync keys.
+      await gotoSyncSession(page, target);
+      await page.waitForURL(/action=email/, { timeout: 15000 });
 
       await fillOutRecoveryPhoneFromEmailFirst({
         page,

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -2,11 +2,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand } from '../../lib/channels';
-import { expect, test } from '../../lib/fixtures/standard';
+import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
 import { SecondaryEmailPage } from '../../pages/settings/secondaryEmail';
+import { SigninPage } from '../../pages/signin';
+import { SigninTokenCodePage } from '../../pages/signinTokenCode';
+
+/**
+ * Firefox 147+ chains the legacy fx_desktop_v3 sign-in into an OAuth re-auth to
+ * derive Sync keys (keys decoupling): after the first password + token code, the
+ * flow redirects to context=oauth_webchannel_v1 and re-prompts for the password
+ * and a second token code before completing.
+ */
+async function completeForceAuthSignIn(
+  target: BaseTarget,
+  page: Page,
+  signin: SigninPage,
+  signinTokenCode: SigninTokenCodePage,
+  creds: { email: string; password: string }
+): Promise<void> {
+  await signin.fillOutPasswordForm(creds.password);
+  await expect(page).toHaveURL(/signin_token_code/);
+  let code = await target.emailClient.getVerifyLoginCode(creds.email);
+  await signinTokenCode.fillOutCodeForm(code);
+
+  await signin.fillOutPasswordForm(creds.password);
+  await expect(page).toHaveURL(/signin_token_code/);
+  code = await target.emailClient.getVerifyLoginCode(creds.email);
+  await signinTokenCode.fillOutCodeForm(code);
+}
 
 const makeUid = () =>
   [...Array(32)]
@@ -31,19 +56,11 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         uid: undefined,
       });
-      await signin.fillOutPasswordForm(credentials.password);
-
-      // fails on this chck for react (message not sent)
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(
-        FirefoxCommand.LinkAccount
-      );
-      await expect(page).toHaveURL(/signin_token_code/);
-      const code = await target.emailClient.getVerifyLoginCode(
-        credentials.email
-      );
-      await signinTokenCode.fillOutCodeForm(code);
+      await completeForceAuthSignIn(target, page, signin, signinTokenCode, {
+        email: credentials.email,
+        password: credentials.password,
+      });
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(FirefoxCommand.Login);
     });
 
     test('sync v3 with a registered email, registered uid', async ({
@@ -60,20 +77,12 @@ test.describe('severity-1 #smoke', () => {
       const credentials = await testAccountTracker.signUpSync();
 
       await fxDesktopV3ForceAuth.open(credentials);
-      await signin.fillOutPasswordForm(credentials.password);
-
-      // fails on this chck for react (message not sent)
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(
-        FirefoxCommand.LinkAccount
-      );
-      await expect(page).toHaveURL(/signin_token_code/);
-      const code = await target.emailClient.getVerifyLoginCode(
-        credentials.email
-      );
-      await signinTokenCode.fillOutCodeForm(code);
+      await completeForceAuthSignIn(target, page, signin, signinTokenCode, {
+        email: credentials.email,
+        password: credentials.password,
+      });
       await expect(page).toHaveURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(FirefoxCommand.Login);
     });
 
     test('sync v3 with a registered email, unregistered uid', async ({
@@ -92,19 +101,12 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         uid,
       });
-      await signin.fillOutPasswordForm(credentials.password);
-      // fails on this chck for react (message not sent)
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(
-        FirefoxCommand.LinkAccount
-      );
-      await expect(page).toHaveURL(/signin_token_code/);
-      const code = await target.emailClient.getVerifyLoginCode(
-        credentials.email
-      );
-      await signinTokenCode.fillOutCodeForm(code);
-      await signinTokenCode.page.waitForURL(/pair/);
+      await completeForceAuthSignIn(target, page, signin, signinTokenCode, {
+        email: credentials.email,
+        password: credentials.password,
+      });
+      await page.waitForURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(FirefoxCommand.Login);
     });
 
     test('blocked with an registered email, unregistered uid', async ({
@@ -128,17 +130,12 @@ test.describe('severity-1 #smoke', () => {
         uid,
       });
       await signin.fillOutPasswordForm(credentials.password);
-      // fails on this check for react (message not sent)
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(
-        FirefoxCommand.LinkAccount
-      );
       await expect(page).toHaveURL(/signin_unblock/);
       const code = await target.emailClient.getUnblockCode(credentials.email);
       await signinUnblock.fillOutCodeForm(code);
 
       await expect(page).toHaveURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-      await fxDesktopV3ForceAuth.checkWebChannelMessage(FirefoxCommand.Login);
 
       // Change primary email to non-blocked email
       await settings.goto();

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -4,6 +4,7 @@
 
 import { FirefoxCommand, LinkAccountResponse } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 settings', () => {
@@ -31,9 +32,7 @@ test.describe('severity-2 #smoke', () => {
         },
       };
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
       await signin.respondToWebChannelMessage(customEventDetail);
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
@@ -79,7 +78,7 @@ test.describe('severity-2 #smoke', () => {
         settings,
         signin,
         signinTokenCode,
-        page
+        page,
       },
       testAccountTracker,
       storageState,
@@ -96,9 +95,7 @@ test.describe('severity-2 #smoke', () => {
         },
       };
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
       await signin.respondToWebChannelMessage(customEventDetail);
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
@@ -158,9 +155,7 @@ test.describe('severity-2 #smoke', () => {
         },
       };
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
       await signin.respondToWebChannelMessage(customEventDetail);
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -5,6 +5,7 @@
 import { getTotpCode } from '../../lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { gotoSyncSession } from '../../lib/sync-helpers';
 
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
@@ -39,9 +40,7 @@ test.describe('severity-2 #smoke', () => {
         preVerified: 'true',
       });
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
@@ -70,9 +69,7 @@ test.describe('severity-2 #smoke', () => {
         preVerified: 'true',
       });
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
@@ -97,9 +94,7 @@ test.describe('severity-2 #smoke', () => {
         preVerified: 'true',
       });
 
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
-      );
+      await gotoSyncSession(page, target);
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13634,14 +13634,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.44.1":
-  version: 1.44.1
-  resolution: "@playwright/test@npm:1.44.1"
+"@playwright/test@npm:1.61.1":
+  version: 1.61.1
+  resolution: "@playwright/test@npm:1.61.1"
   dependencies:
-    playwright: "npm:1.44.1"
+    playwright: "npm:1.61.1"
   bin:
     playwright: cli.js
-  checksum: 10c0/f72669db3dfa83dc12d43ddbce8fbb27a69a80347b515fa00d8467ca640f8c7b7f5f5ff6d6cdfc5a1bce2c7d4b6ee62b988d682ef265f567302998de4f2a64ab
+  checksum: 10c0/45004139eaa7c7ec8129e4ed77a9d734aa09ed40b69162b871e4123f1d70217b7b73651431a9343ed5090d5fed11c6df1bff2a56ff4b87dc7b0371b5da87cf9c
   languageName: node
   linkType: hard
 
@@ -32109,7 +32109,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "functional-tests@workspace:packages/functional-tests"
   dependencies:
-    "@playwright/test": "npm:1.44.1"
+    "@playwright/test": "npm:1.61.1"
     "@types/eslint": "npm:^8"
     "@types/pdf-parse": "npm:^1.1.4"
     "@types/upng-js": "npm:^2"
@@ -44594,27 +44594,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright-core@npm:1.44.1"
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/6ffa3a04822b3df86d7f47a97e4f20318c0c50868ba4311820e6626ecadaab1424fbd0a3d01f0b4228adc0c781115e44b801742a4970b88739f804d82f142d68
+  checksum: 10c0/c28896ba82a602182e240ed4f9c467fb0dd9cb57d510f8aba9f25183fe1cde3a0105725a29baffa4157fe885bbb11e228032a2aad0424111584fde45303f07bd
   languageName: node
   linkType: hard
 
-"playwright@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright@npm:1.44.1"
+"playwright@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.44.1"
+    playwright-core: "npm:1.61.1"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/de827d17746b18ae2ec67d510a640d8ceebf8ee8e3d8399bccffa83b76a967498ca377777e4e6a1daaef4b3c86cb2c44c7468de53d2d915acc61b3b89c032738
+  checksum: 10c0/cea1bc4d2a64ec3ef683891606774029da7b8a8036ed98332565cec2f8e89549ca1fab9a89fbfba4e08e27e0d7e7d148031e965af66d5ff97bb3c34058cfcad0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- The functional suite was pinned to Playwright 1.44.1; upgrading to 1.61.1 (Firefox 151) keeps the browser engine current and unblocks newer test APIs.
- Firefox 151 / decoupled Sync (`keys_optional`) changed signin routing, breaking several Sync and OAuth functional tests.

## This pull request

- Upgrades `@playwright/test` 1.44.1 → 1.61.1 (`packages/functional-tests/package.json`, `yarn.lock`).
- Bumps the `fxa-circleci` CI images v9 → v10 (`.circleci/config.yml`) so the functional-test-runner ships the matching browsers.
- Updates `keys_optional` mocks to be capability-based (Sync not decoupled) rather than browser-version-based in `vpnIntegration.spec.ts`, `passkeyPasswordFallback.spec.ts`, and the `syncV3/*` specs.
- Adds `waitForOauthPage()` in `relier.ts` so email-first/AAL2 nav waits for the settled `/oauth` page, not the intermediate `/authorization` redirect.
- Adds `respondToWebChannelMessageAlways()` in `layout.ts` for flows that re-dispatch `fxa_status`.
- Adds `gotoSyncSession()` in `lib/sync-helpers.ts` to abstract `/pair` navigation across Sync tests.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13647

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**Requires the `-v10` CI image** (`ci-functional-test-runner-v10`) to be published before functional tests pass — built via the `update-ci-image` branch / `force-deploy-fxa-ci-images`. Verify by re-running the "Firefox Functional Tests - Playwright (PR)" job once `-v10` is in the registry.