### PR TITLE
fix(payments-next): [f001] getCart mints Stripe Customer Session secret without ownership check

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -52,9 +52,20 @@ export default async function CheckoutLayout({
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const [cms, cart, session] = await Promise.all([
     cmsDataPromise,
-    cartDataPromise,
+    cartDataPromise.catch((error) => {
+      if (error?.name === 'CartUidMismatchError') {
+        return null;
+      }
+      throw error;
+    }),
     sessionPromise,
   ]);
+
+  // Non-owner cart. Layouts can't redirect without stripping search params, so
+  // render children only and let the page handle the redirect.
+  if (!cart) {
+    return <>{children}</>;
+  }
   const purchaseDetails =
     cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
     cms.defaultPurchase.purchaseDetails;

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
@@ -33,9 +33,20 @@ export default async function UpgradeSuccessLayout({
   const sessionPromise = auth();
   const [cms, cart, session] = await Promise.all([
     cmsDataPromise,
-    cartDataPromise,
+    cartDataPromise.catch((error) => {
+      if (error?.name === 'CartUidMismatchError') {
+        return null;
+      }
+      throw error;
+    }),
     sessionPromise,
   ]);
+
+  // Non-owner cart. Layouts can't redirect without stripping search params, so
+  // render children only and let the page handle the redirect.
+  if (!cart) {
+    return <>{children}</>;
+  }
   const purchaseDetails =
     cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
     cms.defaultPurchase.purchaseDetails;

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
@@ -38,9 +38,20 @@ export default async function UpgradeLayout({
   const sessionPromise = auth();
   const [cms, cart, session] = await Promise.all([
     cmsDataPromise,
-    cartDataPromise,
+    cartDataPromise.catch((error) => {
+      if (error?.name === 'CartUidMismatchError') {
+        return null;
+      }
+      throw error;
+    }),
     sessionPromise,
   ]);
+
+  // Non-owner cart. Layouts can't redirect without stripping search params, so
+  // render children only and let the page handle the redirect.
+  if (!cart) {
+    return <>{children}</>;
+  }
   const purchaseDetails =
     cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
     cms.defaultPurchase.purchaseDetails;

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -174,7 +174,7 @@ export class CheckoutService {
     }
 
     if (cart.uid !== sessionUid) {
-      throw new CartUidMismatchError(cart.uid, sessionUid);
+      throw new CartUidMismatchError(cart.id, sessionUid);
     }
 
     const fxaAccounts = await this.accountManager.getAccounts([uid]);

--- a/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
@@ -10,6 +10,7 @@ import { getRedirect, validateCartState } from '../utils/get-cart';
 import { SupportedPages } from '../utils/types';
 import { URLSearchParams } from 'url';
 import { sanitizePathname } from '../utils/sanitizePathname';
+import { buildRedirectUrl } from '../utils/buildRedirectUrl';
 import {
   StartCartDTO,
   ProcessingCartDTO,
@@ -66,9 +67,28 @@ async function getCartOrRedirectAction(
     : undefined;
   const urlSearchParams = new URLSearchParams(filteredParams);
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';
-  const cart = await getApp().getActionsService().getCart({
-    cartId,
-  });
+  let cart: CartDTO;
+  try {
+    cart = await getApp().getActionsService().getCart({
+      cartId,
+    });
+  } catch (error) {
+    if (error.name === 'CartUidMismatchError') {
+      const [, locale, offeringId, interval] = sanitizePathname(
+        currentPathname
+      ).split('/');
+      const redirectSearchParams = { ...(searchParams ?? {}) };
+      delete redirectSearchParams.cartId;
+      delete redirectSearchParams.cartVersion;
+      redirect(
+        buildRedirectUrl(offeringId, interval, 'new', 'checkout', {
+          locale,
+          searchParams: redirectSearchParams,
+        })
+      );
+    }
+    throw error;
+  }
 
   if (!validateCartState(cart.state, page)) {
     // Sanitize pathname to prevent open redirect vulnerabilities

--- a/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
@@ -11,6 +11,7 @@ import { SupportedPages } from '../utils/types';
 import { URLSearchParams } from 'url';
 import { flattenRouteParams } from '../utils/flatParam';
 import { sanitizePathname } from '../utils/sanitizePathname';
+import { buildRedirectUrl } from '../utils/buildRedirectUrl';
 
 /**
  * Redirect if cart state does not match supported page
@@ -27,9 +28,28 @@ async function validateCartStateAndRedirectAction(
 ) {
   const urlSearchParams = new URLSearchParams(searchParams ? flattenRouteParams(searchParams) : undefined);
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';
-  const { state, isFreeTrial } = await getApp().getActionsService().getDbCart({
-    cartId,
-  });
+  let state, isFreeTrial;
+  try {
+    ({ state, isFreeTrial } = await getApp().getActionsService().getDbCart({
+      cartId,
+    }));
+  } catch (error) {
+    if (error.name === 'CartUidMismatchError') {
+      const [, locale, offeringId, interval] = sanitizePathname(
+        currentPathname
+      ).split('/');
+      const redirectSearchParams = { ...(searchParams ?? {}) };
+      delete redirectSearchParams.cartId;
+      delete redirectSearchParams.cartVersion;
+      redirect(
+        buildRedirectUrl(offeringId, interval, 'new', 'checkout', {
+          locale,
+          searchParams: redirectSearchParams,
+        })
+      );
+    }
+    throw error;
+  }
 
   if (!validateCartState(state, page)) {
     // Sanitize pathname to prevent open redirect vulnerabilities

--- a/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.ts
+++ b/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getSessionUid } from '@fxa/payments/ui-auth';
+import { CartUidMismatchError } from 'libs/payments/cart/src/lib/cart.error';
+
+/**
+ * Throws CartUidMismatchError before the decorated method runs when the cart has
+ * a uid and it does not match the current session uid.
+ */
+export function AssertCartOwnership() {
+  return function (
+    _target: any,
+    _key: string,
+    descriptor: PropertyDescriptor
+  ) {
+    const originalMethod = descriptor.value;
+
+    descriptor.value = async function (this: any, args: any) {
+      const cartId = args?.cartId as string;
+      const sessionUid = await getSessionUid();
+
+      const cart = await this.cartManager.fetchCartById(cartId);
+      if (cart.uid && cart.uid !== sessionUid) {
+        throw new CartUidMismatchError(cart.id, sessionUid);
+      }
+
+      return originalMethod.apply(this, [args]);
+    };
+
+    return descriptor;
+  };
+}

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -7,6 +7,7 @@ import { Inject, Injectable, type LoggerService, Logger } from '@nestjs/common';
 import { GoogleManager } from '@fxa/google';
 import {
   CartInvalidStateForActionError,
+  CartManager,
   CartService,
   SubscriptionAttributionParams,
   SuccessCartDTO,
@@ -71,6 +72,7 @@ import { DetermineChurnCancelEligibilityActionResult } from './validators/Determ
 import { DetermineChurnEligibilityActionArgs } from './validators/DetermineChurnEligibilityActionArgs';
 import { DetermineCancellationInterventionActionArgs } from './validators/DetermineCancellationInterventionActionArgs';
 import { NextIOValidator } from './NextIOValidator';
+import { AssertCartOwnership } from './assertCartOwnership.decorator';
 import { type CommonMetrics } from '@fxa/payments/metrics';
 import { GetCartActionResult } from './validators/GetCartActionResult';
 import { GetChurnInterventionDataActionResult } from './validators/GetChurnInterventionDataActionResult';
@@ -99,6 +101,7 @@ import { GetSubscriptionPageContentActionArgs } from './validators/GetSubscripti
 import { GetTaxAddressArgs } from './validators/GetTaxAddressArgs';
 import { GetTaxAddressResult } from './validators/GetTaxAddressResult';
 import {
+  CartUidMismatchError,
   CartVersionMismatchError,
   InvalidPromoCodeCartError,
   SetupCartAccountNotFoundError,
@@ -153,6 +156,7 @@ import { GetCMSChurnInterventionActionArgs } from './validators/GetCMSChurnInter
 export class NextJSActionsService {
   constructor(
     private cartService: CartService,
+    private cartManager: CartManager,
     private taxService: TaxService,
     private checkoutTokenManager: CheckoutTokenManager,
     private churnInterventionService: ChurnInterventionService,
@@ -225,20 +229,22 @@ export class NextJSActionsService {
     }
   }
 
-  @SanitizeExceptions()
+  @SanitizeExceptions({ allowlist: [CartUidMismatchError] })
   @NextIOValidator(GetDbCartActionArgs, GetDbCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async getDbCart(args: { cartId: string }) {
     const cart = await this.cartService.getDbCart(args.cartId);
 
     return cart;
   }
 
-  @SanitizeExceptions()
+  @SanitizeExceptions({ allowlist: [CartUidMismatchError] })
   @NextIOValidator(GetCartActionArgs, GetCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async getCart(args: { cartId: string }) {
     return this.cartService.getCart(args.cartId);
   }
@@ -281,6 +287,7 @@ export class NextJSActionsService {
   @NextIOValidator(GetCartActionArgs, GetSuccessCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async getSuccessCart(args: { cartId: string }): Promise<SuccessCartDTO> {
     const cart = await this.cartService.getCart(args.cartId);
 
@@ -454,6 +461,7 @@ export class NextJSActionsService {
   @NextIOValidator(UpdateCartActionArgs, UpdateCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async updateCart(args: {
     cartId: string;
     version: number;
@@ -477,6 +485,7 @@ export class NextJSActionsService {
   @NextIOValidator(GetCouponArgs, GetCouponResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async getCoupon(args: { cartId: string; version: number }) {
     const couponCode = await this.cartService.getCoupon({
       cartId: args.cartId,
@@ -489,6 +498,7 @@ export class NextJSActionsService {
   @NextIOValidator(RestartCartActionArgs, RestartCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async restartCart(args: { cartId: string }) {
     const cart = await this.cartService.restartCart(args.cartId);
 
@@ -525,6 +535,7 @@ export class NextJSActionsService {
   @NextIOValidator(FinalizeCartWithErrorArgs, undefined)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async finalizeCartWithError(args: {
     cartId: string;
     errorReasonId: CartErrorReasonId;
@@ -539,6 +550,7 @@ export class NextJSActionsService {
   @NextIOValidator(FinalizeProcessingCartActionArgs, undefined)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async finalizeProcessingCart(args: { cartId: string }) {
     await this.cartService.finalizeProcessingCart(args.cartId);
   }
@@ -753,6 +765,7 @@ export class NextJSActionsService {
   @NextIOValidator(GetNeedsInputActionArgs, getNeedsInputActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async getNeedsInput(args: { cartId: string }) {
     return await this.cartService.getNeedsInput(args.cartId);
   }
@@ -761,7 +774,11 @@ export class NextJSActionsService {
   @NextIOValidator(SubmitNeedsInputActionArgs, undefined)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
-  async submitNeedsInput(args: { cartId: string; requestArgs: CommonMetrics }) {
+  @AssertCartOwnership()
+  async submitNeedsInput(args: {
+    cartId: string;
+    requestArgs: CommonMetrics;
+  }) {
     await this.cartService.submitNeedsInput(args.cartId, args.requestArgs);
   }
 
@@ -972,6 +989,7 @@ export class NextJSActionsService {
   @NextIOValidator(UpdateTaxAddressActionArgs, UpdateTaxAddressActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
+  @AssertCartOwnership()
   async updateTaxAddress(args: {
     cartId: string;
     version: number;


### PR DESCRIPTION
## Because

* Cart read/mutate paths must verify ownership when cart.uid is set to prevent an attacker with a cart's UUID from reading someone else's information.

## This pull request

* Adds a uid check to various cart read/mutate actions.
* Redirects accordingly when this error is thrown

## Issue that this pull request solves

Closes:
* [PAY-3795](https://mozilla-hub.atlassian.net/browse/PAY-3795)
* [PAY-3797](https://mozilla-hub.atlassian.net/browse/PAY-3797)
* [PAY-3809](https://mozilla-hub.atlassian.net/browse/PAY-3809)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)


https://github.com/user-attachments/assets/3f9e2522-9dad-420b-9636-fe5f8192b200



https://github.com/user-attachments/assets/1e18898d-1081-4d70-99e9-dcc34cac6751


## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3795]: https://mozilla-hub.atlassian.net/browse/PAY-3795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PAY-3797]: https://mozilla-hub.atlassian.net/browse/PAY-3797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAY-3809]: https://mozilla-hub.atlassian.net/browse/PAY-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