### PR TITLE
test(functional-tests): Add functional test for the Free Access Program

### DIFF
--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -12,7 +12,10 @@ import { Credentials } from './targets';
 import { BaseTarget } from './targets/base';
 import { MfaScope } from 'fxa-settings/src/lib/types';
 import { getTotpCode } from './totp';
-import { SessionStatus } from 'fxa-auth-client/lib/client';
+import {
+  SessionStatus,
+  SignedInAccountData,
+} from 'fxa-auth-client/lib/client';
 
 enum EmailPrefix {
   BLOCKED = 'blocked',
@@ -315,6 +318,43 @@ export class TestAccountTracker {
       options
     );
     this.accounts.push(credentials);
+    return credentials;
+  }
+
+  /**
+   * Signs into a fixed, shared account if it already exists, otherwise creates
+   * it (pre-verified). Unlike the generated-account helpers, the email/password
+   * are supplied by the caller because the account is fixed across runs.
+   *
+   * Only accounts created by this run are tracked for teardown: destroying a
+   * pre-existing shared account would be a destructive side effect on shared
+   * environments and could break other runs that expect it to persist.
+   * @param email fixed email address of the shared account
+   * @param password fixed password of the shared account
+   * @returns Credentials when created this run, or SignedInAccountData when the
+   *   account already existed and was signed into. Both expose `sessionToken`.
+   */
+  async signInOrCreateSharedAccount(
+    email: string,
+    password: string
+  ): Promise<Credentials | SignedInAccountData> {
+    const { exists } = await this.target.authClient.accountStatusByEmail(
+      email,
+      {},
+      this.target.ciHeader
+    );
+
+    if (exists) {
+      return this.target.authClient.signIn(
+        { primary: email, original: email },
+        password,
+        {},
+        this.target.ciHeader
+      );
+    }
+
+    const credentials = await this.target.createAccount(email, password);
+    this.accounts.push({ email, password });
     return credentials;
   }
 

--- a/packages/functional-tests/tests-payments-next/free-access-program.spec.ts
+++ b/packages/functional-tests/tests-payments-next/free-access-program.spec.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, test } from '../lib/fixtures/payments';
+
+const FREE_ACCESS_EMAIL = '123donefreeaccess@restmail.net';
+const FREE_ACCESS_CAPABILITY = '123donePro';
+const FREE_ACCESS_PASSWORD = process.env.FREE_ACCESS_PROGRAM_PWD;
+
+test.describe('severity-2 #smoke', () => {
+  test.beforeEach(async ({}, { project }) => {
+    test.skip(
+      project.name.includes('production'),
+      'Free Access Program relies on non-production Strapi configuration'
+    );
+    test.skip(
+      !FREE_ACCESS_PASSWORD,
+      'FREE_ACCESS_PROGRAM_PWD is not set; required to provision the free-access account'
+    );
+  });
+
+  test('grants the 123donePro capability via the auth-server profile', async ({
+    target,
+    testAccountTracker,
+  }) => {
+    // Guaranteed set by the beforeEach skip above.
+    const password = FREE_ACCESS_PASSWORD as string;
+
+    const credentials = await testAccountTracker.signInOrCreateSharedAccount(
+      FREE_ACCESS_EMAIL,
+      password
+    );
+
+    const profile = await target.authClient.accountProfile(
+      credentials.sessionToken,
+      target.ciHeader
+    );
+
+    // `subscriptionsByClientId` maps each client id to its capability slugs;
+    // the free-access grant appears here even without a subscription.
+    const capabilities = Object.values(
+      profile.subscriptionsByClientId ?? {}
+    ).flat();
+
+    expect(capabilities).toContain(FREE_ACCESS_CAPABILITY);
+  });
+});


### PR DESCRIPTION
## Because

- The Free Access Program (PAY-3780) grants subscription capabilities to users
  configured in Strapi without an actual subscription, but there was no
  automated coverage confirming the granted capability is actually broadcast.
  This adds a functional test so regressions in that path are caught.

## This pull request

- Adds `packages/functional-tests/tests-payments-next/free-access-program.spec.ts`,
  a functional test that provisions the configured free-access account
  (`123donefreeaccess@restmail.net`) and asserts the auth-server profile returns
  the `123donePro` capability under `subscriptionsByClientId`.
- Sources the account password from the `FREE_ACCESS_PROGRAM_PWD` environment
  variable (skipping when unset), and skips in production, since the feature
  depends on environment-specific Strapi configuration.

## Issue that this pull request solves

Closes: PAY-3781

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Running this test requires the target environment to have the Free Access
Program enabled (`FREE_ACCESS_PROGRAM_ENABLED`) with Strapi configured to grant
`123donePro` to `123donefreeaccess@restmail.net`, and `FREE_ACCESS_PROGRAM_PWD`
provided as a CI secret. The test skips automatically when
`FREE_ACCESS_PROGRAM_PWD` is unset and in production.