### PR TITLE
chore(auth): Add firefox client id to OAUTH_TOKEN_EXCHANGE_CLIENT_IDS

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1443,6 +1443,7 @@ const convictConf = convict({
           '3332a18d142636cb',
           'a2270f727f45f648',
           '3c49430b43dfba77',
+          '5882386c6d801776',
         ],
         env: 'OAUTH_TOKEN_EXCHANGE_CLIENT_IDS',
       },


### PR DESCRIPTION
## Because

- Firefox team needs this to test token exchanges.

## This pull request

- Adds firefox client id to the default list.

## Issue that this pull request solves

Closes: FXA-14122

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
