### PR TITLE
fix(oauth): correct typo in refresh token test description

### DIFF
--- a/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
@@ -3292,7 +3292,7 @@ describe('#integration - /v1', function () {
         expect(clients2[0].client_id).toBe(client2Id.toString('hex'));
       });
 
-      it('should seperately list different refresh tokens from the same client', async () => {
+      it('should separately list different refresh tokens from the same client', async () => {
         await makeAccessToken(client1, user1, ['profile']);
         await makeAccessToken(client1, user1, ['other', 'scope']);
         await makeRefreshToken(client2, user1, ['profile']);


### PR DESCRIPTION
## Because

- An OAuth integration test description misspelled "separately" as "seperately".
- No linked issue; this is a one-character test string correction with no runtime impact.

## This pull request

- Corrects the test description in `oauth_api.in.spec.ts` with no other changes.

## Issue that this pull request solves

Closes: (none — test typo only)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally. — N/A: test string only.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate). — N/A
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts` (single-line change)
- Suggested review order: verify spelling change only
- Risky or complex parts: none

## Test plan

- [ ] `grep -r seperately packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts` returns no matches