### PR TITLE
fix(ci): stop storybook gh-pages deploys cancelling each other

### DIFF
--- a/.github/workflows/cleanup-storybooks.yml
+++ b/.github/workflows/cleanup-storybooks.yml
@@ -38,6 +38,12 @@ jobs:
           set -euo pipefail
           NOW=$(date +%s)
           REMOVED=0
+          # Record the dirs to prune so the push step can re-apply them onto the
+          # latest gh-pages (non-destructive) instead of force-pushing an orphan,
+          # which would clobber a storybook deploy running concurrently.
+          REMOVE_LIST="${RUNNER_TEMP:-/tmp}/sb-remove.txt"
+          : > "$REMOVE_LIST"
+          echo "REMOVE_LIST=${REMOVE_LIST}" >> "$GITHUB_ENV"
           # Open PR dirs kept this run as "updated_ts<TAB>pr<TAB>dir", for the cap below.
           KEPT=()
 
@@ -49,7 +55,7 @@ jobs:
             # failure keep the dir and let the next scheduled run retry.
             if ! META=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '{state,updated_at}' 2>&1); then
               if printf '%s' "$META" | grep -q 'HTTP 404'; then
-                rm -rf "$dir"
+                rm -rf "$dir"; echo "$dir" >> "$REMOVE_LIST"
                 echo "Removed pr-${PR_NUMBER} (PR not found)"
                 REMOVED=$((REMOVED + 1))
               else
@@ -65,11 +71,11 @@ jobs:
             AGE_DAYS=$(( (NOW - UPDATED_TS) / 86400 ))
 
             if [ "$STATE" = "closed" ]; then
-              rm -rf "$dir"
+              rm -rf "$dir"; echo "$dir" >> "$REMOVE_LIST"
               echo "Removed pr-${PR_NUMBER} (closed)"
               REMOVED=$((REMOVED + 1))
             elif [ "$AGE_DAYS" -gt "$MAX_AGE_DAYS" ]; then
-              rm -rf "$dir"
+              rm -rf "$dir"; echo "$dir" >> "$REMOVE_LIST"
               echo "Removed pr-${PR_NUMBER} (stale: ${AGE_DAYS}d > ${MAX_AGE_DAYS}d)"
               REMOVED=$((REMOVED + 1))
             else
@@ -85,7 +91,7 @@ jobs:
             mapfile -t SORTED < <(printf '%s\n' "${KEPT[@]}" | sort -n)
             for ((i = 0; i < OVER; i++)); do
               IFS=$'\t' read -r _ts pr dir <<<"${SORTED[i]}"
-              rm -rf "$dir"
+              rm -rf "$dir"; echo "$dir" >> "$REMOVE_LIST"
               echo "Removed pr-${pr} (over cap of ${MAX_KEEP})"
             done
             REMOVED=$((REMOVED + OVER))
@@ -100,28 +106,40 @@ jobs:
           path: main-repo
           persist-credentials: false
 
-      - name: Regenerate root index.html
-        run: node main-repo/_scripts/generate-storybook-index.js
+      - name: Commit and push pruned gh-pages
         env:
           STORYBOOKS_DIR: gh-pages/storybooks
           REPO_NAME: ${{ github.event.repository.name }}
           REPO_OWNER: ${{ github.repository_owner }}
-
-      - name: Commit and push to gh-pages
         run: |
-          cd gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C gh-pages config user.name "github-actions[bot]"
+          git -C gh-pages config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "Nothing changed, skipping push"
-            exit 0
-          fi
+          # Non-destructive, retry-on-reject update: re-apply the recorded deletions
+          # and regenerate the index on top of the latest gh-pages, so a storybook
+          # deploy running concurrently is never clobbered. Replaces the old orphan
+          # force-push, which (now that deploys use a per-PR concurrency group) could
+          # wipe a deploy that landed between this job's checkout and its push.
+          pushed=0
+          for attempt in 1 2 3 4 5; do
+            git -C gh-pages fetch --depth 1 origin gh-pages
+            git -C gh-pages reset --hard origin/gh-pages
 
-          # Create orphan branch (no history) with current content
-          git checkout --orphan gh-pages-new
-          git add -A
-          git commit -m "chore: prune storybooks for ${REMOVED} closed/stale/over-cap PR(s)"
+            while IFS= read -r d; do
+              [ -n "$d" ] || continue
+              rm -rf "$d"
+            done < "${REMOVE_LIST:-/dev/null}"
 
-          # Replace gh-pages with the new orphan branch
-          git push --force origin gh-pages-new:gh-pages
+            node main-repo/_scripts/generate-storybook-index.js
+
+            git -C gh-pages add -A
+            if git -C gh-pages diff --cached --quiet; then
+              echo "Nothing to prune after sync"; pushed=1; break
+            fi
+            git -C gh-pages commit -m "chore: prune storybooks for ${REMOVED} closed/stale/over-cap PR(s)"
+            if git -C gh-pages push origin HEAD:gh-pages; then
+              echo "Pushed pruned gh-pages (attempt ${attempt})"; pushed=1; break
+            fi
+            echo "gh-pages advanced during cleanup; retrying (attempt ${attempt})"
+          done
+          [ "$pushed" = "1" ] || { echo "Failed to push cleanup after retries" >&2; exit 1; }

