### PR TITLE
fix(payments-ui): move checkoutSubmit emit server-side

### DIFF
--- a/libs/payments/cart/src/lib/cart.utils.ts
+++ b/libs/payments/cart/src/lib/cart.utils.ts
@@ -66,24 +66,29 @@ export function stripeErrorToErrorReasonId(
   }
 }
 
-export const stripeToSubPlatPaymentType: Partial<Record<
-  Stripe.PaymentMethod.Type,
-  SubPlatPaymentMethodType
->> = {
+export const stripeToSubPlatPaymentType: Partial<
+  Record<Stripe.PaymentMethod.Type, SubPlatPaymentMethodType>
+> = {
   card: SubPlatPaymentMethodType.Card,
   link: SubPlatPaymentMethodType.Link,
 };
 
-export const stripeWalletToSubPlatPaymentType: Partial<Record<
-  Stripe.PaymentMethod.Card.Wallet.Type,
-  SubPlatPaymentMethodType
->> = {
+export const stripeWalletToSubPlatPaymentType: Partial<
+  Record<Stripe.PaymentMethod.Card.Wallet.Type, SubPlatPaymentMethodType>
+> = {
   apple_pay: SubPlatPaymentMethodType.ApplePay,
   google_pay: SubPlatPaymentMethodType.GooglePay,
 };
 
+export const stripePaymentElementTypeToSubPlatPaymentType: Partial<
+  Record<string, SubPlatPaymentMethodType>
+> = {
+  ...stripeToSubPlatPaymentType,
+  ...stripeWalletToSubPlatPaymentType,
+};
+
 export function convertStripePaymentMethodTypeToSubPlat(
-  stripePaymentMethod: Stripe.PaymentMethod,
+  stripePaymentMethod: Stripe.PaymentMethod
 ): SubPlatPaymentMethodType {
   if (stripePaymentMethod.type === 'card') {
     const walletType = stripePaymentMethod.card?.wallet?.type;
@@ -92,5 +97,8 @@ export function convertStripePaymentMethodTypeToSubPlat(
       SubPlatPaymentMethodType.Card
     );
   }
-  return stripeToSubPlatPaymentType[stripePaymentMethod.type] ?? SubPlatPaymentMethodType.Stripe;
+  return (
+    stripeToSubPlatPaymentType[stripePaymentMethod.type] ??
+    SubPlatPaymentMethodType.Stripe
+  );
 }

--- a/libs/payments/events/src/lib/emitter.types.ts
+++ b/libs/payments/events/src/lib/emitter.types.ts
@@ -60,7 +60,6 @@ export type TrialConvertedEvents = {
 export const PaymentsEmitterEventsKeys = [
   'checkoutView',
   'checkoutEngage',
-  'checkoutSubmit',
 ] as const;
 export type PaymentsEmitterEventsKeysType =
   (typeof PaymentsEmitterEventsKeys)[number];

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.spec.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const mockCheckoutCartWithStripe = jest.fn();
+const mockGetActionsService = jest.fn(() => ({
+  checkoutCartWithStripe: mockCheckoutCartWithStripe,
+}));
+
+jest.mock('../nestapp/app', () => ({
+  __esModule: true,
+  getApp: () => ({
+    getActionsService: mockGetActionsService,
+  }),
+}));
+
+jest.mock('@fxa/payments/ui-auth', () => ({
+  __esModule: true,
+  getSessionUid: async () => 'uid-abc-123',
+}));
+
+jest.mock('../utils/getAdditionalRequestArgs', () => ({
+  __esModule: true,
+  getAdditionalRequestArgs: async () => ({
+    ipAddress: '127.0.0.1',
+    userAgent: 'jest',
+    deviceType: 'desktop',
+    experimentationId: '',
+    isFreeTrial: false,
+  }),
+}));
+
+import { checkoutCartWithStripe } from './checkoutCartWithStripe';
+
+const MOCK_ATTRIBUTION = {
+  utm_campaign: '',
+  utm_content: '',
+  utm_medium: '',
+  utm_source: '',
+  utm_term: '',
+  session_flow_id: '',
+  session_entrypoint: '',
+  session_entrypoint_experiment: '',
+  session_entrypoint_variation: '',
+};
+
+describe('checkoutCartWithStripe', () => {
+  beforeEach(() => {
+    mockCheckoutCartWithStripe.mockReset();
+  });
+
+  it('forwards paymentMethod to the actions service', async () => {
+    await checkoutCartWithStripe(
+      'cart-1',
+      1,
+      'ctoken_abc',
+      'card',
+      MOCK_ATTRIBUTION,
+      { cartId: 'cart-1' },
+      {}
+    );
+
+    expect(mockCheckoutCartWithStripe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cartId: 'cart-1',
+        version: 1,
+        confirmationTokenId: 'ctoken_abc',
+        paymentMethod: 'card',
+      })
+    );
+  });
+
+  it('forwards apple_pay as the paymentMethod when selected', async () => {
+    await checkoutCartWithStripe(
+      'cart-1',
+      1,
+      'ctoken_abc',
+      'apple_pay',
+      MOCK_ATTRIBUTION,
+      {},
+      {}
+    );
+
+    expect(mockCheckoutCartWithStripe).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentMethod: 'apple_pay' })
+    );
+  });
+
+  it('propagates errors from the actions service', async () => {
+    mockCheckoutCartWithStripe.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      checkoutCartWithStripe(
+        'cart-1',
+        1,
+        'ctoken_abc',
+        'card',
+        MOCK_ATTRIBUTION,
+        {},
+        {}
+      )
+    ).rejects.toThrow('boom');
+  });
+});

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
@@ -14,6 +14,7 @@ export const checkoutCartWithStripe = async (
   cartId: string,
   version: number,
   confirmationTokenId: string,
+  paymentMethod: string,
   attribution: SubscriptionAttributionParams,
   params: Record<string, string | string[] | undefined>,
   searchParams: Record<string, string | string[] | undefined>
@@ -29,6 +30,7 @@ export const checkoutCartWithStripe = async (
     cartId,
     version,
     confirmationTokenId,
+    paymentMethod,
     attribution,
     requestArgs,
     sessionUid,

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.spec.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.spec.ts
@@ -54,20 +54,4 @@ describe('recordEmitterEventAction', () => {
     );
   });
 
-  it('forwards paymentProvider and paymentMethod for checkoutSubmit', async () => {
-    await recordEmitterEventAction(
-      'checkoutSubmit',
-      { cartId: 'cart-1' },
-      {},
-      'stripe',
-      'card'
-    );
-
-    expect(mockRecordEmitterEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        eventName: 'checkoutSubmit',
-        paymentProvider: 'stripe',
-      })
-    );
-  });
 });

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
@@ -6,41 +6,12 @@
 import { getApp } from '../nestapp/app';
 import { flattenRouteParams } from '../utils/flatParam';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
