### PR TITLE
fix(auth-server): use current primary email over signup email

### DIFF
--- a/.claude/rules/primary-vs-signup-email.md
+++ b/.claude/rules/primary-vs-signup-email.md
@@ -1,0 +1,37 @@
+---
+paths:
+  - "packages/fxa-auth-server/lib/routes/**"
+  - "packages/fxa-auth-server/lib/senders/**"
+  - "packages/fxa-shared/db/models/auth/account.ts"
+  - "libs/shared/account/**"
+---
+
+# FXA — signup email vs current primary email
+
+`account.email` (the `accounts.email` column) is the **immutable signup email** — it never
+changes, even when the user changes their primary (which only flips `isPrimary` in the
+`emails` table). The **current primary** is `account.primaryEmail.email` (see
+`Account.findByUid`). Reaching for `account.email` when you mean "the user's email" is a
+common footgun: it works for accounts that never changed their primary, so it passes tests
+and review, then sends a **stale address** for the accounts that did.
+
+Use the **current primary** (`account.primaryEmail.email`) for anything user-facing or
+identity-representing — email recipients, WebAuthn display names, and attached-service
+notifications. A valid account always has a primary email (creation seeds one; it can't be
+deleted), so dereference it directly — no `?? account.email` fallback for a state that
+can't occur.
+
+`account.email` is correct **only** for the original/signup address itself (e.g. an
+`originalEmail` field) or at account creation, where signup == primary.
+
+```ts
+// ✗ signup email as the WebAuthn display name
+generateRegistrationChallenge(uid, account.email);
+
+// ✓ current primary
+generateRegistrationChallenge(uid, account.primaryEmail.email);
+```
+
+**Sending email:** target the primary _verified_ address —
+`account.emails?.find((e) => e.isPrimary && e.isVerified)?.email || account.email` (see
+`senders/fxa-mailer-format.ts`), or use `FxaMailerFormat.account(account)`.

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -604,7 +604,7 @@ export class LinkedAccountHandler {
       request,
       account: {
         uid: accountRecord.uid,
-        email: accountRecord.primaryEmail.email,
+        primaryEmail: accountRecord.primaryEmail,
         locale: accountRecord.locale,
       },
       service,

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -154,7 +154,11 @@ describe('passkeys routes', () => {
         emailCode: 'emailcode123',
         emailVerified: true,
         verifierSetAt: 1234567890,
-        primaryEmail: { email: TEST_EMAIL, isVerified: true },
+        primaryEmail: {
+          email: TEST_EMAIL,
+          emailCode: 'emailcode123',
+          isVerified: true,
+        },
         emails: [{ email: TEST_EMAIL, isPrimary: true, isVerified: true }],
       }),
       createPasskeyVerifiedSessionToken: jest.fn().mockResolvedValue({
@@ -293,6 +297,59 @@ describe('passkeys routes', () => {
           },
         })
       ).rejects.toThrow('Client has sent too many requests');
+    });
+
+    describe('when the primary email differs from the signup email', () => {
+      // A user who changed their primary email: the immutable signup address
+      // on accounts.email diverges from the current primary in the emails table.
+      const signupEmail = 'original-signup@example.com';
+      const currentPrimaryEmail = 'current-primary@example.com';
+
+      beforeEach(() => {
+        db.account = jest.fn().mockResolvedValue({
+          uid: UID,
+          email: signupEmail,
+          emailCode: 'emailcode123',
+          emailVerified: true,
+          verifierSetAt: 1234567890,
+          primaryEmail: {
+            email: currentPrimaryEmail,
+            emailCode: 'emailcode123',
+            isVerified: true,
+          },
+          emails: [
+            { email: signupEmail, isPrimary: false, isVerified: true },
+            { email: currentPrimaryEmail, isPrimary: true, isVerified: true },
+          ],
+        });
+      });
+
+      it('registers the passkey with the current primary email', async () => {
+        await runTest('/passkey/registration/start', {
+          auth: {
+            credentials: { uid: UID, id: SESSION_TOKEN_ID, email: signupEmail },
+          },
+        });
+
+        expect(
+          mockPasskeyService.generateRegistrationChallenge
+        ).toHaveBeenCalledWith(UID, currentPrimaryEmail);
+      });
+
+      it('keys the customs rate-limit check on the current primary email', async () => {
+        await runTest('/passkey/registration/start', {
+          auth: {
+            credentials: { uid: UID, id: SESSION_TOKEN_ID, email: signupEmail },
+          },
+        });
+
+        expect(customs.checkAuthenticated).toHaveBeenCalledWith(
+          expect.anything(),
+          UID,
+          currentPrimaryEmail,
+          'passkeyRegisterStart'
+        );
+      });
     });
   });
 
