### PR TITLE
fix(auth-server): add histogram to disabled StatsD mock

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -23,6 +23,7 @@ const {
 } = require('@fxa/shared/cms');
 const TracingProvider = require('fxa-shared/tracing/node-tracing');
 
+const { createNoopStatsd } = require('../lib/noop-statsd');
 const { AppError: error } = require('@fxa/accounts/errors');
 const { JWTool } = require('@fxa/vendored/jwtool');
 const { StatsD } = require('hot-shots');
@@ -84,11 +85,7 @@ async function run(config) {
           log.error('statsd.error', err);
         },
       })
-    : {
-        increment: () => {},
-        timing: () => {},
-        close: () => {},
-      };
+    : createNoopStatsd();
   Container.set(StatsD, statsd);
 
   const log = require('../lib/log')({

--- a/packages/fxa-auth-server/lib/noop-statsd.js
+++ b/packages/fxa-auth-server/lib/noop-statsd.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+/**
+ * No-op StatsD client used when metrics collection is disabled.
+ * Must implement every method invoked via optional chaining on the
+ * metrics object (e.g. redis histogram calls).
+ */
+function createNoopStatsd() {
+  return {
+    increment: () => {},
+    timing: () => {},
+    histogram: () => {},
+    close: () => {},
+  };
+}
+
+module.exports = { createNoopStatsd };

--- a/packages/fxa-auth-server/lib/noop-statsd.spec.ts
+++ b/packages/fxa-auth-server/lib/noop-statsd.spec.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { createNoopStatsd } = require('../lib/noop-statsd');
+
+describe('createNoopStatsd', () => {
+  it('implements methods used by auth-server metrics callers', () => {
+    const statsd = createNoopStatsd();
+
+    expect(() => {
+      statsd.increment('test.increment');
+      statsd.timing('test.timing', 1);
+      statsd.histogram('test.histogram', 42);
+      statsd.close();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Because

- When `config.statsd.enabled` is false, `key_server.js` registers a no-op StatsD client in the DI container.
- Redis metrics code calls `this.metrics?.histogram(...)`. Optional chaining skips null/undefined objects, but if `metrics` exists without a `histogram` method, the call throws at runtime.
- Reported in #16491.

## This pull request

- Adds a `createNoopStatsd()` helper that implements `increment`, `timing`, `histogram`, and `close`.
- Uses the helper when StatsD is disabled in `key_server.js`.
- Adds unit tests covering the no-op client method surface.

## Issue that this pull request solves

Closes: #16491

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/lib/noop-statsd.js`, `packages/fxa-auth-server/bin/key_server.js`
- Suggested review order: read helper + test first, then the one-line call site change in `key_server.js`
- Risky or complex parts: none — behavior change is limited to the disabled-StatsD code path

## Test plan

- [ ] `yarn jest packages/fxa-auth-server/lib/noop-statsd.spec.ts` passes
- [ ] Auth server starts with `STATSD_ENABLE=false` and redis histogram metrics do not throw