### PR TITLE
refactor(settings): Upgrade to react-hook-form v7

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -47,6 +47,7 @@
     "helmet": "^8.0.0",
     "mozlog": "^3.0.2",
     "on-headers": "^1.1.0",
+    "react-hook-form": "^7.54.0",
     "react-router": "7.18.0",
     "react-scripts": "^5.0.1",
     "serve-static": "^1.16.0"

--- a/packages/fxa-admin-panel/src/components/PageRateLimiting/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRateLimiting/index.tsx
@@ -117,11 +117,10 @@ export const PageRateLimiting = () => {
         </label>
         <input
           id={`rate-limit-${id}`}
-          name={id}
           type={type}
           placeholder={label}
           className="bg-grey-50 rounded w-full py-2 px-3 placeholder-grey-500"
-          ref={register}
+          {...register(id)}
         />
       </div>
     );

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -174,7 +174,7 @@
     "react-async-hook": "^4.0.0",
     "react-dev-utils": "^12.0.1",
     "react-easy-crop": "^5.2.0",
-    "react-hook-form": "^6.15.8",
+    "react-hook-form": "^7.54.0",
     "react-markdown": "^8.0.5",
     "react-refresh": "^0.16.0",
     "react-router": "7.18.0",

--- a/packages/fxa-settings/src/components/FormChoice/index.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/index.tsx
@@ -44,7 +44,7 @@ const FormChoice = ({
   formChoices,
   onSubmit,
   isSubmitting,
-                      cmsButton
+  cmsButton,
 }: FormChoiceProps) => {
   const { register, handleSubmit, watch } = useForm<FormChoiceData>();
   const selectedOption = watch('choice');
@@ -63,9 +63,8 @@ const FormChoice = ({
               className="input-radio"
               type="radio"
               id={choice.id}
-              name="choice"
               value={choice.value}
-              ref={register({ required: true })}
+              {...register('choice', { required: true })}
             />
             <label
               className={classNames(

--- a/packages/fxa-settings/src/components/FormPassword/index.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useState } from 'react';
 import { ReactComponent as ValidIcon } from './valid.svg';
 import { ReactComponent as InvalidIcon } from './invalid.svg';
 import { ReactComponent as UnsetIcon } from './unset.svg';
-import { UseFormMethods, ValidateResult } from 'react-hook-form';
+import { UseFormReturn, ValidateResult } from 'react-hook-form';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import InputPassword from '../InputPassword';
 import PasswordValidator from '../../lib/password-validator';
@@ -15,13 +15,17 @@ import { SETTINGS_PATH } from '../../constants';
 import { logViewEvent, settingsViewName } from '../../lib/metrics';
 import { useNavigate } from 'react-router';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFormReturn = UseFormReturn<any>;
+
 type FormPasswordProps = {
-  formState: UseFormMethods['formState'];
-  errors: UseFormMethods['errors'];
+  formState: AnyFormReturn['formState'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors: Record<string, any>;
   onSubmit: () => void;
-  trigger: UseFormMethods['trigger'];
-  register: UseFormMethods['register'];
-  getValues: UseFormMethods['getValues'];
+  trigger: AnyFormReturn['trigger'];
+  register: AnyFormReturn['register'];
+  getValues: AnyFormReturn['getValues'];
   primaryEmail: string;
   newPasswordErrorText?: string;
   setNewPasswordErrorText: React.Dispatch<
@@ -67,6 +71,11 @@ export const FormPassword = ({
   onFocusMetricsEvent,
   loading,
 }: FormPasswordProps) => {
+  // Eagerly read formState properties so react-hook-form's Proxy subscribes
+  // to each one. Short-circuit `||` in the disabled expression would skip
+  // later accesses, preventing re-renders when those properties change.
+  const { isDirty, isValid, dirtyFields } = formState;
+
   const navigate = useNavigate();
   const goHome = useCallback(
     () => navigate(SETTINGS_PATH + '#password', { replace: true }),
@@ -93,21 +102,21 @@ export const FormPassword = ({
       >
         <li data-testid="change-password-length">
           <ValidationIcon
-            isSet={formState.dirtyFields.newPassword}
+            isSet={dirtyFields.newPassword}
             hasError={errors.newPassword?.types?.length}
           />
           <Localized id="pw-8-chars">At least 8 characters</Localized>
         </li>
         <li data-testid="change-password-email">
           <ValidationIcon
-            isSet={formState.dirtyFields.newPassword}
+            isSet={dirtyFields.newPassword}
             hasError={errors.newPassword?.types?.notEmail}
           />
           <Localized id="pw-not-email">Not your email address</Localized>
         </li>
         <li data-testid="change-password-common">
           <ValidationIcon
-            isSet={formState.dirtyFields.newPassword}
+            isSet={dirtyFields.newPassword}
             hasError={errors.newPassword?.types?.uncommon}
           />
           <Localized id="pw-commonly-used">
@@ -116,7 +125,7 @@ export const FormPassword = ({
         </li>
         <li data-testid="change-password-match">
           <ValidationIcon
-            isSet={formState.dirtyFields.confirmPassword}
+            isSet={dirtyFields.confirmPassword}
             hasError={errors.confirmPassword?.types?.validate}
           />
           <Localized id="pw-change-must-match">
@@ -156,7 +165,6 @@ export const FormPassword = ({
         {setCurrentPasswordErrorText && (
           <Localized id="pw-change-current-password" attrs={{ label: true }}>
             <InputPassword
-              name="oldPassword"
               label="Enter current password"
               className="mb-2"
               errorText={currentPasswordErrorText}
@@ -166,7 +174,7 @@ export const FormPassword = ({
                 }
                 trigger('oldPassword');
               }}
-              inputRef={register({
+              registration={register('oldPassword', {
                 required: true,
               })}
               prefixDataTestId="current-password"
@@ -176,7 +184,6 @@ export const FormPassword = ({
 
         <Localized id="pw-change-new-password" attrs={{ label: true }}>
           <InputPassword
-            name="newPassword"
             label="Enter new password"
             className="mb-2"
             errorText={newPasswordErrorText}
@@ -187,7 +194,7 @@ export const FormPassword = ({
               }
               trigger(['newPassword', 'confirmPassword']);
             }}
-            inputRef={register({
+            registration={register('newPassword', {
               required: true,
               validate: {
                 length: (value: string) => value.length > 7,
@@ -199,9 +206,7 @@ export const FormPassword = ({
                     '@fxa/vendored/common-password-list'
                   );
                   const input = value.toLowerCase();
-                  return (
-                    !isCommon(input) && !passwordValidator.isBanned(input)
-                  );
+                  return !isCommon(input) && !passwordValidator.isBanned(input);
                 },
               },
             })}
@@ -211,11 +216,10 @@ export const FormPassword = ({
 
         <Localized id="pw-change-confirm-password" attrs={{ label: true }}>
           <InputPassword
-            name="confirmPassword"
             label="Confirm new password"
             onChange={() => trigger(['newPassword', 'confirmPassword'])}
             onFocusCb={onFocusMetricsEvent ? onFocus : undefined}
-            inputRef={register({
+            registration={register('confirmPassword', {
               required: true,
               validate: (value: string) => value === getValues().newPassword,
             })}
@@ -240,7 +244,7 @@ export const FormPassword = ({
             data-testid="save-password-button"
             type="submit"
             className="cta-primary cta-base-p mx-2 flex-1"
-            disabled={!formState.isDirty || !formState.isValid || loading}
+            disabled={!isDirty || !isValid || loading}
           >
             Save
           </button>

--- a/packages/fxa-settings/src/components/FormPassword/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/mocks.tsx
@@ -20,7 +20,7 @@ export const Subject = ({ includeCurrentPw = true }) => {
     useState<string>();
   const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
 
-  const { handleSubmit, register, getValues, errors, formState, trigger } =
+  const { handleSubmit, register, getValues, formState, trigger } =
     useForm<FormData>({
       mode: 'onTouched',
       criteriaMode: 'all',
@@ -37,7 +37,7 @@ export const Subject = ({ includeCurrentPw = true }) => {
     <FormPassword
       {...{
         formState,
-        errors,
+        errors: formState.errors,
         trigger,
         register,
         getValues,

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useState } from 'react';
-import { UseFormMethods } from 'react-hook-form';
+import { UseFormReturn } from 'react-hook-form';
 import InputPassword from '../InputPassword';
 import PasswordValidator from '../../lib/password-validator';
 import { FtlMsg } from 'fxa-react/lib/utils';
@@ -13,14 +13,17 @@ import CmsButtonWithFallback, { CmsButtonType } from '../CmsButtonWithFallback';
 
 export type PasswordFormType = 'signup' | 'reset' | 'post-verify-set-password';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFormReturn = UseFormReturn<any>;
+
 export type FormPasswordWithInlineCriteriaProps = {
   passwordFormType: PasswordFormType;
-  formState: UseFormMethods['formState'];
-  errors: UseFormMethods['errors'];
+  formState: AnyFormReturn['formState'];
+  errors: Record<string, any>;
   onSubmit: (e?: React.BaseSyntheticEvent) => Promise<void>;
-  trigger: UseFormMethods['trigger'];
-  register: UseFormMethods['register'];
-  getValues: UseFormMethods['getValues'];
+  trigger: AnyFormReturn['trigger'];
+  register: AnyFormReturn['register'];
+  getValues: AnyFormReturn['getValues'];
   email: string;
   loading: boolean;
   disableButtonUntilValid?: boolean;
@@ -93,6 +96,10 @@ export const FormPasswordWithInlineCriteria = ({
   submitButtonGleanId,
   cmsButton,
 }: FormPasswordWithInlineCriteriaProps) => {
+  // Eagerly read formState properties so react-hook-form's Proxy subscribes
+  // to each one regardless of short-circuit evaluation in disabled expressions.
+  const { isValid, dirtyFields } = formState;
+
   const passwordValidator = new PasswordValidator(email);
   const [passwordMatchErrorText, setPasswordMatchErrorText] =
     useState<string>('');
@@ -166,7 +173,7 @@ export const FormPasswordWithInlineCriteria = ({
       setPasswordMatchErrorText(localizedPasswordMatchError);
     }
 
-    if (!formState.isValid && showConfirmPasswordInput) {
+    if (!isValid && showConfirmPasswordInput) {
       trigger('confirmPassword');
     }
   };
@@ -188,11 +195,11 @@ export const FormPasswordWithInlineCriteria = ({
       setSROnlyConfirmPwdFeedbackMessage(srOnlyPasswordsMatch);
     }
 
-    if (!formState.isValid) {
+    if (!isValid) {
       trigger('newPassword');
     }
   }, [
-    formState,
+    isValid,
     ftlMsgResolver,
     getValues,
     localizedPasswordMatchError,
@@ -270,15 +277,12 @@ export const FormPasswordWithInlineCriteria = ({
         <div className="relative mb-4" aria-atomic="true">
           <FtlMsg id={templateValues.passwordFtlId} attrs={{ label: true }}>
             <InputPassword
-              name="newPassword"
               label={templateValues.passwordLabel}
               onFocusCb={onNewPwdFocus}
               onBlurCb={onNewPwdBlur}
               onChange={() => onChangePassword('newPassword')}
-              hasErrors={
-                formState.dirtyFields.newPassword ? errors.newPassword : false
-              }
-              inputRef={register({
+              hasErrors={dirtyFields.newPassword ? errors.newPassword : false}
+              registration={register('newPassword', {
                 required: true,
                 validate: {
                   length: (value: string) =>
@@ -312,14 +316,13 @@ export const FormPasswordWithInlineCriteria = ({
               attrs={{ label: true }}
             >
               <InputPassword
-                name="confirmPassword"
                 label={templateValues.confirmPasswordLabel}
                 className="text-start"
                 onFocusCb={onFocusConfirmPassword}
                 onBlurCb={onBlurConfirmPassword}
                 onChange={() => onChangePassword('confirmPassword')}
                 hasErrors={errors.confirmPassword && passwordMatchErrorText}
-                inputRef={register({
+                registration={register('confirmPassword', {
                   required: true,
                   validate: (value: string) =>
                     value === getValues().newPassword,
@@ -373,9 +376,7 @@ export const FormPasswordWithInlineCriteria = ({
           <CmsButtonWithFallback
             type="submit"
             className="cta-primary cta-xl"
-            disabled={
-              loading || (disableButtonUntilValid && !formState.isValid)
-            }
+            disabled={loading || (disableButtonUntilValid && !isValid)}
             data-glean-id={submitButtonGleanId && submitButtonGleanId}
             buttonColor={cmsButton?.color}
             buttonText={cmsButton?.text}

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/mocks.tsx
@@ -25,7 +25,7 @@ export const Subject = ({
     alert('Form submitted! (onFormSubmit called)');
   };
 
-  const { handleSubmit, register, getValues, errors, formState, trigger } =
+  const { handleSubmit, register, getValues, formState, trigger } =
     useForm<FormData>({
       mode: 'onTouched',
       criteriaMode: 'all',
@@ -39,7 +39,7 @@ export const Subject = ({
     <FormPasswordWithInlineCriteria
       {...{
         formState,
-        errors,
+        errors: formState.errors,
         trigger,
         register,
         getValues,

--- a/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
@@ -32,14 +32,14 @@ describe('FormPhoneNumber', () => {
             localizedCTAText="Send code"
             submitPhoneNumber={mockSubmit}
             infoBannerContent={{
-            localizedDescription: 'This is a banner description',
-            localizedHeading: 'This is a banner heading',
-          }}
-          infoBannerLink={{
-            localizedText: 'This is a banner link',
-            path: '#',
-          }}
-        />
+              localizedDescription: 'This is a banner description',
+              localizedHeading: 'This is a banner heading',
+            }}
+            infoBannerLink={{
+              localizedText: 'This is a banner link',
+              path: '#',
+            }}
+          />
         </MemoryRouter>
       );
     });
@@ -107,7 +107,9 @@ describe('FormPhoneNumber', () => {
       await waitFor(
         async () => await user.type(getPhoneInput(), '(123) 123-1234')
       );
-      expect(getSubmitButton()).toBeEnabled();
+      await waitFor(() => {
+        expect(getSubmitButton()).toBeEnabled();
+      });
       await waitFor(async () => await user.click(getSubmitButton()));
       expect(mockSubmit).toHaveBeenCalledWith('+11231231234');
     });

--- a/packages/fxa-settings/src/components/FormPhoneNumber/index.tsx
+++ b/packages/fxa-settings/src/components/FormPhoneNumber/index.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import InputPhoneNumber from '../InputPhoneNumber';
+import InputPhoneNumber, { defaultCountries } from '../InputPhoneNumber';
 import Banner from '../Banner';
 import { BannerContentProps, BannerLinkProps } from '../Banner/interfaces';
 import { GleanClickEventDataAttrs } from '../../lib/types';
@@ -39,9 +39,14 @@ const FormPhoneNumber = ({
       criteriaMode: 'all',
       defaultValues: {
         phoneNumber: '',
-        countryCode: '',
+        countryCode:
+          defaultCountries.find((c) => c.id === 1)?.code ||
+          defaultCountries[0].code,
       },
     });
+  // Eagerly read isDirty so react-hook-form's Proxy subscribes to it
+  // even when isSubmitting short-circuits the disabled expression.
+  const { isDirty } = formState;
 
   // Use `useWatch` to observe the `phoneNumber` field without causing re-renders
   const phoneNumberInput: string | undefined = useWatch({
@@ -115,7 +120,7 @@ const FormPhoneNumber = ({
           className="cta-primary cta-xl"
           disabled={
             isSubmitting ||
-            !formState.isDirty ||
+            !isDirty ||
             phoneNumberInput === undefined ||
             phoneNumberInput.replace(/\D/g, '').length !== 10
           }

--- a/packages/fxa-settings/src/components/FormSetupAccount/interfaces.ts
+++ b/packages/fxa-settings/src/components/FormSetupAccount/interfaces.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { UseFormMethods } from 'react-hook-form';
+import { UseFormReturn } from 'react-hook-form';
 import { SetPasswordFormData } from '../../pages/PostVerify/SetPassword/interfaces';
 import { SignupFormData } from '../../pages/Signup/interfaces';
 import { syncEngineConfigs } from '../../lib/sync-engines';
@@ -10,12 +10,16 @@ import { CmsButtonType } from '../CmsButtonWithFallback';
 
 export type FormSetupAccountData = SignupFormData | SetPasswordFormData;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFormReturn = UseFormReturn<any>;
+
 export type FormSetupAccountProps = {
-  formState: UseFormMethods['formState'];
-  errors: UseFormMethods['errors'];
-  trigger: UseFormMethods['trigger'];
-  register: UseFormMethods['register'];
-  getValues: UseFormMethods['getValues'];
+  formState: AnyFormReturn['formState'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors: Record<string, any>;
+  trigger: AnyFormReturn['trigger'];
+  register: AnyFormReturn['register'];
+  getValues: AnyFormReturn['getValues'];
   onFocus?: () => void;
   email: string;
   onFocusMetricsEvent?: () => void;

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -94,15 +94,18 @@ const FormVerifyCode = ({
     }
   };
 
-  const { handleSubmit, register, errors, watch } = useForm<FormData>({
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+    setValue,
+  } = useForm<FormData>({
     mode: 'onBlur',
     criteriaMode: 'all',
     defaultValues: {
       code: '',
     },
   });
-
-  const codeValue = watch('code');
 
   const localizedDefaultCodeRequiredMessage = ftlMsgResolver.getMsg(
     'form-verify-code-default-error',
@@ -137,21 +140,11 @@ const FormVerifyCode = ({
     }
   };
 
-  useEffect(() => {
-    if (codeValue && codeValue.length > 0) {
-      const isValid = new RegExp(formAttributes.pattern).test(codeValue);
-      setIsDisabled(!isValid);
-    } else {
-      setIsDisabled(true);
-    }
-  }, [codeValue, formAttributes.pattern]);
-
   return (
     <form noValidate {...{ className }} onSubmit={handleSubmit(onSubmit)}>
       {/* Using `type="text" inputmode="numeric"` shows the numeric keyboard on mobile
       and strips out whitespace on desktop, but does not add an incrementer. */}
       <InputText
-        name="code"
         type="text"
         inputMode={inputMode}
         label={localizedLabel}
@@ -159,6 +152,11 @@ const FormVerifyCode = ({
           if (inputMode === InputModeEnum.numeric) {
             e.target.value = e.target.value.replace(/[^0-9]/g, '');
           }
+          const value = e.target.value;
+          setValue('code', value);
+          const isValid =
+            value.length > 0 && new RegExp(formAttributes.pattern).test(value);
+          setIsDisabled(!isValid);
           if (setClearMessages) {
             setClearMessages(true);
           } else {
@@ -178,9 +176,7 @@ const FormVerifyCode = ({
         spellCheck={false}
         prefixDataTestId={viewName}
         tooltipPosition="bottom"
-        inputRef={register({
-          required: true,
-        })}
+        registration={register('code', { required: true })}
       />
 
       <FtlMsg id={formAttributes.submitButtonFtlId}>

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
@@ -31,11 +31,12 @@ const FormVerifyTotp = ({
   className = '',
   cmsButton,
 }: FormVerifyTotpProps) => {
-  const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCodeReady, setIsCodeReady] = useState(false);
 
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const { handleSubmit, register } = useForm<VerifyTotpFormData>({
+  const { handleSubmit, register, setValue } = useForm<VerifyTotpFormData>({
     mode: 'onBlur',
     criteriaMode: 'all',
     defaultValues: {
@@ -56,23 +57,31 @@ const FormVerifyTotp = ({
       codeType === 'numeric' ? /[^0-9]/g : /[^a-zA-Z0-9]/g,
       ''
     );
+    // Mutate the DOM value so the user sees the filtered text, then sync
+    // RHF's internal state via setValue. registration.onChange (called first
+    // by InputText) may have captured the unfiltered value, so setValue
+    // ensures RHF's store matches the filtered value on submit.
     e.target.value = filteredCode;
-    e.target.value.length === codeLength
-      ? setIsSubmitDisabled(false)
-      : setIsSubmitDisabled(true);
+    setValue('code', filteredCode);
+    setIsCodeReady(filteredCode.length === codeLength);
   };
 
   const onSubmit = async ({ code }: VerifyTotpFormData) => {
     clearBanners && clearBanners();
-    setIsSubmitDisabled(true);
+    setIsSubmitting(true);
     // Only submit the code if it is the correct length
     // Otherwise, show an error message
     if (code.length !== codeLength) {
       setErrorMessage(
         getLocalizedErrorMessage(ftlMsgResolver, AuthUiErrors.INVALID_OTP_CODE)
       );
-    } else if (!isSubmitDisabled) {
-      await verifyCode(code);
+      setIsSubmitting(false);
+    } else {
+      try {
+        await verifyCode(code);
+      } finally {
+        setIsSubmitting(false);
+      }
     }
   };
 
@@ -101,7 +110,6 @@ const FormVerifyTotp = ({
       {/* Using `type="text" inputmode="numeric"` shows the numeric keyboard on mobile
       and strips out whitespace on desktop, but does not add an incrementer. */}
       <InputText
-        name="code"
         type="text"
         inputMode={codeType === 'numeric' ? 'numeric' : 'text'}
         label={localizedInputLabel}
@@ -111,25 +119,25 @@ const FormVerifyTotp = ({
         anchorPosition="start"
         autoComplete="one-time-code"
         spellCheck={false}
-        inputRef={register({ required: true })}
+        registration={register('code', { required: true })}
         hasErrors={!!errorMessage}
         ariaDescribedBy={errorBannerId}
       />
 
-        <CmsButtonWithFallback
-          type="submit"
-          className="cta-primary cta-xl"
-          disabled={isSubmitDisabled}
-          title={isSubmitDisabled ? getDisabledButtonTitle() : ''}
-          {...(gleanDataAttrs && {
-            'data-glean-id': gleanDataAttrs.id,
-            'data-glean-label': gleanDataAttrs.label,
-            'data-glean-type': gleanDataAttrs.type,
-          })}
-          buttonColor={cmsButton?.color}
-        >
-          {localizedSubmitButtonText}
-        </CmsButtonWithFallback>
+      <CmsButtonWithFallback
+        type="submit"
+        className="cta-primary cta-xl"
+        disabled={!isCodeReady || isSubmitting}
+        title={!isCodeReady ? getDisabledButtonTitle() : ''}
+        {...(gleanDataAttrs && {
+          'data-glean-id': gleanDataAttrs.id,
+          'data-glean-label': gleanDataAttrs.label,
+          'data-glean-type': gleanDataAttrs.type,
+        })}
+        buttonColor={cmsButton?.color}
+      >
+        {localizedSubmitButtonText}
+      </CmsButtonWithFallback>
     </form>
   );
 };

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -8,9 +8,7 @@ import { ReactComponent as OpenEye } from './eye-open.svg';
 import { ReactComponent as ClosedEye } from './eye-closed.svg';
 import { useFtlMsgResolver } from '../../models';
 
-export type InputPasswordProps = Omit<InputTextProps, 'type'> & {
-  inputRefDOM?: React.RefObject<HTMLInputElement>;
-};
+export type InputPasswordProps = Omit<InputTextProps, 'type'>;
 
 export const InputPassword = ({
   defaultValue,
@@ -23,6 +21,7 @@ export const InputPassword = ({
   onBlurCb,
   inputRef,
   inputRefDOM,
+  registration,
   hasErrors,
   errorText,
   name,
@@ -82,6 +81,7 @@ export const InputPassword = ({
           onBlurCb,
           className,
           inputRef,
+          registration,
           hasErrors,
           errorText,
           name,

--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import InputText from '../InputText';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models';
-import { UseFormMethods } from 'react-hook-form';
+import { UseFormReturn } from 'react-hook-form';
 
 interface Country {
   id: number;
@@ -20,8 +20,10 @@ interface Country {
 export type InputPhoneNumberProps = {
   countries?: Country[];
   hasErrors?: boolean;
-  register: UseFormMethods['register'];
-  setValue: UseFormMethods['setValue'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register: UseFormReturn<any>['register'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setValue: UseFormReturn<any>['setValue'];
   errorBannerId?: string;
 };
 
@@ -81,24 +83,35 @@ const InputPhoneNumber = ({
     sortedLocalizedCountries[0];
   const [selectedCountry, setSelectedCountry] = useState(defaultCountry);
 
+  // Register phone number with validation. We override onChange below
+  // because handleInputChange formats the value before setting it.
+  const phoneRegistration = register('phoneNumber', {
+    required: true,
+    pattern: selectedCountry.validationPattern,
+  });
+
   const localizedLabel = ftlMsgResolver.getMsg(
     'input-phone-number-enter-number',
     'Enter phone number'
   );
 
   const handleCountryChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedCountry = sortedLocalizedCountries.find(
+    const newCountry = sortedLocalizedCountries.find(
       (country) => country.id === parseInt(event.target.value, 10)
     );
-    if (selectedCountry) {
-      setSelectedCountry(selectedCountry);
+    if (newCountry) {
+      setSelectedCountry(newCountry);
+      setValue('countryCode', newCountry.code);
     }
   };
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = event.target.value;
     const formattedValue = formatPhoneNumber(inputValue);
-    setValue('phoneNumber', formattedValue);
+    setValue('phoneNumber', formattedValue, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
   };
 
   // Format the phone number as the user types - for easier review by the user
@@ -178,25 +191,21 @@ const InputPhoneNumber = ({
       </div>
 
       {/* Because the country code may not be unique, the above `select`'s `value` must
-       be by country ID. This hidden input allows us to access it in the form data. */}
-      <input
-        type="hidden"
-        name="countryCode"
-        value={selectedCountry.code}
-        ref={register()}
-      />
+       be by country ID. The countryCode field is kept in react-hook-form state via setValue(). */}
       <InputText
-        name="phoneNumber"
         type="tel"
         label={localizedLabel}
         required
         className="text-start w-full"
         autoComplete="off"
         spellCheck={false}
-        inputRef={register({
-          required: true,
-          pattern: selectedCountry.validationPattern,
-        })}
+        registration={{
+          ...phoneRegistration,
+          // Override onChange to no-op: handleInputChange manages the form value
+          // via setValue with formatting. Letting registration.onChange also run
+          // would cause a race condition (it validates the raw unformatted input).
+          onChange: async () => {},
+        }}
         {...{ hasErrors }}
         onChange={handleInputChange}
         aria-describedby={errorBannerId}

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -8,9 +8,11 @@ import React, {
   useCallback,
   ReactElement,
   Ref,
+  useRef,
 } from 'react';
 import classNames from 'classnames';
 import { Tooltip } from '../Tooltip';
+import { UseFormRegisterReturn } from 'react-hook-form';
 
 export type InputTextProps = {
   value?: string;
@@ -25,6 +27,9 @@ export type InputTextProps = {
   inputOnlyClassName?: string;
   inputRef?: Ref<HTMLInputElement>;
   inputRefDOM?: Ref<HTMLInputElement>;
+  /** react-hook-form v7 register() return value. When provided, ref/onChange/onBlur/name
+   *  are taken from this object (merged with any explicit onChange/onBlurCb/inputRefDOM). */
+  registration?: UseFormRegisterReturn;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   onFocusCb?: () => void;
   onBlurCb?: () => void;
@@ -70,6 +75,7 @@ export const InputText = ({
   inputOnlyClassName = '',
   inputRef,
   inputRefDOM,
+  registration,
   type = 'text',
   name,
   prefixDataTestId = '',
@@ -126,6 +132,11 @@ export const InputText = ({
     return prefixDataTestId ? `${prefixDataTestId}-${id}` : id;
   }
 
+  // Store registration ref in a mutable ref to avoid combinedRef recreation
+  // on every render (register() returns a new object each call in v7).
+  const registrationRefLatest = useRef(registration?.ref);
+  registrationRefLatest.current = registration?.ref;
+
   const combinedRef = useCallback(
     (element: HTMLInputElement | null) => {
       if (inputRefDOM) {
@@ -133,12 +144,16 @@ export const InputText = ({
           inputRefDOM as React.MutableRefObject<HTMLInputElement | null>
         ).current = element;
       }
-      if (inputRef && typeof inputRef === 'function') {
-        inputRef(element);
+      const refToCall = registrationRefLatest.current || inputRef;
+      if (refToCall && typeof refToCall === 'function') {
+        refToCall(element);
       }
     },
     [inputRef, inputRefDOM]
   );
+
+  // When registration is provided, use its name
+  const effectiveName = registration ? registration.name : name;
 
   return (
     <label
@@ -187,14 +202,22 @@ export const InputText = ({
               : ''
           )}
           data-testid={formatDataTestId('input-field')}
-          onChange={textFieldChange}
+          onChange={(e) => {
+            // registration.onChange must fire first to update form state
+            // before any trigger() calls in the component's onChange
+            registration?.onChange(e);
+            textFieldChange(e);
+          }}
           ref={combinedRef}
           aria-describedby={ariaDescribedBy}
+          onBlur={(e) => {
+            registration?.onBlur(e);
+            onBlur(e);
+          }}
           {...{
-            name,
+            name: effectiveName,
             disabled,
             onFocus,
-            onBlur,
             onPaste,
             placeholder,
             type,

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
@@ -142,10 +142,9 @@ export const RecoveryKeySetupHint = ({
         <ControlledCharacterCount {...{ control }} />
         <FtlMsg id="flow-recovery-key-hint-input-v2" attrs={{ label: true }}>
           <InputText
-            name="hint"
             label="Enter a hint (optional)"
             prefixDataTestId="hint"
-            inputRef={register()}
+            registration={register('hint')}
             onChange={() => {
               setHintError(undefined);
               setLocalizedErrorMessage('');

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
@@ -65,6 +65,9 @@ export const FlowRecoveryKeyConfirmPwd = ({
       password: '',
     },
   });
+  // Eagerly read isDirty so react-hook-form's Proxy subscribes to it
+  // even when isLoading short-circuits the disabled expression.
+  const { isDirty } = formState;
 
   const createRecoveryKey = useCallback(async () => {
     const password = getValues('password');
@@ -151,7 +154,6 @@ export const FlowRecoveryKeyConfirmPwd = ({
           })}
         >
           <InputPassword
-            name="password"
             label={ftlMsgResolver.getMsg(
               'flow-recovery-key-confirm-pwd-input-label',
               'Enter your password'
@@ -159,7 +161,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
             onChange={() => {
               errorText && setErrorText(undefined);
             }}
-            inputRef={register({
+            registration={register('password', {
               required: true,
             })}
             {...{ errorText }}
@@ -169,7 +171,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
               <button
                 className="cta-primary cta-xl w-full mt-4"
                 type="submit"
-                disabled={isLoading || !formState.isDirty}
+                disabled={isLoading || !isDirty}
               >
                 Create account recovery key
               </button>
@@ -180,7 +182,7 @@ export const FlowRecoveryKeyConfirmPwd = ({
               <button
                 className="cta-primary cta-xl w-full mt-4"
                 type="submit"
-                disabled={isLoading || !formState.isDirty}
+                disabled={isLoading || !isDirty}
               >
                 Create new account recovery key
               </button>

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
@@ -117,12 +117,11 @@ export const ModalMfaProtected = ({
 
         <div className="mt-4 mb-8">
           <InputText
-            name="confirmationCode"
             label={ftlMsgResolver.getMsg(
               'modal-mfa-protected-input-label',
               'Enter 6-digit code'
             )}
-            inputRef={register({
+            registration={register('confirmationCode', {
               required: true,
               pattern: /^\s*[0-9]{6}\s*$/,
             })}

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
@@ -145,7 +145,6 @@ export const ModalVerifySession = ({
 
           <div className="mt-4 mb-6">
             <InputText
-              name="verificationCode"
               label={l10n.getString(
                 'mvs-enter-verification-code-2',
                 null,
@@ -156,7 +155,7 @@ export const ModalVerifySession = ({
                   setErrorText(undefined);
                 }
               }}
-              inputRef={register({
+              registration={register('verificationCode', {
                 required: true,
                 pattern: /^\s*[0-9]{6}\s*$/,
               })}

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
@@ -34,23 +34,16 @@ type FormData = {
 // eslint-disable-next-line no-empty-pattern
 export const PageChangePassword = () => {
   usePageViewEvent('settings.change-password');
-  const {
-    handleSubmit,
-    register,
-    getValues,
-    setValue,
-    errors,
-    formState,
-    trigger,
-  } = useForm<FormData>({
-    mode: 'onTouched',
-    criteriaMode: 'all',
-    defaultValues: {
-      oldPassword: '',
-      newPassword: '',
-      confirmPassword: '',
-    },
-  });
+  const { handleSubmit, register, getValues, setValue, formState, trigger } =
+    useForm<FormData>({
+      mode: 'onTouched',
+      criteriaMode: 'all',
+      defaultValues: {
+        oldPassword: '',
+        newPassword: '',
+        confirmPassword: '',
+      },
+    });
   const account = useAccount();
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -121,7 +114,7 @@ export const PageChangePassword = () => {
         <FormPassword
           {...{
             formState,
-            errors,
+            errors: formState.errors,
             trigger,
             register,
             getValues,

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
@@ -40,7 +40,7 @@ export const PageCreatePassword = () => {
   const handleMfaError = useMfaErrorHandler();
   usePageViewEvent('settings.create-password');
 
-  const { handleSubmit, register, getValues, errors, formState, trigger } =
+  const { handleSubmit, register, getValues, formState, trigger } =
     useForm<FormData>({
       mode: 'onTouched',
       criteriaMode: 'all',
@@ -115,7 +115,7 @@ export const PageCreatePassword = () => {
         <FormPassword
           {...{
             formState,
-            errors,
+            errors: formState.errors,
             trigger,
             register,
             getValues,

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -87,10 +87,11 @@ export const PageDeleteAccount = () => {
       password: '',
     },
   });
-  // TODO: the `.errors.password` clause shouldn't be necessary, but `isValid` isn't updating
-  // properly. I think this is a bug in react-hook-form.
-  const disabled =
-    !formState.isDirty || !formState.isValid || !!formState.errors.password;
+  // Read all formState properties eagerly so react-hook-form's Proxy
+  // subscribes to each one. Short-circuit `||` would skip later accesses,
+  // preventing re-renders when those properties change.
+  const { isDirty, isValid, errors } = formState;
+  const disabled = !isDirty || !isValid || !!errors.password;
   const [errorText, setErrorText] = useState<string>();
   const [confirmed, setConfirmed] = useState<boolean>(false);
   const [subtitleText, setSubtitleText] = useState<string>(
@@ -291,7 +292,6 @@ export const PageDeleteAccount = () => {
                 attrs={{ label: true }}
               >
                 <InputPassword
-                  name="password"
                   label="Enter password"
                   prefixDataTestId="delete-account-confirm"
                   onChange={() => {
@@ -299,7 +299,7 @@ export const PageDeleteAccount = () => {
                       setErrorText(undefined);
                     }
                   }}
-                  inputRef={register({
+                  registration={register('password', {
                     required: true,
                     minLength: 8,
                   })}

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
@@ -41,6 +41,9 @@ export const PageDisplayName = () => {
       displayName: initialValue,
     },
   });
+  // Eagerly read formState properties so react-hook-form's Proxy subscribes
+  // to each one regardless of short-circuit evaluation.
+  const { isDirty, isValid } = formState;
   const isValidDisplayName = validateDisplayName(initialValue);
 
   const onSubmit = useCallback(
@@ -68,13 +71,12 @@ export const PageDisplayName = () => {
           <div className="my-6">
             <Localized id="display-name-input" attrs={{ label: true }}>
               <InputText
-                name="displayName"
                 label="Enter display name"
                 className="mb-2"
                 data-testid="display-name-input"
                 autoFocus
                 onChange={() => trigger('displayName')}
-                inputRef={register({
+                registration={register('displayName', {
                   validate: isValidDisplayName,
                 })}
               />
@@ -96,9 +98,7 @@ export const PageDisplayName = () => {
                 type="submit"
                 data-testid="submit-display-name"
                 className="cta-primary cta-base-p mx-2 flex-1"
-                disabled={
-                  !formState.isDirty || !formState.isValid || account.loading
-                }
+                disabled={!isDirty || !isValid || account.loading}
               >
                 Save
               </button>

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -37,6 +37,9 @@ export const PageSecondaryEmailVerify = () => {
       verificationCode: '',
     },
   });
+  // Eagerly read formState properties so react-hook-form's Proxy subscribes
+  // to each one regardless of short-circuit evaluation.
+  const { isDirty, isValid } = formState;
   const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
   const goHome = useCallback(
@@ -132,8 +135,7 @@ export const PageSecondaryEmailVerify = () => {
     }
   }, [email, navigateWithQuery]);
 
-  const buttonDisabled =
-    !formState.isDirty || !formState.isValid || account.loading;
+  const buttonDisabled = !isDirty || !isValid || account.loading;
   const resendDisabled =
     resendCodeLoading || account.loading || resendCooldownActive;
   return (
@@ -173,14 +175,13 @@ export const PageSecondaryEmailVerify = () => {
               attrs={{ label: true }}
             >
               <InputText
-                name="verificationCode"
                 label="Enter your confirmation code"
                 onChange={() => {
                   if (errorText) {
                     setErrorText(undefined);
                   }
                 }}
-                inputRef={register({
+                registration={register('verificationCode', {
                   required: true,
                   pattern: /^\s*[0-9]{6}\s*$/,
                 })}

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -665,7 +665,9 @@ const PasskeyRenameModal = ({
               }
               setSubmitError(null);
             }}
-            inputRef={register({ validate: localizeValidationError })}
+            registration={register('name', {
+              validate: localizeValidationError,
+            })}
           />
         </div>
         <div className="flex justify-center mx-2 mt-6">

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -96,6 +96,15 @@ jest.mock('./MfaGuard', () => ({
   useMfaErrorHandler: () => mockMfaErrorHandler,
 }));
 
+// Mock VerifiedSessionGuard to avoid async sessionStatus calls
+jest.mock('./VerifiedSessionGuard', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+  VerifiedSessionGuard: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
 // Default behavior: render mock guard element
 mockMfaGuard.mockImplementation(({ children }: { children: ReactNode }) => (
   <div data-testid="mfa-guard">MockMfaGuard</div>
@@ -201,9 +210,7 @@ describe('Settings App', () => {
     });
 
     renderWithRouter(
-      <AppContext.Provider
-        value={mockAppContext({ account: brokenAccount })}
-      >
+      <AppContext.Provider value={mockAppContext({ account: brokenAccount })}>
         <Subject />
       </AppContext.Provider>,
       { route: SETTINGS_PATH }
@@ -340,10 +347,7 @@ describe('Settings App', () => {
   });
 
   it('routes to PageSettings', async () => {
-    const {
-      getByTestId,
-      router,
-    } = renderWithRouter(
+    const { getByTestId, router } = renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
         <Subject />
       </AppContext.Provider>,
@@ -358,10 +362,7 @@ describe('Settings App', () => {
   });
 
   it('routes to PageDisplayName', async () => {
-    const {
-      getByTestId,
-      router,
-    } = renderWithRouter(
+    const { getByTestId, router } = renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
         <Subject />
       </AppContext.Provider>,
@@ -374,10 +375,7 @@ describe('Settings App', () => {
   });
 
   it('routes to PageAvatar', async () => {
-    const {
-      getAllByTestId,
-      router,
-    } = renderWithRouter(
+    const { getAllByTestId, router } = renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
         <Subject />
       </AppContext.Provider>,
@@ -413,10 +411,7 @@ describe('Settings App', () => {
     }));
 
     const session = mockSession(true);
-    const {
-      getByTestId,
-      router,
-    } = renderWithRouter(
+    const { getByTestId, router } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
         <Subject />
       </AppContext.Provider>,
@@ -430,10 +425,7 @@ describe('Settings App', () => {
 
   it('routes to PageDeleteAccount', async () => {
     const session = mockSession(true);
-    const {
-      getByTestId,
-      router,
-    } = renderWithRouter(
+    const { getByTestId, router } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
         <Subject />
       </AppContext.Provider>,
@@ -446,9 +438,7 @@ describe('Settings App', () => {
   });
 
   it('redirects to ConnectedServices', async () => {
-    const {
-      router,
-    } = renderWithRouter(
+    const { router } = renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
         <Subject />
       </AppContext.Provider>,
@@ -464,9 +454,7 @@ describe('Settings App', () => {
   });
 
   it('redirects to PageAvatar', async () => {
-    const {
-      router,
-    } = renderWithRouter(
+    const { router } = renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
         <Subject />
       </AppContext.Provider>,
@@ -544,10 +532,7 @@ describe('Settings App', () => {
           ...MOCK_ACCOUNT,
           hasPassword,
         } as unknown as Account;
-        const {
-          getByTestId,
-          router,
-        } = renderWithRouter(
+        const { getByTestId, router } = renderWithRouter(
           <AppContext.Provider value={mockAppContext({ session, account })}>
             <Subject />
           </AppContext.Provider>,

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -205,10 +205,9 @@ export const Index = ({
         <FtlMsg id="index-email-input" attrs={{ label: true }}>
           <InputText
             className="mt-8"
-            name="email"
             inputMode="email"
             label="Enter your email"
-            inputRef={register()}
+            registration={register('email')}
             inputRefDOM={emailInputRef}
             errorText={tooltipErrorMessage}
             onChange={handleInputChange}

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
@@ -64,23 +64,16 @@ export const SetPassword = ({
     [createPasswordHandler, ftlMsgResolver, gleanReason]
   );
 
-  const {
-    handleSubmit,
-    register,
-    getValues,
-    errors,
-    formState,
-    trigger,
-    watch,
-  } = useForm<SetPasswordFormData>({
-    mode: 'onChange',
-    criteriaMode: 'all',
-    defaultValues: {
-      email,
-      newPassword: '',
-      confirmPassword: '',
-    },
-  });
+  const { handleSubmit, register, getValues, formState, trigger, watch } =
+    useForm<SetPasswordFormData>({
+      mode: 'onChange',
+      criteriaMode: 'all',
+      defaultValues: {
+        email,
+        newPassword: '',
+        confirmPassword: '',
+      },
+    });
 
   // Fire engage on the first keystroke into the password field (not on focus
   // alone) so the event reflects actual user intent to type a password.
@@ -147,7 +140,7 @@ export const SetPassword = ({
       <FormSetupAccount
         {...{
           formState,
-          errors,
+          errors: formState.errors,
           trigger,
           register,
           getValues,

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -174,7 +174,6 @@ const AccountRecoveryConfirmKey = ({
           <InputText
             type="text"
             label="Enter your 32-character account recovery key"
-            name="recoveryKey"
             autoFocus
             // Crockford base32 encoding is case insensitive, so visually display as
             // uppercase here but don't bother transforming the submit data to match
@@ -183,7 +182,7 @@ const AccountRecoveryConfirmKey = ({
             autoComplete="off"
             spellCheck={false}
             prefixDataTestId="account-recovery-confirm-key"
-            inputRef={register({ required: true })}
+            registration={register('recoveryKey', { required: true })}
             onChange={handleChange}
             hasErrors={!!errorMessage}
           />

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -53,7 +53,7 @@ const CompleteResetPassword = ({
 
   const showRecoveryKeyLink = !!(recoveryKeyExists && !hasConfirmedRecoveryKey);
 
-  const { handleSubmit, register, getValues, errors, formState, trigger } =
+  const { handleSubmit, register, getValues, formState, trigger } =
     useForm<CompleteResetPasswordFormData>({
       mode: 'onTouched',
       criteriaMode: 'all',
@@ -112,7 +112,7 @@ const CompleteResetPassword = ({
         <FormPasswordWithInlineCriteria
           {...{
             email,
-            errors,
+            errors: formState.errors,
             formState,
             getValues,
             register,

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.tsx
@@ -94,12 +94,11 @@ const ResetPassword = ({
           <InputText
             type="email"
             label="Enter your email"
-            name="email"
             onChange={() => setErrorMessage('')}
             autoFocus
             autoComplete="username"
             spellCheck={false}
-            inputRef={register()}
+            registration={register('email')}
           />
         </FtlMsg>
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.tsx
@@ -58,7 +58,7 @@ const SigninPasskeyFallback = ({
     'Valid password required'
   );
 
-  const { handleSubmit, register, watch } = useForm<FormData>({
+  const { handleSubmit, register, watch, formState } = useForm<FormData>({
     mode: 'onTouched',
     criteriaMode: 'all',
     defaultValues: { password: '' },
@@ -166,15 +166,18 @@ const SigninPasskeyFallback = ({
           attrs={{ label: true }}
         >
           <InputPassword
-            name="password"
             label="Password"
             className="mb-6"
-            errorText={passwordTooltipErrorText}
+            errorText={
+              passwordTooltipErrorText || formState.errors.password?.message
+            }
             anchorPosition="start"
             tooltipPosition="bottom"
             autoFocus
             onChange={() => setPasswordTooltipErrorText('')}
-            inputRef={register()}
+            registration={register('password', {
+              required: localizedValidPasswordError,
+            })}
             prefixDataTestId="signin-passkey-fallback-password"
           />
         </FtlMsg>

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -352,7 +352,6 @@ const Signin = ({
         <input type="email" className="hidden" value={email} disabled />
 
         <InputPassword
-          name="password"
           anchorPosition="start"
           className="mb-5"
           label={localizedPasswordFormLabel}
@@ -375,7 +374,7 @@ const Signin = ({
             // if the request errored, loading state must be marked as false to reenable submission on input type
             setSigninLoading(false);
           }}
-          inputRef={register()}
+          registration={register('password')}
         />
 
         <div className="flex">

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -92,7 +92,7 @@ export const Signup = ({
     string[]
   >([]);
 
-  const { handleSubmit, register, getValues, errors, formState, trigger } =
+  const { handleSubmit, register, getValues, formState, trigger } =
     useForm<SignupFormData>({
       mode: 'onChange',
       criteriaMode: 'all',
@@ -328,7 +328,7 @@ export const Signup = ({
         {...{
           passwordFormType: 'signup',
           formState,
-          errors,
+          errors: formState.errors,
           trigger,
           register,
           getValues,

--- a/yarn.lock
+++ b/yarn.lock
@@ -33671,6 +33671,7 @@ __metadata:
     pm2: "npm:^7.0.0"
     postcss-import: "npm:^16.1.0"
     prettier: "npm:^3.5.3"
+    react-hook-form: "npm:^7.54.0"
     react-router: "npm:7.18.0"
     react-scripts: "npm:^5.0.1"
     serve-static: "npm:^1.16.0"
@@ -34316,7 +34317,7 @@ __metadata:
     react-async-hook: "npm:^4.0.0"
     react-dev-utils: "npm:^12.0.1"
     react-easy-crop: "npm:^5.2.0"
-    react-hook-form: "npm:^6.15.8"
+    react-hook-form: "npm:^7.54.0"
     react-markdown: "npm:^8.0.5"
     react-refresh: "npm:^0.16.0"
     react-router: "npm:7.18.0"
@@ -49826,12 +49827,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^6.15.8":
-  version: 6.15.8
-  resolution: "react-hook-form@npm:6.15.8"
+"react-hook-form@npm:^7.54.0":
+  version: 7.84.0
+  resolution: "react-hook-form@npm:7.84.0"
   peerDependencies:
-    react: ^16.8.0 || ^17
-  checksum: 10c0/7a41e476d53ce78a9d37390cdabc53016eb0e6fce86563ec9c2b67f03d6db27366f4ff57498427e9e2c3e37cc92020740fa570b7dbaaf21fa4b72397fa71f77e
+    react: ^16.8.0 || ^17 || ^18 || ^19
+  checksum: 10c0/9af7e9850ac3c41e6a03fe2fc5a236525603dd8ab983194ffb8e893dba1d26b518ae02989192786d8c1f109793adb93d6de46385bee2b04ff06267f7431bdf8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

  - react-hook-form v6 does not support React 19, blocking the planned upgrade
  - v6 is unmaintained and has known issues with formState reactivity

## This pull request

- Bumps react-hook-form from ^6.15.8 to ^7.54.0
- Adds `registration` prop to InputText/InputPassword for v7's register() API
- Migrates all 30+ form components from inputRef={register({...})} to registration={register('fieldName', {...})}
- Updates type interfaces from UseFormMethods to UseFormReturn
- Moves errors from top-level useForm destructure to formState.errors
- Fixes InputPhoneNumber to use setValue with shouldDirty/shouldValidate (v7 no longer auto-tracks dirty state via setValue)
- Updates tests for v7's async formState updates (userEvent over fireEvent, waitFor for formState assertions, VerifiedSessionGuard mock)

## Issue that this pull request solves

Closes: PAY-3633

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.