@@ -482,7 +539,15 @@ describe('passkeys routes', () => {
     });
 
     it('sets showSyncPasswordNote to false for passwordless accounts', async () => {
-      db.account.mockResolvedValueOnce({ email: TEST_EMAIL, verifierSetAt: 0 });
+      db.account.mockResolvedValueOnce({
+        email: TEST_EMAIL,
+        primaryEmail: {
+          email: TEST_EMAIL,
+          emailCode: 'emailcode123',
+          isVerified: true,
+        },
+        verifierSetAt: 0,
+      });
 
       await runTest('/passkey/registration/finish', {
         auth: {
@@ -1108,7 +1173,11 @@ describe('passkeys routes', () => {
         emailCode: 'emailcode123',
         emailVerified: true,
         verifierSetAt: 0,
-        primaryEmail: { email: TEST_EMAIL, isVerified: true },
+        primaryEmail: {
+          email: TEST_EMAIL,
+          emailCode: 'emailcode123',
+          isVerified: true,
+        },
         emails: [{ email: TEST_EMAIL, isPrimary: true, isVerified: true }],
       });
 
@@ -1574,12 +1643,19 @@ describe('passkeys routes', () => {
   });
 
   describe('PasskeyHandler.createPasskeySessionToken', () => {
+    // Signup fields differ from the primary to prove the token seeds from the
+    // current primary, not the immutable signup address on account.email.
     const mockAccount = {
       uid: UID,
-      email: TEST_EMAIL,
-      emailCode: 'emailcode123',
-      emailVerified: true,
+      email: 'original-signup@example.com',
+      emailCode: 'signup-code-000',
+      emailVerified: false,
       verifierSetAt: 1234567890,
+      primaryEmail: {
+        email: TEST_EMAIL,
+        emailCode: 'emailcode123',
+        isVerified: true,
+      },
     };
 
     const mockRequest = {

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -67,7 +67,7 @@ interface DB {
     emailVerified: boolean;
     verifierSetAt: number;
     locale?: string;
-    primaryEmail: { email: string; isVerified: boolean };
+    primaryEmail: { email: string; emailCode: string; isVerified: boolean };
     emails: Array<{ email: string; isPrimary: boolean; isVerified: boolean }>;
   }>;
   sessions(uid: string): Promise<unknown[]>;
@@ -128,16 +128,18 @@ export class PasskeyHandler {
     };
 
     const account = await this.db.account(uid);
+    const email = account.primaryEmail.email;
+
     await this.customs.checkAuthenticated(
       request,
       uid,
-      account.email,
+      email,
       'passkeyRegisterStart'
     );
 
     const options = await this.service.generateRegistrationChallenge(
       uid,
-      account.email
+      email
     );
 
     return options;
@@ -165,7 +167,7 @@ export class PasskeyHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
-      account.email,
+      account.primaryEmail.email,
       'passkeyRegisterFinish'
     );
 
@@ -253,7 +255,7 @@ export class PasskeyHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
-      account.email,
+      account.primaryEmail.email,
       'passkeysList'
     );
 
@@ -302,7 +304,7 @@ export class PasskeyHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
-      account.email,
+      account.primaryEmail.email,
       'passkeyDelete'
     );
 
@@ -351,7 +353,7 @@ export class PasskeyHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
-      account.email,
+      account.primaryEmail.email,
       'passkeysRename'
     );
 
@@ -535,7 +537,7 @@ export class PasskeyHandler {
         request,
         account: {
           uid: account.uid,
-          email: account.primaryEmail.email,
+          primaryEmail: account.primaryEmail,
           locale: account.locale,
         },
         service,
@@ -576,18 +578,19 @@ export class PasskeyHandler {
   async createPasskeySessionToken(
     account: {
       uid: string;
-      email: string;
-      emailCode: string;
-      emailVerified: boolean;
       verifierSetAt: number;
+      primaryEmail: { email: string; emailCode: string; isVerified: boolean };
     },
     request: AuthRequest
   ) {
+    // Seed the token's email fields from the current primary (email, code, and
+    // verified state together), matching the login path — not the immutable
+    // signup address on `account.email`.
     const sessionToken = await this.db.createPasskeyVerifiedSessionToken({
       uid: account.uid,
-      email: account.email,
-      emailCode: account.emailCode,
-      emailVerified: account.emailVerified,
+      email: account.primaryEmail.email,
+      emailCode: account.primaryEmail.emailCode,
+      emailVerified: account.primaryEmail.isVerified,
       verifierSetAt: account.verifierSetAt,
       uaBrowser: request.app.ua.browser,
       uaBrowserVersion: request.app.ua.browserVersion,

--- a/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
@@ -291,6 +291,7 @@ describe('/account/passwordless/send_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: 0,
         emails: [{ email: TEST_EMAIL, isPrimary: true }],
       })
@@ -309,6 +310,7 @@ describe('/account/passwordless/send_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: Date.now(),
       })
     );
@@ -409,6 +411,7 @@ describe('/account/passwordless/confirm_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailCode: hexString(16),
         verifierSetAt: 0,
       })
@@ -488,10 +491,13 @@ describe('/account/passwordless/confirm_code', () => {
   });
 
   it('should create session for existing account with valid code', () => {
+    // Primary differs from the signup email; the login notification must use the primary.
+    const currentPrimaryEmail = 'current-primary@mozilla.com';
     mockDB.accountRecord = jest.fn(() =>
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: currentPrimaryEmail, isVerified: true },
         emailCode: hexString(16),
         verifierSetAt: 0,
       })
@@ -534,7 +540,11 @@ describe('/account/passwordless/confirm_code', () => {
       expect(mockLog.notifyAttachedServices).toHaveBeenCalledWith(
         'login',
         mockRequest,
-        expect.objectContaining({ email: TEST_EMAIL, uid, deviceCount: 3 })
+        expect.objectContaining({
+          email: currentPrimaryEmail,
+          uid,
+          deviceCount: 3,
+        })
       );
     });
   });
@@ -548,6 +558,7 @@ describe('/account/passwordless/confirm_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailCode: hexString(16),
         verifierSetAt: 0,
       })
@@ -597,6 +608,7 @@ describe('/account/passwordless/confirm_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailCode: hexString(16),
         verifierSetAt: 0,
       })
@@ -645,6 +657,7 @@ describe('/account/passwordless/confirm_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: 0,
       })
     );
