### PR TITLE
chore(auth): Surface auth-server tests in VS Code test explorer

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -13,7 +13,11 @@ marketplace you trust, and verify the publisher before installing.
 - GitHub Markdown Preview (`bierner.github-markdown-preview`)
 - Firefox Debugger (`firefox-devtools.vscode-firefox-debug`) — required for the "Attach to Firefox" launch config
 - Playwright (`ms-playwright.playwright`) — picks up `playwright.env` from `settings.json`
-- Jest (`Orta.vscode-jest`) — picks up `jest.jestCommandLine` from `settings.json`
+- Jest (`Orta.vscode-jest`) — picks up `jest.jestCommandLine` from `settings.json`.
+  fxa-auth-server specs are surfaced in the test explorer and debuggable; the
+  per-test timeout is lifted automatically while a debugger is attached. Known
+  limitation: without `--forceExit`, debug sessions for some auth-server suites
+  stay alive after completion on leaked test handles (FXA-13712).
 
 ## Debugging PM2-managed processes
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,18 @@
 import { getJestProjectsAsync } from '@nx/jest';
 
+// fxa-auth-server runs Jest via shell scripts, not an `@nx/jest:jest` target,
+// so getJestProjectsAsync() never discovers it and its specs don't appear in
+// the VS Code Jest test explorer (FXA-13439). This file is editor-only (read
+// by jest.jestCommandLine in .vscode/settings.json; no CI job or package
+// script uses it), so we append the package's configs here. Their testMatch
+// patterns are mutually exclusive, so no spec is listed twice.
+const authServerProjects = [
+  '<rootDir>/packages/fxa-auth-server/jest.config.js',
+  '<rootDir>/packages/fxa-auth-server/jest.integration.config.js',
+  '<rootDir>/packages/fxa-auth-server/jest.oauth-api.config.js',
+  '<rootDir>/packages/fxa-auth-server/jest.scripts.config.js',
+];
+
 export default async () => ({
-  projects: await getJestProjectsAsync(),
+  projects: [...(await getJestProjectsAsync()), ...authServerProjects],
 });

--- a/packages/fxa-auth-server/jest.config.js
+++ b/packages/fxa-auth-server/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
   clearMocks: true,
   workerIdleMemoryLimit: '512MB',
   setupFiles: ['<rootDir>/jest.setup.js', '<rootDir>/jest.setup-resolve.js'],
