### PR TITLE
chore(vscode): Set Jest runMode to on-demand

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,8 @@
     "**/temp": true,
     "*.sass-cache": true
   },
-  "jest.jestCommandLine": "node_modules/.bin/jest --config jest.config.ts"
+  "jest.jestCommandLine": "node_modules/.bin/jest --config jest.config.ts",
+  "jest.runMode": {
+    "type": "on-demand"
+  }
 }


### PR DESCRIPTION
## Because

- Without a defined runMode for jest in vscode, it defaults to [watch](https://github.com/jest-community/vscode-jest#runmode), and this means file changes can have wide effect on running tests locally when it's not needed yet

## This pull request

- Explicitly sets the runMode to `on-demand` meaning tests are not run until explicitly requested. Saving local resources and overhead in testing everything for minor changes

## Issue that this pull request solves

Closes: FXA-14079

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