@@ -667,6 +680,7 @@ describe('/account/passwordless/confirm_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: 0,
       })
     );
@@ -721,6 +735,7 @@ describe('/account/passwordless/confirm_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: Date.now(),
       })
     );
@@ -741,6 +756,7 @@ describe('/account/passwordless/confirm_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailCode: hexString(16),
         verifierSetAt: 0,
       })
@@ -880,6 +896,7 @@ describe('passwordless CMS customization', () => {
         Promise.resolve({
           uid,
           email: TEST_EMAIL,
+          primaryEmail: { email: TEST_EMAIL, isVerified: true },
           verifierSetAt: 0,
           emails: [{ email: TEST_EMAIL, isPrimary: true }],
         })
@@ -1022,6 +1039,7 @@ describe('passwordless CMS customization', () => {
         Promise.resolve({
           uid,
           email: TEST_EMAIL,
+          primaryEmail: { email: TEST_EMAIL, isVerified: true },
           verifierSetAt: 0,
           emails: [{ email: TEST_EMAIL, isPrimary: true }],
         })
@@ -1149,6 +1167,7 @@ describe('passwordless security events', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: 0,
         emails: [{ email: TEST_EMAIL, isPrimary: true }],
       })
@@ -1192,6 +1211,7 @@ describe('passwordless security events', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailCode: hexString(16),
         verifierSetAt: 0,
       })
@@ -1381,6 +1401,7 @@ describe('passwordless statsd metrics', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: 0,
         emails: [{ email: TEST_EMAIL, isPrimary: true }],
       })
@@ -1422,6 +1443,7 @@ describe('passwordless statsd metrics', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailCode: hexString(16),
         verifierSetAt: 0,
       })
@@ -1605,6 +1627,7 @@ describe('/account/passwordless/resend_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: 0,
         emails: [{ email: TEST_EMAIL, isPrimary: true }],
       })
