### PR TITLE
feat(pairing): Create deep-link pairing POC

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -118,6 +118,10 @@ const settingsConfig = {
     clients: config.get('pairing.clients'),
     serverBaseUri: config.get('pairing.server_base_uri'),
   },
+  mobileStoreLinks: {
+    ios: config.get('mobileStoreLinks.ios'),
+    android: config.get('mobileStoreLinks.android'),
+  },
   rolloutRates: {
     keyStretchV2: config.get('rolloutRates.keyStretchV2'),
     generalizedReactApp: config.get('rolloutRates.generalizedReactApp'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -369,6 +369,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'REACT_CONVERSION_WEB_CHANNEL_EXAMPLE_ROUTES',
     },
+    pocPairingRoutes: {
+      default: true,
+      doc: 'FXA-13863: Enable the throwaway deep-link pairing POC pages (poc_deep_link, poc_pair_init, poc_pair_start)',
+      format: Boolean,
+      env: 'REACT_CONVERSION_POC_PAIRING_ROUTES',
+    },
   },
   brandMessagingMode: {
     default: 'none',
@@ -789,6 +795,22 @@ const conf = (module.exports = convict({
       env: 'PAIRING_SERVER_BASE_URI',
     },
   },
+  mobileStoreLinks: {
+    ios: {
+      default:
+        'https://apps.apple.com/app/firefox-private-safe-browser/id989804926',
+      doc: 'App Store URL for Firefox iOS (used by the deep-link interstitial store fallback).',
+      env: 'MOBILE_STORE_LINK_IOS',
+      format: String,
+    },
+    android: {
+      default:
+        'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
+      doc: 'Play Store URL for Firefox Android (used by the deep-link interstitial store fallback).',
+      env: 'MOBILE_STORE_LINK_ANDROID',
+      format: String,
+    },
+  },
   payments_next_hosted_url: {
     default: 'http://localhost:3035',
     doc: 'the url of the Payments-Next server',
@@ -1149,6 +1171,10 @@ conf.set('process_type', path.basename(process.argv[1], '.js'));
 // Always send CSP headers in development mode
 if (conf.get('env') === 'development') {
   conf.set('csp.enabled', true);
+  // FXA-13863: enable the throwaway deep-link pairing POC pages locally so they
+  // are available for development/testing. They remain gated (default off) in
+  // stage/prod unless REACT_CONVERSION_POC_PAIRING_ROUTES is set.
+  conf.set('showReactApp.pocPairingRoutes', true);
 }
 
 const DEV_CONFIG_PATH = path.join(__dirname, '..', 'config', 'local.json');

--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -21,6 +21,7 @@ module.exports = function (config, i18n, statsd, glean) {
     redirectVersionedToUnversioned('reset_password'),
     redirectVersionedToUnversioned('verify_email'),
     require('./routes/get-apple-app-site-association')(),
+    require('./routes/get-assetlinks-json')(),
     require('./routes/get-frontend-pairing').default(reactRouteGroups),
     require('./routes/get-frontend').default(reactRouteGroups),
     require('./routes/get-oauth-success').default(reactRouteGroups),

--- a/packages/fxa-content-server/server/lib/routes/get-apple-app-site-association.js
+++ b/packages/fxa-content-server/server/lib/routes/get-apple-app-site-association.js
@@ -19,7 +19,18 @@ module.exports = function () {
     // from `/.well-known/apple-app-site-association` path, describing what apps can open which links.
     // The structure below enables FxiOS Fennec (developer builds), FirefoxBeta (Test Flight builds)
     // and Firefox (App store builds) to open FxA links.
-    const paths = ['/verify_email', '/complete_signin'];
+    //
+    // FXA-13863: `/pair*` and `/poc_deep_link` are added to validate the deep-link
+    // round-trip for the new native-camera pairing QR flow. The Firefox iOS app
+    // must also register `applinks:accounts.firefox.com` in its Associated Domains
+    // entitlement and handle these paths for Universal Links to open the app.
+    const paths = [
+      '/verify_email',
+      '/complete_signin',
+      '/pair',
+      '/pair/*',
+      '/poc_deep_link',
+    ];
     res.json({
       applinks: {
         apps: [],

--- a/packages/fxa-content-server/server/lib/routes/get-assetlinks-json.js
+++ b/packages/fxa-content-server/server/lib/routes/get-assetlinks-json.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+module.exports = function () {
+  const route = {};
+  route.method = 'get';
+  route.path = '/.well-known/assetlinks.json';
+
+  route.process = function (req, res) {
+    // charset must be set on json responses.
+    res.charset = 'utf-8';
+
+    // FXA-13863: Android App Links. To make an https://accounts.firefox.com link
+    // open Firefox directly from the native camera (instead of the browser),
+    // Android requires a Digital Asset Links statement served from
+    // `/.well-known/assetlinks.json`. See:
+    // https://developer.android.com/training/app-links/verify-android-applinks
+    //
+    // Each entry grants the named app permission to handle links for this domain.
+    // The `sha256_cert_fingerprints` MUST be the signing certificate fingerprints
+    // of the released Firefox Android builds — these are owned by the mobile team
+    // (cross-team work in FXA-13732) and are PLACEHOLDERS here. App Links will not
+    // verify until the real fingerprints are supplied AND the app declares an
+    // intent filter with android:autoVerify="true" for accounts.firefox.com.
+    const sha256CertFingerprints = [
+      // TODO(FXA-13732): replace with real Firefox Android signing fingerprints
+      'YOUR_RELEASE_SHA256_FINGERPRINT_HERE',
+    ];
+
+    // Release, Beta, and Nightly package names for Firefox Android (Fenix).
+    const packageNames = [
+      'org.mozilla.firefox',
+      'org.mozilla.firefox_beta',
+      'org.mozilla.fenix',
+    ];
+
+    res.json(
+      packageNames.map((packageName) => ({
+        relation: ['delegate_permission/common.handle_all_urls'],
+        target: {
+          namespace: 'android_app',
+          package_name: packageName,
+          sha256_cert_fingerprints: sha256CertFingerprints,
+        },
+      }))
+    );
+  };
+
+  return route;
+};

--- a/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
@@ -91,6 +91,9 @@ const FRONTEND_ROUTES = [
   'verify_secondary_email',
   'would_you_like_to_sync',
   'web_channel_example',
+  'poc_deep_link', // FXA-13863 throwaway deep-link POC test page
+  'poc_pair_init', // FXA-13863 throwaway open-or-store interstitial
+  'poc_pair_start', // FXA-13863 throwaway pairing-start placeholder
 ];
 
 // The array is converted into a RegExp

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -178,6 +178,20 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       routes: reactRoute.getRoutes(['web_channel_example']),
       fullProdRollout: false,
     },
+
+    // FXA-13863 throwaway deep-link pairing POC pages. Gated behind
+    // `showReactApp.pocPairingRoutes`; served only when that flag is on
+    // (fullProdRollout: true means flag-on serves React for everyone, no
+    // `?showReactApp=true` needed).
+    pocPairingRoutes: {
+      featureFlagOn: showReactApp.pocPairingRoutes,
+      routes: reactRoute.getRoutes([
+        'poc_deep_link',
+        'poc_pair_init',
+        'poc_pair_start',
+      ]),
+      fullProdRollout: true,
+    },
   };
 };
 

--- a/packages/fxa-content-server/server/lib/routes/react-app/types.ts
+++ b/packages/fxa-content-server/server/lib/routes/react-app/types.ts
@@ -58,6 +58,7 @@ type ShowReactApp = {
   postVerifyCADViaQRRoutes: boolean;
   postVerifyThirdPartyAuthRoutes: boolean;
   webChannelExampleRoutes: boolean;
+  pocPairingRoutes: boolean;
 };
 
 export interface ReactRouteGroups {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -141,6 +141,9 @@ const SignupConfirmed = lazy(
   () => import('../../pages/Signup/SignupConfirmed')
 );
 const WebChannelExample = lazy(() => import('../../pages/WebChannelExample'));
+const PocDeepLink = lazy(() => import('../../pages/PocDeepLink'));
+const PocPairInit = lazy(() => import('../../pages/PocPairInit'));
+const PocPairStart = lazy(() => import('../../pages/PocPairStart'));
 const SignoutSync = lazy(() => import('../Settings/SignoutSync'));
 const InlineRecoveryKeySetupContainer = lazy(
   () => import('../../pages/InlineRecoveryKeySetup/container')
@@ -580,6 +583,9 @@ const AuthAndAccountSetupRoutes = ({
         {/* Other */}
         <Clear path="/clear/*" />
         <WebChannelExample path="/web_channel_example/*" />
+        <PocDeepLink path="/poc_deep_link/*" />
+        <PocPairInit path="/poc_pair_init/*" />
+        <PocPairStart path="/poc_pair_start/*" />
         <CookiesDisabled path="cookies_disabled" />
 
         {/* Post verify */}

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -102,6 +102,10 @@ export interface Config {
     clients: string[];
     serverBaseUri: string;
   };
+  mobileStoreLinks: {
+    ios: string;
+    android: string;
+  };
   rolloutRates?: {
     keyStretchV2?: number;
     generalizedReactApp?: number;
@@ -223,6 +227,10 @@ export function getDefault() {
     pairing: {
       clients: [],
       serverBaseUri: 'wss://channelserver.services.mozilla.com',
+    },
+    mobileStoreLinks: {
+      ios: 'https://apps.apple.com/app/firefox-private-safe-browser/id989804926',
+      android: 'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
     },
     featureFlags: {
       recoveryCodeSetupOnSyncSignIn: false,

--- a/packages/fxa-settings/src/pages/PocDeepLink/index.tsx
+++ b/packages/fxa-settings/src/pages/PocDeepLink/index.tsx
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * FXA-13863 — Deep-link proof of concept (THROWAWAY).
+ *
+ * Renders a scannable QR code used to validate, on real iOS & Android devices,
+ * whether a QR scanned with the *native* camera can open Firefox straight into
+ * pairing and fall back to the app store when Firefox is not installed.
+ *
+ * The QR encodes an https `/poc_pair_init` interstitial. The native camera only acts
+ * on http(s) URLs, so this is what a scanned QR must encode; /poc_pair_init then
+ * attempts the firefox:// custom scheme and falls back to the store.
+ *
+ * This page is intentionally minimal and unlocalized. It is a temporary test
+ * harness feeding FXA-13865 (v2 QR URL format) and FXA-13732 (mobile work) and
+ * is expected to be removed once findings are captured. Do NOT build production
+ * pairing on top of it.
+ */
+
+import React, { useState } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import AppLayout from '../../components/AppLayout';
+import CardHeader from '../../components/CardHeader';
+import QRCode from '../../components/QRCode';
+import { usePageViewEvent } from '../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../constants';
+import { useConfig } from '../../models';
+
+export const viewName = 'poc_deep_link';
+
+// Sample pairing params. Used only to verify whether params survive the
+// deep-link / store round-trip; not real channel credentials.
+const DEFAULT_CHANNEL_ID = 'pocChannelId00000000000000000000';
+const DEFAULT_CHANNEL_KEY = 'pocChannelKey0000000000000000000000000000000';
+
+/**
+ * The initial URL we want Firefox to open. `window.location.origin` keeps the
+ * default correct across dev (LAN IP) / stage / prod. Override with `?url=` (or
+ * just edit it live in the input on the page).
+ */
+function getInitialTarget(search: string) {
+  const params = new URLSearchParams(search);
+  const origin =
+    typeof window !== 'undefined'
+      ? window.location.origin
+      : 'https://accounts.firefox.com';
+  const sampleQuery = new URLSearchParams({
+    channel_id: params.get('channel_id') || DEFAULT_CHANNEL_ID,
+    channel_key: params.get('channel_key') || DEFAULT_CHANNEL_KEY,
+  }).toString();
+  return params.get('url') || `${origin}/poc_pair_start?${sampleQuery}`;
+}
+
+/**
+ * Build the SCANNABLE https `/poc_pair_init` URL for the current target. The native
+ * camera only acts on http(s) URLs, so this is what the QR must encode;
+ * /poc_pair_init then attempts the firefox:// custom scheme and falls back to the store.
+ */
+function buildPairInitLink(targetUrl: string) {
+  const origin =
+    typeof window !== 'undefined'
+      ? window.location.origin
+      : 'https://accounts.firefox.com';
+  return `${origin}/poc_pair_init?url=${encodeURIComponent(targetUrl)}`;
+}
+
+const Section = ({
+  title,
+  description,
+  url,
+}: {
+  title: string;
+  description: string;
+  url: string;
+}) => {
+  const config = useConfig();
+  return (
+    <div className="flex flex-col items-center gap-3 max-w-xs">
+      <b>{title}</b>
+      <p className="text-sm text-grey-400 text-center">{description}</p>
+      <QRCode
+        value={url}
+        localizedLabel={`QR code encoding ${url}`}
+        size={200}
+      />
+      <code className="text-xs break-all text-center">{url}</code>
+      <a className="link-blue text-sm" href={url}>
+        Tap to open on this device
+      </a>
+      <div className="flex gap-4">
+        <a
+          className="link-blue text-sm"
+          href={config.mobileStoreLinks.ios}
+          target="_blank"
+          rel="noreferrer"
+        >
+          iOS store fallback
+        </a>
+        <a
+          className="link-blue text-sm"
+          href={config.mobileStoreLinks.android}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Android store fallback
+        </a>
+      </div>
+    </div>
+  );
+};
+
+const PocDeepLink = (props: RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+
+  const search =
+    typeof window !== 'undefined' ? window.location.search : props.location?.search || '';
+  const [targetUrl, setTargetUrl] = useState(() => getInitialTarget(search));
+  const pairInitLink = buildPairInitLink(targetUrl);
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingText="Deep-link POC"
+        headingTextFtlId="poc_deep_link-header"
+      />
+      <p className="text-sm text-grey-400 mt-2">
+        Scan with the device&apos;s{' '}
+        <b>native camera</b> (or tap on-device) to test the round-trip. Edit the
+        target URL below (the QR updates live), or override it via{' '}
+        <code>?url=</code>.
+      </p>
+      <label className="block mt-4 text-sm">
+        <span className="font-bold">Target URL Firefox should open</span>
+        <input
+          type="url"
+          inputMode="url"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="mt-1 w-full rounded border border-grey-300 p-2 text-sm font-mono dark:bg-grey-800 dark:text-grey-10"
+          value={targetUrl}
+          onChange={(e) => setTargetUrl(e.target.value)}
+          placeholder="https://accounts.firefox.com/pair?channel_id=…"
+        />
+      </label>
+      <div className="flex flex-wrap justify-center gap-10 mt-6">
+        <Section
+          title="Scan this — /poc_pair_init interstitial (https)"
+          description="The QR a native camera can actually open. Lands on /poc_pair_init, which tries to open Firefox at the target URL and, if it doesn't open, redirects to the app store."
+          url={pairInitLink}
+        />
+      </div>
+    </AppLayout>
+  );
+};
+
+export default PocDeepLink;

--- a/packages/fxa-settings/src/pages/PocPairInit/index.tsx
+++ b/packages/fxa-settings/src/pages/PocPairInit/index.tsx
@@ -1,0 +1,235 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import AppLayout from '../../components/AppLayout';
+import CardHeader from '../../components/CardHeader';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { usePageViewEvent } from '../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../constants';
+import { useConfig } from '../../models';
+
+export const viewName = 'poc_pair_init';
+
+const DEFAULT_TIMEOUT_MS = 1500;
+const DEFAULT_CHANNEL_ID = 'pocChannelId00000000000000000000';
+const DEFAULT_CHANNEL_KEY = 'pocChannelKey0000000000000000000000000000000';
+
+function detectPlatform(ua: string) {
+  const isIos = /iPhone|iPad|iPod/i.test(ua);
+  const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(ua);
+  // 'fxios' covers Firefox on iOS, which does not contain 'firefox' in its UA.
+  const isFirefox = /firefox|fxios/i.test(ua);
+  return { isIos, isAndroid: isMobile && !isIos, isMobile, isFirefox };
+}
+
+// Custom-scheme guards for the iOS deep link. Anything not matching (or a
+// dangerous scheme like javascript:/data:) falls back to a safe constant, so
+// user input can never turn the `location.href = deepLink` into an XSS vector.
+const DANGEROUS_SCHEMES = new Set(['javascript', 'data', 'vbscript', 'file', 'blob']);
+const SAFE_SCHEME = /^[a-z][a-z0-9.+-]*$/;
+const SAFE_ACTION = /^[a-z0-9/_-]+$/i;
+
+/**
+ * Only allow same-origin http(s) URLs. Returns the sanitized href, or null for
+ * cross-origin / javascript: / data: / malformed input. This closes the CodeQL
+ * "client-side URL redirect" and "client-side XSS" findings: every navigation
+ * sink (location.assign, location.href, the desktop <a href>) receives a value
+ * that has been validated against the current origin.
+ */
+function sameOriginHttpUrl(raw: string, origin: string): string | null {
+  try {
+    const u = new URL(raw, origin);
+    if ((u.protocol === 'http:' || u.protocol === 'https:') && u.origin === origin) {
+      return u.href;
+    }
+  } catch {
+    // not a parseable URL — treat as unsafe
+  }
+  return null;
+}
+
+function readConfig(search: string) {
+  const params = new URLSearchParams(search);
+  const protocol = window.location.protocol.replace(':', '');
+  const origin =
+    typeof window !== 'undefined'
+      ? window.location.origin
+      : 'https://accounts.firefox.com';
+
+  const rawScheme = (params.get('scheme') || 'firefox').toLowerCase();
+  const scheme =
+    SAFE_SCHEME.test(rawScheme) && !DANGEROUS_SCHEMES.has(rawScheme)
+      ? rawScheme
+      : 'firefox';
+
+  const rawAction = (params.get('action') || 'open-url').replace(/^\/+/, '');
+  const action = SAFE_ACTION.test(rawAction) ? rawAction : 'open-url';
+
+  const timeout = Number(params.get('timeout')) || DEFAULT_TIMEOUT_MS;
+
+  const sampleQuery = new URLSearchParams({
+    channel_id: params.get('channel_id') || DEFAULT_CHANNEL_ID,
+    channel_key: params.get('channel_key') || DEFAULT_CHANNEL_KEY,
+  }).toString();
+  const defaultTarget = `${origin}/poc_pair_start?${sampleQuery}`;
+
+  // `?url=` may only point at our own origin — blocks open-redirects and
+  // javascript:/data: URLs. Anything else falls back to the default target.
+  const target =
+    sameOriginHttpUrl(params.get('url') || defaultTarget, origin) || defaultTarget;
+
+  return { target, timeout, scheme, action, protocol };
+}
+
+type Status = 'redirecting' | 'prompt' | 'attempting' | 'desktop';
+
+const PocPairInit = (props: RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+
+  const search =
+    typeof window !== 'undefined'
+      ? window.location.search
+      : props.location?.search || '';
+  const { target, timeout, scheme, action, protocol } = readConfig(search);
+
+  const config = useConfig();
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  const { isIos, isAndroid, isMobile, isFirefox } = detectPlatform(ua);
+  const storeName = isIos ? 'App Store' : 'Play Store';
+  const storeUrl = isIos
+    ? config.mobileStoreLinks.ios
+    : config.mobileStoreLinks.android;
+
+  // Android: package-pinned intent:// that opens the target in Firefox, with a
+  // built-in store fallback (S.browser_fallback_url) when it isn't installed.
+  // NOTE: a "Choose activity" chooser can still appear — Chrome strips an
+  // explicit `component` from intent:// for security, so we can't force a
+  // direct launch that way. The real no-chooser mechanism is verified Android
+  // App Links (https + assetlinks.json + app autoVerify), which
+  // cannot work in the local http setup, and must be done in a follow up. For
+  // this POC, we will have to live the activity chooser when testing on local host.
+  const deepLink = isAndroid
+    ? `intent://${target.replace(/^https?:\/\//, '')}` +
+      `#Intent;scheme=${protocol};package=org.mozilla.firefox;` +
+      `S.browser_fallback_url=${encodeURIComponent(storeUrl)};end`
+    : `${scheme}://${action}?url=${encodeURIComponent(target)}`;
+
+  const [status, setStatus] = useState<Status>(
+    isFirefox ? 'redirecting' : isMobile ? 'prompt' : 'desktop'
+  );
+  // Ref so the visibility listener and the timer share one source of truth.
+  const appOpenedRef = useRef(false);
+  // Holds the teardown for the in-flight attempt so we can clean up on unmount.
+  const cleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  // Already in Firefox: skip the button entirely and navigate the current tab
+  // straight to the target. A firefox:// scheme navigation from inside Firefox
+  // does nothing, and no app hand-off is needed — we're already in Firefox.
+  useEffect(() => {
+    if (isFirefox) {
+      window.location.assign(target);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Triggered by a user gesture (button tap). Attaching the listeners and firing
+  // the deep link synchronously here preserves the user-activation that iOS needs
+  // to follow a custom scheme, and ensures the listeners are live before we fire.
+  const continueWithFirefox = () => {
+    cleanupRef.current?.();
+    appOpenedRef.current = false;
+    setStatus('attempting');
+
+    // The store fallback differs by platform. On Android the intent:// URL's
+    // `S.browser_fallback_url` handles the not-installed case natively, so no JS
+    // fallback is needed. On iOS the custom scheme silently no-ops when Firefox
+    // isn't installed, so we watch for the app opening and, failing that within
+    // `timeout`, redirect to the App Store.
+    if (!isAndroid) {
+      // Primary signal: page hidden/backgrounded ⇒ the app opened ⇒ cancel store.
+      const onHidden = () => {
+        if (document.hidden) {
+          appOpenedRef.current = true;
+        }
+      };
+      const onLeave = () => {
+        appOpenedRef.current = true;
+      };
+      document.addEventListener('visibilitychange', onHidden);
+      window.addEventListener('pagehide', onLeave);
+      window.addEventListener('blur', onLeave);
+
+      // Still here after `timeout` ⇒ Firefox didn't open ⇒ go to the store.
+      // replace() so Back doesn't loop the user back into this interstitial.
+      const timer = window.setTimeout(() => {
+        if (!appOpenedRef.current && !document.hidden) {
+          window.location.replace(storeUrl);
+        }
+      }, timeout);
+
+      cleanupRef.current = () => {
+        document.removeEventListener('visibilitychange', onHidden);
+        window.removeEventListener('pagehide', onLeave);
+        window.removeEventListener('blur', onLeave);
+        window.clearTimeout(timer);
+        cleanupRef.current = null;
+      };
+    }
+
+    // Fire the attempt within the gesture, after any listeners are attached.
+    window.location.href = deepLink;
+  };
+
+  return (
+    <AppLayout>
+      <CardHeader headingText="Pair Start" headingTextFtlId="poc_pair_init-header" />
+
+      {status === 'redirecting' && (
+        <p className="text-sm text-grey-400 mt-2">Continuing in Firefox…</p>
+      )}
+
+      {status === 'desktop' && (
+        <p className="text-sm text-grey-400 mt-2">
+          This open-or-store flow is for mobile. On desktop, just open the target
+          directly:{' '}
+          <a className="link-blue break-all" href={target}>
+            {target}
+          </a>
+          .
+        </p>
+      )}
+
+      {(status === 'prompt' || status === 'attempting') && (
+        <div className="flex flex-col gap-4 mt-2">
+          <p className="text-sm text-grey-400">
+            {'To continue, you’ll need to use Firefox. Tap below to open it — ' +
+              `if Firefox isn’t installed, you’ll be taken to the ${storeName}.`}
+          </p>
+          <button
+            className="cta-primary cta-xl"
+            onClick={continueWithFirefox}
+          >
+            Continue with Firefox
+          </button>
+          {status === 'attempting' && (
+            <p className="flex items-center justify-center gap-2 text-sm text-grey-400">
+              <LoadingSpinner imageClassName="w-4 h-4 animate-spin" />
+              Opening Firefox…
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Debug block — POC visibility into what this page resolved. */}
+      <pre className="text-xs text-start break-all whitespace-pre-wrap mt-6 text-grey-400">
+        {`deepLink: ${deepLink}\ntarget:   ${target}\ntimeout:  ${timeout}ms`}
+      </pre>
+    </AppLayout>
+  );
+};
+
+export default PocPairInit;

--- a/packages/fxa-settings/src/pages/PocPairStart/index.tsx
+++ b/packages/fxa-settings/src/pages/PocPairStart/index.tsx
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * FXA-13863 — Pairing start placeholder (THROWAWAY).
+ *
+ * This is where the deep-link flow lands inside Firefox once pairing begins.
+ * For now it is a static placeholder. In later versions this page will invoke
+ * the pairing channel server and notify the waiting desktop client.
+ */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+import AppLayout from '../../components/AppLayout';
+import CardHeader from '../../components/CardHeader';
+import { usePageViewEvent } from '../../lib/metrics';
+import { REACT_ENTRYPOINT } from '../../constants';
+
+export const viewName = 'poc_pair_start';
+
+const PocPairStart = (_: RouteComponentProps) => {
+  usePageViewEvent(viewName, REACT_ENTRYPOINT);
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingText="Pairing Started"
+        headingTextFtlId="poc_pair_start-header"
+      />
+      <p className="text-sm text-grey-400 mt-2">
+        Initiating connection to pairing channel
+      </p>
+    </AppLayout>
+  );
+};
+
+export default PocPairStart;


### PR DESCRIPTION
## Because:
 - The new native-camera QR pairing flow needs a proof of concept to prove the deep-link round-trip works on real iOS & Android devices, and to learn what association files / app registrations it requires, before we lock the v2 QR URL format and wire it into /pair.

## This PR
 - Adds throwaway fxa-settings pages, gated behind the new showReactApp.pocPairingRoutes feature flag: * /poc_deep_link  - QR test harness with a live-editable target URL * /poc_pair_init  - open-or-store interstitial: navigates straight to the target when already in Firefox, otherwise attempts firefox://open-url on a user gesture and falls back to the app store on timeout * /poc_pair_start - pairing-start placeholder for future channel work
 - Serves Android App Links via /.well-known/assetlinks.json and extends the apple-app-site-association with the /pair and /poc_deep_link paths (fingerprints are placeholders pending mobile-team input, FXA-13732).
 - Makes the mobile app-store links config-driven via mobileStoreLinks in content-server, surfaced through settingsConfig and consumed with useConfig().
 - Adds the showReactApp.pocPairingRoutes flag (env REACT_CONVERSION_POC_PAIRING_ROUTES), enabled in development and off by default in stage/prod, and serves the POC routes only when it is enabled.



## Issue that this pull request solves

Closes: FXA-13863, FXA-13794

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Determine your local area network IP. (e.g. `ipconfig getifaddr en0` > `192.168.0.200`)
- Open http://192.168.0.200/poc_deep_link on your desktop
- Scan the QR code with your phone.
- Experiment with android and ios
- Experiment with firefox being:
  - The default browser
  - Not installed at all
  - Installed but not the default browser
 
## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a throwaway proof of concept; it is not production ready and will not be enabled on production! The flow is designed to vet the various states that Firefox can exist in on a mobile device such as: installed and set as default browser, installed but not default browser, or not installed. It is also designed to validate that the deep linking works as expected on ios and android.

An exploratory doc and flow chart accompanies this work. Ping me for a link.
