### PR TITLE
feat(settings): add passkey rename ui

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -701,6 +701,22 @@ export default class AuthClient {
     );
   }
 
+  private async sessionPatch(
+    path: string,
+    sessionToken: hexstring,
+    payload: object,
+    headers?: Headers
+  ) {
+    return this.authedRequest(
+      'PATCH',
+      path,
+      sessionToken,
+      tokenType.sessionToken,
+      payload,
+      headers
+    );
+  }
+
   private async sessionDelete(
     path: string,
     sessionToken: hexstring,
@@ -3675,20 +3691,20 @@ export default class AuthClient {
   /**
    * Renames the passkey identified by `credentialId`.
    *
-   * @param jwt MFA JWT with scope `mfa:passkey`
+   * @param sessionToken The user's current verified session token
    * @param credentialId The base64url-encoded credential ID of the passkey to rename
    * @param name The new display name for the passkey
    * @param headers Optional additional headers
    */
   async renamePasskey(
-    jwt: string,
+    sessionToken: hexstring,
     credentialId: string,
     name: string,
     headers?: Headers
   ): Promise<Passkey> {
-    return this.jwtPatch(
+    return this.sessionPatch(
       `/passkey/${encodeURIComponent(credentialId)}`,
-      jwt,
+      sessionToken,
       { name },
       headers
     );

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -339,7 +339,7 @@ export class PasskeyHandler {
   /**
    * Handles `PATCH /passkey/:credentialId`.
    *
-   * @param request - Authenticated Hapi request with a valid MFA JWT.
+   * @param request - Hapi request authenticated with a verified session token.
    * @returns Updated passkey metadata object.
    */
   async renamePasskey(request: AuthRequest) {
@@ -983,8 +983,7 @@ export const passkeyRoutes = (
         ...PASSKEYS_API_DOCS.PASSKEY_CREDENTIAL_PATCH,
         pre: [{ method: passkeysEnabledCheck }],
         auth: {
-          strategy: 'mfa',
-          scope: ['mfa:passkey'],
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {

--- a/packages/fxa-settings/src/components/Icons/en.ftl
+++ b/packages/fxa-settings/src/components/Icons/en.ftl
@@ -59,6 +59,10 @@ close-icon-aria-label =
 code-icon-aria-label =
     .aria-label = Code
 
+# Used to decorate an edit or rename control
+edit-icon-aria-label =
+    .aria-label = Edit
+
 error-icon-aria-label =
     .aria-label = Error
 

--- a/packages/fxa-settings/src/components/Icons/icon_pencil.min.svg
+++ b/packages/fxa-settings/src/components/Icons/icon_pencil.min.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a.996.996 0 0 0 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>

--- a/packages/fxa-settings/src/components/Icons/index.tsx
+++ b/packages/fxa-settings/src/components/Icons/index.tsx
@@ -24,6 +24,7 @@ import { ReactComponent as InformationOutlineBlue } from './icon_information_cir
 import { ReactComponent as Lightbulb } from './icon_lightbulb.min.svg';
 import { ReactComponent as LoadingArrow } from './icon_loading_arrow.min.svg';
 import { ReactComponent as Passkey } from './icon_passkey.min.svg';
+import { ReactComponent as Pencil } from './icon_pencil.min.svg';
 
 type AlertMode = 'alert' | 'attention' | 'warning';
 function getAlertAria(mode: AlertMode) {
@@ -315,6 +316,15 @@ export const PasskeyIcon = ({ className, ariaHidden }: ImageProps) => (
     Image={Passkey}
     ariaLabel="Passkey"
     ariaLabelFtlId="passkey-icon-aria-label"
+    {...{ className, ariaHidden }}
+  />
+);
+
+export const EditIcon = ({ className, ariaHidden }: ImageProps) => (
+  <PreparedIcon
+    Image={Pencil}
+    ariaLabel="Edit"
+    ariaLabelFtlId="edit-icon-aria-label"
     {...{ className, ariaHidden }}
   />
 );

--- a/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
@@ -57,4 +57,17 @@ passkey-delete-modal-confirm-button = Delete passkey
 passkey-delete-success = Passkey deleted
 passkey-delete-error = There was a problem deleting your passkey. Try again in a few minutes.
 
+passkey-sub-row-rename-title = Rename passkey
+passkey-rename-modal-heading = Rename passkey
+passkey-rename-modal-description = Enter a new name for this passkey.
+passkey-rename-input-label = Passkey name
+passkey-rename-save-button = Save
+passkey-rename-cancel-button = Cancel
+passkey-rename-error-empty = Enter a name for this passkey
+passkey-rename-error-too-long = The name must contain fewer than 256 characters.
+passkey-rename-error-invalid = Only letters, numbers, punctuation marks and symbols are allowed.
+passkey-rename-error-duplicate = A passkey with this name already exists
+passkey-rename-success = Passkey renamed
+passkey-rename-error = There was a problem renaming your passkey. Try again in a few minutes.
+
 ##

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
@@ -27,6 +27,25 @@ export default {
       const mockAccount = {
         ...MOCK_ACCOUNT,
         deletePasskey: async () => {},
+        // Fake a successful rename so Save works in Storybook. Validation
+        // errors (empty, too long, invalid, duplicate) still surface
+        // client-side before this is ever called.
+        renamePasskey: async () => {},
+        // A sibling passkey so the duplicate-name check is exercisable — type
+        // "Existing passkey" in the rename dialog to trigger it.
+        passkeys: [
+          {
+            credentialId: 'existing',
+            name: 'Existing passkey',
+            createdAt: new Date('2025-01-01').getTime(),
+            lastUsedAt: null,
+            transports: ['internal'],
+            aaguid: 'aaguid-existing',
+            backupEligible: true,
+            backupState: true,
+            prfEnabled: false,
+          },
+        ],
       };
       return (
         <AppContext.Provider

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
@@ -8,6 +8,7 @@ import SubRow, {
   BackupCodesSubRow,
   BackupPhoneSubRow,
   PasskeySubRow,
+  validatePasskeyName,
 } from './index';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import {
@@ -34,6 +35,8 @@ const mockAlertBar = {
 
 let mockAccount = {
   deletePasskey: jest.fn(),
+  renamePasskey: jest.fn(),
+  passkeys: [] as Passkey[],
 };
 
 jest.mock('../../../lib/glean', () => ({
@@ -44,6 +47,9 @@ jest.mock('../../../lib/glean', () => ({
       passkeyDeleteView: jest.fn(),
       passkeyDeleteSuccessView: jest.fn(),
       passkeyDeleteSubmitFrontendError: jest.fn(),
+      passkeyRenameView: jest.fn(),
+      passkeyRenameSuccessView: jest.fn(),
+      passkeyRenameSubmitFrontendError: jest.fn(),
       mfaGuardView: jest.fn(),
       mfaGuardSubmitSuccess: jest.fn(),
     },
@@ -315,6 +321,8 @@ describe('PasskeySubRow', () => {
 
   beforeEach(() => {
     mockAccount.deletePasskey.mockClear();
+    mockAccount.renamePasskey.mockClear();
+    mockAccount.passkeys = [];
     mockAlertBar.success.mockClear();
     mockAlertBar.error.mockClear();
     (GleanMetrics.accountPref.passkeyDeleteView as jest.Mock).mockClear();
@@ -323,6 +331,13 @@ describe('PasskeySubRow', () => {
     ).mockClear();
     (
       GleanMetrics.accountPref.passkeyDeleteSubmitFrontendError as jest.Mock
+    ).mockClear();
+    (GleanMetrics.accountPref.passkeyRenameView as jest.Mock).mockClear();
+    (
+      GleanMetrics.accountPref.passkeyRenameSuccessView as jest.Mock
+    ).mockClear();
+    (
+      GleanMetrics.accountPref.passkeyRenameSubmitFrontendError as jest.Mock
     ).mockClear();
     (GleanMetrics.handleClickEvent as jest.Mock).mockClear();
     mockHasJwt = true;
@@ -523,5 +538,271 @@ describe('PasskeySubRow', () => {
       await screen.findByText('Enter confirmation code')
     ).toBeInTheDocument();
     expect(screen.queryByText('Delete your passkey?')).not.toBeInTheDocument();
+  });
+
+  describe('rename', () => {
+    it('renders a rename button', () => {
+      renderPasskeySubRow();
+      expect(
+        screen.getByRole('button', { name: /rename passkey/i })
+      ).toBeInTheDocument();
+    });
+
+    it('opens the rename dialog and records a view event', async () => {
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      expect(
+        await screen.findByRole('heading', { name: 'Rename passkey' })
+      ).toBeInTheDocument();
+      expect(GleanMetrics.accountPref.passkeyRenameView).toHaveBeenCalledTimes(
+        1
+      );
+    });
+
+    it('opens the dialog with the name pre-filled', async () => {
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      expect(await screen.findByRole('textbox')).toHaveValue('MacBook Pro');
+    });
+
+    it('opens the dialog when the passkey name is clicked', async () => {
+      renderPasskeySubRow();
+      // Clicking the visible name text (inside the trigger button) opens it.
+      await userEvent.click(screen.getByText('MacBook Pro'));
+      expect(await screen.findByRole('textbox')).toHaveValue('MacBook Pro');
+    });
+
+    it('calls renamePasskey with the trimmed new name on save', async () => {
+      mockAccount.renamePasskey.mockResolvedValue(undefined);
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.type(input, '  Work laptop  ');
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(mockAccount.renamePasskey).toHaveBeenCalledWith(
+        'passkey-1',
+        'Work laptop'
+      );
+    });
+
+    it('shows a success banner and closes the dialog when rename succeeds', async () => {
+      mockAccount.renamePasskey.mockResolvedValue(undefined);
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      await userEvent.type(screen.getByRole('textbox'), ' 2');
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockAlertBar.success).toHaveBeenCalledWith('Passkey renamed');
+      });
+      expect(
+        GleanMetrics.accountPref.passkeyRenameSuccessView
+      ).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows a generic error banner when rename fails unexpectedly', async () => {
+      mockAccount.renamePasskey.mockRejectedValue(new Error('boom'));
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      await userEvent.type(screen.getByRole('textbox'), ' 2');
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      // The error shows inside the modal, not in the (occluded) alert bar.
+      expect(
+        await screen.findByText(
+          'There was a problem renaming your passkey. Try again in a few minutes.'
+        )
+      ).toBeInTheDocument();
+      expect(mockAlertBar.error).not.toHaveBeenCalled();
+      expect(
+        GleanMetrics.accountPref.passkeyRenameSubmitFrontendError
+      ).toHaveBeenCalledWith({ event: { reason: 'server_error' } });
+    });
+
+    it('shows a localized auth error when rename fails with an auth error', async () => {
+      mockAccount.renamePasskey.mockRejectedValue(
+        AuthUiErrors.PASSKEY_NOT_FOUND
+      );
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      await userEvent.type(screen.getByRole('textbox'), ' 2');
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(await screen.findByText('Passkey not found')).toBeInTheDocument();
+      expect(
+        GleanMetrics.accountPref.passkeyRenameSubmitFrontendError
+      ).toHaveBeenCalledWith({ event: { reason: 'auth_error' } });
+    });
+
+    it('closes the dialog without calling renamePasskey when cancelled', async () => {
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      });
+      expect(mockAccount.renamePasskey).not.toHaveBeenCalled();
+    });
+
+    it('keeps the save button enabled on open', async () => {
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+
+    it('disables save while an error is shown and re-enables it once the input is edited', async () => {
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(
+        screen.getByText('Enter a name for this passkey')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+      await userEvent.type(input, 'New name');
+      expect(
+        screen.queryByText('Enter a name for this passkey')
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+
+    it('does not validate or show an error while typing before submit', async () => {
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      // Clearing makes the name invalid (empty), but nothing is submitted yet.
+      await userEvent.clear(screen.getByRole('textbox'));
+      expect(
+        screen.queryByText('Enter a name for this passkey')
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows an error and does not submit when the name is cleared', async () => {
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      await userEvent.clear(screen.getByRole('textbox'));
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+      expect(
+        screen.getByText('Enter a name for this passkey')
+      ).toBeInTheDocument();
+      expect(mockAccount.renamePasskey).not.toHaveBeenCalled();
+    });
+
+    it('blocks renaming to a name already used by another passkey', async () => {
+      mockAccount.passkeys = [
+        mockPasskey,
+        { ...mockPasskey, credentialId: 'passkey-2', name: 'Work laptop' },
+      ];
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      // Case-insensitive match against the sibling passkey "Work laptop".
+      await userEvent.type(input, 'work LAPTOP');
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(
+        screen.getByText('A passkey with this name already exists')
+      ).toBeInTheDocument();
+      expect(mockAccount.renamePasskey).not.toHaveBeenCalled();
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('allows renaming to a name only used by the passkey being edited', async () => {
+      mockAccount.passkeys = [
+        mockPasskey,
+        { ...mockPasskey, credentialId: 'passkey-2', name: 'Work laptop' },
+      ];
+      mockAccount.renamePasskey.mockResolvedValue(undefined);
+      renderPasskeySubRow();
+      await userEvent.click(
+        screen.getByRole('button', { name: /rename passkey/i })
+      );
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Home desktop');
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(mockAccount.renamePasskey).toHaveBeenCalledWith(
+        'passkey-1',
+        'Home desktop'
+      );
+    });
+  });
+});
+
+describe('validatePasskeyName', () => {
+  it('returns undefined for a valid name', () => {
+    expect(validatePasskeyName('My Passkey')).toBeUndefined();
+  });
+
+  it('returns undefined for a name at the 255-character limit', () => {
+    expect(validatePasskeyName('a'.repeat(255))).toBeUndefined();
+  });
+
+  it('returns "empty" for an empty string', () => {
+    expect(validatePasskeyName('')).toBe('empty');
+  });
+
+  it('returns "empty" for a whitespace-only string', () => {
+    expect(validatePasskeyName('   ')).toBe('empty');
+  });
+
+  it('returns "too-long" for a name over 255 characters', () => {
+    expect(validatePasskeyName('a'.repeat(256))).toBe('too-long');
+  });
+
+  it('returns "duplicate" when the name matches another passkey (case-insensitive)', () => {
+    expect(validatePasskeyName('Work Laptop', ['work laptop'])).toBe(
+      'duplicate'
+    );
+  });
+
+  it('returns undefined when the name is unique among existing passkeys', () => {
+    expect(validatePasskeyName('Phone', ['Work Laptop'])).toBeUndefined();
+  });
+
+  it('returns "invalid" for a name containing control characters', () => {
+    expect(validatePasskeyName('bad\u0000name')).toBe('invalid');
+  });
+
+  // Most emoji are above the Basic Multilingual Plane (BMP), i.e. code points
+  // beyond U+FFFF encoded as UTF-16 surrogate pairs. These are allowed, matching
+  // the auth-server validator used for passkey and device names.
+  it('allows a name containing emoji', () => {
+    expect(validatePasskeyName('My Passkey \u{1F510}')).toBeUndefined();
   });
 });

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -3,13 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import classNames from 'classnames';
 import { Passkey } from 'fxa-auth-client/browser';
 import { useAlertBar, useAccount, useFtlMsgResolver } from '../../../models';
 import { isAuthUiError } from '../../../lib/auth-errors/auth-errors';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
+import { DISPLAY_SAFE_UNICODE_WITH_NON_BMP } from '../../../constants';
 import { MfaGuard, useMfaErrorHandler } from '../MfaGuard';
 import { MfaReason } from '../../../lib/types';
+import InputText from '../../InputText';
+import { Banner } from '../../Banner';
 import {
   AlertFullIcon as AlertIcon,
   BackupCodesDisabledIcon,
@@ -17,6 +21,7 @@ import {
   BackupRecoverySmsDisabledIcon,
   BackupRecoverySmsIcon,
   CheckmarkGreenIcon,
+  EditIcon,
   LightbulbIcon,
   PasskeyIcon,
 } from '../../Icons';
@@ -43,6 +48,9 @@ type SubRowProps = {
   statusIcon?: 'checkmark' | 'alert';
   border?: boolean;
   localizedRowTitle: string;
+  // When provided, replaces the default row-title text — lets a consumer render
+  // its own title area (e.g. the passkey row's inline rename control).
+  rowTitleContent?: React.ReactNode;
   localizedDeleteIconTitle?: string;
   message?: React.ReactNode;
   onDeleteClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -74,6 +82,7 @@ const SubRow = ({
   onCtaClick,
   onDeleteClick,
   localizedRowTitle,
+  rowTitleContent,
   localizedDeleteIconTitle,
   linkExternalProps,
   deleteGleanId,
@@ -120,7 +129,9 @@ const SubRow = ({
         <div className="flex flex-row justify-between flex-1 flex-wrap items-center">
           <div className="flex items-center gap-2">
             <div className="grow-0 shrink-0">{icon}</div>
-            <p className="font-semibold">{localizedRowTitle}</p>
+            {rowTitleContent ?? (
+              <p className="font-semibold">{localizedRowTitle}</p>
+            )}
           </div>
           <div>
             <div
@@ -358,6 +369,46 @@ const formatDateText = (timestamp: number): string => {
   }).format(new Date(timestamp));
 };
 
+export const PASSKEY_NAME_MAX_LENGTH = 255;
+
+export type PasskeyNameError = 'empty' | 'too-long' | 'invalid' | 'duplicate';
+
+/**
+ * Validates a proposed passkey name (non-empty after trimming, max 255 chars,
+ * display-safe unicode including emoji), mirroring the
+ * authoritative auth-server rules.
+ *
+ * The duplicate check (case-insensitive, against `existingNames` — the other
+ * passkeys on the account) is a UX-only guard; the backend does not enforce
+ * name uniqueness on rename, so this only prevents obvious dupes in the UI.
+ *
+ * Returns an error code, or undefined if valid.
+ */
+export const validatePasskeyName = (
+  name: string,
+  existingNames: string[] = []
+): PasskeyNameError | undefined => {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return 'empty';
+  }
+  if (trimmed.length > PASSKEY_NAME_MAX_LENGTH) {
+    return 'too-long';
+  }
+  if (!DISPLAY_SAFE_UNICODE_WITH_NON_BMP.test(trimmed)) {
+    return 'invalid';
+  }
+  const normalized = trimmed.toLocaleLowerCase();
+  if (
+    existingNames.some(
+      (other) => other.trim().toLocaleLowerCase() === normalized
+    )
+  ) {
+    return 'duplicate';
+  }
+  return undefined;
+};
+
 type PasskeyDeleteModalProps = {
   passkey: Passkey;
   onDismiss: () => void;
@@ -468,8 +519,188 @@ const PasskeyDeleteModal = ({
   );
 };
 
+type PasskeyRenameModalProps = {
+  passkey: Passkey;
+  onDismiss: () => void;
+};
+
+type PasskeyNameFormData = { name: string };
+
+const PasskeyRenameModal = ({
+  passkey,
+  onDismiss,
+}: PasskeyRenameModalProps) => {
+  const account = useAccount();
+  const ftlMsgResolver = useFtlMsgResolver();
+  const alertBar = useAlertBar();
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  // Submit/server errors surface inside the modal — the alert bar would render
+  // behind the open modal.
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  // Validate only on submit (never while typing), so the error appears only
+  // when the user clicks Save.
+  const { register, handleSubmit, formState, clearErrors } =
+    useForm<PasskeyNameFormData>({
+      mode: 'onSubmit',
+      reValidateMode: 'onSubmit',
+      defaultValues: { name: passkey.name },
+    });
+
+  useEffect(() => {
+    GleanMetrics.accountPref.passkeyRenameView();
+  }, []);
+
+  // Names of the account's other passkeys, used to block obvious duplicates.
+  const otherPasskeyNames = (account.passkeys ?? [])
+    .filter((p) => p.credentialId !== passkey.credentialId)
+    .map((p) => p.name);
+
+  const localizeValidationError = (name: string): string | true => {
+    switch (validatePasskeyName(name, otherPasskeyNames)) {
+      case 'empty':
+        return ftlMsgResolver.getMsg(
+          'passkey-rename-error-empty',
+          'Enter a name for this passkey'
+        );
+      case 'too-long':
+        return ftlMsgResolver.getMsg(
+          'passkey-rename-error-too-long',
+          'The name must contain fewer than 256 characters.'
+        );
+      case 'invalid':
+        return ftlMsgResolver.getMsg(
+          'passkey-rename-error-invalid',
+          'Only letters, numbers, punctuation marks and symbols are allowed.'
+        );
+      case 'duplicate':
+        return ftlMsgResolver.getMsg(
+          'passkey-rename-error-duplicate',
+          'A passkey with this name already exists'
+        );
+      default:
+        return true;
+    }
+  };
+
+  const onSubmit = useCallback(
+    async ({ name }: PasskeyNameFormData) => {
+      setIsSaving(true);
+      setSubmitError(null);
+      try {
+        await account.renamePasskey(passkey.credentialId, name.trim());
+        GleanMetrics.accountPref.passkeyRenameSuccessView();
+        // a hack to avoid alert bar being immediately removed
+        setTimeout(() => {
+          alertBar.success(
+            ftlMsgResolver.getMsg('passkey-rename-success', 'Passkey renamed')
+          );
+        }, 0);
+        onDismiss();
+      } catch (error) {
+        const gleanReason = isAuthUiError(error)
+          ? 'auth_error'
+          : 'server_error';
+        GleanMetrics.accountPref.passkeyRenameSubmitFrontendError({
+          event: { reason: gleanReason },
+        });
+        const localizedError = isAuthUiError(error)
+          ? getLocalizedErrorMessage(ftlMsgResolver, error)
+          : ftlMsgResolver.getMsg(
+              'passkey-rename-error',
+              'There was a problem renaming your passkey. Try again in a few minutes.'
+            );
+        setSubmitError(localizedError);
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [account, passkey.credentialId, alertBar, ftlMsgResolver, onDismiss]
+  );
+
+  return (
+    <Modal
+      onDismiss={onDismiss}
+      hasButtons={false}
+      headerId="passkey-rename-header"
+      descId="passkey-rename-desc"
+    >
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <FtlMsg id="passkey-rename-modal-heading">
+          <h2
+            id="passkey-rename-header"
+            className="font-bold text-xl mb-4 -mt-2 mx-4"
+          >
+            Rename passkey
+          </h2>
+        </FtlMsg>
+        <FtlMsg id="passkey-rename-modal-description">
+          <p id="passkey-rename-desc" className="sr-only">
+            Enter a new name for this passkey.
+          </p>
+        </FtlMsg>
+        {submitError && (
+          <Banner
+            type="error"
+            content={{ localizedDescription: submitError }}
+            className="mx-4"
+          />
+        )}
+        <div className="mx-4">
+          <InputText
+            name="name"
+            label={ftlMsgResolver.getMsg(
+              'passkey-rename-input-label',
+              'Passkey name'
+            )}
+            defaultValue={passkey.name}
+            autoFocus
+            prefixDataTestId="passkey-rename"
+            hasErrors={!!formState.errors.name}
+            errorText={formState.errors.name?.message}
+            tooltipPosition="bottom"
+            onChange={() => {
+              // Clear validation + submit errors as soon as the user edits.
+              if (formState.errors.name) {
+                clearErrors('name');
+              }
+              setSubmitError(null);
+            }}
+            inputRef={register({ validate: localizeValidationError })}
+          />
+        </div>
+        <div className="flex justify-center mx-2 mt-6">
+          <FtlMsg id="passkey-rename-cancel-button">
+            <button
+              type="button"
+              className="cta-neutral mx-2 flex-1 cta-xl"
+              onClick={onDismiss}
+              disabled={isSaving}
+              data-testid="passkey-rename-cancel-button"
+            >
+              Cancel
+            </button>
+          </FtlMsg>
+          <FtlMsg id="passkey-rename-save-button">
+            <button
+              type="submit"
+              className="cta-primary mx-2 flex-1 cta-xl"
+              disabled={isSaving || !!formState.errors.name}
+              data-testid="passkey-rename-save-button"
+              data-glean-id="account_pref_passkey_rename_submit"
+            >
+              Save
+            </button>
+          </FtlMsg>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
 export const PasskeySubRow = ({ passkey }: PasskeySubRowProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
+  const [renameModalRevealed, revealRenameModal, hideRenameModal] =
+    useBooleanState();
   const [deleteModalRevealed, revealDeleteModal, hideDeleteModal] =
     useBooleanState();
 
@@ -512,6 +743,30 @@ export const PasskeySubRow = ({ passkey }: PasskeySubRowProps) => {
         idPrefix="passkey"
         icon={<PasskeyIcon ariaHidden className="h-8 w-5 text-purple-600" />}
         localizedRowTitle={passkey.name}
+        rowTitleContent={
+          // Single control (name + decorative pencil) that opens the rename
+          // dialog; the accessible name conveys the action.
+          <button
+            type="button"
+            className="group flex items-center gap-2 text-start rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            onClick={revealRenameModal}
+            data-testid="passkey-rename-button"
+          >
+            <span className="font-semibold group-hover:underline">
+              {passkey.name}
+            </span>
+            <EditIcon
+              ariaHidden
+              className="w-4 h-4 shrink-0 text-grey-500 group-hover:text-grey-900"
+            />
+            <span className="sr-only">
+              {ftlMsgResolver.getMsg(
+                'passkey-sub-row-rename-title',
+                'Rename passkey'
+              )}
+            </span>
+          </button>
+        }
         localizedDescription={localizedDescription}
         // TODO (passkeys phase 2): show upgrade prompt when passkey.prfEnabled
         onDeleteClick={(event) => {
@@ -527,6 +782,9 @@ export const PasskeySubRow = ({ passkey }: PasskeySubRowProps) => {
         )}
         deleteGleanId="account_pref_passkey_delete_submit"
       />
+      {renameModalRevealed && (
+        <PasskeyRenameModal passkey={passkey} onDismiss={hideRenameModal} />
+      )}
       {deleteModalRevealed && (
         <MfaGuard
           requiredScope="passkey"

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -75,3 +75,9 @@ export const LINK = {
 export const DISPLAY_SAFE_UNICODE: RegExp =
   // eslint-disable-next-line no-control-regex
   /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uD800-\uDFFF\uE000-\uF8FF\uFFF9-\uFFFC\uFFFE-\uFFFF])*$/;
+
+// Like DISPLAY_SAFE_UNICODE but also allows emoji (code points above U+FFFF),
+// matching the auth_server validator for device and passkey names.
+export const DISPLAY_SAFE_UNICODE_WITH_NON_BMP: RegExp =
+  // eslint-disable-next-line no-control-regex
+  /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uE000-\uF8FF\uFFF9-\uFFFC\uFFFE-\uFFFF])*$/;

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -1477,6 +1477,49 @@ describe('lib/glean', () => {
         );
         sinon.assert.calledOnce(spy);
       });
+
+      it('submits a ping with the account_pref_passkey_rename_view event name', async () => {
+        const spy = sandbox.spy(accountPref.passkeyRenameView, 'record');
+        GleanMetrics.accountPref.passkeyRenameView();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_passkey_rename_view'
+        );
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_passkey_rename_submit_frontend_error event name and a reason', async () => {
+        const spy = sandbox.spy(
+          accountPref.passkeyRenameSubmitFrontendError,
+          'record'
+        );
+        GleanMetrics.accountPref.passkeyRenameSubmitFrontendError({
+          event: { reason: 'server_error' },
+        });
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_passkey_rename_submit_frontend_error'
+        );
+        sinon.assert.calledOnce(spy);
+        sinon.assert.calledOnce(setEventReasonStub);
+        sinon.assert.calledWith(setEventReasonStub, 'server_error');
+      });
+
+      it('submits a ping with the account_pref_passkey_rename_success_view event name', async () => {
+        const spy = sandbox.spy(accountPref.passkeyRenameSuccessView, 'record');
+        GleanMetrics.accountPref.passkeyRenameSuccessView();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_passkey_rename_success_view'
+        );
+        sinon.assert.calledOnce(spy);
+      });
     });
 
     describe('accountBanner', () => {

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -754,6 +754,17 @@ const recordEventMetric = (
     case 'account_pref_passkey_delete_success_view':
       accountPref.passkeyDeleteSuccessView.record();
       break;
+    case 'account_pref_passkey_rename_view':
+      accountPref.passkeyRenameView.record();
+      break;
+    case 'account_pref_passkey_rename_submit_frontend_error':
+      accountPref.passkeyRenameSubmitFrontendError.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
+    case 'account_pref_passkey_rename_success_view':
+      accountPref.passkeyRenameSuccessView.record();
+      break;
     case 'account_banner_create_recovery_key_view':
       accountBanner.createRecoveryKeyView.record();
       break;

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -37,7 +37,6 @@ export enum MfaReason {
   createRecoveryKey = 'create recovery key',
   removeRecoveryKey = 'remove recovery key',
   createPasskey = 'create passkey',
-  renamePasskey = 'rename passkey',
   removePasskey = 'remove passkey',
   test = 'test',
 }

--- a/packages/fxa-settings/src/models/Account.test.ts
+++ b/packages/fxa-settings/src/models/Account.test.ts
@@ -13,6 +13,7 @@ import {
   updateExtendedAccountState,
 } from '../lib/account-storage';
 import AuthClient from 'fxa-auth-client/browser';
+import { AuthUiErrors } from '../lib/auth-errors/auth-errors';
 
 jest.mock('../lib/config', () => ({
   servers: { profile: { url: 'default-url' } },
@@ -192,6 +193,47 @@ describe('Account', () => {
       expect(updateExtendedAccountState).toHaveBeenCalledWith(
         expect.objectContaining({ hasPassword: true })
       );
+    });
+  });
+
+  describe('renamePasskey', () => {
+    let account: Account;
+    let authClient: jest.Mocked<
+      Pick<AuthClient, 'renamePasskey' | 'listPasskeys'>
+    >;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      authClient = {
+        renamePasskey: jest.fn().mockResolvedValue(undefined),
+        listPasskeys: jest.fn().mockResolvedValue([]),
+      } as unknown as jest.Mocked<
+        Pick<AuthClient, 'renamePasskey' | 'listPasskeys'>
+      >;
+      (sessionToken as jest.Mock).mockReturnValue('test-token');
+      account = new Account(authClient as unknown as AuthClient);
+    });
+
+    it('renames the passkey using the verified session token', async () => {
+      await account.renamePasskey('cred-1', 'Work laptop');
+      expect(authClient.renamePasskey).toHaveBeenCalledWith(
+        'test-token',
+        'cred-1',
+        'Work laptop'
+      );
+    });
+
+    it('refreshes the passkey list after renaming', async () => {
+      await account.renamePasskey('cred-1', 'Work laptop');
+      expect(authClient.listPasskeys).toHaveBeenCalledWith('test-token');
+    });
+
+    it('throws an invalid-token error without calling the client when there is no session token', async () => {
+      (sessionToken as jest.Mock).mockReturnValue(null);
+      await expect(account.renamePasskey('cred-1', 'Work laptop')).rejects.toBe(
+        AuthUiErrors.INVALID_TOKEN
+      );
+      expect(authClient.renamePasskey).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1535,12 +1535,14 @@ export class Account implements AccountData {
 
   /**
    * Renames the passkey identified by `credentialId`.
-   * Requires a cached MFA JWT with scope `passkey`.
+   * Renaming is non-destructive, so it uses the verified session token rather
+   * than an MFA JWT.
    */
   async renamePasskey(credentialId: string, name: string): Promise<void> {
-    const jwt = this.getCachedJwtByScope('passkey');
+    const token = sessionToken();
+    if (!token) throw AuthUiErrors.INVALID_TOKEN;
     await this.withLoadingStatus(
-      this.authClient.renamePasskey(jwt, credentialId, name)
+      this.authClient.renamePasskey(token, credentialId, name)
     );
     await this.refresh('passkeys');
   }

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -3869,6 +3869,58 @@ account_pref:
     expires: never
     data_sensitivity:
       - interaction
+  passkey_rename_view:
+    type: event
+    description: |
+      User opens the rename passkey dialog
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-13250
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+    expires: never
+    data_sensitivity:
+      - interaction
+  passkey_rename_submit_frontend_error:
+    type: event
+    description: |
+      Passkey rename fails; error alert banner displays
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-13250
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: Error type - auth_error or server_error
+        type: string
+  passkey_rename_success_view:
+    type: event
+    description: |
+      Passkey successfully renamed; success alert banner displays
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-13250
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+    expires: never
+    data_sensitivity:
+      - interaction
 account_banner:
   create_recovery_key_view:
     type: event

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -443,6 +443,56 @@ export const passkeyDeleteView = new EventMetricType(
 );
 
 /**
+ * Passkey rename fails; error alert banner displays
+ *
+ * Generated from `account_pref.passkey_rename_submit_frontend_error`.
+ */
+export const passkeyRenameSubmitFrontendError = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'passkey_rename_submit_frontend_error',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);
+
+/**
+ * Passkey successfully renamed; success alert banner displays
+ *
+ * Generated from `account_pref.passkey_rename_success_view`.
+ */
+export const passkeyRenameSuccessView = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'passkey_rename_success_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User opens the rename passkey dialog
+ *
+ * Generated from `account_pref.passkey_rename_view`.
+ */
+export const passkeyRenameView = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'passkey_rename_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * User clicks on the Get free scan link on the new Monitor promotion in the
  * account settings side panel
  *

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -281,6 +281,10 @@ export const eventsMap = {
     passkeyDeleteSubmitFrontendError:
       'account_pref_passkey_delete_submit_frontend_error',
     passkeyDeleteSuccessView: 'account_pref_passkey_delete_success_view',
+    passkeyRenameView: 'account_pref_passkey_rename_view',
+    passkeyRenameSubmitFrontendError:
+      'account_pref_passkey_rename_submit_frontend_error',
+    passkeyRenameSuccessView: 'account_pref_passkey_rename_success_view',
   },
 
   accountBanner: {


### PR DESCRIPTION
## Because

- Passkeys are auto-named generically at creation (e.g. "Passkey", "Platform
  Passkey"), and users had no way to rename them to something meaningful.
- Renaming is non-destructive, so it should not require an MFA/OTP step-up the
  way passkey removal does.

## This pull request

- Adds a passkey rename control in `packages/fxa-settings/src/components/Settings/SubRow/index.tsx`:
  the passkey name and a decorative pencil form a single button that opens a rename
  modal dialog (`PasskeyRenameModal`, reusing the same `Modal` component as the delete dialog)
  with Save/Cancel.
- Changes `PATCH /passkey/{credentialId}` in `packages/fxa-auth-server/lib/routes/passkeys.ts`
  from the `mfa` strategy to `verifiedSessionToken`; the delete route keeps its MFA guard.
- Adds a `sessionPatch` helper in `packages/fxa-auth-client/lib/client.ts` and repoints
  `renamePasskey` to a session token; `Account.renamePasskey` uses the cached session token.
- Validates the new name on submit (non-empty, max 255, display-safe unicode, plus a
  client-side duplicate-name guard) and shows an inline error without calling the API until valid.
- Adds Glean `passkey_rename` view/submit/success/error events (`fxa-ui-metrics.yaml` + regenerated
  web bindings) and new FTL strings in `SubRow/en.ftl`.

## Issue that this pull request solves

Closes: FXA-13962

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the auth-strategy change in `packages/fxa-auth-server/lib/routes/passkeys.ts`
  (rename → verified session token; delete unchanged) and the rename modal + validation in
  `packages/fxa-settings/src/components/Settings/SubRow/index.tsx`.
- Suggested review order: `passkeys.ts` → `client.ts` → `Account.ts` → `SubRow/index.tsx` → tests.
- Risky or complex parts: the rename-route auth downgrade — verified session enforces AAL2 and the
  handler scopes the DB write by `uid` + `credentialId`, so ownership is server-enforced.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

<img width="770" height="83" alt="image" src="https://github.com/user-attachments/assets/34d54851-95af-4db1-af06-263f06bc85a2" />

<img width="367" height="280" alt="image" src="https://github.com/user-attachments/assets/738052d2-88bb-4b64-aba3-11c2f3dbac60" />

## Other information (Optional)

Any other information that is important to this pull request.