@@ -1635,6 +1658,7 @@ describe('/account/passwordless/resend_code', () => {
       Promise.resolve({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         verifierSetAt: Date.now(),
       })
     );
@@ -1904,6 +1928,7 @@ describe('passwordless service validation', () => {
       mockDB.accountRecord = jest.fn(() => ({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailVerified: true,
         verifierSetAt: 0,
       }));
@@ -1920,6 +1945,7 @@ describe('passwordless service validation', () => {
       mockDB.accountRecord = jest.fn(() => ({
         uid,
         email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
         emailVerified: true,
         verifierSetAt: 0,
       }));
@@ -2058,6 +2084,7 @@ describe('existing passwordless accounts bypass flag and allowlist', () => {
         Promise.resolve({
           uid,
           email: TEST_EMAIL,
+          primaryEmail: { email: TEST_EMAIL, isVerified: true },
           verifierSetAt: 0,
           emails: [{ email: TEST_EMAIL, isPrimary: true }],
         })
@@ -2088,6 +2115,7 @@ describe('existing passwordless accounts bypass flag and allowlist', () => {
         Promise.resolve({
           uid,
           email: TEST_EMAIL,
+          primaryEmail: { email: TEST_EMAIL, isVerified: true },
           verifierSetAt: 0,
           emails: [{ email: TEST_EMAIL, isPrimary: true }],
         })
@@ -2155,6 +2183,7 @@ describe('existing passwordless accounts bypass flag and allowlist', () => {
         Promise.resolve({
           uid,
           email: TEST_EMAIL,
+          primaryEmail: { email: TEST_EMAIL, isVerified: true },
           emailCode: hexString(16),
           verifierSetAt: 0,
         })
@@ -2200,6 +2229,7 @@ describe('existing passwordless accounts bypass flag and allowlist', () => {
         Promise.resolve({
           uid,
           email: TEST_EMAIL,
+          primaryEmail: { email: TEST_EMAIL, isVerified: true },
           verifierSetAt: 0,
           emails: [{ email: TEST_EMAIL, isPrimary: true }],
         })

--- a/packages/fxa-auth-server/lib/routes/passwordless.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.ts
@@ -354,7 +354,7 @@ class PasswordlessHandler {
       request,
       account: {
         uid: account.uid,
-        email: account.email,
+        primaryEmail: account.primaryEmail,
         locale: account.locale,
       },
       service,

--- a/packages/fxa-auth-server/lib/routes/utils/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/account.spec.ts
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { fetchRpCmsData, getOptionalCmsEmailConfig } = require('./account');
+import type { AuthLogger } from '../../types';
+
+const {
+  fetchRpCmsData,
+  getOptionalCmsEmailConfig,
+  notifyAttachedServicesForAccountSession,
+} = require('./account');
 
 describe('fetchRpCmsData', () => {
   const mockRequest = {
@@ -302,5 +308,79 @@ describe('getOptionalCmsEmailConfig', () => {
       subject: 'Short Code Subject',
       template: 'short-code-template',
     });
+  });
+});
+
+describe('notifyAttachedServicesForAccountSession', () => {
+  const uid = 'f9416ce3703e4916a4cd6b1e665a3f1a';
+  const CURRENT_PRIMARY_EMAIL = 'current-primary@example.com';
+
+  const request = {
+    app: { geo: { location: { country: 'United States', countryCode: 'US' } } },
+    headers: { 'user-agent': 'test-agent' },
+  };
+
+  // The account carries only the current primary email — the helper no longer
+  // accepts a bare `email`, so a stale signup address can't be passed.
+  const account = {
+    uid,
+    primaryEmail: { email: CURRENT_PRIMARY_EMAIL },
+    locale: 'en',
+  };
+
+  let log: jest.Mocked<Pick<AuthLogger, 'notifyAttachedServices'>>;
+
+  beforeEach(() => {
+    log = { notifyAttachedServices: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('sends the login notification with the current primary email', async () => {
+    await notifyAttachedServicesForAccountSession({
+      log,
+      request,
+      account,
+      service: 'sync',
+      deviceCount: 2,
+      isNewAccount: false,
+      emailVerified: true,
+      profileChanged: false,
+    });
+
+    expect(log.notifyAttachedServices).toHaveBeenCalledWith('login', request, {
+      country: 'United States',
+      countryCode: 'US',
+      deviceCount: 2,
+      email: CURRENT_PRIMARY_EMAIL,
+      service: 'sync',
+      uid,
+      userAgent: 'test-agent',
+    });
+  });
+
+  it('sends the verified notification with the current primary email for a new verified account', async () => {
+    await notifyAttachedServicesForAccountSession({
+      log,
+      request,
+      account,
+      service: 'sync',
+      deviceCount: 1,
+      isNewAccount: true,
+      emailVerified: true,
+      profileChanged: false,
+    });
+
+    expect(log.notifyAttachedServices).toHaveBeenCalledWith(
+      'verified',
+      request,
+      {
+        country: 'United States',
+        countryCode: 'US',
+        email: CURRENT_PRIMARY_EMAIL,
+        locale: 'en',
+        service: 'sync',
+        uid,
+        userAgent: 'test-agent',
+      }
+    );
   });
 });

--- a/packages/fxa-auth-server/lib/routes/utils/account.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/account.ts
@@ -108,7 +108,7 @@ export const fetchRpCmsData = async (
 export async function notifyAttachedServicesForAccountSession(options: {
   log: AuthLogger;
   request: AuthRequest;
-  account: { uid: string; email: string; locale?: string };
+  account: { uid: string; primaryEmail: { email: string }; locale?: string };
   service: string | undefined;
   deviceCount: number;
   isNewAccount: boolean;
@@ -125,6 +125,7 @@ export async function notifyAttachedServicesForAccountSession(options: {
     emailVerified,
     profileChanged,
   } = options;
+  const email = account.primaryEmail.email;
 
   const geoData = request.app.geo;
   const country = geoData.location && geoData.location.country;
@@ -139,7 +140,7 @@ export async function notifyAttachedServicesForAccountSession(options: {
       log.notifyAttachedServices('verified', request, {
         country,
         countryCode,
-        email: account.email,
+        email,
         locale: account.locale,
         service,
         uid: account.uid,
@@ -154,7 +155,7 @@ export async function notifyAttachedServicesForAccountSession(options: {
       country,
       countryCode,
       deviceCount,
-      email: account.email,
+      email,
       service,
       uid: account.uid,
       userAgent,


### PR DESCRIPTION
## Because

- A passkey credential's WebAuthn display name and the account-session
  notifications sent to attached services were built from `account.email` — the
  immutable *signup* email, which never changes when a user updates their primary
  email. Anyone who had changed their primary address therefore saw a stale,
  unrecognized email in their platform passkey manager / sign-in picker and in
  attached-service (e.g. profile sync) notifications.
- `account.email` (signup) vs `account.primaryEmail` (current) is an easy footgun:
  it passes tests and review whenever signup == primary, so it needs a guard
  against recurrence.

## This pull request

- Uses the account's current primary email (`account.primaryEmail.email`) instead
  of the signup email across the passkey routes in
  `packages/fxa-auth-server/lib/routes/passkeys.ts`: the WebAuthn registration
  display name, all five customs checks (register start/finish, list, delete,
  rename), and the passkey session token (`email`, `emailCode`, `emailVerified`,
  matching the login path).
- Hardens `notifyAttachedServicesForAccountSession` in
  `packages/fxa-auth-server/lib/routes/utils/account.ts` to require `primaryEmail`
  and derive the notified email from it, so a bare signup email can no longer be
  passed; updates the passwordless, passkey, and linked-account call sites
  (`passwordless.ts` was the one sending the signup email).
- Adds `.claude/rules/primary-vs-signup-email.md`, an auto-loaded editing rule
  documenting which email to use.
- Extends unit tests in `passkeys.spec.ts`, `utils/account.spec.ts`, and
  `passwordless.spec.ts` using accounts whose signup and primary emails differ.

## Issue that this pull request solves

Closes: FXA-14106

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/routes/utils/account.ts` (notify-helper contract change) and its three call sites; `lib/routes/passkeys.ts` (registration email, the five customs checks, and `createPasskeySessionToken`).
- Suggested review order: notify helper → call sites (`passkeys.ts`, `passwordless.ts`, `linked-accounts.ts`) → passkey session-token seeding → tests.
- Risky or complex parts: the removed `?? account.email` fallback relies on the invariant that a valid account always has a primary email; the passkey session token now seeds `email`/`emailCode`/`emailVerified` together from the primary.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- The **passwordless** attached-service notification fix was an audit-driven fast-follow: auditing this bug class across auth-server surfaced `passwordless.ts` sending the signup email to attached services after a primary-email change. Fixed here under FXA-14106.
- Follow-up **FXA-14117** covers the non-passkey remainder: session tokens created by the password-reset, password-change, and passwordless flows still seed from the signup email (delivery is unaffected; it surfaces via `/recovery_email/status`, email-body template variables, and logs).
- Adds a Claude editing rule (`.claude/rules/primary-vs-signup-email.md`) that auto-loads on auth-server routes/senders and the account model to prevent reintroducing the signup-vs-primary footgun.
