### PR TITLE
chore(auth): Record email template in statsd metric

### DIFF
--- a/packages/fxa-auth-server/lib/account-events.spec.ts
+++ b/packages/fxa-auth-server/lib/account-events.spec.ts
@@ -91,7 +91,8 @@ describe('Account Events', () => {
       );
       expect(statsd.increment).toHaveBeenCalledTimes(1);
       expect(statsd.increment).toHaveBeenCalledWith(
-        'accountEvents.recordEmailEvent.write'
+        'accountEvents.recordEmailEvent.write',
+        { template: 'verifyLoginCode' }
       );
     });
 

--- a/packages/fxa-auth-server/lib/account-events.ts
+++ b/packages/fxa-auth-server/lib/account-events.ts
@@ -137,7 +137,9 @@ export class AccountEventsManager {
       }
 
       await this.usersDbRef?.doc(uid).collection('events').add(emailEvent);
-      this.statsd.increment('accountEvents.recordEmailEvent.write');
+      this.statsd.increment('accountEvents.recordEmailEvent.write', {
+        template: message.template
+      });
     } catch (err) {
       // Failing to write to events shouldn't break anything
       this.statsd.increment('accountEvents.recordEmailEvent.error');


### PR DESCRIPTION
## Because

- We want to know graph the types of email being sent

## This pull request

- Adds the email template name to the statsd metric

## Issue that this pull request solves

Closes: FXA-14142

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
