### PR TITLE
feat(shared): make session token expiry configurable from auth-server config

### DIFF
--- a/packages/fxa-auth-server/lib/db.ts
+++ b/packages/fxa-auth-server/lib/db.ts
@@ -83,6 +83,11 @@ export const createDB = (
   const { enabled: TOKEN_PRUNING_ENABLED, maxAge: TOKEN_PRUNING_MAX_AGE } =
     config.tokenPruning;
 
+  // Configure the shared model's expiry from the server's config
+  if (MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE) {
+    RawSessionToken.sessionExpiryMs = MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE;
+  }
+
   class DB {
     redis: any;
     knex: Knex | null;

--- a/packages/fxa-shared/db/models/auth/session-token.ts
+++ b/packages/fxa-shared/db/models/auth/session-token.ts
@@ -11,12 +11,14 @@ import {
 } from '../../transformers';
 import { convertError, notFound } from '../../mysql';
 
-//TODO FIXME unhardcode the 28 day expiry
 function notExpired(token: SessionToken) {
-  return !!(token.deviceId || token.createdAt > Date.now() - 2419200000);
+  return !!(
+    token.deviceId ||
+    token.createdAt > Date.now() - SessionToken.sessionExpiryMs
+  );
 }
 
-const VERIFICATION_METHOD = {
+export const VERIFICATION_METHOD = {
   email: 0,
   'email-2fa': 1,
   'totp-2fa': 2,
@@ -55,6 +57,7 @@ export function verificationMethodToString(
 export class SessionToken extends BaseToken {
   public static tableName = 'sessionTokens';
   public static idColumn = 'tokenId';
+  public static sessionExpiryMs = 2419200000; // 28 days
 
   protected $uuidFields = [
     'tokenId',

--- a/packages/fxa-shared/test/db/models/auth/session-token.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/session-token.spec.ts
@@ -1,0 +1,121 @@
+import 'mocha';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { SessionToken } from '../../../../db/models/auth';
+import { uuidTransformer } from '../../../../db/transformers';
+import crypto from 'crypto';
+
+const toRandomBuff = (size) =>
+  uuidTransformer.to(crypto.randomBytes(size).toString('hex'));
+
+describe('SessionToken Unit Tests', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('filters out expired tokens (older than 28 days by default)', async () => {
+    const now = Date.now();
+    // 28 days in milliseconds is 2419200000
+    const validTime = now - 2419200000 + 10000; // 10 seconds remaining
+    const expiredTime = now - 2419200000 - 10000; // 10 seconds overdue
+
+    const uidBuff = toRandomBuff(16);
+
+    const validRow = {
+      tokenId: toRandomBuff(16),
+      tokenData: toRandomBuff(16),
+      uid: uidBuff,
+      createdAt: validTime,
+      lastAccessTime: validTime,
+      authAt: 1,
+      verificationMethod: 0,
+      verifiedAt: 0,
+      mustVerify: 0,
+      deviceId: null, // explicit null for no device
+      emailVerified: 1,
+      email: 'test@test.com',
+      emailCode: 'code',
+      deviceCallbackIsExpired: 0,
+    };
+
+    const expiredRow = {
+      ...validRow,
+      tokenId: toRandomBuff(16),
+      createdAt: expiredTime,
+    };
+
+    sandbox.stub(SessionToken, 'callProcedure').resolves({
+      rows: [validRow, expiredRow],
+    });
+
+    const tokens = await SessionToken.findByUid(
+      '0123456789abcdef0123456789abcdef'
+    );
+
+    assert.equal(
+      tokens.length,
+      1,
+      'Should return exactly 1 token (the valid one)'
+    );
+    assert.equal(tokens[0].createdAt, validTime);
+  });
+
+  it('respects configured expiry', async () => {
+    const originalExpiry = SessionToken.sessionExpiryMs;
+    try {
+      // Set expiry to 1 hour
+      SessionToken.sessionExpiryMs = 60 * 60 * 1000; // 1 hour
+      const now = Date.now();
+      const validTime = now - 30 * 60 * 1000; // 30 mins old (valid)
+      const expiredTime = now - 90 * 60 * 1000; // 90 mins old (expired)
+
+      const uidBuff = toRandomBuff(16);
+
+      const validRow = {
+        tokenId: toRandomBuff(16),
+        tokenData: toRandomBuff(16),
+        uid: uidBuff,
+        createdAt: validTime,
+        lastAccessTime: validTime,
+        authAt: 1,
+        verificationMethod: 0,
+        verifiedAt: 0,
+        mustVerify: 0,
+        deviceId: null,
+        emailVerified: 1,
+        email: 'test@test.com',
+        emailCode: 'code',
+        deviceCallbackIsExpired: 0,
+      };
+
+      const expiredRow = {
+        ...validRow,
+        tokenId: toRandomBuff(16),
+        createdAt: expiredTime,
+      };
+
+      sandbox.stub(SessionToken, 'callProcedure').resolves({
+        rows: [validRow, expiredRow],
+      });
+
+      const tokens = await SessionToken.findByUid(
+        '0123456789abcdef0123456789abcdef'
+      );
+
+      assert.equal(
+          tokens.length,
+          1,
+          'Should return exactly 1 token (the valid one)'
+      );
+      assert.equal(tokens[0].createdAt, validTime);
+    } finally {
+      SessionToken.sessionExpiryMs = originalExpiry;
+    }
+  });
+});


### PR DESCRIPTION
## Because

- `SessionToken` expiry filtering used a hardcoded 28-day value with an open FIXME to make it configurable.
- Auth-server already defines `tokenLifetimes.sessionTokenWithoutDevice`; the shared model should respect that setting.

## This pull request

- Set `SessionToken.sessionExpiryMs` from auth-server config during DB initialization.
- Add unit tests for session token expiry filtering logic in `fxa-shared`.

## Issue that this pull request solves

Closes: (none — addresses FIXME in session-token.ts; split from #19940 per maintainer feedback)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate). — N/A
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
  - `packages/fxa-auth-server/lib/db.ts` (config wiring)
  - `packages/fxa-shared/db/models/auth/session-token.ts` (static expiry property)
  - `packages/fxa-shared/test/db/models/auth/session-token.spec.ts` (new tests)
- Suggested review order: model change → db wiring → unit tests
- Risky or complex parts: default 28-day fallback when config value is unset

## Test plan

- [ ] `yarn test fxa-shared` — session-token unit tests pass
- [ ] Auth-server starts and session token pruning respects configured expiry