### PR TITLE
fix(recovery-phone): use reg limit consistently across phone flows

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -910,6 +910,18 @@ describe('RecoveryPhoneService', () => {
       expect(result).toBe(true);
     });
 
+    it('rejects phone number that has been used for too many accounts', async () => {
+      mockRecoveryPhoneManager.getUnconfirmed.mockResolvedValueOnce({
+        isSetup: true,
+        phoneNumber,
+      });
+      mockRecoveryPhoneManager.getCountByPhoneNumber.mockResolvedValueOnce(5);
+
+      await expect(service.changePhoneNumber(uid, code)).rejects.toThrow(
+        new RecoveryPhoneRegistrationLimitReached(phoneNumber)
+      );
+    });
+
     it('returns false if there is no existing unconfirmed code', async () => {
       mockRecoveryPhoneManager.changePhoneNumber.mockResolvedValue(true);
       mockRecoveryPhoneManager.getUnconfirmed.mockResolvedValueOnce({});

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -325,6 +325,7 @@ export class RecoveryPhoneService {
   /**
    * Updates the existing recovery phone number with the new one associated to the code provided.
    *
+   * @throws {RecoveryPhoneRegistrationLimitReached} If the phone number has been registered for too many accounts
    * @param uid
    * @param code
    * @returns
@@ -343,6 +344,17 @@ export class RecoveryPhoneService {
     if (isSetup !== true) {
       // this code was not for a setup operation, can't proceed.
       return false;
+    }
+
+    // Rejects the phone number if it has been registered for too many accounts
+    const countByPhoneNumber =
+      await this.recoveryPhoneManager.getCountByPhoneNumber(phoneNumber);
+
+    if (
+      this.config.maxRegistrationsPerNumber &&
+      countByPhoneNumber >= this.config.maxRegistrationsPerNumber
+    ) {
+      throw new RecoveryPhoneRegistrationLimitReached(phoneNumber);
     }
 
     const lookupData = await this.getPhoneNumberLookupData(phoneNumber);

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -667,6 +667,8 @@ class RecoveryPhoneHandler {
         throw AppError.recoveryPhoneNumberDoesNotExist();
       } else if (error instanceof RecoveryNumberAlreadyExistsError) {
         throw AppError.recoveryPhoneNumberAlreadyExists();
+      } else if (error instanceof RecoveryPhoneRegistrationLimitReached) {
+        throw AppError.recoveryPhoneRegistrationLimitReached();
       } else {
         throw AppError.backendServiceFailure(
           'RecoveryPhoneService',


### PR DESCRIPTION
## Because

- The recovery phone registration limit was applied in some setup paths but not when changing an existing number, leaving the check inconsistent across flows.

## This pull request

- Applies the existing `getCountByPhoneNumber()` limit check in `changePhoneNumber()`, matching `setupPhoneNumber()` and `confirmSetupCode()`.
- Adds a unit test covering the registration-limit case.

## Issue that this pull request solves

Closes: FXA-14069

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
