### PR TITLE
feat(payments-api): add auth-guard logging

### DIFF
--- a/apps/payments/api/src/app/app.module.ts
+++ b/apps/payments/api/src/app/app.module.ts
@@ -15,7 +15,7 @@ import {
   BillingAndSubscriptionsController,
   BillingAndSubscriptionsService,
 } from '@fxa/payments/api-server';
-import { AuthModule } from '@fxa/payments/auth';
+import { AuthModule, FxaOAuthAuthGuard } from '@fxa/payments/auth';
 import {
   MeteringAuthGuard,
   MeteringCloudTasksGuard,
@@ -114,6 +114,7 @@ import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregat
       useClass: SentryGlobalFilter,
     },
     Logger,
+    FxaOAuthAuthGuard,
     AccountCustomerManager,
     AccountDatabaseNestFactory,
     AccountManager,

--- a/libs/payments/auth/src/index.ts
+++ b/libs/payments/auth/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/current-user.decorator';
 export * from './lib/fxa-oauth-auth.guard';
 export * from './lib/fxa-access-token.schemas';
 export * from './lib/fxa-oauth.config';
+export * from './lib/fxa-oauth.error';

--- a/libs/payments/auth/src/lib/fxa-oauth-auth.guard.passport.spec.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth-auth.guard.passport.spec.ts
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  ExecutionContext,
+  type LoggerService,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { StatsD } from 'hot-shots';
+
+import passport from 'passport';
+
+import { FxaOAuthAuthGuard } from './fxa-oauth-auth.guard';
+import { FxaOAuthJwtStrategy } from './fxa-oauth-jwt.strategy';
+import { FxaOAuthVerifyStrategy } from './fxa-oauth-verify.strategy';
+import { MockFxaOAuthConfig } from './fxa-oauth.config';
+
+// Avoid a real JWKS fetch when the JWT strategy is constructed.
+jest.mock('jwks-rsa', () => ({
+  passportJwtSecret: jest.fn(
+    () => (_req: unknown, _raw: unknown, done: (e: unknown, k: string) => void) =>
+      done(null, 'mock-secret')
+  ),
+}));
+
+const NORMALIZED_PATH = 'v1/billing-and-subscriptions';
+const config = {
+  ...MockFxaOAuthConfig,
+  fxaOAuthServerUrl: 'http://localhost:9000',
+};
+
+/**
+ * Runs as a normal unit test — no server, DB, or ports; jwks-rsa and fetch are
+ * mocked. "Real passport chain" here means it wires the actual @nestjs/passport
+ * + passport multi-strategy machinery (not handleRequest in isolation), because
+ * the guard's 401-vs-503 verdict and auth.fail reason tag depend on an
+ * in-process wiring assumption: that when an opaque (non-JWT) token makes the
+ * JWT strategy fail and the verify strategy then also fails, passport delivers
+ * BOTH failures to handleRequest as an `info` array. A passport upgrade that
+ * changed that shape would regress the verdict — this test would catch it.
+ */
+describe('FxaOAuthAuthGuard (real passport chain)', () => {
+  let guard: FxaOAuthAuthGuard;
+  let statsd: jest.Mocked<Pick<StatsD, 'increment' | 'timing'>>;
+  let logger: jest.Mocked<Pick<LoggerService, 'warn' | 'error' | 'log'>>;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Constructing the strategies registers them with passport under their
+    // names ('fxa-oauth-jwt', 'fxa-oauth-verify'), which the guard resolves.
+    new FxaOAuthJwtStrategy(config);
+    new FxaOAuthVerifyStrategy(config);
+
+    statsd = { increment: jest.fn(), timing: jest.fn() };
+    logger = { warn: jest.fn(), error: jest.fn(), log: jest.fn() };
+    guard = new FxaOAuthAuthGuard(
+      logger as unknown as LoggerService,
+      statsd as unknown as StatsD
+    );
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    // Strategies register in passport's process-global registry by name;
+    // de-register so this suite can't leak into others sharing those names.
+    passport.unuse('fxa-oauth-jwt');
+    passport.unuse('fxa-oauth-verify');
+  });
+
+  // An opaque token (no dots) makes the JWT strategy fail structurally, so the
+  // verify strategy runs as the fallback.
+  function contextForOpaqueToken(): ExecutionContext {
+    const req = {
+      method: 'GET',
+      url: `/${NORMALIZED_PATH}`,
+      headers: { authorization: 'Bearer opaque-not-a-jwt-token' },
+      route: { path: `/${NORMALIZED_PATH}` },
+    };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => ({}),
+        getNext: () => undefined,
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  it('maps an opaque token + verify 5xx to 503 (upstream wins in the info array)', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    } as Response);
+
+    await expect(guard.canActivate(contextForOpaqueToken())).rejects.toThrow(
+      ServiceUnavailableException
+    );
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'OAuthVerifyServerError',
+      path: NORMALIZED_PATH,
+    });
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps an opaque token + verify 4xx to 401', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    } as Response);
+
+    await expect(guard.canActivate(contextForOpaqueToken())).rejects.toThrow(
+      UnauthorizedException
+    );
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'OAuthTokenRejectedError',
+      path: NORMALIZED_PATH,
+    });
+  });
+});

