### PR TITLE
feat(auth-server): add feature flag for the Free Access Program

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -243,20 +243,22 @@ async function run(config) {
       );
       Container.set(DefaultCmsConfigurationManager, defaultCmsManager);
 
-      freeAccessConfigurationManager =
-        new FreeAccessProgramConfigurationManager(
-          strapiClientConfig,
-          strapiClient,
-          firestore,
-          log
+      if (config.subscriptions.freeAccessProgram.enabled) {
+        freeAccessConfigurationManager =
+          new FreeAccessProgramConfigurationManager(
+            strapiClientConfig,
+            strapiClient,
+            firestore,
+            log
+          );
+        freeAccessJournalManagerConfig = Object.assign(
+          new FreeAccessProgramJournalManagerConfig(),
+          {
+            collectionName:
+              config.subscriptions.freeAccessProgramJournal.collectionName,
+          }
         );
-      freeAccessJournalManagerConfig = Object.assign(
-        new FreeAccessProgramJournalManagerConfig(),
-        {
-          collectionName:
-            config.subscriptions.freeAccessProgramJournal.collectionName,
-        }
-      );
+      }
     }
 
     const { createStripeHelper } = require('../lib/payments/stripe');

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1161,6 +1161,14 @@ const convictConf = convict({
         default: 'subplat-free-access-program-journal',
       },
     },
+    freeAccessProgram: {
+      enabled: {
+        doc: 'Indicates whether the Free Access Program is enabled',
+        format: Boolean,
+        env: 'FREE_ACCESS_PROGRAM_ENABLED',
+        default: false,
+      },
+    },
   },
   currenciesToCountries: {
     doc: 'Mapping from ISO 4217 three-letter currency codes to list of ISO 3166-1 alpha-2 two-letter country codes: {"EUR": ["DE", "FR"], "USD": ["CA", "GB", "US" ]}  Requirement for only one currency per country. Tested at runtime. Must be uppercased.',

--- a/packages/fxa-auth-server/scripts/free-access-program-reconcile.ts
+++ b/packages/fxa-auth-server/scripts/free-access-program-reconcile.ts
@@ -40,6 +40,12 @@ async function main() {
     });
     return 0;
   }
+  if (!config.subscriptions.freeAccessProgram?.enabled) {
+    log.warn('free-access-program-reconcile.skipped', {
+      reason: 'free-access-program-disabled',
+    });
+    return 0;
+  }
   const strapiClientConfig = config.cms?.strapiClient;
   if (
     !strapiClientConfig?.graphqlApiUri ||


### PR DESCRIPTION
## Because

* The Free Access Program needs to be enable-able and disable-able independently of CMS setup for controlled rollout.

## This pull request

* Adds `subscriptions.freeAccessProgram.enabled` Convict boolean (env `FREE_ACCESS_PROGRAM_ENABLED`, default false).
* Gates FAP DI registration in `key_server.js` so consumers using `Container.has(FreeAccessProgramService)` transparently short-circuit.
* Adds an early-return skip in the reconcile cron script when disabled.

## Issue that this pull request solves

Closes: #PAY-3789

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
