### PR TITLE
fix(auth-server): reset recovery methods when starting TOTP setup

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -49,6 +49,12 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
 
         const { uid } = request.auth.credentials;
 
+        // Backup codes may only be regenerated once TOTP is enabled. See FXA-14058.
+        const hasTotpToken = await otpUtils.hasTotpToken({ uid });
+        if (!hasTotpToken) {
+          throw errors.totpTokenNotFound();
+        }
+
         const recoveryCodes = await db.replaceRecoveryCodes(
           uid,
           RECOVERY_CODE_COUNT
@@ -195,6 +201,12 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
         log.begin('updateRecoveryCodes', request);
 
         const { uid } = request.auth.credentials;
+
+        // Backup codes may only be replaced once TOTP is enabled. See FXA-14058.
+        const hasTotpToken = await otpUtils.hasTotpToken({ uid });
+        if (!hasTotpToken) {
+          throw errors.totpTokenNotFound();
+        }
 
         const { recoveryCodes } = request.payload;
         await db.updateRecoveryCodes(uid, recoveryCodes);

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.spec.ts
@@ -90,6 +90,9 @@ describe('backup authentication codes', () => {
   describe('GET /recoveryCodes', () => {
     it('should replace backup authentication codes in TOTP session', () => {
       requestOptions.credentials.authenticatorAssuranceLevel = 2;
+      db.totpToken = jest.fn(() =>
+        Promise.resolve({ verified: true, enabled: true })
+      );
       return runTest('/recoveryCodes', requestOptions, 'GET').then(
         (res: any) => {
           expect(res.recoveryCodes).toHaveLength(2);
@@ -120,12 +123,25 @@ describe('backup authentication codes', () => {
         }
       );
     });
+
+    it('rejects with totpTokenNotFound when TOTP is not enabled', async () => {
+      db.totpToken = jest.fn(() => Promise.resolve({ enabled: false }));
+      await expect(
+        runTest('/recoveryCodes', requestOptions, 'GET')
+      ).rejects.toMatchObject({
+        errno: error.totpTokenNotFound().errno,
+      });
+      expect(db.replaceRecoveryCodes).not.toHaveBeenCalled();
+    });
   });
 
   describe('PUT /recoveryCodes', () => {
     it('should overwrite backup authentication codes in TOTP session', () => {
       requestOptions.credentials.authenticatorAssuranceLevel = 2;
       requestOptions.payload.recoveryCodes = ['123'];
+      db.totpToken = jest.fn(() =>
+        Promise.resolve({ verified: true, enabled: true })
+      );
 
       return runTest('/recoveryCodes', requestOptions, 'PUT').then(
         (res: any) => {
@@ -158,6 +174,17 @@ describe('backup authentication codes', () => {
           });
         }
       );
+    });
+
+    it('rejects with totpTokenNotFound when TOTP is not enabled', async () => {
+      requestOptions.payload.recoveryCodes = ['123'];
+      db.totpToken = jest.fn(() => Promise.resolve({ enabled: false }));
+      await expect(
+        runTest('/recoveryCodes', requestOptions, 'PUT')
+      ).rejects.toMatchObject({
+        errno: error.totpTokenNotFound().errno,
+      });
+      expect(db.updateRecoveryCodes).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -79,6 +79,18 @@ module.exports = (
     ? `${config.serviceName} - ${environment}`
     : `${config.serviceName}`;
 
+  // Clears recovery methods that predate a fresh TOTP setup. See FXA-14058.
+  async function clearPreexistingRecoveryMethods(uid) {
+    await backupCodeManager.deleteRecoveryCodes(uid);
+    try {
+      await recoveryPhoneService.removePhoneNumber(uid);
+    } catch (err) {
+      if (!(err instanceof RecoveryNumberNotExistsError)) {
+        throw err;
+      }
+    }
+  }
+
   // Handler function for TOTP replace start (used by MFA route)
   async function totpReplaceStartHandler(request) {
     log.begin('totp.replace.create', request);
@@ -454,6 +466,8 @@ module.exports = (
             TOTP_SECRET_REDIS_TTL
           );
         } else {
+          await clearPreexistingRecoveryMethods(uid);
+
           secret = authenticator.generateSecret();
           await authServerCacheRedis.set(
             toRedisTotpSecretKey(uid),

--- a/packages/fxa-auth-server/lib/routes/totp.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/totp.spec.ts
@@ -4,7 +4,10 @@
 
 import { Container } from 'typedi';
 import { AppError as authErrors } from '@fxa/accounts/errors';
-import { RecoveryPhoneService } from '@fxa/accounts/recovery-phone';
+import {
+  RecoveryPhoneService,
+  RecoveryNumberNotExistsError,
+} from '@fxa/accounts/recovery-phone';
 import { BackupCodeManager } from '@fxa/accounts/two-factor';
 import { createMock } from '@golevelup/ts-jest';
 import { StatsD } from 'hot-shots';
@@ -181,6 +184,12 @@ describe('totp', () => {
     Container.set(RecoveryPhoneService, mockRecoveryPhoneService);
     Container.set(BackupCodeManager, mockBackupCodeManager);
 
+    // Two /totp/create tests below make removePhoneNumber reject; reset it each
+    // test so that behavior can't leak (clearMocks does not reset implementations).
+    mockRecoveryPhoneService.removePhoneNumber
+      .mockReset()
+      .mockResolvedValue(true);
+
     glean.twoStepAuthRemove.success.mockClear();
   });
 
@@ -208,6 +217,68 @@ describe('totp', () => {
           expect.objectContaining({ uid: 'uid' })
         );
       });
+    });
+
+    // FXA-14058: a fresh setup starts from a clean recovery-method slate.
+    it('clears pre-existing recovery methods when starting a fresh setup', async () => {
+      await setup(
+        { db: { email: TEST_EMAIL, emailVerified: true } },
+        {},
+        '/totp/create',
+        requestOptions
+      );
+      expect(mockBackupCodeManager.deleteRecoveryCodes).toHaveBeenCalledWith(
+        'uid'
+      );
+      expect(mockRecoveryPhoneService.removePhoneNumber).toHaveBeenCalledWith(
+        'uid'
+      );
+    });
+
+    it('still creates the token when there is no recovery phone to remove', async () => {
+      mockRecoveryPhoneService.removePhoneNumber.mockRejectedValue(
+        new RecoveryNumberNotExistsError('uid')
+      );
+      const response = await setup(
+        { db: { email: TEST_EMAIL, emailVerified: true } },
+        {},
+        '/totp/create',
+        requestOptions
+      );
+      expect(response.secret).toBeTruthy();
+    });
+
+    it('does not create the token if clearing a recovery method fails', async () => {
+      mockRecoveryPhoneService.removePhoneNumber.mockRejectedValue(
+        new Error('db unavailable')
+      );
+      await expect(
+        setup(
+          { db: { email: TEST_EMAIL, emailVerified: true } },
+          {},
+          '/totp/create',
+          requestOptions
+        )
+      ).rejects.toThrow('db unavailable');
+      expect(authServerCacheRedis.set).not.toHaveBeenCalled();
+    });
+
+    it('does not clear recovery methods when re-entering an in-progress setup', async () => {
+      await setup(
+        { db: { email: TEST_EMAIL, emailVerified: true }, redis: { secret } },
+        {},
+        '/totp/create',
+        requestOptions
+      );
+      expect(mockBackupCodeManager.deleteRecoveryCodes).not.toHaveBeenCalled();
+      expect(mockRecoveryPhoneService.removePhoneNumber).not.toHaveBeenCalled();
+      // The existing setup secret's TTL is refreshed rather than regenerated.
+      expect(authServerCacheRedis.set).toHaveBeenCalledWith(
+        expect.stringContaining(':secret:'),
+        secret,
+        'EX',
+        3600
+      );
     });
   });
 


### PR DESCRIPTION
## Because

- Recovery codes and a recovery phone can be added to an account that has no TOTP, but starting a new TOTP setup did not clear them, so a stale recovery method could carry over once TOTP was enabled.
- `GET`/`PUT /recoveryCodes` did not require an enabled TOTP token, unlike `POST /recoveryCodes`.

## This pull request

- Clears any pre-existing recovery codes and recovery phone at the start of a fresh TOTP setup (`/totp/create`), so only the recovery method chosen during setup remains after enablement. The clear runs only when a new setup secret is generated (not on re-entry/reload) and before the secret is created, so it fails closed.
- Rejects `GET`/`PUT /recoveryCodes` when TOTP is not enabled, matching the existing `POST /recoveryCodes` guard.
- Adds unit tests for the cleared-on-setup and guard behavior.

## Issue that this pull request solves

Closes: FXA-14058

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
