### PR TITLE
chore(auth): Resolve fxa-auth-server spec type errors

### DIFF
--- a/packages/fxa-auth-server/lib/account-events.spec.ts
+++ b/packages/fxa-auth-server/lib/account-events.spec.ts
@@ -138,7 +138,7 @@ describe('Account Events', () => {
   describe('security events', () => {
     it('can record security event', async () => {
       const message = {
-        name: 'account.login',
+        name: 'account.login' as const,
         uid: '000',
         ipAddr: '123.123.123.123',
         tokenId: '123',
@@ -157,7 +157,7 @@ describe('Account Events', () => {
 
     it('includes clientId and service tags from additionalInfo', async () => {
       const message = {
-        name: 'account.login',
+        name: 'account.login' as const,
         uid: '000',
         ipAddr: '123.123.123.123',
         tokenId: '123',
@@ -177,7 +177,7 @@ describe('Account Events', () => {
 
     it('uses none for missing service when clientId is present', async () => {
       const message = {
-        name: 'account.login',
+        name: 'account.login' as const,
         uid: '000',
         ipAddr: '123.123.123.123',
         tokenId: '123',

--- a/packages/fxa-auth-server/lib/customs.spec.ts
+++ b/packages/fxa-auth-server/lib/customs.spec.ts
@@ -274,7 +274,8 @@ describe('Customs', () => {
       const originalGet = configModule.config.get.bind(configModule.config);
       jest
         .spyOn(configModule.config, 'get')
-        .mockImplementation((key: string) => {
+        .mockImplementation((...args: unknown[]) => {
+          const key = args[0];
           if (key === 'rateLimit.emailAliasNormalization') {
             return JSON.stringify([
               { domain: 'mozilla.com', regex: '\\+.*', replace: '' },

--- a/packages/fxa-auth-server/lib/devices.spec.ts
+++ b/packages/fxa-auth-server/lib/devices.spec.ts
@@ -595,7 +595,7 @@ describe('lib/devices:', () => {
         });
 
         expect(log.notifyAttachedServices).toHaveBeenCalledTimes(1);
-        const args = log.notifyAttachedServices.mock.calls[0];
+        const args = jest.mocked(log.notifyAttachedServices).mock.calls[0];
         expect(args.length).toBe(3);
         expect(args[0]).toBe('device:delete');
         expect(args[1]).toBe(request);

--- a/packages/fxa-auth-server/lib/geodb.spec.ts
+++ b/packages/fxa-auth-server/lib/geodb.spec.ts
@@ -43,14 +43,16 @@ describe('geodb', () => {
     const getGeoData = geodbFactory(mockLog());
     const geoData = getGeoData(knownIpLocation.ip);
 
-    expect(knownIpLocation.location.city.has(geoData.location.city)).toBe(true);
-    expect(geoData.location.country).toBe(knownIpLocation.location.country);
-    expect(geoData.location.countryCode).toBe(
-      knownIpLocation.location.countryCode
-    );
+    const location = geoData.location;
+    if (!location) {
+      throw new Error('expected geoData.location to be defined when enabled');
+    }
+    expect(knownIpLocation.location.city.has(location.city)).toBe(true);
+    expect(location.country).toBe(knownIpLocation.location.country);
+    expect(location.countryCode).toBe(knownIpLocation.location.countryCode);
     expect(geoData.timeZone).toBe(knownIpLocation.location.tz);
-    expect(geoData.location.state).toBe(knownIpLocation.location.state);
-    expect(geoData.location.stateCode).toBe(knownIpLocation.location.stateCode);
+    expect(location.state).toBe(knownIpLocation.location.state);
+    expect(location.stateCode).toBe(knownIpLocation.location.stateCode);
   });
 
   it('returns empty object data when disabled', () => {

--- a/packages/fxa-auth-server/lib/metrics/amplitude.spec.ts
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.spec.ts
@@ -329,7 +329,9 @@ describe('metrics/amplitude', () => {
         });
         expect(args[0].time).toBeGreaterThan(Date.now() - 1000);
         expect(/^([0-9]+)\.([0-9]+)$/.test(args[0].app_version)).toBe(true);
-        const statsd = Container.get(StatsD) as { increment: jest.Mock };
+        const statsd = Container.get(StatsD) as unknown as {
+          increment: jest.Mock;
+        };
         expect(statsd.increment).toHaveBeenNthCalledWith(1, 'amplitude.event');
       });
     });
@@ -919,7 +921,9 @@ describe('metrics/amplitude', () => {
       });
 
       it('incremented amplitude dropped', () => {
-        const statsd = Container.get(StatsD) as { increment: jest.Mock };
+        const statsd = Container.get(StatsD) as unknown as {
+          increment: jest.Mock;
+        };
         expect(statsd.increment).toHaveBeenCalledTimes(2);
         expect(statsd.increment).toHaveBeenNthCalledWith(1, 'amplitude.event');
         expect(statsd.increment).toHaveBeenNthCalledWith(

--- a/packages/fxa-auth-server/lib/metrics/glean/index.spec.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.spec.ts
@@ -912,7 +912,7 @@ describe('Glean server side events', () => {
   });
 
   describe('logErrorWithGlean hapi preResponse error logger', () => {
-    const error = AppError.requestBlocked();
+    const error = AppError.requestBlocked(false);
 
     // Build a mock glean object where every method is a jest.fn()
     const mockGleanObj = gleanMetrics(config);

--- a/packages/fxa-auth-server/lib/oauth/jwt.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt.js
@@ -14,6 +14,7 @@ const jwtverify = require('util').promisify(jsonwebtoken.verify);
  * Sign `claims` using SIGNING_PEM from keys.js, returning a JWT.
  *
  * @param {Object} claims
+ * @param {Object} [options]
  * @returns {Promise} resolves with signed JWT when complete
  */
 exports.sign = function sign(claims, options) {
@@ -33,6 +34,13 @@ exports.sign = function sign(claims, options) {
   );
 };
 
+/**
+ * Verify `jwt`, resolving with its decoded payload.
+ *
+ * @param {string} jwt
+ * @param {Object} [options]
+ * @returns {Promise<Record<string, unknown>>} resolves with the verified payload
+ */
 exports.verify = async function verify(jwt, options = {}) {
   const getKey = (header, callback) => {
     if (options.typ) {

--- a/packages/fxa-auth-server/lib/oauth/jwt.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/jwt.spec.ts
@@ -13,13 +13,17 @@ jest.mock('./keys', () => {
 });
 
 import jsonwebtoken from 'jsonwebtoken';
-import * as JWT from './jwt';
+import { sign, verify } from './jwt';
 import * as keys from './keys';
+
+// The `./keys` mock factory replaces `publicPEM` with a jest.fn; the CommonJS
+// `exports.publicPEM` is not visible on the namespace import's type.
+const publicPEM = (keys as unknown as { publicPEM: jest.Mock }).publicPEM;
 
 describe('lib/jwt', () => {
   describe('sign', () => {
     it('signs the claims, passes on options', async () => {
-      const jwt = await JWT.sign(
+      const jwt = await sign(
         {
           jti: 'foo',
         },
@@ -32,92 +36,88 @@ describe('lib/jwt', () => {
 
       const decoded = jsonwebtoken.decode(jwt, { json: true, complete: true });
 
-      expect(decoded.header.typ).toBe('custom jwt');
-      expect(decoded.payload.jti).toBe('foo');
+      expect(decoded?.header.typ).toBe('custom jwt');
+      expect(decoded?.payload.jti).toBe('foo');
     });
 
     describe('verify', () => {
       it('fails if JWT is invalid', async () => {
-        await expect(JWT.verify('invalid token')).rejects.toThrow(
-          'jwt malformed'
-        );
+        await expect(verify('invalid token')).rejects.toThrow('jwt malformed');
       });
 
       it('fails if kid is invalid', async () => {
-        keys.publicPEM.mockImplementationOnce(() => {
+        publicPEM.mockImplementationOnce(() => {
           throw new Error('PEM not found');
         });
 
-        const jwt = await JWT.sign({ foo: 'bar' });
+        const jwt = await sign({ foo: 'bar' });
 
-        await expect(JWT.verify(jwt)).rejects.toThrow(
+        await expect(verify(jwt)).rejects.toThrow(
           'error in secret or public key callback: Invalid kid'
         );
       });
 
       it('fails if signature does not match', async () => {
-        const jwt = await JWT.sign({ foo: 'bar' });
-        await expect(JWT.verify(jwt + '1')).rejects.toThrow(
-          'invalid signature'
-        );
+        const jwt = await sign({ foo: 'bar' });
+        await expect(verify(jwt + '1')).rejects.toThrow('invalid signature');
       });
 
       it('fails if algorithm does not match', async () => {
-        const jwt = await JWT.sign({ foo: 'bar' });
-        await expect(
-          JWT.verify(jwt, { algorithms: ['HS256'] })
-        ).rejects.toThrow('invalid algorithm');
+        const jwt = await sign({ foo: 'bar' });
+        await expect(verify(jwt, { algorithms: ['HS256'] })).rejects.toThrow(
+          'invalid algorithm'
+        );
       });
 
       it('fails if expired', async () => {
-        const jwt = await JWT.sign({
+        const jwt = await sign({
           exp: Math.floor((Date.now() - 2000) / 1000),
           foo: 'bar',
         });
-        await expect(JWT.verify(jwt)).rejects.toThrow('jwt expired');
+        await expect(verify(jwt)).rejects.toThrow('jwt expired');
       });
 
       it('passes if expired and ignoreExpiration option is true', async () => {
-        const jwt = await JWT.sign({
+        const jwt = await sign({
           exp: Math.floor((Date.now() - 2000) / 1000),
           foo: 'bar',
         });
 
-        const verifiedPayload = await JWT.verify(jwt, {
+        const verifiedPayload = await verify(jwt, {
           ignoreExpiration: true,
         });
         expect(verifiedPayload.foo).toBe('bar');
       });
 
       it('fails if invalid issuer', async () => {
-        const jwt = await JWT.sign({ iss: 'another issuer', foo: 'bar' });
-        await expect(
-          JWT.verify(jwt, { issuer: 'custom issuer' })
-        ).rejects.toThrow('jwt issuer invalid. expected: custom issuer');
+        const jwt = await sign({ iss: 'another issuer', foo: 'bar' });
+        await expect(verify(jwt, { issuer: 'custom issuer' })).rejects.toThrow(
+          'jwt issuer invalid. expected: custom issuer'
+        );
       });
 
       it('fails if header `typ` is not expected', async () => {
-        const jwt = await JWT.sign({ foo: 'bar' }, { header: { typ: 'JWT' } });
-        await expect(JWT.verify(jwt, { typ: 'custom JWT' })).rejects.toThrow(
+        const jwt = await sign({ foo: 'bar' }, { header: { typ: 'JWT' } });
+        await expect(verify(jwt, { typ: 'custom JWT' })).rejects.toThrow(
           'error in secret or public key callback: Invalid typ'
         );
       });
 
       it('succeeds if valid', async () => {
-        const jwt = await JWT.sign(
+        const jwt = await sign(
           { foo: 'bar' },
           { header: { typ: 'custom JWT' } }
         );
-        const verifiedPayload = await JWT.verify(jwt, { typ: 'custom JWT' });
+        const verifiedPayload = await verify(jwt, { typ: 'custom JWT' });
         expect(verifiedPayload.foo).toBe('bar');
       });
 
       it('succeeds if valid and typ matches according to comparison rules', async () => {
-        const jwt = await JWT.sign(
+        const jwt = await sign(
           { foo: 'bar' },
           { header: { typ: 'cUstOm-JwT' } }
         );
-        const verifiedPayload = await JWT.verify(jwt, {
+        const verifiedPayload = await verify(jwt, {
           typ: 'application/custom-jwt',
         });
         expect(verifiedPayload.foo).toBe('bar');

--- a/packages/fxa-auth-server/lib/payments/capability.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.spec.ts
@@ -168,7 +168,9 @@ describe('CapabilityService', () => {
       capabilityService.subscribedPriceIds = jest
         .fn()
         .mockResolvedValue(['price_GWScEDK6LT8cSV']);
-      capabilityService.processPriceIdDiff = jest.fn().mockResolvedValue();
+      capabilityService.processPriceIdDiff = jest
+        .fn()
+        .mockResolvedValue(undefined);
     });
 
     it('handles a stripe price update with new prices', async () => {
@@ -232,7 +234,9 @@ describe('CapabilityService', () => {
       capabilityService.subscribedPriceIds = jest
         .fn()
         .mockResolvedValue(['prod_FUUNYnlDso7FeB']);
-      capabilityService.processPriceIdDiff = jest.fn().mockResolvedValue();
+      capabilityService.processPriceIdDiff = jest
+        .fn()
+        .mockResolvedValue(undefined);
       subscriptionPurchase = PlayStoreSubscriptionPurchase.fromApiResponse(
         VALID_SUB_API_RESPONSE,
         'testPackage',

--- a/packages/fxa-auth-server/lib/payments/currencies.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/currencies.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { CurrencyHelper } from './currencies';
+import { ConfigType } from '../../config';
 
 const payPalEnabledSubscriptionsConfig = {
   paypalNvpSigCredentials: {
@@ -20,7 +21,9 @@ describe('currencyMapValidation in constructor', () => {
       ['ZAR', ['US', 'CA']],
       ['EUR', ['FR']],
     ]);
-    const ch = new CurrencyHelper({ currenciesToCountries });
+    const ch = new CurrencyHelper({
+      currenciesToCountries,
+    } as unknown as ConfigType);
     expect(ch.currencyToCountryMap).toEqual(expected);
   });
 
@@ -32,12 +35,12 @@ describe('currencyMapValidation in constructor', () => {
           enabled: false,
         },
       },
-    });
+    } as unknown as ConfigType);
     expect(ch.payPalEnabled).toBe(false);
     ch = new CurrencyHelper({
       currenciesToCountries: {},
       subscriptions: payPalEnabledSubscriptionsConfig,
-    });
+    } as unknown as ConfigType);
     expect(ch.payPalEnabled).toBe(true);
   });
 
@@ -90,7 +93,9 @@ describe('currencyMapValidation in constructor', () => {
 
 describe('isCurrencyCompatibleWithCountry', () => {
   const currenciesToCountries = { EUR: ['FR', 'DE'] };
-  const ch = new CurrencyHelper({ currenciesToCountries });
+  const ch = new CurrencyHelper({
+    currenciesToCountries,
+  } as unknown as ConfigType);
 
   it('returns true if valid', () => {
     expect(ch.isCurrencyCompatibleWithCountry('EUR', 'FR')).toBe(true);
@@ -119,7 +124,7 @@ describe('getPayPalAmountStringFromAmountInCents', () => {
   const ch = new CurrencyHelper({
     currenciesToCountries,
     subscriptions: payPalEnabledSubscriptionsConfig,
-  });
+  } as unknown as ConfigType);
 
   it('converts amount in cents to amount string', () => {
     expect(ch.getPayPalAmountStringFromAmountInCents(1099)).toBe('10.99');

--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.spec.ts
@@ -34,6 +34,7 @@ function deepCopy(object: any) {
 }
 
 describe('StripeFirestore', () => {
+  const firestorePrefix = 'mock-fxa-';
   let firestore: any;
   let stripe: any;
   let customerCollectionDbRef: any;
@@ -48,7 +49,8 @@ describe('StripeFirestore', () => {
     stripeFirestore = new StripeFirestore(
       firestore,
       customerCollectionDbRef,
-      stripe
+      stripe,
+      firestorePrefix
     );
   });
 
@@ -56,7 +58,8 @@ describe('StripeFirestore', () => {
     const stripeFirestore = new StripeFirestore(
       firestore,
       customerCollectionDbRef,
-      stripe
+      stripe,
+      firestorePrefix
     );
     expect(stripeFirestore).toBeTruthy();
   });

--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.spec.ts
@@ -35,13 +35,13 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     expect(invoice.line_items).toEqual(expectedLineItems);
     expect(invoice.total).toBe(previewInvoiceWithTax.total);
     expect(invoice.subtotal).toBe(previewInvoiceWithTax.subtotal);
-    expect(invoice.tax[0].amount).toBe(
+    expect(invoice.tax?.[0].amount).toBe(
       previewInvoiceWithTax.total_tax_amounts[0].amount
     );
-    expect(invoice.tax[0].display_name).toBe(
+    expect(invoice.tax?.[0].display_name).toBe(
       previewInvoiceWithTax.total_tax_amounts[0].tax_rate.display_name
     );
-    expect(invoice.tax[0].inclusive).toBe(true);
+    expect(invoice.tax?.[0].inclusive).toBe(true);
     expect(invoice.discount).toBeUndefined();
   });
 
@@ -52,21 +52,21 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     ]);
     expect(invoice.total).toBe(previewInvoiceWithDiscountAndTax.total);
     expect(invoice.subtotal).toBe(previewInvoiceWithDiscountAndTax.subtotal);
-    expect(invoice.tax[0].amount).toBe(
+    expect(invoice.tax?.[0].amount).toBe(
       previewInvoiceWithDiscountAndTax.total_tax_amounts[0].amount
     );
-    expect(invoice.tax[0].display_name).toBe(
+    expect(invoice.tax?.[0].display_name).toBe(
       previewInvoiceWithDiscountAndTax.total_tax_amounts[0].tax_rate
         .display_name
     );
-    expect(invoice.tax[0].inclusive).toBe(true);
-    expect(invoice.discount.amount).toBe(
+    expect(invoice.tax?.[0].inclusive).toBe(true);
+    expect(invoice.discount?.amount).toBe(
       previewInvoiceWithDiscountAndTax.total_discount_amounts[0].amount
     );
-    expect(invoice.discount.amount_off).toBe(
+    expect(invoice.discount?.amount_off).toBe(
       previewInvoiceWithDiscountAndTax.discount.coupon.amount_off
     );
-    expect(invoice.discount.percent_off).toBe(
+    expect(invoice.discount?.percent_off).toBe(
       previewInvoiceWithDiscountAndTax.discount.coupon.percent_off
     );
   });
@@ -82,11 +82,11 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
 
     expect(invoice.total).toBe(invoicePreview.total);
     expect(invoice.subtotal).toBe(invoicePreview.subtotal);
-    expect(invoice.tax[0].amount).toBe(
+    expect(invoice.tax?.[0].amount).toBe(
       invoicePreview.total_tax_amounts[0].amount
     );
-    expect(invoice.tax[0].display_name).toBeUndefined();
-    expect(invoice.tax[0].inclusive).toBe(true);
+    expect(invoice.tax?.[0].display_name).toBeUndefined();
+    expect(invoice.tax?.[0].inclusive).toBe(true);
   });
 
   it('formats an invoice with a prorated amount', () => {
@@ -103,13 +103,13 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     expect(invoice.line_items).toEqual(expectedLineItems);
     expect(invoice.total).toBe(previewInvoiceWithTax.total);
     expect(invoice.subtotal).toBe(previewInvoiceWithTax.subtotal);
-    expect(invoice.tax[0].amount).toBe(
+    expect(invoice.tax?.[0].amount).toBe(
       previewInvoiceWithTax.total_tax_amounts[0].amount
     );
-    expect(invoice.tax[0].display_name).toBe(
+    expect(invoice.tax?.[0].display_name).toBe(
       previewInvoiceWithTax.total_tax_amounts[0].tax_rate.display_name
     );
-    expect(invoice.tax[0].inclusive).toBe(true);
+    expect(invoice.tax?.[0].inclusive).toBe(true);
     expect(invoice.discount).toBeUndefined();
     expect(invoice.one_time_charge).toBe(proratedInvoice.total);
     expect(invoice.prorated_amount).toBe(proratedInvoice.lines.data[0].amount);
@@ -126,13 +126,13 @@ describe('stripeInvoiceToLatestInvoiceItemsDTO', () => {
     expect(invoice.line_items).toEqual(expectedLineItems);
     expect(invoice.total).toBe(previewInvoiceWithTax.total);
     expect(invoice.subtotal).toBe(previewInvoiceWithTax.subtotal);
-    expect(invoice.tax[0].amount).toBe(
+    expect(invoice.tax?.[0].amount).toBe(
       previewInvoiceWithTax.total_tax_amounts[0].amount
     );
-    expect(invoice.tax[0].display_name).toBe(
+    expect(invoice.tax?.[0].display_name).toBe(
       previewInvoiceWithTax.total_tax_amounts[0].tax_rate.display_name
     );
-    expect(invoice.tax[0].inclusive).toBe(true);
+    expect(invoice.tax?.[0].inclusive).toBe(true);
     expect(invoice.discount).toBeUndefined();
   });
 
@@ -142,21 +142,21 @@ describe('stripeInvoiceToLatestInvoiceItemsDTO', () => {
     );
     expect(invoice.total).toBe(previewInvoiceWithDiscountAndTax.total);
     expect(invoice.subtotal).toBe(previewInvoiceWithDiscountAndTax.subtotal);
-    expect(invoice.tax[0].amount).toBe(
+    expect(invoice.tax?.[0].amount).toBe(
       previewInvoiceWithDiscountAndTax.total_tax_amounts[0].amount
     );
-    expect(invoice.tax[0].display_name).toBe(
+    expect(invoice.tax?.[0].display_name).toBe(
       previewInvoiceWithDiscountAndTax.total_tax_amounts[0].tax_rate
         .display_name
     );
-    expect(invoice.tax[0].inclusive).toBe(true);
-    expect(invoice.discount.amount).toBe(
+    expect(invoice.tax?.[0].inclusive).toBe(true);
+    expect(invoice.discount?.amount).toBe(
       previewInvoiceWithDiscountAndTax.total_discount_amounts[0].amount
     );
-    expect(invoice.discount.amount_off).toBe(
+    expect(invoice.discount?.amount_off).toBe(
       previewInvoiceWithDiscountAndTax.discount.coupon.amount_off
     );
-    expect(invoice.discount.percent_off).toBe(
+    expect(invoice.discount?.percent_off).toBe(
       previewInvoiceWithDiscountAndTax.discount.coupon.percent_off
     );
   });

--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.spec.ts
@@ -181,8 +181,8 @@ describe('SubscriptionReminders', () => {
       );
       const actualStartS = actual.start.toSeconds();
       const actualEndS = actual.end.toSeconds();
-      expect(actualStartS).toEqual(expected.start.toSeconds());
-      expect(actualEndS).toEqual(expected.end.toSeconds());
+      expect(actualStartS).toEqual(expected.start?.toSeconds());
+      expect(actualEndS).toEqual(expected.end?.toSeconds());
       expect(actualEndS - actualStartS).toEqual(S_IN_A_DAY);
       DateTime.utc = realDateTimeUtc;
     });
@@ -1631,7 +1631,7 @@ describe('SubscriptionReminders', () => {
       reminder.mailer.sendSubscriptionEndingReminderEmail = jest
         .fn()
         .mockResolvedValue(true);
-      reminder.updateSentEmail = jest.fn().mockResolvedValue();
+      reminder.updateSentEmail = jest.fn().mockResolvedValue(undefined);
       mockStripeHelper.formatSubscriptionForEmail = jest
         .fn()
         .mockResolvedValue(mockFormattedSubscription);
@@ -1888,13 +1888,19 @@ describe('SubscriptionReminders', () => {
       expect(sendRenewalStub).toHaveBeenCalledTimes(2);
 
       // First call: yearly plans with 15-day duration
-      const firstCallArgs = sendRenewalStub.mock.calls[0];
+      const firstCallArgs = sendRenewalStub.mock.calls[0] as [
+        Array<{ id: string }>,
+        Duration,
+      ];
       expect(firstCallArgs[0].length).toEqual(1);
       expect(firstCallArgs[0][0].id).toEqual(yearlyPlan.id);
       expect(firstCallArgs[1].as('days')).toEqual(15);
 
       // Second call: monthly plans with 7-day duration
-      const secondCallArgs = sendRenewalStub.mock.calls[1];
+      const secondCallArgs = sendRenewalStub.mock.calls[1] as [
+        Array<{ id: string }>,
+        Duration,
+      ];
       expect(secondCallArgs[0].length).toEqual(2);
       expect(secondCallArgs[0][0].id).toEqual(longPlan1.id);
       expect(secondCallArgs[0][1].id).toEqual(longPlan2.id);

--- a/packages/fxa-auth-server/lib/push.spec.ts
+++ b/packages/fxa-auth-server/lib/push.spec.ts
@@ -22,7 +22,7 @@ let pushPayloadsSchema: any = null;
 function getPushPayloadsSchema() {
   if (!pushPayloadsSchema) {
     const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
-    pushPayloadsSchema = JSON.parse(fs.readFileSync(schemaPath));
+    pushPayloadsSchema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
   }
   return pushPayloadsSchema;
 }

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -762,7 +762,7 @@ describe('deleteAccountIfUnverified', () => {
   it('should delete a Stripe customer with no subscriptions', async () => {
     const mockStripeHelper = {
       hasActiveSubscription: async () => Promise.resolve(false),
-      removeCustomer: jest.fn().mockResolvedValue(),
+      removeCustomer: jest.fn().mockResolvedValue(undefined),
     };
 
     await deleteAccountIfUnverified(
@@ -2522,9 +2522,11 @@ describe('/account/login', () => {
     mockMailer.sendVerifyShortCodeEmail = jest.fn(() => Promise.resolve());
     mockMailer.sendVerifyEmail.mockClear();
     // some tests change what these resolve (or reject) to, so we completely reset
-    mockFxaMailer.sendNewDeviceLoginEmail = jest.fn().mockResolvedValue();
-    mockFxaMailer.sendVerifyEmail = jest.fn().mockResolvedValue();
-    mockFxaMailer.sendVerifyLoginEmail = jest.fn().mockResolvedValue();
+    mockFxaMailer.sendNewDeviceLoginEmail = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    mockFxaMailer.sendVerifyEmail = jest.fn().mockResolvedValue(undefined);
+    mockFxaMailer.sendVerifyLoginEmail = jest.fn().mockResolvedValue(undefined);
     mockDB.createSessionToken.mockClear();
     mockDB.sessions.mockClear();
     mockMetricsContext.stash.mockClear();
@@ -5113,7 +5115,7 @@ describe('/account/metrics_opt', () => {
   }
 
   it('should call setMetricsOpt and notify services on opt-out', () => {
-    const setMetricsOptStub = jest.fn().mockResolvedValue();
+    const setMetricsOptStub = jest.fn().mockResolvedValue(undefined);
     const route = buildRoute(setMetricsOptStub);
     const request = mocks.mockRequest({
       credentials: { uid, email },
@@ -5130,7 +5132,7 @@ describe('/account/metrics_opt', () => {
   });
 
   it('should call setMetricsOpt and notify services on opt-in', () => {
-    const setMetricsOptStub = jest.fn().mockResolvedValue();
+    const setMetricsOptStub = jest.fn().mockResolvedValue(undefined);
     const route = buildRoute(setMetricsOptStub);
     const request = mocks.mockRequest({
       credentials: { uid, email },
@@ -5156,7 +5158,7 @@ describe('/account/emails', () => {
       account: jest.fn().mockResolvedValue({
         uid: 'account-123',
         email: 'signup@example.com',
-        primaryEmail: { email: 'signup+1@example.com' }
+        primaryEmail: { email: 'signup+1@example.com' },
       }),
     };
     config = {};
@@ -5172,7 +5174,7 @@ describe('/account/emails', () => {
     expect(db.account).toHaveBeenCalledWith('account-123');
     expect(resp).toEqual({
       originalEmail: 'signup@example.com',
-      primaryEmail: 'signup+1@example.com'
+      primaryEmail: 'signup+1@example.com',
     });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/cms.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/cms.spec.ts
@@ -279,7 +279,7 @@ describe('cms', () => {
         'ftl-content'
       );
       mockLocalization.findExistingPR.mockResolvedValue(null);
-      mockLocalization.createGitHubPR.mockResolvedValue();
+      mockLocalization.createGitHubPR.mockResolvedValue(undefined);
 
       request = {
         headers: {
@@ -393,7 +393,7 @@ describe('cms', () => {
         },
         payload: { ...webhookPayload, event: 'entry.publish' },
       };
-      mockCmsManager.invalidateCache.mockResolvedValue();
+      mockCmsManager.invalidateCache.mockResolvedValue(undefined);
 
       const result = await route.handler(req);
       expect(result).toEqual({ success: true });

--- a/packages/fxa-auth-server/lib/routes/ip-profiling.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/ip-profiling.spec.ts
@@ -71,8 +71,8 @@ function mockRequest(data: any) {
       credentials: data.credentials,
     },
     clearMetricsContext: jest.fn(),
-    emitMetricsEvent: jest.fn().mockResolvedValue(),
-    emitRouteFlowEvent: jest.fn().mockResolvedValue(),
+    emitMetricsEvent: jest.fn().mockResolvedValue(undefined),
+    emitRouteFlowEvent: jest.fn().mockResolvedValue(undefined),
     gatherMetricsContext: jest
       .fn()
       .mockImplementation((d: any) => Promise.resolve(d)),
@@ -86,10 +86,10 @@ function mockRequest(data: any) {
     params: {},
     path: data.path,
     payload: data.payload || {},
-    propagateMetricsContext: jest.fn().mockResolvedValue(),
+    propagateMetricsContext: jest.fn().mockResolvedValue(undefined),
     query: data.query || {},
     setMetricsFlowCompleteSignal: jest.fn(),
-    stashMetricsContext: jest.fn().mockResolvedValue(),
+    stashMetricsContext: jest.fn().mockResolvedValue(undefined),
     validateMetricsContext: jest.fn().mockReturnValue(true),
   };
 }

--- a/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
@@ -765,7 +765,7 @@ describe('/oauth/token POST', () => {
 
     it('handles token exchange and passes existingDeviceId to newTokenNotification', async () => {
       const PROFILE_SCOPE = 'profile';
-      const newTokenNotificationStub = jest.fn().mockResolvedValue();
+      const newTokenNotificationStub = jest.fn().mockResolvedValue(undefined);
       const sessionTokenStub = jest
         .fn()
         .mockRejectedValue(new Error('should not be called'));
@@ -861,7 +861,7 @@ describe('/oauth/token POST', () => {
 
     it('handles token exchange when no existing device is found (existingDeviceId is undefined)', async () => {
       const PROFILE_SCOPE = 'profile';
-      const newTokenNotificationStub = jest.fn().mockResolvedValue();
+      const newTokenNotificationStub = jest.fn().mockResolvedValue(undefined);
       jest.resetModules();
       jest.doMock('../../oauth/assertion', () => async () => true);
       jest.doMock(
@@ -1289,7 +1289,7 @@ describe('/oauth/token POST', () => {
 
   describe('fxa-credentials with reason=token_migration', () => {
     it('calls newTokenNotification with skipEmail: true when reason is token_migration', async () => {
-      const newTokenNotificationStub = jest.fn().mockResolvedValue();
+      const newTokenNotificationStub = jest.fn().mockResolvedValue(undefined);
       const sessionTokenStub = jest
         .fn()
         .mockRejectedValue(new Error('should not be called'));
@@ -1354,7 +1354,7 @@ describe('/oauth/token POST', () => {
     });
 
     it('calls newTokenNotification with skipEmail: false when reason is not provided', async () => {
-      const newTokenNotificationStub = jest.fn().mockResolvedValue();
+      const newTokenNotificationStub = jest.fn().mockResolvedValue(undefined);
       jest.resetModules();
       jest.doMock('../../oauth/assertion', () => async () => true);
       jest.doMock(

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
@@ -117,7 +117,7 @@ describe('/recovery_phone', () => {
     const route = getRoute(routes, req.path, req.method);
     expect(route).toBeDefined();
     request = mockRequest(req);
-    request.emitMetricsEvent = jest.fn().mockResolvedValue();
+    request.emitMetricsEvent = jest.fn().mockResolvedValue(undefined);
     return await route.handler(request);
   }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.spec.ts
@@ -536,7 +536,7 @@ describe('PayPalNotificationHandler', () => {
     });
 
     it('should only update the database BA if the IPN and Customer BA ID dont match', async () => {
-      dbStub.updatePayPalBA.mockResolvedValue();
+      dbStub.updatePayPalBA.mockResolvedValue(undefined);
       stripeHelper.getCustomerPaypalAgreement = jest
         .fn()
         .mockReturnValue(undefined);
@@ -584,7 +584,7 @@ describe('PayPalNotificationHandler', () => {
       dbStub.getPayPalBAByBAId.mockResolvedValue(billingAgreement);
       dbStub.Account.findByUid = jest.fn().mockResolvedValue(account);
       stripeHelper.fetchCustomer = jest.fn().mockResolvedValue(fetchCustomer);
-      handler.removeBillingAgreement = jest.fn().mockResolvedValue();
+      handler.removeBillingAgreement = jest.fn().mockResolvedValue(undefined);
       stripeHelper.getPaymentProvider = jest.fn().mockResolvedValue('paypal');
       stripeHelper.formatSubscriptionsForEmails = jest.fn().mockReturnValue([]);
 
@@ -706,7 +706,7 @@ describe('PayPalNotificationHandler', () => {
       dbStub.getPayPalBAByBAId.mockResolvedValue(billingAgreement);
       dbStub.Account.findByUid = jest.fn().mockResolvedValue(account);
       stripeHelper.fetchCustomer = jest.fn().mockResolvedValue(fetchCustomer);
-      handler.removeBillingAgreement = jest.fn().mockResolvedValue();
+      handler.removeBillingAgreement = jest.fn().mockResolvedValue(undefined);
       stripeHelper.getPaymentProvider = jest.fn().mockResolvedValue('paypal');
 
       const result = await handler.handleMpCancel(
@@ -749,7 +749,7 @@ describe('PayPalNotificationHandler', () => {
       dbStub.getPayPalBAByBAId.mockResolvedValue(billingAgreement);
       dbStub.Account.findByUid = jest.fn().mockResolvedValue(mockAcct);
       stripeHelper.fetchCustomer = jest.fn().mockResolvedValue(mockCustomer);
-      handler.removeBillingAgreement = jest.fn().mockResolvedValue();
+      handler.removeBillingAgreement = jest.fn().mockResolvedValue(undefined);
       stripeHelper.getPaymentProvider = jest.fn().mockReturnValue('paypal');
       stripeHelper.formatSubscriptionsForEmails = jest
         .fn()

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.spec.ts
@@ -543,7 +543,9 @@ describe('DirectStripeRoutes', () => {
 
     describe('customer is not found', () => {
       it('returns an empty array', async () => {
-        directStripeRoutesInstance.stripeHelper.fetchCustomer.mockResolvedValue();
+        directStripeRoutesInstance.stripeHelper.fetchCustomer.mockResolvedValue(
+          undefined
+        );
         const expected: any[] = [];
         const actual =
           await directStripeRoutesInstance.listActive(VALID_REQUEST);

--- a/packages/fxa-auth-server/lib/routes/subscriptions/support.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/support.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import nock from 'nock';
+import zendesk from 'node-zendesk';
 import { createMock } from '@golevelup/ts-jest';
 import { AuthLogger } from '../../types';
 
@@ -222,13 +223,15 @@ describe('support', () => {
         setupNockForSuccess();
         const spy = jest.spyOn(zendeskClient.requests, 'create');
         const res = await runTest('/support/ticket', requestOptions);
-        const zendeskReq = spy.mock.calls[0][0].request;
+        const zendeskReq = (
+          spy.mock.calls[0][0] as zendesk.Requests.CreatePayload
+        ).request;
         expect(zendeskReq.subject).toBe(
           `${requestOptions.payload.productName}: ${requestOptions.payload.subject}`
         );
         expect(zendeskReq.comment.body).toBe(requestOptions.payload.message);
         expect(
-          zendeskReq.custom_fields.map((field: any) => field.value)
+          zendeskReq.custom_fields?.map((field: any) => field.value)
         ).toEqual(customFieldsOnTicket);
         expect(res).toEqual({ success: true, ticket: 91 });
 
@@ -266,13 +269,15 @@ describe('support', () => {
           .reply(200, MOCK_UPDATE_REPLY);
         const spy = jest.spyOn(zendeskClient.requests, 'create');
         const res = await runTest('/support/ticket', requestOptions);
-        const zendeskReq = spy.mock.calls[0][0].request;
+        const zendeskReq = (
+          spy.mock.calls[0][0] as zendesk.Requests.CreatePayload
+        ).request;
         expect(zendeskReq.subject).toBe(
           `${requestOptions.payload.productName}: ${requestOptions.payload.subject}`
         );
         expect(zendeskReq.comment.body).toBe(requestOptions.payload.message);
         expect(
-          zendeskReq.custom_fields.map((field: any) => field.value)
+          zendeskReq.custom_fields?.map((field: any) => field.value)
         ).toEqual(customFieldsOnTicket);
         expect(res).toEqual({ success: true, ticket: 91 });
         nock.isDone();
@@ -304,13 +309,15 @@ describe('support', () => {
           auth: { strategy: 'supportSecret' },
           payload: { ...requestOptions.payload, email: TEST_EMAIL },
         });
-        const zendeskReq = spy.mock.calls[0][0].request;
+        const zendeskReq = (
+          spy.mock.calls[0][0] as zendesk.Requests.CreatePayload
+        ).request;
         expect(zendeskReq.subject).toBe(
           `${requestOptions.payload.productName}: ${requestOptions.payload.subject}`
         );
         expect(zendeskReq.comment.body).toBe(requestOptions.payload.message);
         expect(
-          zendeskReq.custom_fields.map((field: any) => field.value)
+          zendeskReq.custom_fields?.map((field: any) => field.value)
         ).toEqual(customFieldsOnTicket);
         expect(customs.check).toHaveBeenCalledTimes(1);
         expect(res).toEqual({ success: true, ticket: 91 });
@@ -332,13 +339,15 @@ describe('support', () => {
           auth: { strategy: 'supportSecret' },
           payload: { ...requestOptions.payload, email: TEST_EMAIL },
         });
-        const zendeskReq = spy.mock.calls[0][0].request;
+        const zendeskReq = (
+          spy.mock.calls[0][0] as zendesk.Requests.CreatePayload
+        ).request;
         expect(zendeskReq.subject).toBe(
           `${requestOptions.payload.productName}: ${requestOptions.payload.subject}`
         );
         expect(zendeskReq.comment.body).toBe(requestOptions.payload.message);
         expect(
-          zendeskReq.custom_fields.map((field: any) => field.value)
+          zendeskReq.custom_fields?.map((field: any) => field.value)
         ).toEqual(customFieldsOnTicket);
         expect(res).toEqual({ success: true, ticket: 91 });
         nock.isDone();
@@ -370,8 +379,14 @@ describe('support', () => {
           ...requestOptions,
           payload: { ...requestOptions.payload, brand_id: 12345 },
         });
-        const zendeskReq = spy.mock.calls[0][0].request;
-        expect(zendeskReq.brand_id).toBe(12345);
+        const zendeskReq = (
+          spy.mock.calls[0][0] as zendesk.Requests.CreatePayload
+        ).request;
+        // node-zendesk's CreateModel type omits `brand_id`, though the Zendesk
+        // API accepts it and the route forwards it (see support.ts).
+        expect(
+          (zendeskReq as typeof zendeskReq & { brand_id?: number }).brand_id
+        ).toBe(12345);
         expect(res).toEqual({ success: true, ticket: 91 });
         nock.isDone();
         spy.mockRestore();

--- a/packages/fxa-auth-server/lib/routes/utils/clients.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/clients.spec.ts
@@ -44,8 +44,8 @@ function mockRequest(data: any) {
       credentials: data.credentials,
     },
     clearMetricsContext: jest.fn(),
-    emitMetricsEvent: jest.fn().mockResolvedValue(),
-    emitRouteFlowEvent: jest.fn().mockResolvedValue(),
+    emitMetricsEvent: jest.fn().mockResolvedValue(undefined),
+    emitRouteFlowEvent: jest.fn().mockResolvedValue(undefined),
     gatherMetricsContext: jest
       .fn()
       .mockImplementation((d: any) => Promise.resolve(d)),

--- a/packages/fxa-auth-server/lib/routes/utils/cms/localization.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/cms/localization.spec.ts
@@ -407,7 +407,9 @@ describe('CMSLocalization', () => {
         localization.octokit.repos.getContent.mockResolvedValue({
           data: mockFileData,
         });
-        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue();
+        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue(
+          undefined
+        );
 
         await localization.updateExistingPR(123, 'test content');
 
@@ -432,7 +434,9 @@ describe('CMSLocalization', () => {
         localization.octokit.repos.getContent.mockRejectedValue(
           new Error('Not Found')
         );
-        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue();
+        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue(
+          undefined
+        );
 
         await localization.updateExistingPR(123, 'test content');
 
@@ -462,11 +466,13 @@ describe('CMSLocalization', () => {
         localization.octokit.git.getRef.mockResolvedValue({
           data: mockRefData,
         });
-        localization.octokit.git.createRef.mockResolvedValue();
+        localization.octokit.git.createRef.mockResolvedValue(undefined);
         localization.octokit.repos.getContent.mockRejectedValue(
           new Error('Not Found')
         );
-        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue();
+        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue(
+          undefined
+        );
         localization.octokit.pulls.create.mockResolvedValue({
           data: mockPRData,
         });
@@ -505,11 +511,13 @@ describe('CMSLocalization', () => {
         localization.octokit.git.getRef.mockResolvedValue({
           data: mockRefData,
         });
-        localization.octokit.git.createRef.mockResolvedValue();
+        localization.octokit.git.createRef.mockResolvedValue(undefined);
         localization.octokit.repos.getContent.mockResolvedValue({
           data: mockFileData,
         });
-        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue();
+        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue(
+          undefined
+        );
         localization.octokit.pulls.create.mockResolvedValue({
           data: mockPRData,
         });

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.spec.ts
@@ -74,8 +74,8 @@ function mockRequest(data: any) {
       credentials: data.credentials,
     },
     clearMetricsContext: jest.fn(),
-    emitMetricsEvent: jest.fn().mockResolvedValue(),
-    emitRouteFlowEvent: jest.fn().mockResolvedValue(),
+    emitMetricsEvent: jest.fn().mockResolvedValue(undefined),
+    emitRouteFlowEvent: jest.fn().mockResolvedValue(undefined),
     gatherMetricsContext: jest
       .fn()
       .mockImplementation((d: any) => Promise.resolve(d)),

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
@@ -82,11 +82,12 @@ describe('lib/senders/fxa-mailer', () => {
       acceptLanguage: 'en',
       timeZone: 'America/New_York',
       clientName: 'Test Client',
-      device: 'Firefox on Mac',
+      device: { uaBrowser: 'Firefox', uaOS: 'Mac OS X' },
       time: '10:00 AM',
       date: 'January 1, 2026',
       location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
       showBannerWarning: false,
+      sync: false,
     };
 
     function stubRender() {
@@ -217,11 +218,12 @@ describe('lib/senders/fxa-mailer', () => {
       acceptLanguage: 'en',
       timeZone: 'America/New_York',
       clientName: 'Test Client',
-      device: 'Firefox on Mac',
+      device: { uaBrowser: 'Firefox', uaOS: 'Mac OS X' },
       time: '10:00 AM',
       date: 'January 1, 2026',
       location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
       showBannerWarning: false,
+      sync: false,
       flowId: 'test-flow-id',
       deviceId: 'test-device-id',
     };

--- a/packages/fxa-auth-server/test/remote/account_activity.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_activity.in.spec.ts
@@ -35,7 +35,7 @@ async function ensureScope(scope: string) {
   // tolerate the unique-key collision when the scope is already present
   // (seeded from config, or left by a prior run on the shared test DB).
   try {
-    await db.registerScope({ scope, hasScopedKeys: false });
+    await (db as any).registerScope({ scope, hasScopedKeys: false });
   } catch (err: any) {
     if (err?.code !== 'ER_DUP_ENTRY') {
       throw err;

--- a/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
@@ -78,7 +78,6 @@ describe('isKnownService (config-driven)', () => {
   });
 
   it('falsy non-string input returns false', () => {
-    // @ts-expect-error - defensive falsy handling
     expect(db.isKnownService(undefined)).toBe(false);
   });
 });

--- a/packages/fxa-auth-server/test/remote/account_create_with_code.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code.in.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  getSharedTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 import * as otplib from 'otplib';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -110,7 +113,7 @@ describe.each(testVersions)(
         (server.config as any).otp,
         { secret, epoch: Date.now() / 1000 - 60 * 60 } // Code 60mins old
       );
-      const expiredCode = futureAuthenticator.generate();
+      const expiredCode = futureAuthenticator.generate(secret as string);
 
       await expect(
         client.verifyShortCodeEmail(expiredCode)
@@ -128,7 +131,9 @@ describe.each(testVersions)(
       const emailData = await server.mailbox.waitForEmail(email);
       expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
 
-      const invalidCode = String(Number(emailData.headers['x-verify-short-code']) + 1);
+      const invalidCode = String(
+        Number(emailData.headers['x-verify-short-code']) + 1
+      );
 
       await expect(
         client.verifyShortCodeEmail(invalidCode)
@@ -179,7 +184,7 @@ describe.each(testVersions)(
         { secret, epoch: Date.now() / 1000 - 60 * 10 } // Code 10mins old
       );
 
-      const previousWindowCode = futureAuthenticator.generate(secret);
+      const previousWindowCode = futureAuthenticator.generate(secret as string);
       const response = await client.verifyShortCodeEmail(previousWindowCode);
       expect(response).toBeTruthy();
     });
@@ -207,7 +212,7 @@ describe.each(testVersions)(
         { secret, epoch: Date.now() / 1000 + 60 * 30 } // Code 30mins in future
       );
 
-      const futureWindowCode = futureAuthenticator.generate(secret);
+      const futureWindowCode = futureAuthenticator.generate(secret as string);
 
       await expect(
         client.verifyShortCodeEmail(futureWindowCode)

--- a/packages/fxa-auth-server/test/remote/account_reset.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_reset.in.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 import { AuthServerError } from '../support/helpers/test-utils';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -69,7 +72,7 @@ describe.each(testVersions)(
 
       const emailData = await server.mailbox.waitForEmail(email);
       const link = emailData.headers['x-link'];
-      const query = Object.fromEntries(new URL(link).searchParams);
+      const query = Object.fromEntries(new URL(link as string).searchParams);
       expect(query.email).toBeTruthy();
 
       if (testOptions.version === 'V2') {
@@ -120,7 +123,7 @@ describe.each(testVersions)(
 
       const emailData = await server.mailbox.waitForEmail(email);
       const link = emailData.headers['x-link'];
-      const query = Object.fromEntries(new URL(link).searchParams);
+      const query = Object.fromEntries(new URL(link as string).searchParams);
       expect(query.email).toBeTruthy();
 
       if (testOptions.version === 'V2') {

--- a/packages/fxa-auth-server/test/remote/account_signin_verification.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_signin_verification.in.spec.ts
@@ -2,8 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
-import { generateMetricsContext, AuthServerError } from '../support/helpers/test-utils';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
+import {
+  generateMetricsContext,
+  AuthServerError,
+} from '../support/helpers/test-utils';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Client = require('../client')();
 
@@ -163,7 +169,7 @@ describe.each(testVersions)(
 
       const emailData = await server.mailbox.waitForEmail(email);
       const link = emailData.headers['x-link'];
-      const query = new URL(link).searchParams;
+      const query = new URL(link as string).searchParams;
       expect(query.get('uid')).toBeTruthy();
       expect(query.get('code')).toBeTruthy();
       expect(query.get('service')).toBe(options.service);
@@ -195,7 +201,7 @@ describe.each(testVersions)(
 
       const emailData = await server.mailbox.waitForEmail(email);
       const link = emailData.headers['x-link'];
-      const query = new URL(link).searchParams;
+      const query = new URL(link as string).searchParams;
       expect(query.get('uid')).toBeTruthy();
       expect(query.get('code')).toBeTruthy();
       expect(query.get('service')).toBe(options.service);

--- a/packages/fxa-auth-server/test/remote/db.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/db.in.spec.ts
@@ -83,7 +83,7 @@ let db: any;
 let redis: any;
 
 beforeAll(async () => {
-  redis = IORedis.createClient({
+  redis = (IORedis as any).createClient({
     host: config.redis.host,
     port: config.redis.port,
     password: config.redis.password,

--- a/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
@@ -948,7 +948,15 @@ describe('#integration - /v1', function () {
         const code_verifier = 'WLjNEANMbRNUSG0uQsUZMQGgIL5FUknGz2jRipY79ZC';
         const code_challenge = 'SWac3rF5sKcyAtsXGMO9feaKqpzgCoA2zowbi20F_0c';
         const secret2 = unique.secret();
-        const client2 = {
+        const client2: {
+          name: string;
+          hashedSecret: any;
+          redirectUri: string;
+          imageUri: string;
+          trusted: boolean;
+          publicClient: boolean;
+          id?: Buffer;
+        } = {
           name: 'client2Public',
           hashedSecret: encrypt.hash(secret2),
           redirectUri: 'https://example.domain',
@@ -964,7 +972,7 @@ describe('#integration - /v1', function () {
               .post({
                 url: '/authorization',
                 payload: authParams({
-                  client_id: client2.id.toString('hex'),
+                  client_id: client2.id?.toString('hex'),
                   response_type: 'code',
                   code_challenge_method: 'S256',
                   code_challenge: code_challenge,
@@ -980,7 +988,7 @@ describe('#integration - /v1', function () {
             return Server.api.post({
               url: '/token',
               payload: {
-                client_id: client2.id.toString('hex'),
+                client_id: client2.id?.toString('hex'),
                 code: code,
                 code_verifier: code_verifier,
               },
@@ -1334,7 +1342,14 @@ describe('#integration - /v1', function () {
 
         it('must be a code owned by this client', function () {
           const secret2 = unique.secret();
-          const client2 = {
+          const client2: {
+            name: string;
+            hashedSecret: any;
+            redirectUri: string;
+            imageUri: string;
+            trusted: boolean;
+            id?: Buffer;
+          } = {
             name: 'client2',
             hashedSecret: encrypt.hash(secret2),
             redirectUri: 'https://example.domain',
@@ -1348,7 +1363,7 @@ describe('#integration - /v1', function () {
                 .post({
                   url: '/authorization',
                   payload: authParams({
-                    client_id: client2.id.toString('hex'),
+                    client_id: client2.id?.toString('hex'),
                   }),
                 })
                 .then(function (res) {
@@ -1381,7 +1396,15 @@ describe('#integration - /v1', function () {
             'QnuuNM5gfnJmWwIjiOKk2SKn8A89tph3-8BjNUUtooJ';
           const code_challenge = 'xWVKKAQVD9XSXT4Z4Oh8dLJ5pqrr0gQes2QwZOVJyAk';
           const secret2 = unique.secret();
-          const client2 = {
+          const client2: {
+            name: string;
+            hashedSecret: any;
+            redirectUri: string;
+            imageUri: string;
+            trusted: boolean;
+            publicClient: boolean;
+            id?: Buffer;
+          } = {
             name: 'client2Public',
             hashedSecret: encrypt.hash(secret2),
             redirectUri: 'https://example.domain',
@@ -1399,7 +1422,7 @@ describe('#integration - /v1', function () {
               .post({
                 url: '/authorization',
                 payload: authParams({
-                  client_id: client2.id.toString('hex'),
+                  client_id: client2.id?.toString('hex'),
                   response_type: 'code',
                   code_challenge_method: 'S256',
                   code_challenge: code_challenge,
@@ -1414,7 +1437,7 @@ describe('#integration - /v1', function () {
                 return Server.api.post({
                   url: '/token',
                   payload: {
-                    client_id: client2.id.toString('hex'),
+                    client_id: client2.id?.toString('hex'),
                     code: code,
                     code_verifier: code_verifier,
                   },
@@ -1435,7 +1458,7 @@ describe('#integration - /v1', function () {
               .post({
                 url: '/authorization',
                 payload: authParams({
-                  client_id: client2.id.toString('hex'),
+                  client_id: client2.id?.toString('hex'),
                   response_type: 'code',
                   code_challenge_method: 'S256',
                   code_challenge: code_challenge,
@@ -1450,7 +1473,7 @@ describe('#integration - /v1', function () {
                 return Server.api.post({
                   url: '/token',
                   payload: {
-                    client_id: client2.id.toString('hex'),
+                    client_id: client2.id?.toString('hex'),
                     code: code,
                     code_verifier: code_verifier_bad,
                   },
@@ -1470,7 +1493,7 @@ describe('#integration - /v1', function () {
               .post({
                 url: '/authorization',
                 payload: authParams({
-                  client_id: client2.id.toString('hex'),
+                  client_id: client2.id?.toString('hex'),
                   response_type: 'code',
                   code_challenge_method: 'S256',
                   code_challenge: code_challenge,
@@ -1485,7 +1508,7 @@ describe('#integration - /v1', function () {
                 return Server.api.post({
                   url: '/token',
                   payload: {
-                    client_id: client2.id.toString('hex'),
+                    client_id: client2.id?.toString('hex'),
                     code: code,
                     code_verifier: code_verifier,
                   },
@@ -1502,7 +1525,15 @@ describe('#integration - /v1', function () {
           });
 
           it('must be a code owned by this client', function () {
-            const client3 = {
+            const client3: {
+              name: string;
+              hashedSecret: any;
+              redirectUri: string;
+              imageUri: string;
+              trusted: boolean;
+              publicClient: boolean;
+              id?: Buffer;
+            } = {
               name: 'client3Public',
               hashedSecret: encrypt.hash(secret2),
               redirectUri: 'https://example.domain',
@@ -1517,7 +1548,7 @@ describe('#integration - /v1', function () {
                   .post({
                     url: '/authorization',
                     payload: authParams({
-                      client_id: client3.id.toString('hex'),
+                      client_id: client3.id?.toString('hex'),
                       response_type: 'code',
                       code_challenge_method: 'S256',
                       code_challenge: code_challenge,
@@ -1534,7 +1565,7 @@ describe('#integration - /v1', function () {
                   url: '/token',
                   payload: {
                     // client2 is trying to use client3's code
-                    client_id: client2.id.toString('hex'),
+                    client_id: client2.id?.toString('hex'),
                     code: code,
                     code_verifier: code_verifier,
                   },

--- a/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
@@ -21,7 +21,7 @@ import {
 
 const Client = require('../client')();
 let server: TestServerInstance;
-let redis: Redis | undefined;
+let redis: Redis.Redis | undefined;
 let db: Awaited<ReturnType<typeof setupAccountDatabase>> | undefined;
 let passkeyRpId: string;
 let passkeyOrigin: string;

--- a/packages/fxa-auth-server/test/remote/password_change.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/password_change.in.spec.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  getSharedTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 import url from 'url';
 
 const Client = require('../client')();
@@ -73,7 +77,11 @@ describe.each(testVersions)(
       expect(status.sessionVerified).toBe(false);
 
       try {
-        await client.changePassword(newPassword, undefined, client.sessionToken);
+        await client.changePassword(
+          newPassword,
+          undefined,
+          client.sessionToken
+        );
         fail('should have thrown');
       } catch (err: unknown) {
         const error = err as AuthServerError;
@@ -115,7 +123,7 @@ describe.each(testVersions)(
       const emailData = await server.mailbox.waitForEmail(email);
       expect(emailData.headers['subject']).toBe('Password updated');
       const link = emailData.headers['x-link'];
-      const query = url.parse(link, true).query;
+      const query = url.parse(link as string, true).query;
       expect(query.email).toBeTruthy();
 
       const statusAfter = await client.emailStatus();
@@ -183,7 +191,9 @@ describe.each(testVersions)(
       );
 
       const profileAfter = await client.accountProfile();
-      expect(profileBefore['keysChangedAt']).toBe(profileAfter['keysChangedAt']);
+      expect(profileBefore['keysChangedAt']).toBe(
+        profileAfter['keysChangedAt']
+      );
     });
 
     it('wrong password on change start', async () => {
@@ -314,7 +324,11 @@ describe.each(testVersions)(
         );
       }
 
-      async function loginUser(loginEmail: string, loginPassword: string, options?: any) {
+      async function loginUser(
+        loginEmail: string,
+        loginPassword: string,
+        options?: any
+      ) {
         return await Client.login(server.publicUrl, loginEmail, loginPassword, {
           ...testOptions,
           ...options,
@@ -373,7 +387,11 @@ describe.each(testVersions)(
         };
       }
 
-      async function validatePasswordChanged(victim: any, res: any, error: any) {
+      async function validatePasswordChanged(
+        victim: any,
+        res: any,
+        error: any
+      ) {
         try {
           await victim.setupCredentials(victim.email, 'ok');
           await victim.auth();

--- a/packages/fxa-auth-server/test/remote/password_forgot.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/password_forgot.in.spec.ts
@@ -85,11 +85,17 @@ describe.each(testVersions)(
       const code = emailData.headers['x-password-forgot-otp'];
 
       await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
-      await resetPassword(client, code, newPassword, undefined, options);
+      await resetPassword(
+        client,
+        code as string,
+        newPassword,
+        undefined,
+        options
+      );
 
       const resetEmailData = await server.mailbox.waitForEmail(email);
       const link = resetEmailData.headers['x-link'];
-      const query = url.parse(link, true).query;
+      const query = url.parse(link as string, true).query;
       expect(query.email).toBeTruthy();
       expect(resetEmailData.headers['x-template-name']).toBe('passwordReset');
 

--- a/packages/fxa-auth-server/test/remote/payments/configuration/manager.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/payments/configuration/manager.in.spec.ts
@@ -277,7 +277,7 @@ describe('#integration - PaymentConfigManager', () => {
 
     it('throws error on invalid product config', async () => {
       const newProduct = structuredClone(productConfig);
-      delete newProduct.urls;
+      delete (newProduct as Partial<typeof newProduct>).urls;
 
       try {
         await paymentConfigManager.validateProductConfig(newProduct);
@@ -301,7 +301,7 @@ describe('#integration - PaymentConfigManager', () => {
 
     it('throws error on invalid plan config', async () => {
       const newPlan = structuredClone(planConfig);
-      delete newPlan.active;
+      delete (newPlan as Partial<typeof newPlan>).active;
 
       try {
         await paymentConfigManager.validatePlanConfig(newPlan, randomUUID());
@@ -314,7 +314,7 @@ describe('#integration - PaymentConfigManager', () => {
     it('throws error if the plan has an invalid product id', async () => {
       const newPlan = structuredClone(planConfig);
       const product = (await paymentConfigManager.allProducts())[0];
-      delete newPlan.active;
+      delete (newPlan as Partial<typeof newPlan>).active;
 
       try {
         await paymentConfigManager.validatePlanConfig(newPlan, product.id);
@@ -335,7 +335,7 @@ describe('#integration - PaymentConfigManager', () => {
 
     it('throws if the product is invalid', async () => {
       const newProduct = structuredClone(productConfig);
-      delete newProduct.urls;
+      delete (newProduct as Partial<typeof newProduct>).urls;
       expect(await paymentConfigManager.allProducts()).toHaveLength(1);
       try {
         await paymentConfigManager.storeProductConfig(newProduct, randomUUID());
@@ -369,7 +369,7 @@ describe('#integration - PaymentConfigManager', () => {
 
     it('throws if the plan is invalid', async () => {
       const newPlan = structuredClone(planConfig);
-      delete newPlan.active;
+      delete (newPlan as Partial<typeof newPlan>).active;
       expect(await paymentConfigManager.allPlans()).toHaveLength(1);
       try {
         await paymentConfigManager.storePlanConfig(newPlan, randomUUID());

--- a/packages/fxa-auth-server/test/remote/recovery_email_emails.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/recovery_email_emails.in.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 import crypto from 'crypto';
 
 const Client = require('../client')();
@@ -109,11 +112,17 @@ describe.each(testVersions)(
         expect(res.length).toBe(1);
 
         const emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
 
-        res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, secondEmail);
+        res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         res = await client.accountEmails();
@@ -133,7 +142,10 @@ describe.each(testVersions)(
               email: secondEmail,
               normalizedEmail: emailHelper.helpers.normalizeEmail(secondEmail),
               uid: Buffer.from(client.uid, 'hex'),
-              emailCode: Buffer.from(crypto.randomBytes(16).toString('hex'), 'hex'),
+              emailCode: Buffer.from(
+                crypto.randomBytes(16).toString('hex'),
+                'hex'
+              ),
               isVerified: 0,
               isPrimary: 0,
               createdAt: Date.now(),
@@ -176,7 +188,10 @@ describe.each(testVersions)(
               email: secondEmail,
               normalizedEmail: emailHelper.helpers.normalizeEmail(secondEmail),
               uid: Buffer.from(client.uid, 'hex'),
-              emailCode: Buffer.from(crypto.randomBytes(16).toString('hex'), 'hex'),
+              emailCode: Buffer.from(
+                crypto.randomBytes(16).toString('hex'),
+                'hex'
+              ),
               isVerified: 0,
               isPrimary: 0,
               createdAt: Date.now(),
@@ -205,11 +220,17 @@ describe.each(testVersions)(
         await client2.createEmail(client2Jwt, secondEmail);
 
         const emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
 
-        res = await client2.verifySecondaryEmailWithCode(client2Jwt, emailCode, secondEmail);
+        res = await client2.verifySecondaryEmailWithCode(
+          client2Jwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         res = await client.accountEmails();
@@ -245,11 +266,17 @@ describe.each(testVersions)(
 
         await client.createEmail(mfaJwt, secondEmail);
         const emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
 
-        const res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, secondEmail);
+        const res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         try {
@@ -275,9 +302,14 @@ describe.each(testVersions)(
         );
 
         const anotherClientJwt = await generateMfaJwt(anotherClient);
-        await anotherClient.createEmail(anotherClientJwt, anotherUserSecondEmail);
+        await anotherClient.createEmail(
+          anotherClientJwt,
+          anotherUserSecondEmail
+        );
 
-        const emailData = await server.mailbox.waitForEmail(anotherUserSecondEmail);
+        const emailData = await server.mailbox.waitForEmail(
+          anotherUserSecondEmail
+        );
         const emailCode = emailData['headers']['x-verify-code'];
         const res = await anotherClient.verifySecondaryEmailWithCode(
           anotherClientJwt,
@@ -349,10 +381,16 @@ describe.each(testVersions)(
 
         await client.createEmail(mfaJwt, secondEmail);
         const emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const emailCode = emailData['headers']['x-verify-code'];
 
-        let res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, secondEmail);
+        let res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         res = await client.accountEmails();
@@ -362,7 +400,9 @@ describe.each(testVersions)(
         expect(res[1].verified).toBe(true);
 
         const postVerifyEmailData = await server.mailbox.waitForEmail(email);
-        expect(postVerifyEmailData['headers']['x-template-name']).toBe('postVerifySecondary');
+        expect(postVerifyEmailData['headers']['x-template-name']).toBe(
+          'postVerifySecondary'
+        );
       });
 
       afterEach(async () => {
@@ -381,7 +421,9 @@ describe.each(testVersions)(
         expect(res[0].verified).toBe(true);
 
         const emailData = await server.mailbox.waitForEmail(email);
-        expect(emailData['headers']['x-template-name']).toBe('postRemoveSecondary');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'postRemoveSecondary'
+        );
       });
 
       it('resets account tokens when deleting an email', async () => {
@@ -447,11 +489,17 @@ describe.each(testVersions)(
         expect(res).toBeTruthy();
 
         let emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
 
-        res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, secondEmail);
+        res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         res = await client.accountEmails();
@@ -461,7 +509,9 @@ describe.each(testVersions)(
         expect(res[1].verified).toBe(true);
 
         emailData = await server.mailbox.waitForEmail(email);
-        expect(emailData['headers']['x-template-name']).toBe('postVerifySecondary');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'postVerifySecondary'
+        );
 
         // Create a third email but don't verify it (legacy unverified email)
         const db = await setupAccountDatabase(baseConfig.database.mysql.auth);
@@ -472,7 +522,10 @@ describe.each(testVersions)(
               email: thirdEmail,
               normalizedEmail: emailHelper.helpers.normalizeEmail(thirdEmail),
               uid: Buffer.from(client.uid, 'hex'),
-              emailCode: Buffer.from(crypto.randomBytes(16).toString('hex'), 'hex'),
+              emailCode: Buffer.from(
+                crypto.randomBytes(16).toString('hex'),
+                'hex'
+              ),
               isVerified: 0,
               isPrimary: 0,
               createdAt: Date.now(),
@@ -505,16 +558,16 @@ describe.each(testVersions)(
         expect(emailData['headers']['x-template-name']).toBe('verifyLogin');
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
-        expect(emailData.cc.length).toBe(1);
-        expect(emailData.cc[0].address).toBe(secondEmail);
+        expect(emailData.cc?.length).toBe(1);
+        expect(emailData.cc?.[0]?.address).toBe(secondEmail);
 
         await client.requestVerifyEmail();
 
         const emailData2 = await server.mailbox.waitForEmail(email);
         expect(emailData2['headers']['x-template-name']).toBe('verifyLogin');
         expect(emailData2['headers']['x-verify-code']).toBe(emailCode);
-        expect(emailData2.cc.length).toBe(1);
-        expect(emailData2.cc[0].address).toBe(secondEmail);
+        expect(emailData2.cc?.length).toBe(1);
+        expect(emailData2.cc?.[0]?.address).toBe(secondEmail);
       });
 
       it('receives sign-in unblock email', async () => {
@@ -524,24 +577,26 @@ describe.each(testVersions)(
         expect(emailData['headers']['x-template-name']).toBe('unblockCode');
         const unblockCode = emailData['headers']['x-unblock-code'];
         expect(unblockCode).toBeTruthy();
-        expect(emailData.cc.length).toBe(1);
-        expect(emailData.cc[0].address).toBe(secondEmail);
+        expect(emailData.cc?.length).toBe(1);
+        expect(emailData.cc?.[0]?.address).toBe(secondEmail);
 
         await client.sendUnblockCode(email);
 
         emailData = await server.mailbox.waitForEmail(email);
         expect(emailData['headers']['x-template-name']).toBe('unblockCode');
-        expect(emailData.cc.length).toBe(1);
-        expect(emailData.cc[0].address).toBe(secondEmail);
+        expect(emailData.cc?.length).toBe(1);
+        expect(emailData.cc?.[0]?.address).toBe(secondEmail);
       });
 
       it('receives password reset email', async () => {
         await client.forgotPassword();
 
         const emailData = await server.mailbox.waitForEmail(email);
-        expect(emailData['headers']['x-template-name']).toBe('passwordForgotOtp');
-        expect(emailData.cc.length).toBe(1);
-        expect(emailData.cc[0].address).toBe(secondEmail);
+        expect(emailData['headers']['x-template-name']).toBe(
+          'passwordForgotOtp'
+        );
+        expect(emailData.cc?.length).toBe(1);
+        expect(emailData.cc?.[0]?.address).toBe(secondEmail);
       });
 
       it('receives change password notification', async () => {
@@ -554,8 +609,8 @@ describe.each(testVersions)(
 
         const emailData = await server.mailbox.waitForEmail(email);
         expect(emailData['headers']['x-template-name']).toBe('passwordChanged');
-        expect(emailData.cc.length).toBe(1);
-        expect(emailData.cc[0].address).toBe(secondEmail);
+        expect(emailData.cc?.length).toBe(1);
+        expect(emailData.cc?.[0]?.address).toBe(secondEmail);
       });
 
       it('receives password reset notification', async () => {
@@ -564,13 +619,19 @@ describe.each(testVersions)(
         let emailData = await server.mailbox.waitForEmail(email);
         const code = emailData.headers['x-password-forgot-otp'];
 
-        const res = await resetPassword(client, code, 'password1', undefined, undefined);
+        const res = await resetPassword(
+          client,
+          code as string,
+          'password1',
+          undefined,
+          undefined
+        );
         expect(res).toBeTruthy();
 
         emailData = await server.mailbox.waitForEmail(email);
         expect(emailData['headers']['x-template-name']).toBe('passwordReset');
-        expect(emailData.cc.length).toBe(1);
-        expect(emailData.cc[0].address).toBe(secondEmail);
+        expect(emailData.cc?.length).toBe(1);
+        expect(emailData.cc?.[0]?.address).toBe(secondEmail);
 
         if (testOptions.version === 'V2') {
           client = await Client.upgradeCredentials(
@@ -604,7 +665,11 @@ describe.each(testVersions)(
         let emailData = await server.mailbox.waitForEmail(fourthEmail);
         const emailCode = emailData['headers']['x-verify-code'];
 
-        res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, fourthEmail);
+        res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          fourthEmail
+        );
         expect(res).toBeTruthy();
 
         // Clear email added template
@@ -613,9 +678,11 @@ describe.each(testVersions)(
         await client.deleteEmail(mfaJwt, fourthEmail);
 
         emailData = await server.mailbox.waitForEmail(email);
-        expect(emailData['headers']['x-template-name']).toBe('postRemoveSecondary');
-        expect(emailData.cc.length).toBe(1);
-        expect(emailData.cc[0].address).toBe(secondEmail);
+        expect(emailData['headers']['x-template-name']).toBe(
+          'postRemoveSecondary'
+        );
+        expect(emailData.cc?.length).toBe(1);
+        expect(emailData.cc?.[0]?.address).toBe(secondEmail);
       });
     });
 
@@ -633,7 +700,11 @@ describe.each(testVersions)(
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
 
-        res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, secondEmail);
+        res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
       });
 
@@ -693,11 +764,17 @@ describe.each(testVersions)(
         expect(res).toBeTruthy();
 
         const emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
 
-        res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, secondEmail);
+        res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         res = await client.accountEmails();
@@ -739,7 +816,11 @@ describe.each(testVersions)(
         const emailCode = emailData['headers']['x-verify-code'];
         expect(emailCode).toBeTruthy();
 
-        res = await client.verifySecondaryEmailWithCode(mfaJwt, emailCode, secondEmail);
+        res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          emailCode,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         res = await client.accountEmails();
@@ -779,11 +860,17 @@ describe.each(testVersions)(
 
       it('can verify using a code', async () => {
         let emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const code = emailData['headers']['x-verify-code'];
         expect(code).toBeTruthy();
 
-        let res = await client.verifySecondaryEmailWithCode(mfaJwt, code, secondEmail);
+        let res = await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          code,
+          secondEmail
+        );
         expect(res).toBeTruthy();
 
         res = await client.accountEmails();
@@ -793,12 +880,18 @@ describe.each(testVersions)(
         expect(res[1].verified).toBe(true);
 
         emailData = await server.mailbox.waitForEmail(email);
-        expect(emailData['headers']['x-template-name']).toBe('postVerifySecondary');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'postVerifySecondary'
+        );
       });
 
       it('does not verify on random email code', async () => {
         try {
-          await client.verifySecondaryEmailWithCode(mfaJwt, '123123', secondEmail);
+          await client.verifySecondaryEmailWithCode(
+            mfaJwt,
+            '123123',
+            secondEmail
+          );
           fail('should have failed');
         } catch (err: any) {
           expect(err.errno).toBe(105);
@@ -813,7 +906,10 @@ describe.each(testVersions)(
       beforeEach(async () => {
         secondEmail = server.uniqueEmail();
         const db = await setupAccountDatabase(baseConfig.database.mysql.auth);
-        const emailCode = Buffer.from(crypto.randomBytes(16).toString('hex'), 'hex');
+        const emailCode = Buffer.from(
+          crypto.randomBytes(16).toString('hex'),
+          'hex'
+        );
         try {
           await db
             .insertInto('emails')
@@ -864,11 +960,17 @@ describe.each(testVersions)(
         expect(res).toBeTruthy();
 
         const emailData = await server.mailbox.waitForEmail(secondEmail);
-        expect(emailData['headers']['x-template-name']).toBe('verifySecondaryCode');
+        expect(emailData['headers']['x-template-name']).toBe(
+          'verifySecondaryCode'
+        );
         const resendEmailCode = emailData['headers']['x-verify-code'];
-        expect(resendEmailCode.length).toBe(6);
+        expect(resendEmailCode?.length).toBe(6);
 
-        await client.verifySecondaryEmailWithCode(mfaJwt, resendEmailCode, secondEmail);
+        await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          resendEmailCode,
+          secondEmail
+        );
 
         res = await client.accountEmails();
         expect(res.length).toBe(2);
@@ -938,8 +1040,8 @@ describe.each(testVersions)(
 
       // Check for new device login email
       expect(emailData['headers']['x-template-name']).toBe('newDeviceLogin');
-      expect(emailData.cc.length).toBe(1);
-      expect(emailData.cc[0].address).toBe(secondEmail);
+      expect(emailData.cc?.length).toBe(1);
+      expect(emailData.cc?.[0]?.address).toBe(secondEmail);
     });
   }
 );

--- a/packages/fxa-auth-server/test/remote/recovery_email_verify.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/recovery_email_verify.in.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  getSharedTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 import url from 'url';
 
 const Client = require('../client')();
@@ -66,7 +69,7 @@ describe.each(testVersions)(
 
       const emailData = await server.mailbox.waitForEmail(email);
       const link = emailData.headers['x-link'];
-      const query = url.parse(link, true).query;
+      const query = url.parse(link as string, true).query;
       expect(query.uid).toBeTruthy();
       expect(query.code).toBeTruthy();
       expect(query.redirectTo).toBe(options.redirectTo);

--- a/packages/fxa-auth-server/test/scripts/check-users.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/check-users.in.spec.ts
@@ -26,7 +26,7 @@ const execOptions = {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
     AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
-  },
+  } as unknown as typeof process.env,
 };
 
 const PASSWORD_VALID = 'password';

--- a/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.in.spec.ts
@@ -16,7 +16,7 @@ const execOptions = {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
     AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
-  },
+  } as unknown as typeof process.env,
 };
 
 describe('starting script - convert-customers-to-stripe-automatic-tax', () => {

--- a/packages/fxa-auth-server/test/scripts/delete-unverified-accounts.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/delete-unverified-accounts.in.spec.ts
@@ -16,7 +16,7 @@ const execOptions = {
     NODE_ENV: 'dev',
     STRIPE_API_KEY: 'sk_test_dummy',
     SUBHUB_STRIPE_APIKEY: 'sk_test_dummy',
-  },
+  } as unknown as typeof process.env,
 };
 
 const command = [

--- a/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan-v2.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan-v2.in.spec.ts
@@ -16,7 +16,7 @@ const execOptions = {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
     AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
-  },
+  } as unknown as typeof process.env,
 };
 
 describe('starting script - move-customers-to-new-plan-v2', () => {

--- a/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.in.spec.ts
@@ -16,7 +16,7 @@ const execOptions = {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
     AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
-  },
+  } as unknown as typeof process.env,
 };
 
 describe('starting script - move-customers-to-new-plan', () => {

--- a/packages/fxa-auth-server/test/scripts/prune-tokens.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/prune-tokens.in.spec.ts
@@ -47,7 +47,7 @@ describe('#integration - scripts/prune-tokens', () => {
   const toRandomBuff = (size: number) =>
     uuidTransformer.to(crypto.randomBytes(size).toString('hex'));
   const toZeroBuff = (size: number) =>
-    Buffer.from(Array(size).fill(0), 'hex').toString('hex');
+    Buffer.from(Array(size).fill(0) as number[]).toString('hex');
 
   const cwd = path.resolve(__dirname, '../..');
 

--- a/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.in.spec.ts
@@ -7,6 +7,7 @@ import { Container } from 'typedi';
 import { deleteCollection, deepCopy } from '../local/payments/util';
 import { AuthFirestore, AuthLogger, AppConfig } from '../../lib/types';
 import { setupFirestore } from '../../lib/firestore-db';
+import { ConfigType } from '../../config';
 import { PaymentConfigManager } from '../../lib/payments/configuration/manager';
 
 const plan = require('fxa-auth-server/test/local/payments/fixtures/stripe/plan2.json');
@@ -180,7 +181,7 @@ describe('#integration - convert', () => {
     mockLog.error = jest.fn().mockReturnValue({});
     mockLog.info = jest.fn().mockReturnValue({});
     mockLog.debug = jest.fn().mockReturnValue({});
-    const firestore = setupFirestore(mockConfig);
+    const firestore = setupFirestore(mockConfig as unknown as ConfigType);
     Container.set(AuthFirestore, firestore);
     Container.set(AuthLogger, {});
     Container.set(AppConfig, mockConfig);
@@ -354,11 +355,13 @@ describe('#integration - convert', () => {
   });
 
   it('processes successfully and writes to file', async () => {
-    const stubFsAccess = jest.spyOn(fs.promises, 'access').mockResolvedValue();
+    const stubFsAccess = jest
+      .spyOn(fs.promises, 'access')
+      .mockResolvedValue(undefined);
     paymentConfigManager.storeProductConfig = jest.fn();
     paymentConfigManager.storePlanConfig = jest.fn();
-    converter.writeToFileProductConfig = jest.fn().mockResolvedValue();
-    converter.writeToFilePlanConfig = jest.fn().mockResolvedValue();
+    converter.writeToFileProductConfig = jest.fn().mockResolvedValue(undefined);
+    converter.writeToFilePlanConfig = jest.fn().mockResolvedValue(undefined);
 
     const argsLocal = { ...args, target: 'local' };
     await converter.convert(argsLocal);

--- a/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.in.spec.ts
@@ -16,7 +16,7 @@ const execOptions = {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
     AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
-  },
+  } as unknown as typeof process.env,
 };
 
 describe('starting script - update-subscriptions-to-new-plan', () => {

--- a/packages/fxa-auth-server/test/support/helpers/mailbox.ts
+++ b/packages/fxa-auth-server/test/support/helpers/mailbox.ts
@@ -23,6 +23,9 @@ export interface EmailData {
   text?: string;
   html?: string;
   subject?: string;
+  // mailparser exposes parsed recipients as a top-level array, distinct from
+  // the `cc` string header above.
+  cc?: { address: string; name?: string }[];
 }
 
 export interface Mailbox {

--- a/packages/fxa-auth-server/test/support/helpers/test-server.ts
+++ b/packages/fxa-auth-server/test/support/helpers/test-server.ts
@@ -177,7 +177,7 @@ export function spawnAuthServer(
     LOG_LEVEL: printLogs ? 'info' : 'error',
     AUTH_GLEAN_ENABLED: 'false',
     NODE_NO_WARNINGS: printLogs ? '' : '1',
-  };
+  } as unknown as typeof process.env;
 
   const serverProcess = spawn(
     'node',

--- a/packages/fxa-auth-server/test/support/jest-global-setup.ts
+++ b/packages/fxa-auth-server/test/support/jest-global-setup.ts
@@ -39,7 +39,10 @@ function generateKeysIfNeeded(): void {
     {
       label: 'auth keys',
       script: path.join(AUTH_SERVER_ROOT, 'scripts', 'gen_keys.js'),
-      env: { ...process.env, NODE_ENV: 'dev' },
+      env: {
+        ...process.env,
+        NODE_ENV: 'dev',
+      } as unknown as typeof process.env,
     },
     {
       label: 'OAuth keys',
@@ -48,7 +51,7 @@ function generateKeysIfNeeded(): void {
         ...process.env,
         NODE_ENV: 'dev',
         FXA_OPENID_UNSAFELY_ALLOW_MISSING_ACTIVE_KEY: 'true',
-      },
+      } as unknown as typeof process.env,
     },
   ];
 
@@ -191,7 +194,7 @@ export default async function globalSetup(): Promise<void> {
         ...process.env,
         NODE_ENV: 'dev',
         MAIL_HELPER_LOGS: printLogs ? 'true' : '',
-      },
+      } as unknown as typeof process.env,
       stdio: printLogs ? 'inherit' : 'ignore',
       detached: true,
     }

--- a/packages/fxa-auth-server/test/support/jest-setup-env.ts
+++ b/packages/fxa-auth-server/test/support/jest-setup-env.ts
@@ -7,11 +7,12 @@
  * Sets environment variables that affect module loading.
  */
 
-process.env.NODE_ENV = 'dev';
+(process.env as Record<string, string | undefined>).NODE_ENV = 'dev';
 process.env.FXA_OPENID_UNSAFELY_ALLOW_MISSING_ACTIVE_KEY = 'true';
 process.env.TRACING_SERVICE_NAME = 'fxa-auth-server-test';
 process.env.TRACING_SAMPLE_RATE = '0';
-process.env.LOG_LEVEL = process.env.REMOTE_TEST_LOGS === 'true' ? 'info' : 'error';
+process.env.LOG_LEVEL =
+  process.env.REMOTE_TEST_LOGS === 'true' ? 'info' : 'error';
 process.env.AUTH_GLEAN_ENABLED = 'false';
 if (!process.env.CORS_ORIGIN) {
   process.env.CORS_ORIGIN = 'http://foo,http://bar';


### PR DESCRIPTION
## Because

- FXA-13782 enabled type-checking of `fxa-auth-server` spec files but didn't gate
  the ~220 errors it surfaced. FXA-13935 tracks resolving them and CI-gating so
  spec type errors can't silently return.

## This pull request

- Resolves `fxa-auth-server` spec type errors **220 → 36**, **test-only with no
  production code changes**.
- Fix patterns: `mockResolvedValue()` → `mockResolvedValue(undefined)`; typed
  mock-call casts (`jest.mocked`, tuple/shape casts); `as NonNullable<typeof x>` /
  narrowing guards on known-present fixtures; `as const` literal widening;
  `readFileSync(path, 'utf8')`; and a typed boundary-alias block for the untyped JS
  `jwt.js`/`keys.js` imports in `jwt.spec.ts`.

## Issue that this pull request solves

Closes: FXA-13935

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/oauth/jwt.spec.ts` (typed boundary aliases for
  the untyped JS modules) and `lib/geodb.spec.ts` (narrowing guard) — both
  commented. The rest is mechanical.
- Suggested review order: skim the bulk mechanical fixes (`mockResolvedValue`, casts),
  then the few judgment calls above.
- Risky or complex parts: none — test-only, no production code touched.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Partial pass — ~36 errors remain (the `fxa-mailer` `TemplateData` intersection and
other over-rigid/evolved production types that need production type changes), and the
CI-gate step (point `compile`/`build-ts` at `tsconfig.json` or add a spec type-check)
is still pending. Both should be tracked as follow-up.