### PR TITLE
chore(admin): remove support access to WAF tokens

### DIFF
--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -50,7 +50,6 @@ export enum AdminPanelFeature {
   RateLimiting = 'RateLimiting',
   DeleteRecoveryPhone = 'DeleteRecoveryPhone',
   EmailBlocklist = 'EmailBlocklist',
-  WafTokens = 'WafTokens',
   ManageWafTokens = 'ManageWafTokens',
   DomainBlocklist = 'DomainBlocklist',
   OAuthScopes = 'OAuthScopes',
@@ -219,10 +218,6 @@ const defaultAdminPanelPermissions: Permissions = {
   [AdminPanelFeature.EmailBlocklist]: {
     name: 'Manage Email Blocklist',
     level: PermissionLevel.Admin,
-  },
-  [AdminPanelFeature.WafTokens]: {
-    name: 'View WAF Bypass Tokens',
-    level: PermissionLevel.Support,
   },
   [AdminPanelFeature.ManageWafTokens]: {
     name: 'Manage WAF Bypass Tokens',

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -837,7 +837,6 @@ const RelyingPartyRow = ({
 export const PageRelyingParties = () => {
   const { guard } = useGuardContext();
   const { user } = useUserContext();
-  const canViewWafTokens = guard.allow(AdminPanelFeature.WafTokens, user.group);
   const canManageWafTokens = guard.allow(
     AdminPanelFeature.ManageWafTokens,
     user.group
@@ -860,7 +859,7 @@ export const PageRelyingParties = () => {
         Promise<WafBypassTokenDto[]>,
       ] = [
         adminApi.getRelyingParties(),
-        canViewWafTokens
+        canManageWafTokens
           ? adminApi.getWafTokens()
           : Promise.resolve([] as WafBypassTokenDto[]),
       ];
@@ -881,7 +880,7 @@ export const PageRelyingParties = () => {
     } finally {
       setLoading(false);
     }
-  }, [canViewWafTokens]);
+  }, [canManageWafTokens]);
 
   useEffect(() => {
     loadRelyingParties();

--- a/packages/fxa-admin-panel/src/components/PageWafTokens/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageWafTokens/index.tsx
@@ -372,7 +372,7 @@ export const PageWafTokens = () => {
       </Guard>
 
       {!showCreate && tokens.length > 0 && (
-        <Guard features={[AdminPanelFeature.WafTokens]}>
+        <Guard features={[AdminPanelFeature.ManageWafTokens]}>
           {!loading && !error && (
             <table className="w-full mt-4 text-sm">
               <thead>

--- a/packages/fxa-admin-server/src/rest/waf-tokens/waf-tokens.controller.ts
+++ b/packages/fxa-admin-server/src/rest/waf-tokens/waf-tokens.controller.ts
@@ -31,7 +31,8 @@ const CLIENT_ID_RE = /^[0-9a-f]{16}$/i;
 export class WafTokensController {
   constructor(private db: DatabaseService) {}
 
-  @Features(AdminPanelFeature.WafTokens)
+  @Features(AdminPanelFeature.ManageWafTokens)
+  @AuditLog()
   @Get()
   public async listWafTokens(): Promise<WafBypassTokenDto[]> {
     const rows = await this.db.wafBypassTokens


### PR DESCRIPTION
## Because

- WAF bypass tokens (bearer credentials) were listed in plaintext to Support-tier staff, and the read was not audit-logged.

## This pull request

- Gates `listWafTokens` on `ManageWafTokens` (Admin) instead of the Support-level `WafTokens` — the whole feature is now Admin-only, matching how it's used.
- Removes the now-unused `WafTokens` feature (enum + permission entry) and repoints its UI consumers to `ManageWafTokens`.
- Adds `@AuditLog()` to the list read.

## Issue that this pull request solves

Closes: FXA-14067

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- verify Support-level users can no longer list tokens and Admin still can.
