### PR TITLE
refactor(auth): Record sign-in consents in a single atomic upsert

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -322,14 +322,13 @@ class OauthDB extends ConnectedServicesDb {
     );
   }
 
-  // Upserts a consent row for the (uid, scope, service, clientId)
-  // tuple. First write seeds both timestamps to `now`; subsequent
-  // writes preserve firstAuthorizedTosAt and bump lastAuthorizedTosAt.
-  async recordSignInConsent({ uid, scope, service, clientId, now }) {
+  // Upserts a consent row for each scope under (uid, service, clientId) in a
+  // single atomic statement.
+  async recordSignInConsents({ uid, scopes, service, clientId, now }) {
     await this.ready();
-    return this.mysql._upsertAccountConsent(
+    return this.mysql._upsertAccountConsents(
       uid,
-      scope,
+      scopes,
       service,
       clientId,
       now || Date.now()

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -199,15 +199,16 @@ const DELETE_REFRESH_TOKEN_WITH_CLIENT_AND_UID =
 const PRUNE_AUTHZ_CODES =
   'DELETE FROM codes WHERE TIMESTAMPDIFF(SECOND, createdAt, NOW()) > ? LIMIT 10000';
 
-// First insert sets both timestamps to now. Subsequent /authorization
-// completions for the same PK preserve firstAuthorizedTosAt and bump
-// lastAuthorizedTosAt only, using GREATEST to guard against clock skew
-// or reordered writes producing a backwards-moving lastAuthorizedTosAt.
-const QUERY_ACCOUNT_CONSENT_UPSERT =
+// First insert sets both timestamps to now. Later completions for the same PK
+// preserve firstAuthorizedTosAt and bump lastAuthorizedTosAt via GREATEST,
+// guarding against clock skew or reordered writes moving it backwards.
+// The VALUES list is built at call time so all scopes are recorded in one query.
+const QUERY_ACCOUNT_CONSENT_UPSERT_PREFIX =
   'INSERT INTO accountAuthorizations ' +
   '(uid, scope, service, clientId, firstAuthorizedTosAt, lastAuthorizedTosAt) ' +
-  'VALUES (?, ?, ?, ?, ?, ?) ' +
-  'ON DUPLICATE KEY UPDATE ' +
+  'VALUES ';
+const QUERY_ACCOUNT_CONSENT_UPSERT_SUFFIX =
+  ' ON DUPLICATE KEY UPDATE ' +
   'lastAuthorizedTosAt = GREATEST(lastAuthorizedTosAt, VALUES(lastAuthorizedTosAt))';
 const QUERY_ACCOUNT_CONSENT_FIND_SIGNIN =
   'SELECT uid, scope, service, clientId, firstAuthorizedTosAt, lastAuthorizedTosAt ' +
@@ -664,15 +665,25 @@ class MysqlStore extends MysqlOAuthShared {
     return this._write(QUERY_REFRESH_TOKEN_DELETE, [buf(id)]);
   }
 
-  _upsertAccountConsent(uid, scope, service, clientId, now) {
-    return this._write(QUERY_ACCOUNT_CONSENT_UPSERT, [
-      buf(uid),
-      scope,
-      service,
-      buf(clientId),
-      now,
-      now,
-    ]);
+  // Upserts one consent row per scope in a single INSERT. `scopes` must be
+  // non-empty; callers return early when there is nothing to record.
+  _upsertAccountConsents(uid, scopes, service, clientId, now) {
+    if (!Array.isArray(scopes) || scopes.length === 0) {
+      return Promise.resolve();
+    }
+    const uidBuf = buf(uid);
+    const clientIdBuf = buf(clientId);
+    const tuples = scopes.map(() => '(?, ?, ?, ?, ?, ?)').join(', ');
+    const params = [];
+    for (const scope of scopes) {
+      params.push(uidBuf, scope, service, clientIdBuf, now, now);
+    }
+    return this._write(
+      QUERY_ACCOUNT_CONSENT_UPSERT_PREFIX +
+        tuples +
+        QUERY_ACCOUNT_CONSENT_UPSERT_SUFFIX,
+      params
+    );
   }
 
   async _findAccountConsentForSignIn(uid, scope, service) {

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -251,23 +251,16 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
         err: err.message,
       });
     }
-    // allSettled so a second sibling rejection does not become an
-    // unhandled rejection after the first failure has been caught upstream.
-    const results = await Promise.allSettled(
-      Array.from(scopesToConsent).map((scope) =>
-        oauthDB.recordSignInConsent({
-          uid: uidHex,
-          scope,
-          service: serviceValue,
-          clientId: clientIdHex,
-          now,
-        })
-      )
-    );
-    const failure = results.find((r) => r.status === 'rejected');
-    if (failure) {
-      throw failure.reason;
-    }
+    // Single atomic upsert for all scopes, one DB connection. A rejection
+    // bubbles to authorizationHandler's catch, which emits
+    // accountAuthorization.write_failed and keeps sign-in working.
+    await oauthDB.recordSignInConsents({
+      uid: uidHex,
+      scopes: Array.from(scopesToConsent),
+      service: serviceValue,
+      clientId: clientIdHex,
+      now,
+    });
     // Only flag once the write succeeded, so the signal matches what landed.
     if (firstAuthorization) {
       req.app.firstAuthorization = true;

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.spec.ts
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { createMock } from '@golevelup/ts-jest';
+import { AuthLogger } from '../../types';
+
 const Joi = require('joi');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
@@ -12,11 +15,9 @@ const PKCE_CODE_CHALLENGE = 'iyW5ScKr22v_QL-rcW_EGlJrDSOymJvrlXlw4j7JBiQ';
 const PKCE_CODE_CHALLENGE_METHOD = 'S256';
 const DISABLED_CLIENT_ID = 'd15ab1edd15ab1ed';
 
-const noop = () => {};
-
 const SERVICES_WITH_EMAIL_VERIFICATION_CLIENT = '32aaeb6f1c21316a';
 
-const mockLog = { info: noop, debug: noop, warn: noop };
+const mockLog = createMock<AuthLogger>();
 
 const baseConfig = {
   oauthServer: {
@@ -43,7 +44,7 @@ const configuredRoute = require('./authorization')({
 })[1];
 
 const sessionTokenRoute = require('./authorization')({
-  log: { ...mockLog, notifyAttachedServices: noop },
+  log: mockLog,
   oauthDB: {},
   config: {
     ...baseConfig,
@@ -356,7 +357,7 @@ describe('/authorization POST consent write', () => {
         s === 'sync' ? SYNC_SCOPE : undefined
       ),
       getServiceForCanonicalScope: jest.fn(() => undefined),
-      recordSignInConsent: jest.fn().mockResolvedValue(undefined),
+      recordSignInConsents: jest.fn().mockResolvedValue(undefined),
       hasConsentForService: jest.fn().mockResolvedValue(false),
       hasConsentForClient: jest.fn().mockResolvedValue(false),
       ...overrides,
@@ -417,7 +418,7 @@ describe('/authorization POST consent write', () => {
     return { app };
   }
 
-  it('writes one row per requested scope plus the service canonical and consults the allowlist', async () => {
+  it('records every requested scope plus the service canonical in a single call and consults the allowlist', async () => {
     const oauthDB = buildOauthDB();
     const statsd = { increment: jest.fn() };
 
@@ -431,18 +432,17 @@ describe('/authorization POST consent write', () => {
       'sync',
       CLIENT_ID
     );
-    expect(oauthDB.recordSignInConsent).toHaveBeenCalledTimes(3);
-    const scopes = (oauthDB.recordSignInConsent as jest.Mock).mock.calls
-      .map(([arg]) => arg.scope)
-      .sort();
-    expect(scopes).toEqual([SYNC_SCOPE, 'openid', 'profile']);
-    expect(oauthDB.recordSignInConsent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        uid: UID_HEX,
-        service: 'sync',
-        clientId: CLIENT_ID,
-      })
-    );
+    // One call for all scopes — a single DB statement/connection, not one per scope.
+    expect(oauthDB.recordSignInConsents).toHaveBeenCalledTimes(1);
+    const { scopes, ...rest } = (oauthDB.recordSignInConsents as jest.Mock).mock
+      .calls[0][0];
+    expect([...scopes].sort()).toEqual([SYNC_SCOPE, 'openid', 'profile']);
+    expect(rest).toEqual({
+      uid: UID_HEX,
+      service: 'sync',
+      clientId: CLIENT_ID,
+      now: expect.any(Number),
+    });
     expect(statsd.increment).toHaveBeenCalledWith(
       'accountAuthorization.recorded',
       { service: 'sync', access_type: 'offline' }
@@ -459,21 +459,20 @@ describe('/authorization POST consent write', () => {
       payload: { service: 'mystery', scope: 'profile' },
     });
 
-    expect(oauthDB.recordSignInConsent).toHaveBeenCalledWith(
-      expect.objectContaining({ scope: 'profile', service: '' })
+    expect(oauthDB.recordSignInConsents).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: ['profile'], service: '' })
     );
   });
 
-  it('swallows recordSignInConsent failures and emits write_failed', async () => {
+  it('swallows recordSignInConsents failures and emits write_failed', async () => {
     const oauthDB = buildOauthDB({
-      recordSignInConsent: jest.fn().mockRejectedValue(new Error('db down')),
+      recordSignInConsents: jest.fn().mockRejectedValue(new Error('db down')),
     });
-    const log = { ...mockLog, warn: jest.fn() };
     const statsd = { increment: jest.fn() };
 
-    await runHandler({ oauthDB, log, statsd, payload: { scope: 'profile' } });
+    await runHandler({ oauthDB, statsd, payload: { scope: 'profile' } });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(mockLog.warn).toHaveBeenCalledWith(
       'accountAuthorization.write_failed',
       expect.objectContaining({ err: 'db down' })
     );
@@ -492,7 +491,7 @@ describe('/authorization POST consent write', () => {
       payload: { service: 'sync', prompt: 'none' },
     });
 
-    expect(oauthDB.recordSignInConsent).not.toHaveBeenCalled();
+    expect(oauthDB.recordSignInConsents).not.toHaveBeenCalled();
     expect(statsd.increment).toHaveBeenCalledWith(
       'accountAuthorization.skipped',
       {
@@ -518,7 +517,7 @@ describe('/authorization POST consent write', () => {
       UID_HEX,
       CLIENT_ID
     );
-    expect(oauthDB.recordSignInConsent).toHaveBeenCalled();
+    expect(oauthDB.recordSignInConsents).toHaveBeenCalled();
     expect(app.firstAuthorization).toBe(true);
   });
 
@@ -537,12 +536,11 @@ describe('/authorization POST consent write', () => {
 
   it('does not flag firstAuthorization when the consent write fails', async () => {
     const oauthDB = buildOauthDB({
-      recordSignInConsent: jest.fn().mockRejectedValue(new Error('db down')),
+      recordSignInConsents: jest.fn().mockRejectedValue(new Error('db down')),
     });
 
     const { app } = await runHandler({
       oauthDB,
-      log: { ...mockLog, warn: jest.fn() },
       payload: { scope: 'profile' },
     });
 
@@ -553,17 +551,15 @@ describe('/authorization POST consent write', () => {
     const oauthDB = buildOauthDB({
       hasConsentForClient: jest.fn().mockRejectedValue(new Error('read down')),
     });
-    const log = { ...mockLog, warn: jest.fn() };
     const statsd = { increment: jest.fn() };
 
     const { app } = await runHandler({
       oauthDB,
-      log,
       statsd,
       payload: { scope: 'profile' },
     });
 
-    expect(oauthDB.recordSignInConsent).toHaveBeenCalled();
+    expect(oauthDB.recordSignInConsents).toHaveBeenCalled();
     expect(statsd.increment).toHaveBeenCalledWith(
       'accountAuthorization.first_auth_read_failed'
     );
@@ -582,7 +578,7 @@ describe('/authorization POST consent write', () => {
       payload: { service: 'sync' },
     });
 
-    expect(oauthDB.recordSignInConsent).not.toHaveBeenCalled();
+    expect(oauthDB.recordSignInConsents).not.toHaveBeenCalled();
     expect(statsd.increment).toHaveBeenCalledWith(
       'accountAuthorization.skipped',
       {
@@ -609,8 +605,8 @@ describe('/authorization POST consent write', () => {
       'vpn',
       CLIENT_ID
     );
-    expect(oauthDB.recordSignInConsent).toHaveBeenCalledWith(
-      expect.objectContaining({ scope: VPN_SCOPE, service: 'vpn' })
+    expect(oauthDB.recordSignInConsents).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: [VPN_SCOPE], service: 'vpn' })
     );
   });
 
@@ -628,7 +624,7 @@ describe('/authorization POST consent write', () => {
 
     await runHandler({ oauthDB, statsd, payload: { scope: VPN_SCOPE } });
 
-    expect(oauthDB.recordSignInConsent).not.toHaveBeenCalled();
+    expect(oauthDB.recordSignInConsents).not.toHaveBeenCalled();
     expect(statsd.increment).toHaveBeenCalledWith(
       'accountAuthorization.skipped',
       { reason: 'client_not_allowed', service: 'vpn' }
@@ -665,20 +661,14 @@ describe('/authorization POST consent write', () => {
       },
     });
 
-    expect(oauthDB.recordSignInConsent).toHaveBeenCalledTimes(3);
-    const calls = (oauthDB.recordSignInConsent as jest.Mock).mock.calls.map(
-      ([arg]) => ({ scope: arg.scope, service: arg.service })
-    );
-    expect(calls).toEqual(
-      expect.arrayContaining([
-        { scope: VPN_SCOPE, service: 'vpn' },
-        { scope: 'profile', service: 'vpn' },
-        // apps/oldsync's canonical owner is 'sync', but the row is
-        // currently keyed to the URL service='vpn'. FXA-13874 tracks
-        // changing this so it's keyed to 'sync' instead.
-        { scope: SYNC_SCOPE, service: 'vpn' },
-      ])
-    );
+    expect(oauthDB.recordSignInConsents).toHaveBeenCalledTimes(1);
+    const { scopes, service } = (oauthDB.recordSignInConsents as jest.Mock).mock
+      .calls[0][0];
+    expect([...scopes].sort()).toEqual([SYNC_SCOPE, VPN_SCOPE, 'profile']);
+    // apps/oldsync's canonical owner is 'sync', but every row in this grant
+    // is currently keyed to the URL service='vpn'. FXA-13874 tracks changing
+    // this so the apps/oldsync row is keyed to 'sync' instead.
+    expect(service).toBe('vpn');
   });
 });
 
@@ -696,7 +686,7 @@ describe('/oauth/authorization service-driven scope resolution', () => {
 
   function makeRoute(oauthDB: Record<string, any>) {
     return require('./authorization')({
-      log: { ...mockLog, notifyAttachedServices: noop },
+      log: mockLog,
       oauthDB,
       config: baseConfig,
     })[2];

--- a/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
@@ -56,10 +56,12 @@ async function seed(opts: {
   clientId?: string;
   now?: number;
 }) {
-  await db.recordSignInConsent({
+  const { scope, ...rest } = opts;
+  await db.recordSignInConsents({
     clientId: DESKTOP,
     now: Date.now(),
-    ...opts,
+    ...rest,
+    scopes: [scope],
   });
 }
 
@@ -133,6 +135,58 @@ describe('accountAuthorizations repository', () => {
       clientId: IOS,
     });
     expect(await db.listAccountConsentsByUid(id)).toHaveLength(2);
+  });
+
+  it('records one row per scope from a single multi-scope upsert', async () => {
+    const id = track(newUid());
+    const now = Date.now();
+    await db.recordSignInConsents({
+      uid: id,
+      scopes: [OLDSYNC_SCOPE, 'profile', 'openid'],
+      service: 'sync',
+      clientId: DESKTOP,
+      now,
+    });
+    const rows = await db.listAccountConsentsByUid(id);
+    expect(rows.map((r) => r.scope).sort()).toEqual([
+      OLDSYNC_SCOPE,
+      'openid',
+      'profile',
+    ]);
+    expect(await db.hasConsentForSignIn(id, OLDSYNC_SCOPE, 'sync')).toBe(true);
+    expect(await db.hasConsentForSignIn(id, 'profile', 'sync')).toBe(true);
+  });
+
+  it('multi-scope upsert preserves firstAuthorizedTosAt and bumps lastAuthorizedTosAt per row', async () => {
+    const id = track(newUid());
+    const t0 = Date.now();
+    const t1 = t0 + 86_400_000;
+    const batch = {
+      uid: id,
+      scopes: [OLDSYNC_SCOPE, 'profile'],
+      service: 'sync',
+      clientId: DESKTOP,
+    };
+    await db.recordSignInConsents({ ...batch, now: t0 });
+    await db.recordSignInConsents({ ...batch, now: t1 });
+    const rows = await db.listAccountConsentsByUid(id);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(Number(row.firstAuthorizedTosAt)).toBe(t0);
+      expect(Number(row.lastAuthorizedTosAt)).toBe(t1);
+    }
+  });
+
+  it('does not fail if scopes is empty on recordSignInConsents', async () => {
+    const id = track(newUid());
+    await db.recordSignInConsents({
+      uid: id,
+      scopes: [],
+      service: 'sync',
+      clientId: DESKTOP,
+      now: Date.now(),
+    });
+    expect(await db.listAccountConsentsByUid(id)).toHaveLength(0);
   });
 
   it('cross-device: hasConsentForSignIn matches across clientIds', async () => {

--- a/packages/fxa-auth-server/test/remote/account_consents_exchange.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_consents_exchange.in.spec.ts
@@ -62,9 +62,9 @@ describe('#integration - /oauth/token exchange honors accountAuthorizations', ()
   });
 
   async function seed(scope: string, service: string) {
-    await db.recordSignInConsent({
+    await db.recordSignInConsents({
       uid: client.uid,
-      scope,
+      scopes: [scope],
       service,
       clientId: IOS,
       now: Date.now(),


### PR DESCRIPTION
## Because

- `recordAuthorizationRows` upserted one `accountAuthorizations` row per requested scope via `Promise.allSettled`, so an N-scope sign-in briefly held N pooled DB connections. This showed up as elevated OAuth DB connection counts after the June 10 prod deploy (FXA-14077).

## This pull request

- Replaces the per-scope writes with a single multi-row `INSERT ... ON DUPLICATE KEY UPDATE`, built at call time in `_upsertAccountConsents` (`packages/fxa-auth-server/lib/oauth/db/mysql/index.js`), so every scope for a sign-in is recorded in one query/connection.
- Renames `recordSignInConsent`/`_upsertAccountConsent` to the plural `recordSignInConsents`/`_upsertAccountConsents`, taking a `scopes` array, in `packages/fxa-auth-server/lib/oauth/db/index.js` and `authorization.js`.
- Makes the write atomic — all rows land or none — and lets a rejection bubble to the existing `authorizationHandler` catch that emits `accountAuthorization.write_failed` and keeps sign-in working.
- Types the route spec logger mock as `createMock<AuthLogger>()` and adds remote coverage in `test/remote/account_consents.in.spec.ts` for multi-scope row creation and `firstAuthorizedTosAt`/`lastAuthorizedTosAt` preserve/bump behavior.

## Issue that this pull request solves

Closes: FXA-14077

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/oauth/db/mysql/index.js` (`_upsertAccountConsents` query construction), `lib/routes/oauth/authorization.js` (`recordAuthorizationRows` failure handling).
- Suggested review order: mysql query builder → db wrapper → route → tests.
- Risky or complex parts: the dynamic `VALUES` tuple construction (only the tuple count is dynamic; all values are `?`-bound) and the non-empty `scopes` invariant, which holds because `recordAuthorizationRows` returns early when there are no requested scopes.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- **Atomicity change:** the old `Promise.allSettled` path could leave partial rows and surfaced only the first rejection; the single INSERT is now all-or-nothing.
- **Failure metric:** an initial version added a tagged `accountAuthorization.consents_write_failed` statsd/log event, but it was removed in favor of the existing `write_failed` handler to avoid double-counting the same failure. Happy to reintroduce tagged detail in review if we want per-service/scope signal.