--- a/libs/payments/auth/src/lib/fxa-oauth-auth.guard.spec.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth-auth.guard.spec.ts
@@ -2,11 +2,222 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import {
+  ExecutionContext,
+  type LoggerService,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { StatsD } from 'hot-shots';
 import { FxaOAuthAuthGuard } from './fxa-oauth-auth.guard';
+import {
+  JwtInsufficientScopeError,
+  NoBearerTokenError,
+  OAuthTokenRejectedError,
+  OAuthVerifyServerError,
+} from './fxa-oauth.error';
+
+const BILLING_PATH = '/v1/billing-and-subscriptions';
+const NORMALIZED_PATH = 'v1/billing-and-subscriptions';
+
+function makeContext(
+  req: any = { method: 'GET', route: { path: BILLING_PATH } }
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as unknown as ExecutionContext;
+}
 
 describe('FxaOAuthAuthGuard', () => {
+  let guard: FxaOAuthAuthGuard;
+  let statsd: jest.Mocked<Pick<StatsD, 'increment' | 'timing'>>;
+  let logger: jest.Mocked<Pick<LoggerService, 'warn' | 'error' | 'log'>>;
+
+  beforeEach(() => {
+    statsd = { increment: jest.fn(), timing: jest.fn() };
+    logger = { warn: jest.fn(), error: jest.fn(), log: jest.fn() };
+    guard = new FxaOAuthAuthGuard(
+      logger as unknown as LoggerService,
+      statsd as unknown as StatsD
+    );
+  });
+
   it('can be instantiated', () => {
-    const guard = new FxaOAuthAuthGuard();
     expect(guard).toBeDefined();
+  });
+
+  it('returns the authenticated user unchanged', () => {
+    const user = { sub: 'uid', client_id: 'client', scope: ['scope'] };
+    const result = guard.handleRequest(null, user, undefined, makeContext());
+    expect(result).toBe(user);
+  });
+
+  it('does not emit metrics or logs on success', () => {
+    const user = { sub: 'uid', client_id: 'client', scope: ['scope'] };
+    guard.handleRequest(null, user, undefined, makeContext());
+    expect(statsd.increment).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 401 when authentication fails', () => {
+    expect(() =>
+      guard.handleRequest(
+        null,
+        null,
+        new OAuthTokenRejectedError(401),
+        makeContext()
+      )
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('emits an auth.fail counter tagged with the error name and path', () => {
+    try {
+      guard.handleRequest(
+        null,
+        null,
+        new OAuthTokenRejectedError(401),
+        makeContext()
+      );
+    } catch {
+      // rejection is asserted separately
+    }
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'OAuthTokenRejectedError',
+      path: NORMALIZED_PATH,
+    });
+  });
+
+  it('warns with a single line carrying the reason and message', () => {
+    try {
+      guard.handleRequest(
+        null,
+        null,
+        new OAuthTokenRejectedError(401),
+        makeContext()
+      );
+    } catch {
+      // rejection is asserted separately
+    }
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [line] = logger.warn.mock.calls[0];
+    expect(line).toContain('reason=OAuthTokenRejectedError');
+    expect(line).toContain('method=GET');
+    expect(line).toContain(`path=${NORMALIZED_PATH}`);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 503 on an auth-server upstream error', () => {
+    expect(() =>
+      guard.handleRequest(
+        null,
+        null,
+        new OAuthVerifyServerError(503),
+        makeContext()
+      )
+    ).toThrow(ServiceUnavailableException);
+  });
+
+  it('logs upstream verify errors at error level', () => {
+    try {
+      guard.handleRequest(
+        null,
+        null,
+        new OAuthVerifyServerError(503),
+        makeContext()
+      );
+    } catch {
+      // rejection is asserted separately
+    }
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'OAuthVerifyServerError',
+      path: NORMALIZED_PATH,
+    });
+  });
+
+  it('prefers the FxaOAuthError over passport-jwt noise in a multi-strategy array', () => {
+    // Passport hands a two-strategy guard an array of failures; the JWT strategy
+    // failing to parse an opaque token must not mask the verify verdict.
+    const jwtError = Object.assign(new Error('jwt malformed'), {
+      name: 'JsonWebTokenError',
+    });
+    expect(() =>
+      guard.handleRequest(
+        null,
+        null,
+        [jwtError, new OAuthVerifyServerError(503)],
+        makeContext()
+      )
+    ).toThrow(ServiceUnavailableException);
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'OAuthVerifyServerError',
+      path: NORMALIZED_PATH,
+    });
+  });
+
+  it('prefers a later upstream error over a preceding FxaOAuthError (503 not 401)', () => {
+    // A JWT-scope failure (401-class) can precede a verify upstream fault
+    // (503-class) in the strategy-ordered array; the outage must still win.
+    expect(() =>
+      guard.handleRequest(
+        null,
+        null,
+        [new JwtInsufficientScopeError(), new OAuthVerifyServerError(503)],
+        makeContext()
+      )
+    ).toThrow(ServiceUnavailableException);
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'OAuthVerifyServerError',
+      path: NORMALIZED_PATH,
+    });
+  });
+
+  it('falls back to a passport-jwt error name when no FxaOAuthError is present', () => {
+    const jwtError = Object.assign(new Error('jwt expired'), {
+      name: 'TokenExpiredError',
+    });
+    try {
+      guard.handleRequest(null, null, jwtError, makeContext());
+    } catch {
+      // rejection is asserted separately
+    }
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'TokenExpiredError',
+      path: NORMALIZED_PATH,
+    });
+  });
+
+  it('uses reason=unknown and path=unmatched when nothing is known', () => {
+    try {
+      guard.handleRequest(null, null, undefined, makeContext({ method: 'GET' }));
+    } catch {
+      // rejection is asserted separately
+    }
+    expect(statsd.increment).toHaveBeenCalledWith('auth.fail', {
+      reason: 'unknown',
+      path: 'unmatched',
+    });
+  });
+
+  it('never includes the bearer token in the logged line', () => {
+    try {
+      guard.handleRequest(
+        null,
+        null,
+        new NoBearerTokenError(),
+        makeContext({
+          method: 'GET',
+          route: { path: BILLING_PATH },
+          headers: { authorization: 'Bearer super-secret-token' },
+        })
+      );
+    } catch {
+      // rejection is asserted separately
+    }
+    const [line] = logger.warn.mock.calls[0];
+    expect(line).not.toContain('super-secret-token');
+    expect(line).not.toContain('Bearer super-secret-token');
   });
 });

