### PR TITLE
fix(payments-next): [f006] CMS webhook secret length leaked via timingSafeEqual exception

### DIFF
--- a/libs/payments/webhooks/src/lib/cms-webhooks.controller.spec.ts
+++ b/libs/payments/webhooks/src/lib/cms-webhooks.controller.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '@fxa/shared/cms';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
-import { Logger } from '@nestjs/common';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 import type { StrapiValidationWebhookPayload } from './cms-webhooks.types';
 
 describe('CmsWebhooksController', () => {
@@ -67,6 +67,16 @@ describe('CmsWebhooksController', () => {
       );
 
       expect(result).toEqual({ success: true });
+    });
+
+    it('propagates auth failures from the service', async () => {
+      jest
+        .spyOn(service, 'handleValidationWebhook')
+        .mockRejectedValue(new UnauthorizedException());
+
+      await expect(
+        controller.postStrapiValidation('Bearer wrong', mockPayload)
+      ).rejects.toThrow(UnauthorizedException);
     });
   });
 });

--- a/libs/payments/webhooks/src/lib/cms-webhooks.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/cms-webhooks.service.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import { CmsWebhookService } from './cms-webhooks.service';
 import { CmsContentValidationManager, StrapiClient } from '@fxa/shared/cms';
@@ -64,7 +64,9 @@ describe('CmsWebhookService', () => {
   it('rejects invalid authorization', async () => {
     mockStrapiClient.verifyWebhookSignature.mockReturnValue(false);
 
-    await service.handleValidationWebhook('Bearer wrong', mockPayload);
+    await expect(
+      service.handleValidationWebhook('Bearer wrong', mockPayload)
+    ).rejects.toThrow(UnauthorizedException);
 
     expect(statsd.increment).toHaveBeenCalledWith('cms.validation.auth.error');
     expect(validator.validateAll).not.toHaveBeenCalled();

--- a/libs/payments/webhooks/src/lib/cms-webhooks.service.ts
+++ b/libs/payments/webhooks/src/lib/cms-webhooks.service.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { StatsD } from 'hot-shots';
 import * as Sentry from '@sentry/node';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
@@ -34,7 +39,7 @@ export class CmsWebhookService {
     if (!this.strapiClient.verifyWebhookSignature(authorization)) {
       this.statsd.increment('cms.validation.auth.error');
       this.logger.error(new CmsWebhookAuthError());
-      return;
+      throw new UnauthorizedException();
     }
 
     if (!ALLOWED_EVENTS.includes(payload.event)) {

--- a/libs/shared/cms/src/lib/strapi.client.spec.ts
+++ b/libs/shared/cms/src/lib/strapi.client.spec.ts
@@ -206,6 +206,15 @@ describe('StrapiClient', () => {
       expect(strapiClient.verifyWebhookSignature('')).toBe(false);
     });
 
+    it('returns false for an undefined authorization header without throwing', () => {
+      expect(() =>
+        strapiClient.verifyWebhookSignature(undefined as unknown as string)
+      ).not.toThrow();
+      expect(
+        strapiClient.verifyWebhookSignature(undefined as unknown as string)
+      ).toBe(false);
+    });
+
     it('returns false for a mismatched-length header without throwing', () => {
       const longGarbage = 'Bearer ' + 'x'.repeat(WEBHOOK_SECRET.length + 50);
       expect(() => strapiClient.verifyWebhookSignature(longGarbage)).not.toThrow();


### PR DESCRIPTION
## Because

* No length pre-check in verifyWebhookSignature let an attacker learn the secret's byte-length by observing 500 vs 200 responses.
* Auth failures returned 200 {success:true}

## This pull request

* Makes handleValidationWebhook return 401 on auth failure instead of silently returning 200.
* Note: the length check was implemented in the PR for PAY-3780, [here](https://github.com/mozilla/fxa/pull/20764/changes#diff-8de054ceb4efdc79dfae2cfafe08b988a6810134da2c3b8d0538b15224a84871R198-R206)

## Issue that this pull request solves
Closes: #[PAY-3799](https://mozilla-hub.atlassian.net/browse/PAY-3799)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="1250" height="372" alt="image" src="https://github.com/user-attachments/assets/370ef955-f73a-40d8-bf79-f5ad233b8822" />

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3799]: https://mozilla-hub.atlassian.net/browse/PAY-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PAY-3780]: https://mozilla-hub.atlassian.net/browse/PAY-3780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