--- a/.github/workflows/deploy-storybooks.yml
+++ b/.github/workflows/deploy-storybooks.yml
@@ -94,10 +94,12 @@ jobs:
     if: needs.build.outputs.has_storybooks == 'true'
     outputs:
       deploy_dir: ${{ steps.deploy-dir.outputs.path }}
-    # Single concurrency group to prevent conflicts
+    # Per-PR (or per-ref) concurrency: different PRs no longer share one global
+    # lock, so they stop cancelling each other. The non-destructive push below
+    # makes concurrent updates to gh-pages safe without a global serialization group.
     concurrency:
-      group: gh-pages-deploy
-      cancel-in-progress: false
+      group: gh-pages-deploy-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository for scripts
@@ -125,29 +127,23 @@ jobs:
           echo "path=$DEPLOY_DIR" >> $GITHUB_OUTPUT
           echo "DEPLOY_DIR=$DEPLOY_DIR" >> $GITHUB_ENV
 
-      - name: Remove old storybook directory
-        run: rm -rf "gh-pages/${DEPLOY_DIR_PATH}"
-        env:
-          DEPLOY_DIR_PATH: ${{ steps.deploy-dir.outputs.path }}
-
       - name: Download storybooks artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: storybooks-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'main' }}
-          path: gh-pages/${{ steps.deploy-dir.outputs.path }}
+          # Stage outside the gh-pages checkout so the reset --hard below can't wipe it
+          path: ${{ runner.temp }}/storybooks-artifact
 
-      - name: Generate root index.html
-        run: node repo/_scripts/generate-storybook-index.js
+      - name: Update gh-pages branch for artifact storage
         env:
+          DEPLOY_DIR: ${{ steps.deploy-dir.outputs.path }}
+          ARTIFACT_DIR: ${{ runner.temp }}/storybooks-artifact
           STORYBOOKS_DIR: gh-pages/storybooks
           REPO_NAME: ${{ github.event.repository.name }}
           REPO_OWNER: ${{ github.repository_owner }}
-
-      - name: Update gh-pages branch for artifact storage
         run: |
-          cd gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C gh-pages config user.name "github-actions[bot]"
+          git -C gh-pages config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             COMMIT_MSG="Store storybooks for PR ${{ github.event.pull_request.number }}"
@@ -155,13 +151,34 @@ jobs:
             COMMIT_MSG="Store storybooks from main branch"
           fi
 
-          # Create orphan branch (no history) with current content
-          git checkout --orphan gh-pages-new
-          git add -A
-          git commit -m "$COMMIT_MSG"
+          # Optimistic-concurrency update: re-apply our storybooks onto the latest
+          # gh-pages and push, retrying if another PR landed first. Replaces the old
+          # orphan force-push, which required a single global concurrency lock and made
+          # concurrent PRs cancel each other ("higher priority waiting request").
+          for attempt in 1 2 3 4 5; do
+            git -C gh-pages fetch --depth 1 origin gh-pages
+            git -C gh-pages reset --hard origin/gh-pages
 
-          # Replace gh-pages with the new orphan branch
-          git push --force origin gh-pages-new:gh-pages
+            rm -rf "gh-pages/${DEPLOY_DIR}"
+            mkdir -p "gh-pages/${DEPLOY_DIR}"
+            cp -R "${ARTIFACT_DIR}/." "gh-pages/${DEPLOY_DIR}/"
+
+            node repo/_scripts/generate-storybook-index.js
+
+            git -C gh-pages add -A
+            git -C gh-pages commit -m "$COMMIT_MSG" || { echo "Nothing to update"; break; }
+
+            if git -C gh-pages push origin HEAD:gh-pages; then
+              echo "Pushed storybooks to gh-pages (attempt ${attempt})"
+              break
+            fi
+
+            if [ "${attempt}" -eq 5 ]; then
+              echo "Failed to update gh-pages after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "gh-pages advanced during run; retrying (attempt ${attempt})"
+          done
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
## Because

- The deploy-storybooks "prepare" job used a single global concurrency group (gh-pages-deploy) because it force-pushed an orphan gh-pages branch, forcing every PR to serialize. During bursts GitHub keeps only one pending run per group and cancels the rest ("higher priority waiting request"), so most PRs' storybook deploys were cancelled.


## This pull request

- Scopes the prepare-job concurrency per PR/ref so different PRs no longer cancel each other.
- Replaces the orphan force-push with a non-destructive, retry-on-reject push that re-applies the PR's storybooks/pr-<N> subdir and regenerates the index on top of the latest gh-pages, making concurrent updates safe without a global lock.
- Stages the downloaded artifact outside the gh-pages checkout so the reset --hard cannot wipe it.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Generally speaking, I'm wondering why these Storybook issues are popping up more often.
