### PR TITLE
tests(payments): Add test coverage for wallet type, cancel/resubscribe, and UTM tests for Link, Google Pay, and Apple Pay flows

### DIFF
--- a/libs/accounts/email-renderer/project.json
+++ b/libs/accounts/email-renderer/project.json
@@ -21,7 +21,7 @@
     "build-ts": {
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "dependsOn": ["l10n-prime"],
+      "dependsOn": ["l10n-prime", "^build"],
       "options": {
         "outputPath": "dist/libs/accounts/email-renderer",
         "main": "libs/accounts/email-renderer/src/index.ts",

--- a/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.spec.ts
@@ -248,6 +248,48 @@ describe('SubPlat Email Renderer — Lifecycle emails', () => {
     expect(email.html).toContain('http://localhost:3030/update-billing');
   });
 
+  it('renderSubscriptionRenewalReminder renders renewal notice with showTax enabled', async () => {
+    const email = await renderer.renderSubscriptionRenewalReminder(
+      {
+        productName: 'Mozilla VPN',
+        showTax: true,
+        invoiceTotalExcludingTax: '$8.50',
+        invoiceTax: '$1.49',
+        invoiceTotal: '$9.99',
+        planInterval: 'monthly',
+        reminderLength: '6',
+        subscriptionSupportUrl: mockLinkSupport,
+        updateBillingUrl: 'http://localhost:3030/update-billing',
+      },
+      defaultSubscriptionLayoutValues
+    );
+
+    expect(email).toBeDefined();
+    expect(email.html).toContain('Mozilla VPN');
+    expect(email.html).toContain('http://localhost:3030/update-billing');
+    // When showTax is true, tax amount should appear in the rendered output
+    expect(email.html).toContain('$1.49');
+  });
+
+  it('renderSubscriptionRenewalReminder renders renewal notice for yearly plan', async () => {
+    const email = await renderer.renderSubscriptionRenewalReminder(
+      {
+        productName: 'Mozilla VPN',
+        showTax: false,
+        invoiceTotal: '$59.99',
+        planInterval: 'yearly',
+        reminderLength: '14',
+        subscriptionSupportUrl: mockLinkSupport,
+        updateBillingUrl: 'http://localhost:3030/update-billing',
+      },
+      defaultSubscriptionLayoutValues
+    );
+
+    expect(email).toBeDefined();
+    expect(email.html).toContain('Mozilla VPN');
+    expect(email.html).toContain('http://localhost:3030/update-billing');
+  });
+
   it('renderSubscriptionUpgrade renders upgrade confirmation email', async () => {
     const email = await renderer.renderSubscriptionUpgrade(
       {

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -774,6 +774,41 @@ describe('CheckoutService', () => {
       expect(gleanService.recordGenericSubManageEvent).not.toHaveBeenCalled();
     });
 
+    it.each([
+      {
+        paymentForm: SubPlatPaymentMethodType.Link,
+        label: 'Link',
+      },
+      {
+        paymentForm: SubPlatPaymentMethodType.GooglePay,
+        label: 'Google Pay',
+      },
+      {
+        paymentForm: SubPlatPaymentMethodType.ApplePay,
+        label: 'Apple Pay',
+      },
+    ])(
+      'records $label payment form in subscription_success metrics',
+      async ({ paymentForm: walletPaymentForm }) => {
+        await checkoutService.postPaySteps({
+          cart: mockCart,
+          version: mockCart.version,
+          subscription: mockSubscription,
+          uid: mockUid,
+          paymentProvider,
+          paymentForm: walletPaymentForm,
+          isCancelInterstitialOffer: false,
+        });
+
+        expect(statsd.increment).toHaveBeenCalledWith('subscription_success', {
+          payment_provider: paymentProvider,
+          payment_form: walletPaymentForm,
+          offering_id: mockCart.offeringConfigId,
+          interval: mockCart.interval,
+        });
+      }
+    );
+
     it('success - adds coupon code to subscription metadata if it exists', async () => {
       const mockCart = ResultCartFactory({
         couponCode: faker.string.uuid(),
@@ -2133,6 +2168,147 @@ describe('CheckoutService', () => {
 
         expect(cartManager.setNeedsInputCart).toHaveBeenCalledWith(mockCart.id);
       });
+    });
+  });
+
+  describe('UTM attribution propagation', () => {
+    const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+    const mockCart = StripeResponseFactory(
+      ResultCartFactory({
+        uid: faker.string.uuid(),
+        stripeCustomerId: mockCustomer.id,
+        couponCode: faker.string.uuid(),
+      })
+    );
+    const mockPromotionCode = StripeResponseFactory(
+      StripePromotionCodeFactory()
+    );
+    const mockPrice = StripePriceFactory();
+    const mockPricingForCurrency = PricingForCurrencyFactory();
+    const mockConfirmationToken = StripeConfirmationTokenFactory();
+    const mockSubscription = StripeResponseFactory(StripeSubscriptionFactory());
+    const mockPaymentIntent = StripeResponseFactory(
+      StripePaymentIntentFactory({
+        status: 'succeeded',
+        payment_method: StripePaymentMethodFactory().id,
+      })
+    );
+    const mockInvoice = StripeResponseFactory(
+      StripeInvoiceFactory({
+        payment_intent: mockPaymentIntent.id,
+      })
+    );
+    const mockEligibilityResult = SubscriptionEligibilityResultFactory({
+      subscriptionEligibilityResult: EligibilityStatus.CREATE,
+    });
+    const mockPaymentMethod = StripeResponseFactory(
+      StripePaymentMethodFactory()
+    );
+    const mockRequestArgs = CommonMetricsFactory();
+
+    beforeEach(() => {
+      jest
+        .spyOn(checkoutService, 'prePaySteps')
+        .mockResolvedValue(
+          PrePayStepsResultFactory({
+            uid: mockCart.uid,
+            customer: mockCustomer,
+            promotionCode: mockPromotionCode,
+            price: mockPrice,
+            version: mockCart.version + 1,
+            eligibility: mockEligibilityResult,
+          })
+        );
+      jest
+        .spyOn(priceManager, 'retrievePricingForCurrency')
+        .mockResolvedValue(mockPricingForCurrency);
+      jest
+        .spyOn(subscriptionManager, 'create')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(cartManager, 'dangerouslyUpdateProcessingCart')
+        .mockResolvedValue();
+      jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
+      jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(paymentIntentManager, 'confirm')
+        .mockResolvedValue(mockPaymentIntent);
+      jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
+      jest.spyOn(statsd, 'increment');
+      jest.spyOn(checkoutService, 'postPaySteps').mockResolvedValue();
+      jest.spyOn(asyncLocalStorage, 'getStore');
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+      jest
+        .spyOn(checkoutService, 'getFreeTrialEligibility')
+        .mockResolvedValue({ offer: null, userEligible: false });
+    });
+
+    it('passes empty strings for absent UTM params without error', async () => {
+      const emptyAttribution = SubscriptionAttributionFactory({
+        utm_campaign: '',
+        utm_content: '',
+        utm_medium: '',
+        utm_source: '',
+        utm_term: '',
+        session_flow_id: '',
+        session_entrypoint: '',
+        session_entrypoint_experiment: '',
+        session_entrypoint_variation: '',
+      });
+
+      await checkoutService.payWithStripe(
+        mockCart,
+        mockConfirmationToken.id,
+        emptyAttribution,
+        mockRequestArgs,
+        mockCart.uid
+      );
+
+      expect(subscriptionManager.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            utm_campaign: '',
+            utm_content: '',
+            utm_medium: '',
+            utm_source: '',
+            utm_term: '',
+          }),
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('passes populated UTM params through to subscription metadata', async () => {
+      const populatedAttribution = SubscriptionAttributionFactory({
+        utm_campaign: 'spring-sale',
+        utm_content: 'hero-cta',
+        utm_medium: 'email',
+        utm_source: 'newsletter',
+        utm_term: 'vpn-discount',
+      });
+
+      await checkoutService.payWithStripe(
+        mockCart,
+        mockConfirmationToken.id,
+        populatedAttribution,
+        mockRequestArgs,
+        mockCart.uid
+      );
+
+      expect(subscriptionManager.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            utm_campaign: 'spring-sale',
+            utm_content: 'hero-cta',
+            utm_medium: 'email',
+            utm_source: 'newsletter',
+            utm_term: 'vpn-discount',
+          }),
+        }),
+        expect.any(Object)
+      );
     });
   });
 

--- a/libs/payments/ui/src/lib/actions/cancelSubscriptionAtPeriodEnd.spec.ts
+++ b/libs/payments/ui/src/lib/actions/cancelSubscriptionAtPeriodEnd.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { cancelSubscriptionAtPeriodEndAction } from './cancelSubscriptionAtPeriodEnd';
+
+const mockCancelSubscriptionAtPeriodEnd = jest.fn();
+const mockGetActionsService = jest.fn(() => ({
+  cancelSubscriptionAtPeriodEnd: mockCancelSubscriptionAtPeriodEnd,
+}));
+
+jest.mock('../nestapp/app', () => ({
+  __esModule: true,
+  getApp: () => ({
+    getActionsService: mockGetActionsService,
+  }),
+}));
+
+const mockRequireSessionUid = jest.fn();
+jest.mock('@fxa/payments/ui-auth', () => ({
+  __esModule: true,
+  requireSessionUid: () => mockRequireSessionUid(),
+}));
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  __esModule: true,
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+describe('cancelSubscriptionAtPeriodEndAction', () => {
+  const MOCK_UID = 'uid-abc-123';
+  const MOCK_SUBSCRIPTION_ID = 'sub_test_456';
+
+  beforeEach(() => {
+    mockCancelSubscriptionAtPeriodEnd.mockReset();
+    mockRequireSessionUid.mockReset();
+    mockRevalidatePath.mockReset();
+    mockRequireSessionUid.mockResolvedValue(MOCK_UID);
+  });
+
+  it('calls cancelSubscriptionAtPeriodEnd with the session uid and subscription id', async () => {
+    mockCancelSubscriptionAtPeriodEnd.mockResolvedValue({ success: true });
+
+    await cancelSubscriptionAtPeriodEndAction(MOCK_SUBSCRIPTION_ID);
+
+    expect(mockCancelSubscriptionAtPeriodEnd).toHaveBeenCalledWith({
+      uid: MOCK_UID,
+      subscriptionId: MOCK_SUBSCRIPTION_ID,
+    });
+  });
+
+  it('revalidates the cancel page path after successful cancellation', async () => {
+    mockCancelSubscriptionAtPeriodEnd.mockResolvedValue({ success: true });
+
+    await cancelSubscriptionAtPeriodEndAction(MOCK_SUBSCRIPTION_ID);
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      '/[locale]/subscriptions/[subscriptionId]/cancel',
+      'page'
+    );
+  });
+
+  it('returns the result from the actions service', async () => {
+    const mockResult = {
+      subscriptionId: MOCK_SUBSCRIPTION_ID,
+      cancelledAt: 1700000000,
+    };
+    mockCancelSubscriptionAtPeriodEnd.mockResolvedValue(mockResult);
+
+    const result =
+      await cancelSubscriptionAtPeriodEndAction(MOCK_SUBSCRIPTION_ID);
+
+    expect(result).toEqual(mockResult);
+  });
+
+  it('propagates errors when requireSessionUid rejects', async () => {
+    mockRequireSessionUid.mockRejectedValue(new Error('Not authenticated'));
+
+    await expect(
+      cancelSubscriptionAtPeriodEndAction(MOCK_SUBSCRIPTION_ID)
+    ).rejects.toThrow('Not authenticated');
+
+    expect(mockCancelSubscriptionAtPeriodEnd).not.toHaveBeenCalled();
+  });
+
+  it('propagates errors when the actions service rejects', async () => {
+    mockCancelSubscriptionAtPeriodEnd.mockRejectedValue(
+      new Error('Customer mismatch')
+    );
+
+    await expect(
+      cancelSubscriptionAtPeriodEndAction(MOCK_SUBSCRIPTION_ID)
+    ).rejects.toThrow('Customer mismatch');
+  });
+});

--- a/libs/payments/ui/src/lib/actions/resubscribeSubscription.spec.ts
+++ b/libs/payments/ui/src/lib/actions/resubscribeSubscription.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { resubscribeSubscriptionAction } from './resubscribeSubscription';
+
+const mockResubscribeSubscription = jest.fn();
+const mockGetActionsService = jest.fn(() => ({
+  resubscribeSubscription: mockResubscribeSubscription,
+}));
+
+jest.mock('../nestapp/app', () => ({
+  __esModule: true,
+  getApp: () => ({
+    getActionsService: mockGetActionsService,
+  }),
+}));
+
+const mockRequireSessionUid = jest.fn();
+jest.mock('@fxa/payments/ui-auth', () => ({
+  __esModule: true,
+  requireSessionUid: () => mockRequireSessionUid(),
+}));
+
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  __esModule: true,
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+describe('resubscribeSubscriptionAction', () => {
+  const MOCK_UID = 'uid-abc-123';
+  const MOCK_SUBSCRIPTION_ID = 'sub_test_456';
+
+  beforeEach(() => {
+    mockResubscribeSubscription.mockReset();
+    mockRequireSessionUid.mockReset();
+    mockRevalidatePath.mockReset();
+    mockRequireSessionUid.mockResolvedValue(MOCK_UID);
+  });
+
+  it('calls resubscribeSubscription with the session uid and subscription id', async () => {
+    mockResubscribeSubscription.mockResolvedValue({ success: true });
+
+    await resubscribeSubscriptionAction(MOCK_SUBSCRIPTION_ID);
+
+    expect(mockResubscribeSubscription).toHaveBeenCalledWith({
+      uid: MOCK_UID,
+      subscriptionId: MOCK_SUBSCRIPTION_ID,
+    });
+  });
+
+  it('revalidates the stay-subscribed page path after successful resubscribe', async () => {
+    mockResubscribeSubscription.mockResolvedValue({ success: true });
+
+    await resubscribeSubscriptionAction(MOCK_SUBSCRIPTION_ID);
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      '/[locale]/subscriptions/[subscriptionId]/stay-subscribed',
+      'page'
+    );
+  });
+
+  it('returns the result from the actions service', async () => {
+    const mockResult = { subscriptionId: MOCK_SUBSCRIPTION_ID, active: true };
+    mockResubscribeSubscription.mockResolvedValue(mockResult);
+
+    const result = await resubscribeSubscriptionAction(MOCK_SUBSCRIPTION_ID);
+
+    expect(result).toEqual(mockResult);
+  });
+
+  it('propagates errors when requireSessionUid rejects', async () => {
+    mockRequireSessionUid.mockRejectedValue(new Error('Not authenticated'));
+
+    await expect(
+      resubscribeSubscriptionAction(MOCK_SUBSCRIPTION_ID)
+    ).rejects.toThrow('Not authenticated');
+
+    expect(mockResubscribeSubscription).not.toHaveBeenCalled();
+  });
+
+  it('propagates errors when the actions service rejects', async () => {
+    mockResubscribeSubscription.mockRejectedValue(
+      new Error('Subscription already active')
+    );
+
+    await expect(
+      resubscribeSubscriptionAction(MOCK_SUBSCRIPTION_ID)
+    ).rejects.toThrow('Subscription already active');
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
@@ -385,6 +385,109 @@ describe('CheckoutForm', () => {
     expect(screen.getByTestId('paypal-buttons')).toBeInTheDocument();
   });
 
+  describe('wallet payment type handling', () => {
+    it.each([
+      { paymentType: 'link', label: 'Link' },
+      { paymentType: 'google_pay', label: 'Google Pay' },
+      { paymentType: 'apple_pay', label: 'Apple Pay' },
+    ])(
+      'enables submit button when $label wallet type is selected and fields are complete',
+      async ({ paymentType }) => {
+        const user = userEvent.setup();
+        render(<CheckoutForm {...baseProps} />);
+        fireStripeReady();
+
+        await user.click(screen.getByTestId('consent-checkbox'));
+        fireStripeChange({ complete: true, value: { type: paymentType } });
+
+        const submitButton = screen.getByRole('button', {
+          name: /Subscribe Now/i,
+        });
+        expect(submitButton).toHaveAttribute('aria-disabled', 'false');
+      }
+    );
+
+    it.each([
+      { paymentType: 'link', label: 'Link' },
+      { paymentType: 'google_pay', label: 'Google Pay' },
+      { paymentType: 'apple_pay', label: 'Apple Pay' },
+    ])(
+      'calls checkoutCartWithStripe with confirmation token for $label payment type',
+      async ({ paymentType }) => {
+        const user = userEvent.setup();
+        mockElementsSubmit.mockResolvedValue({ error: undefined });
+        mockCreateConfirmationToken.mockResolvedValue({
+          confirmationToken: { id: `ctoken_${paymentType}_123` },
+        });
+        mockCheckoutCartWithStripe.mockResolvedValue(undefined);
+
+        render(<CheckoutForm {...baseProps} />);
+        fireStripeReady();
+        await user.click(screen.getByTestId('consent-checkbox'));
+        fireStripeChange({
+          complete: true,
+          value: { type: paymentType },
+        });
+
+        await user.click(
+          screen.getByRole('button', { name: /Subscribe Now/i })
+        );
+
+        await waitFor(() => {
+          expect(mockCheckoutCartWithStripe).toHaveBeenCalledWith(
+            'cart-id',
+            1,
+            `ctoken_${paymentType}_123`,
+            expect.any(Object),
+            expect.any(Object),
+            expect.any(Object)
+          );
+        });
+
+        await waitFor(() => {
+          expect(mockRouterPush).toHaveBeenCalledWith('./processing');
+        });
+      }
+    );
+
+    it('records the selected payment method type in the emitter event on submit', async () => {
+      const user = userEvent.setup();
+      mockElementsSubmit.mockResolvedValue({ error: undefined });
+      mockCreateConfirmationToken.mockResolvedValue({
+        confirmationToken: { id: 'ctoken_link_submit' },
+      });
+      mockCheckoutCartWithStripe.mockResolvedValue(undefined);
+
+      render(<CheckoutForm {...baseProps} />);
+      fireStripeReady();
+      await user.click(screen.getByTestId('consent-checkbox'));
+      fireStripeChange({
+        complete: true,
+        value: { type: 'link' },
+      });
+
+      await user.click(screen.getByRole('button', { name: /Subscribe Now/i }));
+
+      await waitFor(() => {
+        expect(mockRecordEmitterEventAction).toHaveBeenCalledWith(
+          'checkoutSubmit',
+          expect.any(Object),
+          expect.any(Object),
+          'stripe',
+          'link'
+        );
+      });
+    });
+
+    it('does not show PayPal buttons for non-PayPal wallet types', async () => {
+      render(<CheckoutForm {...baseProps} />);
+      fireStripeReady();
+      fireStripeChange({ complete: true, value: { type: 'google_pay' } });
+
+      expect(screen.queryByTestId('paypal-buttons')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Checkout legal links', () => {
     it('renders the Terms of Service link with the correct href', () => {
       render(<CheckoutForm {...baseProps} />);

--- a/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.test.tsx
@@ -529,6 +529,246 @@ describe('PaymentMethodManagement', () => {
     expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
+  describe('linkInterruptedCard state', () => {
+    it('shows "Save payment method" when user enters card details then switches to link without a saved method', () => {
+      render(<PaymentMethodManagement locale="en" />);
+
+      simulateLoaderStart();
+
+      // User starts entering new card details
+      simulatePaymentChange(
+        buildChangeEvent({
+          complete: true,
+          value: { type: 'card' },
+        })
+      );
+
+      expect(
+        screen.getByRole('button', { name: /save payment method/i })
+      ).toBeInTheDocument();
+
+      // User switches to link without a saved payment method
+      simulatePaymentChange(
+        buildChangeEvent({
+          complete: true,
+          value: { type: 'link' },
+        })
+      );
+
+      // linkInterruptedCard should be true, showing "Save payment method"
+      expect(
+        screen.getByRole('button', { name: /save payment method/i })
+      ).toBeInTheDocument();
+    });
+
+    it('resets linkInterruptedCard state when user switches back to card', () => {
+      render(<PaymentMethodManagement locale="en" />);
+
+      simulateLoaderStart();
+
+      // Enter card details
+      simulatePaymentChange(
+        buildChangeEvent({
+          complete: true,
+          value: { type: 'card' },
+        })
+      );
+
+      // Switch to link (triggers linkInterruptedCard)
+      simulatePaymentChange(
+        buildChangeEvent({
+          complete: true,
+          value: { type: 'link' },
+        })
+      );
+
+      // Switch back to card (resets linkInterruptedCard)
+      simulatePaymentChange(
+        buildChangeEvent({
+          complete: true,
+          value: { type: 'card' },
+        })
+      );
+
+      // Button should still show because isInputNewCardDetails is now true
+      expect(
+        screen.getByRole('button', { name: /save payment method/i })
+      ).toBeInTheDocument();
+    });
+
+    it('does not set linkInterruptedCard when switching from a saved card to link', () => {
+      render(
+        <PaymentMethodManagement
+          locale="en"
+          defaultPaymentMethod={{ id: 'pm_default_123', type: 'card' }}
+        />
+      );
+
+      simulateLoaderStart();
+
+      // Select an existing saved card (not entering new details)
+      simulatePaymentChange(
+        buildChangeEvent({
+          complete: true,
+          value: {
+            type: 'card',
+            payment_method: {
+              id: 'pm_default_123',
+              type: 'card',
+              billing_details: {
+                address: {
+                  city: null,
+                  country: null,
+                  line1: null,
+                  line2: null,
+                  postal_code: null,
+                  state: null,
+                },
+                name: null,
+                email: null,
+                phone: null,
+              },
+            },
+          },
+        })
+      );
+
+      // Switch to link with a saved Link payment method
+      simulatePaymentChange(
+        buildChangeEvent({
+          complete: true,
+          value: {
+            type: 'link',
+            payment_method: {
+              id: 'pm_link_789',
+              type: 'link',
+              billing_details: {
+                address: {
+                  city: null,
+                  country: null,
+                  line1: null,
+                  line2: null,
+                  postal_code: null,
+                  state: null,
+                },
+                name: null,
+                email: null,
+                phone: null,
+              },
+            },
+          },
+        })
+      );
+
+      // linkInterruptedCard should NOT be set because isInputNewCardDetails
+      // was false (user was on a saved card, not entering new card details).
+      // The "Set as default" button appears because this is a non-default
+      // saved method, but "Save payment method" should not appear.
+      expect(
+        screen.queryByRole('button', { name: /save payment method/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {
+          name: /set as default payment method/i,
+        })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('wallet type payment methods', () => {
+    const billingDetails = {
+      address: {
+        city: null,
+        country: null,
+        line1: null,
+        line2: null,
+        postal_code: null,
+        state: null,
+      },
+      name: null,
+      email: null,
+      phone: null,
+    };
+
+    it.each([
+      { walletType: 'google_pay', walletLabel: 'Google Pay' },
+      { walletType: 'apple_pay', walletLabel: 'Apple Pay' },
+    ])(
+      'shows "Set as default" button when a non-default $walletLabel method is selected',
+      ({ walletType }) => {
+        render(
+          <PaymentMethodManagement
+            locale="en"
+            defaultPaymentMethod={{ id: 'pm_default_card', type: 'card' }}
+          />
+        );
+
+        simulateLoaderStart();
+        simulatePaymentChange(
+          buildChangeEvent({
+            complete: true,
+            value: {
+              type: walletType,
+              payment_method: {
+                id: `pm_${walletType}_456`,
+                type: walletType,
+                billing_details: billingDetails,
+              },
+            },
+          })
+        );
+
+        expect(
+          screen.getByRole('button', {
+            name: /set as default payment method/i,
+          })
+        ).toBeInTheDocument();
+      }
+    );
+
+    it.each([
+      { walletType: 'google_pay', walletLabel: 'Google Pay' },
+      { walletType: 'apple_pay', walletLabel: 'Apple Pay' },
+    ])(
+      'does not show button when re-selecting the current default $walletLabel method',
+      ({ walletType }) => {
+        render(
+          <PaymentMethodManagement
+            locale="en"
+            defaultPaymentMethod={{
+              id: `pm_${walletType}_123`,
+              type: walletType,
+            }}
+          />
+        );
+
+        simulateLoaderStart();
+        simulatePaymentChange(
+          buildChangeEvent({
+            complete: true,
+            value: {
+              type: walletType,
+              payment_method: {
+                id: `pm_${walletType}_123`,
+                type: walletType,
+                billing_details: billingDetails,
+              },
+            },
+          })
+        );
+
+        expect(
+          screen.queryByRole('button', {
+            name: /set as default payment method/i,
+          })
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: /save payment method/i })
+        ).not.toBeInTheDocument();
+      }
+    );
+  });
+
   it('displays error message when elements.submit returns an error', async () => {
     const user = userEvent.setup();
 

--- a/libs/payments/webhooks/src/lib/subscription-handler.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/subscription-handler.service.spec.ts
@@ -256,6 +256,42 @@ describe('SubscriptionEventsService', () => {
         );
       });
 
+      it.each([
+        {
+          type: SubPlatPaymentMethodType.Link as const,
+          label: 'Link',
+        },
+        {
+          type: SubPlatPaymentMethodType.GooglePay as const,
+          label: 'Google Pay',
+        },
+        {
+          type: SubPlatPaymentMethodType.ApplePay as const,
+          label: 'Apple Pay',
+        },
+      ])(
+        'should emit the subscriptionEnded event with Stripe provider for $label payment type',
+        async ({ type }) => {
+          jest.spyOn(paymentMethodManager, 'determineType').mockResolvedValue({
+            provider: 'stripe' as const,
+            type,
+            paymentMethodId: `pm_${type}_id`,
+          });
+          await subscriptionEventsService.handleCustomerSubscriptionDeleted(
+            mockEvent,
+            mockEventObjectData
+          );
+
+          expect(mockEmitter.emit).toHaveBeenCalledTimes(1);
+          expect(mockEmitter.emit).toHaveBeenCalledWith(
+            'subscriptionEnded',
+            expect.objectContaining({
+              paymentProvider: PaymentProvider.Stripe,
+            })
+          );
+        }
+      );
+
       it('should emit the subscriptionEnded event, with paymentProvider undefined on error', async () => {
         jest
           .spyOn(customerManager, 'retrieve')


### PR DESCRIPTION
## This pull request

- adds test coverage for wallet type, cancel/resubscribe, and UTM tests for Link, Google Pay, and Apple Pay flows

## Issue that this pull request solves

Closes: PAY-3804

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.