--- a/libs/payments/auth/src/lib/fxa-oauth-auth.guard.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth-auth.guard.ts
@@ -2,8 +2,52 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable } from '@nestjs/common';
+import {
+  ExecutionContext,
+  Inject,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+  UnauthorizedException,
+  type LoggerService,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import type { Request } from 'express';
+import { StatsD } from 'hot-shots';
+
+import { StatsDService, normalizeRoute } from '@fxa/shared/metrics/statsd';
+import { FxaOAuthError, OAuthVerifyUpstreamError } from './fxa-oauth.error';
+
+/**
+ * StatsD counter incremented once per auth rejection, tagged { reason, path }.
+ * `reason` is the failing error's class name (see fxa-oauth.error.ts), so that
+ * set must stay small and stable — it is a metric tag dimension, and an
+ * unbounded/renamed set would blow up cardinality or break dashboards.
+ */
+export const AUTH_FAIL_METRIC = 'auth.fail';
+
+/**
+ * Passport hands a multi-strategy guard the failures from every strategy that
+ * ran — as `err` and/or an array of `info`, in strategy order. For an opaque
+ * token the JWT strategy always "fails" first (it isn't a JWT), so its error is
+ * noise; the meaningful verdict comes from the verify strategy's FxaOAuthError.
+ *
+ * Selection order matters: an upstream fault must win even when another
+ * FxaOAuthError precedes it in the array (e.g. a JWT-scope failure followed by
+ * a verify 5xx), otherwise the outage would be reported as a 401. So prefer any
+ * OAuthVerifyUpstreamError, then any FxaOAuthError, then whatever passport
+ * surfaced (e.g. a passport-jwt TokenExpiredError) — all bounded, useful names.
+ */
+function pickAuthError(err: unknown, info: unknown): Error | undefined {
+  const candidates = [err, ...(Array.isArray(info) ? info : [info])].filter(
+    (c): c is Error => c instanceof Error
+  );
+  return (
+    candidates.find((c) => c instanceof OAuthVerifyUpstreamError) ??
+    candidates.find((c) => c instanceof FxaOAuthError) ??
+    candidates[0]
+  );
+}
 
 /**
  * Route guard that validates FxA OAuth access tokens.
@@ -30,4 +74,45 @@ import { AuthGuard } from '@nestjs/passport';
 export class FxaOAuthAuthGuard extends AuthGuard([
   'fxa-oauth-jwt',
   'fxa-oauth-verify',
-]) {}
+]) {
+  constructor(
+    @Inject(Logger) private readonly logger: LoggerService,
+    @Inject(StatsDService) private readonly statsd: StatsD
+  ) {
+    super();
+  }
+
+  override handleRequest<TUser = any>(
+    err: any,
+    user: TUser,
+    info: any,
+    context: ExecutionContext
+  ): TUser {
+    if (user) {
+      return user;
+    }
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const path = normalizeRoute(req.route?.path);
+    const authError = pickAuthError(err, info);
+    const reason = authError?.name ?? 'unknown';
+
+    this.statsd.increment(AUTH_FAIL_METRIC, { reason, path });
+
+    const line = `auth.fail reason=${reason} method=${req.method} path=${path}${
+      authError ? ` msg="${authError.message}"` : ''
+    }`;
+
+    if (authError instanceof OAuthVerifyUpstreamError) {
+      // The auth server was unreachable or errored — this is our failure, not a
+      // bad token. Surface it as 503 so it isn't miscounted as a client 401.
+      this.logger.error(line, FxaOAuthAuthGuard.name);
+      throw new ServiceUnavailableException();
+    }
+
+    // Genuine auth rejection. Throw a fresh 401 rather than re-throwing the
+    // underlying error, which may be a non-HTTP BaseError (would become a 500).
+    this.logger.warn(line, FxaOAuthAuthGuard.name);
+    throw new UnauthorizedException();
+  }
+}

--- a/libs/payments/auth/src/lib/fxa-oauth-jwt.strategy.spec.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth-jwt.strategy.spec.ts
@@ -2,10 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UnauthorizedException } from '@nestjs/common';
 import { FxaOAuthJwtStrategy } from './fxa-oauth-jwt.strategy';
 import { MockFxaOAuthConfig } from './fxa-oauth.config';
 import { FxaAccessTokenClaimsFactory } from './factories/fxa-access-token-claims.factory';
+import {
+  JwtInsufficientScopeError,
+  JwtInvalidClaimsError,
+} from './fxa-oauth.error';
 
 // Mock jwks-rsa to avoid real JWKS fetching during construction
 jest.mock('jwks-rsa', () => ({
@@ -50,24 +53,30 @@ describe('FxaOAuthJwtStrategy', () => {
     });
   });
 
-  it('throws UnauthorizedException when required scope is missing', () => {
+  it('throws JwtInsufficientScopeError when required scope is missing', () => {
     const claims = FxaAccessTokenClaimsFactory({ scope: 'profile openid' });
     expect(() => strategy.validate(makeReq(), claims)).toThrow(
-      UnauthorizedException
+      JwtInsufficientScopeError
     );
   });
 
-  it('throws UnauthorizedException when scope is empty', () => {
+  it('throws JwtInsufficientScopeError when scope is empty', () => {
     const claims = FxaAccessTokenClaimsFactory({ scope: '' });
     expect(() => strategy.validate(makeReq(), claims)).toThrow(
-      UnauthorizedException
+      JwtInsufficientScopeError
     );
   });
 
-  it('throws UnauthorizedException when scope is undefined', () => {
+  it('throws JwtInvalidClaimsError when scope is undefined (fails schema)', () => {
     const claims = FxaAccessTokenClaimsFactory({ scope: undefined } as any);
     expect(() => strategy.validate(makeReq(), claims)).toThrow(
-      UnauthorizedException
+      JwtInvalidClaimsError
+    );
+  });
+
+  it('throws JwtInvalidClaimsError when the claims fail schema validation', () => {
+    expect(() => strategy.validate(makeReq(), { not: 'valid claims' })).toThrow(
+      JwtInvalidClaimsError
     );
   });
 });

--- a/libs/payments/auth/src/lib/fxa-oauth-jwt.strategy.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth-jwt.strategy.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { passportJwtSecret } from 'jwks-rsa';
 import { ExtractJwt, Strategy } from 'passport-jwt';
@@ -13,6 +13,10 @@ import {
   fxaAccessTokenClaimsSchema,
   FxaOAuthUser,
 } from './fxa-access-token.schemas';
+import {
+  JwtInsufficientScopeError,
+  JwtInvalidClaimsError,
+} from './fxa-oauth.error';
 
 @Injectable()
 export class FxaOAuthJwtStrategy extends PassportStrategy(
@@ -40,12 +44,12 @@ export class FxaOAuthJwtStrategy extends PassportStrategy(
   public validate(req: Request, claims: unknown): FxaOAuthUser {
     const result = fxaAccessTokenClaimsSchema.safeParse(claims);
     if (!result.success) {
-      throw new UnauthorizedException('Invalid token claims');
+      throw new JwtInvalidClaimsError();
     }
 
     const scopes = result.data.scope?.split(' ') ?? [];
     if (!scopes.includes(this.requiredScope)) {
-      throw new UnauthorizedException('Insufficient scope');
+      throw new JwtInsufficientScopeError();
     }
 
     return {

--- a/libs/payments/auth/src/lib/fxa-oauth-verify.strategy.spec.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth-verify.strategy.spec.ts
@@ -5,6 +5,15 @@
 import { FxaOAuthVerifyStrategy } from './fxa-oauth-verify.strategy';
 import { MockFxaOAuthConfig } from './fxa-oauth.config';
 import { FxaVerifyResponseFactory } from './factories/verify-response.factory';
+import {
+  NoBearerTokenError,
+  OAuthTokenRejectedError,
+  OAuthVerifyNetworkError,
+  OAuthVerifyResponseParseError,
+  OAuthVerifyResponseSchemaError,
+  OAuthVerifyServerError,
+  VerifyInsufficientScopeError,
+} from './fxa-oauth.error';
 
 const mockConfig = {
   ...MockFxaOAuthConfig,
@@ -17,6 +26,19 @@ function makeReq(token?: string) {
       authorization: token ? `Bearer ${token}` : undefined,
     },
   } as any;
+}
+
+/** Run the passport verify callback and capture (user, info). */
+function runVerify(
+  strategy: FxaOAuthVerifyStrategy,
+  req: any
+): Promise<{ user: any; info: any }> {
+  return new Promise((resolve, reject) => {
+    (strategy as any)._verify(req, (err: any, user: any, info: any) => {
+      if (err) reject(err);
+      else resolve({ user, info });
+    });
+  });
 }
 
 describe('FxaOAuthVerifyStrategy', () => {
@@ -41,12 +63,7 @@ describe('FxaOAuthVerifyStrategy', () => {
       json: async () => body,
     });
 
-    const result = await new Promise((resolve, reject) => {
-      (strategy as any)._verify(makeReq('valid-token'), (err: any, user: any) => {
-        if (err) reject(err);
-        else resolve(user);
-      });
-    });
+    const { user } = await runVerify(strategy, makeReq('valid-token'));
 
     expect(fetchSpy).toHaveBeenCalledWith(
       'http://localhost:9000/v1/verify',
@@ -55,64 +72,93 @@ describe('FxaOAuthVerifyStrategy', () => {
         body: JSON.stringify({ token: 'valid-token' }),
       })
     );
-    expect(result).toEqual({
+    expect(user).toEqual({
       sub: body.user,
       client_id: body.client_id,
       scope: body.scope,
     });
   });
 
-  it('returns false when required scope is missing', async () => {
+  it('fails with VerifyInsufficientScopeError when required scope is missing', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       json: async () => FxaVerifyResponseFactory({ scope: ['profile'] }),
     });
 
-    const result = await new Promise((resolve) => {
-      (strategy as any)._verify(makeReq('token'), (_err: any, user: any) => {
-        resolve(user);
-      });
-    });
+    const { user, info } = await runVerify(strategy, makeReq('token'));
 
-    expect(result).toBe(false);
+    expect(user).toBe(false);
+    expect(info).toBeInstanceOf(VerifyInsufficientScopeError);
   });
 
-  it('returns false when auth server rejects the token', async () => {
+  it('fails with OAuthTokenRejectedError on a 4xx from the auth server', async () => {
     fetchSpy.mockResolvedValue({
       ok: false,
       status: 401,
       json: async () => ({ message: 'Invalid token' }),
     });
 
-    const result = await new Promise((resolve) => {
-      (strategy as any)._verify(makeReq('bad-token'), (_err: any, user: any) => {
-        resolve(user);
-      });
-    });
+    const { user, info } = await runVerify(strategy, makeReq('bad-token'));
 
-    expect(result).toBe(false);
+    expect(user).toBe(false);
+    expect(info).toBeInstanceOf(OAuthTokenRejectedError);
+    expect(info.message).toContain('401');
   });
 
-  it('returns false when no Bearer token is provided', async () => {
-    const result = await new Promise((resolve) => {
-      (strategy as any)._verify(makeReq(), (_err: any, user: any) => {
-        resolve(user);
-      });
+  it('fails with OAuthVerifyServerError on a 5xx from the auth server', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ message: 'Service Unavailable' }),
     });
 
-    expect(result).toBe(false);
+    const { user, info } = await runVerify(strategy, makeReq('token'));
+
+    expect(user).toBe(false);
+    expect(info).toBeInstanceOf(OAuthVerifyServerError);
+    expect(info.message).toContain('503');
+  });
+
+  it('fails with OAuthVerifyResponseSchemaError when the response fails schema validation', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ unexpected: 'shape' }),
+    });
+
+    const { user, info } = await runVerify(strategy, makeReq('token'));
+
+    expect(user).toBe(false);
+    expect(info).toBeInstanceOf(OAuthVerifyResponseSchemaError);
+  });
+
+  it('fails with OAuthVerifyResponseParseError when the body is not JSON', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error('Unexpected token < in JSON');
+      },
+    });
+
+    const { user, info } = await runVerify(strategy, makeReq('token'));
+
+    expect(user).toBe(false);
+    expect(info).toBeInstanceOf(OAuthVerifyResponseParseError);
+  });
+
+  it('fails with NoBearerTokenError when no Bearer token is provided', async () => {
+    const { user, info } = await runVerify(strategy, makeReq());
+
+    expect(user).toBe(false);
+    expect(info).toBeInstanceOf(NoBearerTokenError);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('returns false when auth server is unreachable', async () => {
+  it('fails with OAuthVerifyNetworkError when the auth server is unreachable', async () => {
     fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
 
-    const result = await new Promise((resolve) => {
-      (strategy as any)._verify(makeReq('token'), (_err: any, user: any) => {
-        resolve(user);
-      });
-    });
+    const { user, info } = await runVerify(strategy, makeReq('token'));
 
-    expect(result).toBe(false);
+    expect(user).toBe(false);
+    expect(info).toBeInstanceOf(OAuthVerifyNetworkError);
   });
 });

--- a/libs/payments/auth/src/lib/fxa-oauth-verify.strategy.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth-verify.strategy.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-custom';
 import { Request } from 'express';
@@ -12,6 +12,15 @@ import {
   FxaOAuthUser,
   fxaVerifyResponseSchema,
 } from './fxa-access-token.schemas';
+import {
+  NoBearerTokenError,
+  OAuthTokenRejectedError,
+  OAuthVerifyNetworkError,
+  OAuthVerifyResponseParseError,
+  OAuthVerifyResponseSchemaError,
+  OAuthVerifyServerError,
+  VerifyInsufficientScopeError,
+} from './fxa-oauth.error';
 
 /**
  * Passport strategy that validates opaque FxA OAuth access tokens by calling
@@ -30,12 +39,18 @@ export class FxaOAuthVerifyStrategy extends PassportStrategy(
 
   constructor(config: FxaOAuthConfig) {
     super(
-      async (req: Request, done: (err: Error | null, user?: any) => void) => {
+      async (
+        req: Request,
+        done: (err: Error | null, user?: any, info?: any) => void
+      ) => {
         try {
           const claims = await this.verifyToken(req);
           done(null, claims);
         } catch (err) {
-          done(null, false);
+          // Surface the specific failure to the guard instead of swallowing it,
+          // so operators can distinguish a rejected token from an auth-server
+          // outage. The verdict is unchanged: auth still fails.
+          done(null, false, err);
         }
       }
     );
@@ -46,27 +61,49 @@ export class FxaOAuthVerifyStrategy extends PassportStrategy(
   private async verifyToken(req: Request): Promise<FxaOAuthUser> {
     const token = this.extractBearerToken(req);
     if (!token) {
-      throw new UnauthorizedException('Bearer token not provided');
+      throw new NoBearerTokenError();
     }
 
-    const res = await fetch(this.verifyUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token }),
-    });
+    let res: Response;
+    try {
+      res = await fetch(this.verifyUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+    } catch (err) {
+      // Network-level failure reaching the auth server — an outage, not a bad
+      // token.
+      throw new OAuthVerifyNetworkError(
+        err instanceof Error ? err : new Error(String(err))
+      );
+    }
 
     if (!res.ok) {
-      throw new UnauthorizedException('Bearer token invalid');
+      // 5xx from the auth server is an upstream problem; 4xx means the token
+      // was rejected.
+      throw res.status >= 500
+        ? new OAuthVerifyServerError(res.status)
+        : new OAuthTokenRejectedError(res.status);
     }
 
-    const verifyResult = fxaVerifyResponseSchema.safeParse(await res.json());
+    let payload: unknown;
+    try {
+      payload = await res.json();
+    } catch (err) {
+      throw new OAuthVerifyResponseParseError(
+        err instanceof Error ? err : new Error(String(err))
+      );
+    }
+
+    const verifyResult = fxaVerifyResponseSchema.safeParse(payload);
     if (!verifyResult.success) {
-      throw new UnauthorizedException('Invalid verify response');
+      throw new OAuthVerifyResponseSchemaError();
     }
     const body = verifyResult.data;
 
     if (!body.scope?.includes(this.requiredScope)) {
-      throw new UnauthorizedException('Insufficient scope');
+      throw new VerifyInsufficientScopeError();
     }
 
     return {

--- a/libs/payments/auth/src/lib/fxa-oauth.error.spec.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth.error.spec.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  FxaOAuthError,
+  JwtInsufficientScopeError,
+  JwtInvalidClaimsError,
+  NoBearerTokenError,
+  OAuthTokenRejectedError,
+  OAuthVerifyNetworkError,
+  OAuthVerifyResponseParseError,
+  OAuthVerifyResponseSchemaError,
+  OAuthVerifyServerError,
+  OAuthVerifyUpstreamError,
+  VerifyInsufficientScopeError,
+} from './fxa-oauth.error';
+
+// Each error is instantiated once here so the `.name` assertion below can run
+// generically. Names are load-bearing: they are tagged on the `auth.fail`
+// metric's `reason` dimension and written to the log, so a rename/typo (or a
+// minifier mangling a class name) would silently corrupt telemetry.
+const CASES: [FxaOAuthError, string][] = [
+  [new NoBearerTokenError(), 'NoBearerTokenError'],
+  [new OAuthTokenRejectedError(401), 'OAuthTokenRejectedError'],
+  [new OAuthVerifyNetworkError(new Error('ECONNREFUSED')), 'OAuthVerifyNetworkError'],
+  [new OAuthVerifyServerError(503), 'OAuthVerifyServerError'],
+  [new OAuthVerifyResponseParseError(new Error('bad json')), 'OAuthVerifyResponseParseError'],
+  [new OAuthVerifyResponseSchemaError(), 'OAuthVerifyResponseSchemaError'],
+  [new VerifyInsufficientScopeError(), 'VerifyInsufficientScopeError'],
+  [new JwtInvalidClaimsError(), 'JwtInvalidClaimsError'],
+  [new JwtInsufficientScopeError(), 'JwtInsufficientScopeError'],
+];
+
+describe('fxa-oauth errors', () => {
+  it.each(CASES)('%o has name matching its class', (error, expectedName) => {
+    expect(error.name).toBe(expectedName);
+    expect(error).toBeInstanceOf(FxaOAuthError);
+  });
+
+  describe('503 grouping (guard maps OAuthVerifyUpstreamError -> 503)', () => {
+    it.each([
+      new OAuthVerifyNetworkError(new Error('ECONNREFUSED')),
+      new OAuthVerifyServerError(503),
+      new OAuthVerifyResponseParseError(new Error('bad json')),
+      new OAuthVerifyResponseSchemaError(),
+    ])('%o is an OAuthVerifyUpstreamError', (error) => {
+      expect(error).toBeInstanceOf(OAuthVerifyUpstreamError);
+    });
+
+    it.each([
+      new NoBearerTokenError(),
+      new OAuthTokenRejectedError(401),
+      new VerifyInsufficientScopeError(),
+      new JwtInvalidClaimsError(),
+      new JwtInsufficientScopeError(),
+    ])('%o is NOT an OAuthVerifyUpstreamError (maps to 401)', (error) => {
+      expect(error).not.toBeInstanceOf(OAuthVerifyUpstreamError);
+    });
+  });
+
+  it('embeds the upstream HTTP status in the message for triage', () => {
+    expect(new OAuthTokenRejectedError(429).message).toContain('429');
+    expect(new OAuthVerifyServerError(502).message).toContain('502');
+  });
+});

--- a/libs/payments/auth/src/lib/fxa-oauth.error.ts
+++ b/libs/payments/auth/src/lib/fxa-oauth.error.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { BaseError } from '@fxa/shared/error';
+
+/**
+ * Base for FxA OAuth auth failures; not thrown directly. Each subclass `name`
+ * is used verbatim as the `auth.fail` metric `reason` tag (see
+ * AUTH_FAIL_METRIC) and in the guard log line, so keep the set small and stable.
+ */
+export class FxaOAuthError extends BaseError {
+  constructor(message: string, info?: Record<string, unknown>, cause?: Error) {
+    super(message, { info, cause });
+    this.name = 'FxaOAuthError';
+  }
+}
+
+export class NoBearerTokenError extends FxaOAuthError {
+  constructor() {
+    super('Bearer token not provided');
+    this.name = 'NoBearerTokenError';
+  }
+}
+
+export class OAuthTokenRejectedError extends FxaOAuthError {
+  constructor(status: number) {
+    super(`Auth server rejected the access token (HTTP ${status})`, { status });
+    this.name = 'OAuthTokenRejectedError';
+  }
+}
+
+/**
+ * OAuthVerifyUpstreamError is not thrown directly. It groups failures that are
+ * the auth server's fault rather than a genuinely bad token — it was
+ * unreachable, returned a 5xx, or returned a 2xx the client can't be blamed for
+ * (non-JSON body, unexpected shape). The guard maps these to a 503 (via
+ * `instanceof`) rather than a client 401, so an outage or deploy-skew surfaces
+ * as a server error and isn't miscounted against clients.
+ */
+export class OAuthVerifyUpstreamError extends FxaOAuthError {
+  constructor(message: string, info?: Record<string, unknown>, cause?: Error) {
+    super(message, info, cause);
+    this.name = 'OAuthVerifyUpstreamError';
+  }
+}
+
+export class OAuthVerifyNetworkError extends OAuthVerifyUpstreamError {
+  constructor(cause: Error) {
+    super(
+      `Auth server verify request failed (${cause.name})`,
+      { detail: cause.name },
+      cause
+    );
+    this.name = 'OAuthVerifyNetworkError';
+  }
+}
+
+export class OAuthVerifyServerError extends OAuthVerifyUpstreamError {
+  constructor(status: number) {
+    super(`Auth server verify returned a server error (HTTP ${status})`, {
+      status,
+    });
+    this.name = 'OAuthVerifyServerError';
+  }
+}
+
+export class OAuthVerifyResponseParseError extends OAuthVerifyUpstreamError {
+  constructor(cause: Error) {
+    super('Auth server verify response was not valid JSON', undefined, cause);
+    this.name = 'OAuthVerifyResponseParseError';
+  }
+}
+
+export class OAuthVerifyResponseSchemaError extends OAuthVerifyUpstreamError {
+  constructor() {
+    super('Auth server verify response failed schema validation');
+    this.name = 'OAuthVerifyResponseSchemaError';
+  }
+}
+
+export class VerifyInsufficientScopeError extends FxaOAuthError {
+  constructor() {
+    super('Verified token is missing the required scope');
+    this.name = 'VerifyInsufficientScopeError';
+  }
+}
+
+export class JwtInvalidClaimsError extends FxaOAuthError {
+  constructor() {
+    super('JWT access token claims failed schema validation');
+    this.name = 'JwtInvalidClaimsError';
+  }
+}
+
+export class JwtInsufficientScopeError extends FxaOAuthError {
+  constructor() {
+    super('JWT access token is missing the required scope');
+    this.name = 'JwtInsufficientScopeError';
+  }
+}

--- a/libs/shared/metrics/statsd/src/lib/statsd-route.middleware.spec.ts
+++ b/libs/shared/metrics/statsd/src/lib/statsd-route.middleware.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { EventEmitter } from 'events';
+import type { LoggerService } from '@nestjs/common';
 import type { NextFunction, Request, Response } from 'express';
 import { StatsD } from 'hot-shots';
 
@@ -135,5 +136,78 @@ describe('StatsDRouteMiddleware', () => {
       'route.request.count',
       expect.objectContaining({ route: 'unmatched', statusCode: '404' })
     );
+  });
+
+  describe('unmatched-route logging', () => {
+    const buildLogger = (): jest.Mocked<Pick<LoggerService, 'debug'>> => ({
+      debug: jest.fn(),
+    });
+
+    it('logs a debug line with method and path for an unmatched route', () => {
+      const logger = buildLogger();
+      middleware = new StatsDRouteMiddleware(
+        statsd as unknown as StatsD,
+        logger as unknown as LoggerService
+      );
+      const req = buildRequest({ method: 'GET', path: '/v1/typo' });
+      const res = buildResponse(404);
+
+      middleware.use(req, res, next);
+      res.finish();
+
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+      expect(logger.debug).toHaveBeenCalledWith(
+        'unmatched route: GET /v1/typo → 404',
+        'StatsDRouteMiddleware'
+      );
+    });
+
+    it('strips CR/LF and caps the client-controlled path at 256 chars', () => {
+      const logger = buildLogger();
+      middleware = new StatsDRouteMiddleware(
+        statsd as unknown as StatsD,
+        logger as unknown as LoggerService
+      );
+      const rawPath = `/inject\r\nFAKE LOG LINE${'a'.repeat(400)}`;
+      const req = buildRequest({ method: 'GET', path: rawPath });
+      const res = buildResponse(404);
+
+      middleware.use(req, res, next);
+      res.finish();
+
+      const expectedPath = rawPath.replace(/[\r\n]/g, '').slice(0, 256);
+      // Fixture must exceed the cap, or this wouldn't exercise truncation.
+      expect(expectedPath).toHaveLength(256);
+      const [line] = logger.debug.mock.calls[0];
+      expect(line).toBe(`unmatched route: GET ${expectedPath} → 404`);
+    });
+
+    it('does not log for a matched route', () => {
+      const logger = buildLogger();
+      middleware = new StatsDRouteMiddleware(
+        statsd as unknown as StatsD,
+        logger as unknown as LoggerService
+      );
+      const req = buildRequest({
+        route: { path: '/v1/billing-and-subscriptions' },
+      } as Partial<Request>);
+      const res = buildResponse(200);
+
+      middleware.use(req, res, next);
+      res.finish();
+
+      expect(logger.debug).not.toHaveBeenCalled();
+    });
+
+    it('does not throw for an unmatched route when no logger is provided', () => {
+      // middleware from beforeEach has no logger injected
+      const req = buildRequest();
+      const res = buildResponse(404);
+
+      expect(() => {
+        middleware.use(req, res, next);
+        res.finish();
+      }).not.toThrow();
+    });
   });
 });

