### PR TITLE
fix(payments): fix Sentry config

### DIFF
--- a/apps/payments/next/app/[locale]/layout.tsx
+++ b/apps/payments/next/app/[locale]/layout.tsx
@@ -38,7 +38,11 @@ export default async function RootProviderLayout({
           debugViewTag: config.gleanClientConfig.debugViewTag,
         },
         sentry: {
-          ...config.sentry, //spread to make sure its a POJO
+          clientDsn: config.sentry.clientDsn,
+          env: config.sentry.env,
+          clientName: config.sentry.clientName,
+          sampleRate: config.sentry.sampleRate,
+          tracesSampleRate: config.sentry.tracesSampleRate,
         },
       }}
       fetchedMessages={fetchedMessages}

--- a/libs/payments/ui/src/lib/client/providers/ConfigProvider.test.ts
+++ b/libs/payments/ui/src/lib/client/providers/ConfigProvider.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { ConfigContextValues } from './ConfigProvider';
+
+describe('ConfigContextValues sentry shape', () => {
+  it('does not include server-only sentry fields', () => {
+    const sentryConfig: ConfigContextValues['sentry'] = {
+      clientDsn: 'https://test@sentry.io/123',
+      env: 'test',
+      clientName: 'test-client',
+      sampleRate: 1,
+      tracesSampleRate: 1,
+    };
+
+    expect(sentryConfig).not.toHaveProperty('dsn');
+    expect(sentryConfig).not.toHaveProperty('serverName');
+    expect(sentryConfig).not.toHaveProperty('authToken');
+  });
+});

--- a/libs/payments/ui/src/lib/client/providers/ConfigProvider.tsx
+++ b/libs/payments/ui/src/lib/client/providers/ConfigProvider.tsx
@@ -20,7 +20,6 @@ export interface ConfigContextValues {
     debugViewTag?: string;
   };
   sentry: {
-    dsn?: string;
     clientDsn?: string;
     env: string;
     clientName: string;
@@ -41,7 +40,6 @@ export const ConfigContext = createContext<ConfigContextValues>({
     channel: '',
   },
   sentry: {
-    dsn: '',
     clientDsn: '',
     env: '',
     clientName: '',

--- a/libs/payments/ui/src/lib/client/providers/Providers.tsx
+++ b/libs/payments/ui/src/lib/client/providers/Providers.tsx
@@ -26,8 +26,11 @@ export function Providers({
     initSentryForNextjsClient({
       release: process.env.version,
       sentry: {
-        ...config.sentry,
         dsn: config.sentry.clientDsn,
+        env: config.sentry.env,
+        clientName: config.sentry.clientName,
+        sampleRate: config.sentry.sampleRate,
+        tracesSampleRate: config.sentry.tracesSampleRate,
         ignoreErrors: [new RegExp(`^${GENERIC_ERROR_MESSAGE}$`)],
       },
     });


### PR DESCRIPTION
## Because

- The spread of `config.sentry` in layout.tsx serialized server-only fields into RSC payload

## This pull request

- Replaces spread with explicit allowlist of client-safe fields

## Issue that this pull request solves

Closes: PAY-3798

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## How to review (Optional)
- In browser devtools console on any payments page:
  document.documentElement.innerHTML.match(/serverName|authToken/gi)
  // Should return null

- Also check the RSC payload:
  document.querySelectorAll('script').forEach(s => {
    if (s.textContent?.includes('serverName'))
  console.log('LEAK:', s.textContent)
  })