-import {
-  PaymentProvidersType,
-  SubPlatPaymentMethodType,
-} from '@fxa/payments/customer';
-import { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
 
-const paymentMethodTypeMap: Record<string, SubPlatPaymentMethodType> = {
-  card: SubPlatPaymentMethodType.Card,
-  link: SubPlatPaymentMethodType.Link,
-  apple_pay: SubPlatPaymentMethodType.ApplePay,
-  google_pay: SubPlatPaymentMethodType.GooglePay,
-  external_paypal: SubPlatPaymentMethodType.PayPal,
-};
-
-async function recordEmitterEventAction(
-  eventName: 'checkoutSubmit',
-  params: Record<string, string | string[] | undefined>,
-  searchParams: Record<string, string | string[] | undefined>,
-  paymentProvider: PaymentProvidersType,
-  paymentMethod: string
-): Promise<void>;
-async function recordEmitterEventAction(
+export async function recordEmitterEventAction(
   eventName: 'checkoutView' | 'checkoutEngage',
   params: Record<string, string | string[] | undefined>,
   searchParams: Record<string, string | string[] | undefined>
-): Promise<void>;
-async function recordEmitterEventAction(
-  eventName: PaymentsEmitterEventsKeysType,
-  params: Record<string, string | string[] | undefined>,
-  searchParams: Record<string, string | string[] | undefined>,
-  paymentProvider?: PaymentProvidersType,
-  paymentMethod?: string
-) {
-  // isFreeTrial is resolved cart-side in populateCommonMetrics, so the FE
-  // no longer needs to thread it through.
+): Promise<void> {
   const requestArgs = {
     ...(await getAdditionalRequestArgs()),
     params: flattenRouteParams(params),
@@ -50,11 +21,5 @@ async function recordEmitterEventAction(
   return getApp().getActionsService().recordEmitterEvent({
     eventName,
     requestArgs,
-    paymentProvider,
-    paymentMethod: paymentMethod
-      ? paymentMethodTypeMap[paymentMethod]
-      : undefined,
   });
 }
-
-export { recordEmitterEventAction };

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
@@ -438,6 +438,7 @@ describe('CheckoutForm', () => {
             'cart-id',
             1,
             `ctoken_${paymentType}_123`,
+            paymentType,
             expect.any(Object),
             expect.any(Object),
             expect.any(Object)
@@ -449,35 +450,6 @@ describe('CheckoutForm', () => {
         });
       }
     );
-
-    it('records the selected payment method type in the emitter event on submit', async () => {
-      const user = userEvent.setup();
-      mockElementsSubmit.mockResolvedValue({ error: undefined });
-      mockCreateConfirmationToken.mockResolvedValue({
-        confirmationToken: { id: 'ctoken_link_submit' },
-      });
-      mockCheckoutCartWithStripe.mockResolvedValue(undefined);
-
-      render(<CheckoutForm {...baseProps} />);
-      fireStripeReady();
-      await user.click(screen.getByTestId('consent-checkbox'));
-      fireStripeChange({
-        complete: true,
-        value: { type: 'link' },
-      });
-
-      await user.click(screen.getByRole('button', { name: /Subscribe Now/i }));
-
-      await waitFor(() => {
-        expect(mockRecordEmitterEventAction).toHaveBeenCalledWith(
-          'checkoutSubmit',
-          expect.any(Object),
-          expect.any(Object),
-          'stripe',
-          'link'
-        );
-      });
-    });
 
     it('does not show PayPal buttons for non-PayPal wallet types', async () => {
       render(<CheckoutForm {...baseProps} />);

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -239,13 +239,6 @@ export function CheckoutForm({
     setLoading(true);
 
     if (cart?.paymentInfo?.type === 'external_paypal') {
-      recordEmitterEventAction(
-        'checkoutSubmit',
-        { ...params },
-        Object.fromEntries(searchParams),
-        'paypal',
-        'external_paypal'
-      );
       if (interstitialOfferBase) {
         glean.recordInterstitialOfferSubmit({
           ...interstitialOfferBase,
@@ -317,16 +310,6 @@ export function CheckoutForm({
       }
     }
 
-    const paymentProvider =
-      selectedPaymentMethod === 'external_paypal' ? 'paypal' : 'stripe';
-
-    recordEmitterEventAction(
-      'checkoutSubmit',
-      { ...params },
-      Object.fromEntries(searchParams),
-      paymentProvider,
-      selectedPaymentMethod
-    );
     if (interstitialOfferBase) {
       glean.recordInterstitialOfferSubmit({
         ...interstitialOfferBase,
@@ -338,6 +321,7 @@ export function CheckoutForm({
       cart.id,
       cart.version,
       confirmationToken.id,
+      selectedPaymentMethod,
       getAttributionParams(searchParams),
       params,
       Object.fromEntries(searchParams)

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -8,6 +8,7 @@ import { GoogleManager } from '@fxa/google';
 import {
   CartInvalidStateForActionError,
   CartService,
+  stripePaymentElementTypeToSubPlatPaymentType,
   SubscriptionAttributionParams,
   SuccessCartDTO,
   TaxChangeAllowedStatus,
@@ -78,9 +79,8 @@ import { GetSuccessCartActionResult } from './validators/GetSuccessCartActionRes
 import {
   CouponErrorCannotRedeem,
   PromotionCodeSanitizedError,
+  SubPlatPaymentMethodType,
   TaxAddress,
-  type PaymentProvidersType,
-  type SubPlatPaymentMethodType,
   type SubplatInterval,
 } from '@fxa/payments/customer';
 import { EligibilityService, LocationStatus } from '@fxa/payments/eligibility';
@@ -608,6 +608,12 @@ export class NextJSActionsService {
     sessionUid?: string;
     token?: string;
   }) {
+    this.emitterService.getEmitter().emit('checkoutSubmit', {
+      ...args.requestArgs,
+      paymentProvider: 'paypal',
+      paymentMethod: SubPlatPaymentMethodType.PayPal,
+    });
+
     await this.cartService.checkoutCartWithPaypal(
       args.cartId,
       args.version,
@@ -626,10 +632,29 @@ export class NextJSActionsService {
     cartId: string;
     version: number;
     confirmationTokenId: string;
+    paymentMethod: string;
     attribution: SubscriptionAttributionParams;
     requestArgs: CommonMetrics;
     sessionUid?: string;
   }) {
+    const mappedPaymentMethod =
+      stripePaymentElementTypeToSubPlatPaymentType[args.paymentMethod];
+
+    if (args.paymentMethod && !mappedPaymentMethod) {
+      const safeToken = /^[a-z_]+$/.test(args.paymentMethod)
+        ? args.paymentMethod
+        : `<invalid:${args.paymentMethod.length}>`;
+      this.log.warn('checkoutSubmit.unmappedPaymentMethod', {
+        paymentMethod: safeToken,
+      });
+    }
+
+    this.emitterService.getEmitter().emit('checkoutSubmit', {
+      ...args.requestArgs,
+      paymentProvider: 'stripe',
+      paymentMethod: mappedPaymentMethod ?? SubPlatPaymentMethodType.Stripe,
+    });
+
     await this.cartService.checkoutCartWithStripe(
       args.cartId,
       args.version,
@@ -720,26 +745,16 @@ export class NextJSActionsService {
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
   async recordEmitterEvent(args: {
-    eventName: string;
+    eventName: 'checkoutView' | 'checkoutEngage';
     requestArgs: CommonMetrics;
-    paymentProvider?: PaymentProvidersType;
-    paymentMethod?: SubPlatPaymentMethodType;
   }) {
-    const { eventName, requestArgs, paymentProvider, paymentMethod } = args;
+    const { eventName, requestArgs } = args;
 
     switch (eventName) {
       case 'checkoutView':
       case 'checkoutEngage': {
         this.emitterService.getEmitter().emit(eventName, {
           ...requestArgs,
-        });
-        break;
-      }
-      case 'checkoutSubmit': {
-        this.emitterService.getEmitter().emit(eventName, {
-          ...requestArgs,
-          paymentProvider,
-          paymentMethod,
         });
         break;
       }
@@ -1086,10 +1101,10 @@ export class NextJSActionsService {
           }
         }
       }
-        return {
-          isValid: true,
-          status: locationStatus,
-        };
+      return {
+        isValid: true,
+        status: locationStatus,
+      };
     } else {
       return {
         isValid: false,

--- a/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithStripeActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithStripeActionArgs.ts
@@ -6,6 +6,7 @@ import { Type } from 'class-transformer';
 import {
   IsNumber,
   IsString,
+  MaxLength,
   ValidateNested,
   IsOptional,
 } from 'class-validator';
@@ -60,6 +61,15 @@ export class CheckoutCartWithStripeActionArgs {
 
   @IsString()
   confirmationTokenId!: string;
+
+  // A Stripe Payment Element type string (e.g. card/link/apple_pay/google_pay).
+  // Not constrained to a fixed set: the enabled types are account-driven and an
+  // unrecognized value is safely bounded to SubPlatPaymentMethodType.Stripe in
+  // NextJSActionsService rather than rejected. MaxLength guards against oversized
+  // input on this publicly callable boundary.
+  @IsString()
+  @MaxLength(64)
+  paymentMethod!: string;
 
   @IsString()
   @IsOptional()

--- a/libs/payments/ui/src/lib/nestapp/validators/RecordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/RecordEmitterEvent.ts
@@ -3,14 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Type } from 'class-transformer';
-import { IsEnum, IsIn, IsOptional, ValidateNested } from 'class-validator';
+import { IsEnum, ValidateNested } from 'class-validator';
 import { PaymentsEmitterEventsKeys } from '@fxa/payments/events';
 import type { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
-import { PaymentProvidersTypePartial } from '@fxa/payments/metrics';
-import {
-  SubPlatPaymentMethodType,
-  type PaymentProvidersType,
-} from '@fxa/payments/customer';
 import { RequestArgs } from './common/RequestArgs';
 
 export class RecordEmitterEventArgs {
@@ -20,12 +15,4 @@ export class RecordEmitterEventArgs {
   @Type(() => RequestArgs)
   @ValidateNested()
   requestArgs!: RequestArgs;
-
-  @IsOptional()
-  @IsIn([...PaymentProvidersTypePartial])
-  paymentProvider?: PaymentProvidersType;
-
-  @IsOptional()
-  @IsEnum(SubPlatPaymentMethodType)
-  paymentMethod?: SubPlatPaymentMethodType;
 }


### PR DESCRIPTION
## Because

* client-side checkoutSubmit fires just before router.push('./processing'), so the Glean ping can be dropped mid-navigation — producing more success events than submit events in the funnel (PAY-3770)

## This pull request

* emit checkoutSubmit from NextJSActionsService.checkoutCartWith{Stripe,Paypal} so it survives client navigation, mirroring the checkoutSuccess pattern
* thread selectedPaymentMethod through the checkoutCartWithStripe server action
* drop the checkoutSubmit path from recordEmitterEventAction and its validator

## Issue that this pull request solves

Closes: #PAY-3770

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
