### PR TITLE
fix(settings): enforce allowlist on authorization action parameter

### DIFF
--- a/packages/fxa-settings/src/models/integrations/data/data.test.ts
+++ b/packages/fxa-settings/src/models/integrations/data/data.test.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { GenericData, ModelValidationErrors } from '../../../lib/model-data';
+import {
+  INTEGRATION_ACTIONS,
+  IntegrationData,
+  WebIntegrationData,
+} from './data';
+
+describe('models/integrations/data', () => {
+  describe('IntegrationData.action allowlist', () => {
+    it.each(INTEGRATION_ACTIONS)(
+      'accepts the allowlisted action "%s"',
+      (action) => {
+        const model = new IntegrationData(new GenericData({ action }));
+        // validate() before reading the getter: the getter also validates but
+        // clears the dirty flag, which would make a later validate() a no-op.
+        expect(() => model.validate()).not.toThrow();
+        expect(model.action).toEqual(action);
+      }
+    );
+
+    it('accepts a missing action', () => {
+      const model = new IntegrationData(new GenericData({}));
+      expect(() => model.validate()).not.toThrow();
+      expect(model.action).toBeUndefined();
+    });
+
+    it('rejects an action outside the allowlist', () => {
+      const model = new IntegrationData(
+        new GenericData({ action: '/evil.example' })
+      );
+      expect(() => model.validate()).toThrow(ModelValidationErrors);
+    });
+
+    // The base allowlist is what closes the open redirect for plain Web
+    // integrations, which inherit `action` from IntegrationData rather than
+    // overriding it (unlike OAuth and Sync integrations).
+    it('rejects an open-redirect action on the inheriting WebIntegrationData', () => {
+      const model = new WebIntegrationData(
+        new GenericData({ action: '/attacker.example/login' })
+      );
+      expect(() => model.validate()).toThrow(ModelValidationErrors);
+    });
+  });
+});

--- a/packages/fxa-settings/src/models/integrations/data/data.ts
+++ b/packages/fxa-settings/src/models/integrations/data/data.ts
@@ -29,6 +29,19 @@ import {
 } from '../../../lib/validation';
 
 /**
+ * Allowlist for the `action` query param. Enforced on the base class so every
+ * integration inherits it, preventing an open redirect via the `action`-derived
+ * `hardNavigate` in AuthorizationContainer.
+ */
+export const INTEGRATION_ACTIONS = [
+  'signin',
+  'signup',
+  'email',
+  'force_auth',
+  'pairing',
+];
+
+/**
  * Base integration class. Fields in this class represents data commonly accessed across many pages and is useful for various flows.
  */
 export class IntegrationData extends ModelDataProvider {
@@ -66,7 +79,7 @@ export class IntegrationData extends ModelDataProvider {
   loginHint: string | undefined;
 
   @IsOptional()
-  @IsString()
+  @IsIn(INTEGRATION_ACTIONS)
   @bind()
   action: string | undefined;
 
@@ -141,7 +154,7 @@ export class SyncBasicIntegrationData extends IntegrationData {
 
   // TODO - Validation - Double check actions
   @IsOptional()
-  @IsIn(['signin', 'signup', 'email', 'force_auth', 'pairing'])
+  @IsIn(INTEGRATION_ACTIONS)
   @bind()
   action: string | undefined;
 
@@ -235,7 +248,7 @@ export class OAuthIntegrationData extends WebIntegrationData {
 
   // TODO - Validation - Double check actions
   @IsOptional()
-  @IsIn(['signin', 'signup', 'email', 'force_auth', 'pairing'])
+  @IsIn(INTEGRATION_ACTIONS)
   @bind()
   action: string | undefined;
 

--- a/packages/fxa-settings/src/pages/Authorization/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.test.tsx
@@ -244,6 +244,23 @@ describe('AuthorizationContainer', () => {
     });
   });
 
+  it('does not hardNavigate to an external origin for a non-allowlisted action', async () => {
+    mockLocationSearch = '?x=1&showReactApp=1';
+    const mockIntegration = {
+      data: {
+        action: '/evil.example',
+      },
+      wantsPromptNone: jest.fn().mockReturnValue(false),
+    };
+
+    render(mockIntegration);
+
+    await waitFor(() => {
+      expect(mockNavigateWithQuery).toHaveBeenCalledWith('/oauth');
+    });
+    expect(ReactUtilsModule.hardNavigate).not.toHaveBeenCalled();
+  });
+
   it('rejects prompt=none and shows error when session is unverified and returnOnError=false for servicesWithEmailVerification client', async () => {
     mockCachedSignIn.mockResolvedValue({
       data: {

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -4,6 +4,7 @@
 
 import { useNavigate, useLocation } from 'react-router';
 import {
+  INTEGRATION_ACTIONS,
   Integration,
   isDefault,
   isOAuthWebIntegration,
@@ -174,14 +175,13 @@ const AuthorizationContainer = ({
     const urlSearchParams = new URLSearchParams(location.search);
     urlSearchParams.delete('showReactApp');
 
-    if (integration.data.action) {
-      if (integration.data.action === 'email') {
+    const action = integration.data.action;
+    if (action && INTEGRATION_ACTIONS.includes(action)) {
+      if (action === 'email') {
         navigateWithQuery('/oauth');
       } else {
         // we'll keep the hard navigate here to support backbone and react pages
-        hardNavigate(
-          `/${integration.data.action}?${urlSearchParams.toString()}`
-        );
+        hardNavigate(`/${action}?${urlSearchParams.toString()}`);
       }
       return;
     }


### PR DESCRIPTION
## Because

- Hardens the `/authorization` route by strictly validating the `action` routing parameter before it is used for navigation.

## This pull request

- Enforces the existing `action` allowlist on the base integration model so every integration validates it consistently.
- Re-checks `action` against the allowlist in `AuthorizationContainer` before navigating (defense in depth).
- Adds model- and container-level unit tests.

## Issue that this pull request solves

Closes: FXA-14057

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
