### PR TITLE
chore(auth): Apply eslint to all auth-server test files

### DIFF
--- a/packages/fxa-auth-server/.eslintrc.json
+++ b/packages/fxa-auth-server/.eslintrc.json
@@ -23,11 +23,16 @@
   "root": true,
   "ignorePatterns": [
     "dist",
-    "fxa-*",
+    // Anchored to the package root so it only ignores top-level vendored fxa-*
+    // dirs. Without the leading slash it matched by basename at any depth and
+    // silently excluded real source/test files (e.g. lib/senders/fxa-mailer*.ts).
+    "/fxa-*",
     "vendor"
   ],
   "overrides": [
     {
+      // Test-only relaxation: specs routinely use crypto.randomBytes directly
+      // for fixtures; the rule guards production async-crypto paths, not tests.
       "files": ["**/*.spec.ts"],
       "env": {
         "jest": true

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer-format.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer-format.ts
@@ -15,7 +15,7 @@ export const FxaMailerFormat = {
       }>;
     };
   }) {
-    let metricsContext = await request.app.metricsContext;
+    const metricsContext = await request.app.metricsContext;
 
     return {
       deviceId: metricsContext.deviceId,

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
@@ -16,7 +16,12 @@ import { AccountEventsManager } from '../account-events';
  * This is jsut a strong typed driver that allows us to validate the params we pass into FxaMailer
  * functions are type safe. Since there's still a lot of code in auth-server that isn't type safe
  * this gives us some level of sanity that we are invoking the mailer methods correctly.
+ *
+ * The functions below are never called — they exist purely so `tsc` type-checks the
+ * argument shapes of each `fxaMailer.send*` invocation. Their being unused is by design,
+ * so `no-unused-vars` is disabled for the whole file.
  */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 // Create dummy mailer
 const fxaMailer = new FxaMailer(

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
@@ -258,7 +258,7 @@ describe('lib/senders/fxa-mailer', () => {
 
     it('does not record an event when uid is missing', async () => {
       stubRender();
-      const { uid: _uid, ...optsWithoutUid } = baseOpts;
+      const optsWithoutUid = { ...baseOpts, uid: undefined };
       await fxaMailer.sendNewDeviceLoginEmail(optsWithoutUid as any);
 
       expect(mockAccountEventsManager.recordEmailEvent).not.toHaveBeenCalled();


### PR DESCRIPTION
Because:

* An unanchored "fxa-*" ignorePattern matched by basename at any depth, silently excluding real source and test files from ESLint.

This commit:

* Anchors the pattern to "/fxa-*" so it only ignores top-level vendored dirs.
* Fixes the latent lint errors the un-ignore surfaces.
* Documents the spec-only async-crypto-random relaxation.

Closes: #FXA-13283

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