--- a/libs/shared/metrics/statsd/src/lib/statsd-route.middleware.ts
+++ b/libs/shared/metrics/statsd/src/lib/statsd-route.middleware.ts
@@ -2,11 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  type LoggerService,
+  NestMiddleware,
+  Optional,
+} from '@nestjs/common';
 import type { NextFunction, Request, Response } from 'express';
 import { StatsD } from 'hot-shots';
 
 import { StatsDService } from './statsd.provider';
+
+/**
+ * Cap for a client-controlled field interpolated into a log line. Bounds
+ * per-line log volume from scanners hitting long/garbage URLs; 256 comfortably
+ * covers any real route path.
+ */
+const MAX_LOG_FIELD_LENGTH = 256;
 
 /**
  * Express middleware that emits StatsD metrics for every HTTP response:
@@ -22,23 +36,45 @@ import { StatsDService } from './statsd.provider';
  * Runs at the Express layer, before Nest's guard/interceptor pipeline,
  * so it captures auth failures (401/403), pipe validation errors,
  * handler exceptions, and successful responses in a single path.
+ *
+ * When no route matched (`req.route` is undefined — a genuine 404, distinct
+ * from a matched handler that threw NotFoundException), it also logs one debug
+ * line with the requested method + path, to help spot clients hitting the
+ * wrong URL. Logging is opt-in: it only fires if a Logger is provided.
  */
 @Injectable()
 export class StatsDRouteMiddleware implements NestMiddleware {
-  constructor(@Inject(StatsDService) private readonly statsd: StatsD) {}
+  constructor(
+    @Inject(StatsDService) private readonly statsd: StatsD,
+    @Optional() @Inject(Logger) private readonly logger?: LoggerService
+  ) {}
 
   use(req: Request, res: Response, next: NextFunction) {
     const start = performance.now();
 
     res.on('finish', () => {
       const elapsed = performance.now() - start;
+      const route = normalizeRoute(req.route?.path);
       const tags = {
         method: req.method,
-        route: normalizeRoute(req.route?.path),
+        route,
         statusCode: String(res.statusCode),
       };
       this.statsd.increment('route.request.count', tags);
       this.statsd.timing('route.request.duration', elapsed, tags);
+
+      if (route === 'unmatched') {
+        // req.path is client-controlled: strip CR/LF (log forging) and cap
+        // length. req.path (not originalUrl) also avoids logging any query
+        // string.
+        const safePath = req.path
+          .replace(/[\r\n]/g, '')
+          .slice(0, MAX_LOG_FIELD_LENGTH);
+        this.logger?.debug?.(
+          `unmatched route: ${req.method} ${safePath} → ${res.statusCode}`,
+          StatsDRouteMiddleware.name
+        );
+      }
     });
 
     next();


### PR DESCRIPTION
## Because

* a failed request to /v1/billing-and-subscriptions returned a generic 401 with no signal about whether the auth guard rejected it or why

## This pull request

* add unique FxaOAuthError subclasses for each auth failure point
* emit an auth.fail metric and one log line (reason = error class) when FxaOAuthAuthGuard rejects a request
* return 503 instead of 401 when the auth server is unreachable during opaque-token verify
* log unmatched routes at debug

## Issue that this pull request solves

Closes: #PAY-3806

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