+  setupFilesAfterEnv: ['<rootDir>/test/jest.debug-timeout.js'],
   testPathIgnorePatterns: ['\\.in\\.spec\\.ts$'],
   // Coverage configuration (enabled via --coverage flag)
   collectCoverageFrom: [

--- a/packages/fxa-auth-server/jest.integration.config.js
+++ b/packages/fxa-auth-server/jest.integration.config.js
@@ -32,7 +32,11 @@ module.exports = {
   globalTeardown: '<rootDir>/test/support/jest-global-teardown.ts',
 
   setupFiles: ['<rootDir>/test/support/jest-setup-env.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/support/jest-setup-integration.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/test/support/jest-setup-integration.ts',
+    // Last so its debug timeout override wins over the config default.
+    ...baseConfig.setupFilesAfterEnv,
+  ],
 
   collectCoverageFrom: [
     'lib/**/*.{ts,js}',

--- a/packages/fxa-auth-server/jest.oauth-api.config.js
+++ b/packages/fxa-auth-server/jest.oauth-api.config.js
@@ -29,7 +29,11 @@ module.exports = {
 
   // No globalSetup/teardown — this test starts its own server in-process
   setupFiles: ['<rootDir>/test/support/jest-setup-env.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/support/jest-setup-integration.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/test/support/jest-setup-integration.ts',
+    // Last so its debug timeout override wins over the config default.
+    ...baseConfig.setupFilesAfterEnv,
+  ],
 
   collectCoverageFrom: [
     'lib/**/*.{ts,js}',

--- a/packages/fxa-auth-server/jest.scripts.config.js
+++ b/packages/fxa-auth-server/jest.scripts.config.js
@@ -26,7 +26,11 @@ module.exports = {
   globalTeardown: '<rootDir>/test/support/jest-global-teardown.ts',
 
   setupFiles: ['<rootDir>/test/support/jest-setup-env.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/support/jest-setup-integration.ts'],
+  setupFilesAfterEnv: [
+    '<rootDir>/test/support/jest-setup-integration.ts',
+    // Last so its debug timeout override wins over the config default.
+    ...baseConfig.setupFilesAfterEnv,
+  ],
 
   collectCoverageFrom: [
     'lib/**/*.{ts,js}',

--- a/packages/fxa-auth-server/test/jest.debug-timeout.js
+++ b/packages/fxa-auth-server/test/jest.debug-timeout.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Lift Jest's per-test timeout when a debugger is attached (FXA-13439). While
+ * paused at a breakpoint the test clock keeps ticking, so specs trip their
+ * timeout before you finish stepping through.
+ *
+ * inspector.url() is the debugger's ws:// URL when attached, undefined otherwise
+ * (so normal/CI runs keep their configured timeouts); execArgv/NODE_OPTIONS also
+ * catch --inspect set before the session opens. Loaded via setupFilesAfterEnv so
+ * `jest` is defined; must run last so its setTimeout() wins over earlier setup.
+ */
+const inspector = require('inspector');
+
+const isDebugging =
+  inspector.url() !== undefined ||
+  process.execArgv.some((arg) => arg.includes('--inspect')) ||
+  (process.env.NODE_OPTIONS || '').includes('--inspect');
+
+if (isDebugging) {
+  // Finite ceiling rather than 0, which Jest treats as "time out immediately".
+  jest.setTimeout(30 * 60 * 1000);
+}


### PR DESCRIPTION
## Because

- fxa-auth-server runs its Jest suites through shell scripts rather than an
  `@nx/jest:jest` target, so `getJestProjectsAsync()` never discovered it and
  its specs never appeared in the VS Code Jest test explorer.
- Developers could not run or debug auth-server unit and integration specs from
  the explorer or inline, unlike every other package in the monorepo.
- Debugging a spec tripped Jest's per-test timeout while paused at a breakpoint.

## This pull request

- Appends auth-server's four Jest configs (`jest.config.js`,
  `jest.integration.config.js`, `jest.oauth-api.config.js`,
  `jest.scripts.config.js`) to the root `jest.config.ts` aggregate so unit and
  integration specs are discoverable in the test explorer. Their `testMatch`
  patterns are mutually exclusive, so no spec is listed twice.
- Adds `packages/fxa-auth-server/test/jest.debug-timeout.js`, which lifts the
  per-test timeout when a debugger is attached, and wires it into all four
  configs (ordered last so it wins over the config default).
- Documents the known debug non-detach limitation in `.vscode/README.md`.

## Issue that this pull request solves

Closes: FXA-13439

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

- You might need to close and re-open vscode for this to take effect. The reload button doesn't always pick up new tests
  - <img width="650" height="728" alt="image" src="https://github.com/user-attachments/assets/2c396088-b364-4a1c-955e-e1025f7218b7" />
- With debugging integration tests, some tests start up the server in a way that allows us to attach debug points to it too!
- Test failures will report inline with the tests when run through the explorer
  - <img width="1553" height="251" alt="Screenshot 2026-06-26 at 14 17 55" src="https://github.com/user-attachments/assets/21b4352c-1ab3-4867-9392-99e6045366f1" />
- And regular break points can be added to unit and integration tests!
  - <img width="1694" height="868" alt="Screenshot 2026-06-26 at 13 58 18" src="https://github.com/user-attachments/assets/0a168f00-07e4-48bf-8ce2-d828a1f0387f" />


## Other information (Optional)

Debug sessions for some auth-server suites won't detach on completion: without
`--forceExit`, leaked test handles keep the process alive. This is a known
limitation that resolves once the leak/`--forceExit` work lands (FXA-13712).