### PR TITLE
test(functional): add Android/iOS pairing flow E2E tests

### DIFF
--- a/packages/functional-tests/lib/android-supplicant.ts
+++ b/packages/functional-tests/lib/android-supplicant.ts
@@ -1,0 +1,520 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * adb-driven Fenix (Firefox for Android) supplicant driver for pairing E2E tests.
+ *
+ * This is the Android analog of the iOS XCUITest supplicant in
+ * `pairingFlowiOS.spec.ts`. Where iOS drives Firefox iOS via XCUITest, here we
+ * drive the Fenix *debug* build via `adb`:
+ *
+ *   1. Point Fenix's FxA server override at the target content server (local,
+ *      stage, or prod — whatever `contentServerUrl` is passed).
+ *   2. Inject the pairing URL into the Sync Debug "Pairing (debug)" hook.
+ *   3. Cold-start the app and navigate Settings -> Sync Debug -> Begin pairing.
+ *   4. That invokes `beginPairingAuthentication`, which runs the supplicant
+ *      OAuth/pairing flow in a custom tab and connects to the channel server.
+ *
+ * The Sync Debug pairing hook is a debug-only addition to Fenix
+ * (`SyncDebugFragment.setupPairingPreferences`). See the pairing test docs
+ * (`docs/pairing/README.md`) for setup and build instructions.
+ *
+ * Prerequisites:
+ *   - An Android emulator/device visible to `adb` (ANDROID_SERIAL to target one).
+ *   - The Fenix debug build with the pairing hook installed
+ *     (org.mozilla.fenix.debug).
+ *   - For the local target only: `adb reverse` (yarn adb-reverse) so the
+ *     emulator's localhost reaches the host stack, plus the localhost
+ *     fxawebchannel manifest match. Stage/prod are reached over the network and
+ *     are already in the stock webchannel allowlist.
+ *
+ * Set ANDROID_PAIRING_DEBUG=1 for verbose logging.
+ */
+
+import { execFileSync } from 'child_process';
+import { writeFileSync } from 'fs';
+
+const DEBUG = !!process.env.ANDROID_PAIRING_DEBUG;
+const debug = (msg: string) =>
+  DEBUG && console.log(`[android-supplicant] ${msg}`);
+
+/** Default Fenix debug application id. */
+const DEFAULT_PACKAGE = 'org.mozilla.fenix.debug';
+const HOME_ACTIVITY = 'org.mozilla.fenix.HomeActivity';
+/**
+ * Deep-link scheme for the debug build (BuildConfig.DEEP_LINK_SCHEME defaults to
+ * "fenix-dev"). `fenix-dev://settings` jumps straight to Settings, which is far
+ * more robust than navigating the home menu (the home screen has several
+ * "More options" buttons that collide with text matching).
+ */
+const DEEP_LINK_SCHEME = process.env.ANDROID_DEEP_LINK_SCHEME || 'fenix-dev';
+
+/**
+ * SharedPreferences file that `Settings` reads (getSharedPreferences("fenix_preferences")).
+ * The FxA server override (`pref_key_override_fxa_server`) lives here.
+ */
+const FENIX_PREFERENCES = 'fenix_preferences.xml';
+/**
+ * Default PreferenceManager file. SyncDebugFragment does NOT set
+ * sharedPreferencesName, so its EditTextPreferences (including the pairing URL,
+ * read via `pref.text`) persist here, NOT in fenix_preferences.xml.
+ */
+const DEFAULT_PREFERENCES = `${DEFAULT_PACKAGE}_preferences.xml`;
+
+const KEY_OVERRIDE_FXA_SERVER = 'pref_key_override_fxa_server';
+const KEY_PAIRING_URL = 'pref_key_sync_debug_pairing_url';
+
+interface UiNode {
+  text: string;
+  desc: string;
+  cx: number;
+  cy: number;
+}
+
+interface AndroidSupplicantOptions {
+  packageName?: string;
+  serial?: string;
+}
+
+export class AndroidSupplicant {
+  private readonly pkg: string;
+  private readonly serial?: string;
+  private cachedSize?: { width: number; height: number };
+
+  constructor(opts: AndroidSupplicantOptions = {}) {
+    this.pkg = opts.packageName || DEFAULT_PACKAGE;
+    this.serial = opts.serial || process.env.ANDROID_SERIAL || undefined;
+  }
+
+  /** Prepend `-s <serial>` when a specific device is targeted. */
+  private argv(args: string[]): string[] {
+    return this.serial ? ['-s', this.serial, ...args] : args;
+  }
+
+  private adb(args: string[], input?: string): string {
+    try {
+      return execFileSync('adb', this.argv(args), {
+        encoding: 'utf8',
+        input,
+        maxBuffer: 32 * 1024 * 1024,
+      });
+    } catch (e) {
+      const err = e as { stderr?: string; message?: string };
+      throw new Error(
+        `adb ${args.join(' ')} failed: ${err.stderr || err.message || e}`
+      );
+    }
+  }
+
+  /**
+   * Run a command inside the app sandbox via run-as. `adb shell` re-tokenizes
+   * argv on the device, so the whole device command is sent as ONE string with
+   * device-side quoting to preserve arg boundaries and redirects. shellCmd must
+   * not contain double quotes.
+   */
+  private runAs(shellCmd: string, input?: string): string {
+    return this.adb(['shell', `run-as ${this.pkg} sh -c "${shellCmd}"`], input);
+  }
+
+  private tap(x: number, y: number): void {
+    this.adb(['shell', 'input', 'tap', String(x), String(y)]);
+  }
+
+  private swipe(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    durationMs: number
+  ): void {
+    const coords = [x1, y1, x2, y2, durationMs].map((n) =>
+      String(Math.round(n))
+    );
+    this.adb(['shell', 'input', 'swipe', ...coords]);
+  }
+
+  /** Effective screen size (Override if set, else Physical); cached. */
+  private screenSize(): { width: number; height: number } {
+    if (this.cachedSize) return this.cachedSize;
+    // `wm size` prints "Physical size: WxH" and, when scaled, "Override size: WxH".
+    const out = this.adb(['shell', 'wm', 'size']);
+    const lines = out.split('\n');
+    const line =
+      lines.find((l) => l.includes('Override size:')) ??
+      lines.find((l) => l.includes('Physical size:')) ??
+      '';
+    const m = line.match(/(\d+)x(\d+)/);
+    this.cachedSize = m
+      ? { width: Number(m[1]), height: Number(m[2]) }
+      : { width: 1080, height: 2400 };
+    return this.cachedSize;
+  }
+
+  /** Scroll the list up to reveal items lower on the screen. */
+  private scrollToReveal(): void {
+    const { width, height } = this.screenSize();
+    this.swipe(width / 2, height * 0.75, width / 2, height * 0.25, 300);
+  }
+
+  /** A tiny scroll to nudge GeckoView into repopulating its a11y tree. */
+  private nudgeAccessibility(): void {
+    const { width, height } = this.screenSize();
+    this.swipe(width / 2, height * 0.5, width / 2, height * 0.48, 100);
+  }
+
+  /**
+   * Verify a device is attached and the Fenix debug build is installed. Grants
+   * camera/notification permissions and points the FxA server override at the
+   * given content server. Cold-starts once so the prefs files exist.
+   */
+  async ensureReady(contentServerUrl: string): Promise<void> {
+    const devices = this.adb(['devices'])
+      .split('\n')
+      .slice(1)
+      .filter((l) => /\tdevice$/.test(l));
+    if (devices.length === 0) {
+      throw new Error(
+        'No adb device found. Boot an emulator and ensure `adb devices` lists it.'
+      );
+    }
+
+    const installed = this.adb(['shell', 'pm', 'list', 'packages', this.pkg]);
+    if (!installed.includes(this.pkg)) {
+      throw new Error(
+        `${this.pkg} is not installed. Build + install the Fenix debug build ` +
+          `with the Sync Debug pairing hook (see docs/pairing/README.md).`
+      );
+    }
+
+    // Best-effort permission grants (ignore failures for already-granted).
+    for (const perm of [
+      'android.permission.CAMERA',
+      'android.permission.POST_NOTIFICATIONS',
+    ]) {
+      try {
+        this.adb(['shell', 'pm', 'grant', this.pkg, perm]);
+      } catch {
+        /* already granted or not requestable */
+      }
+    }
+
+    // Launch once so the prefs files are created, then stop before editing.
+    this.launchHome();
+    await this.waitForProcess(30_000);
+    await sleep(3_000);
+    this.forceStop();
+
+    this.setPrefString(
+      FENIX_PREFERENCES,
+      KEY_OVERRIDE_FXA_SERVER,
+      contentServerUrl
+    );
+    debug(`FxA server override set to ${contentServerUrl}`);
+  }
+
+  /**
+   * Inject the pairing URL (the raw QR value: .../pair#channel_id=...&channel_key=...)
+   * into the Sync Debug pairing hook. App must be stopped first so in-memory
+   * prefs don't overwrite the file; caller cold-starts afterwards.
+   */
+  injectPairingUrl(pairingUrl: string): void {
+    this.forceStop();
+    this.setPrefString(DEFAULT_PREFERENCES, KEY_PAIRING_URL, pairingUrl);
+    debug(`Injected pairing URL into ${DEFAULT_PREFERENCES}`);
+  }
+
+  /**
+   * Cold-start the app and drive Settings -> Sync Debug -> Begin pairing, then
+   * wait until `beginPairingAuthentication` fires with our URL (proving the
+   * supplicant reached app-services and started connecting to the channel).
+   *
+   * Returns the pairing URL as seen in logcat's BeginPairingFlow event.
+   */
+  async beginPairing(timeoutMs = 60_000): Promise<string> {
+    this.adb(['logcat', '-c']);
+    await this.openSyncDebug();
+    await this.tapByText(/^Begin pairing$/, { scroll: true });
+
+    const seen = await this.waitForLog(
+      /BeginPairingFlow\(pairingUrl=\S/,
+      timeoutMs
+    );
+    const match = seen.match(/BeginPairingFlow\(pairingUrl=([^,)]*)/);
+    const url = match ? match[1] : '';
+    debug(`Supplicant started pairing with URL: ${url}`);
+    return url;
+  }
+
+  /**
+   * Wait until the supplicant custom tab has loaded its pairing page and is
+   * connecting to the channel. Distinguishes the real pairing flow (/pair/supp
+   * or a pairing authorization URL) from the FXA-13611 email fallback that a
+   * failed/dead channel would trigger.
+   */
+  async waitForSupplicantOnChannel(timeoutMs = 45_000): Promise<string> {
+    // Wait until the supplicant opens its pairing web flow (custom tab / the
+    // /pair/supp page), i.e. it is connecting to the channel server. Approving
+    // too early races the channel handshake, so we then settle before the
+    // authority approves.
+    const line = await this.waitForLog(
+      /url=[^,]*\/pair\/supp|AddCustomTabAction/,
+      timeoutMs
+    );
+    debug(`Supplicant opened its pairing flow: ${line.slice(0, 120)}`);
+    await sleep(12_000); // settle the channel websocket
+    return line;
+  }
+
+  /**
+   * Tap the supplicant's own "Confirm pairing" button on the /pair/supp/allow
+   * screen inside the custom tab. Pairing needs BOTH sides to confirm: the
+   * authority approves the new device, then the supplicant confirms here.
+   * (uiautomator can read GeckoView web content.)
+   */
+  async confirmPairing(timeoutMs = 45_000): Promise<void> {
+    // The confirm button lives in GeckoView web content, read via uiautomator's
+    // accessibility tree — which GeckoView populates lazily, so a dump can miss
+    // it transiently. Poll, and periodically nudge the page with a tiny scroll
+    // to force the a11y tree to repopulate.
+    const re = /^Confirm pairing$|^Confirm$/i;
+    const deadline = Date.now() + timeoutMs;
+    let attempt = 0;
+    while (Date.now() < deadline) {
+      const node = this.dumpUi().find(
+        (n) => re.test(n.text) || re.test(n.desc)
+      );
+      if (node) {
+        this.tap(node.cx, node.cy);
+        debug('Supplicant confirmed pairing');
+        return;
+      }
+      if (attempt % 3 === 2) {
+        this.nudgeAccessibility();
+      }
+      attempt++;
+      await sleep(1_500);
+    }
+    throw new Error('Supplicant Confirm pairing button not found');
+  }
+
+  /** Close the pairing custom tab (used by the cancel/negative case). */
+  cancel(): void {
+    // Back dismisses the custom tab; a second Back returns Home.
+    this.adb(['shell', 'input', 'keyevent', '4']);
+    this.adb(['shell', 'input', 'keyevent', '4']);
+    debug('Closed pairing custom tab (cancel)');
+  }
+
+  /** Force-stop the app; safe to call between tests. */
+  forceStop(): void {
+    try {
+      this.adb(['shell', 'am', 'force-stop', this.pkg]);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /** Grab a screenshot to a local path for diagnostics. */
+  screenshot(localPath: string): void {
+    const png = execFileSync(
+      'adb',
+      this.argv(['exec-out', 'screencap', '-p']),
+      {
+        maxBuffer: 64 * 1024 * 1024,
+      }
+    );
+    writeFileSync(localPath, png);
+  }
+
+  /** Recent logcat, for attaching to test output on failure. */
+  dumpLogcat(): string {
+    try {
+      return this.adb(['logcat', '-d']);
+    } catch {
+      return '';
+    }
+  }
+
+  private setPrefString(prefsFile: string, key: string, value: string): void {
+    const remote = `shared_prefs/${prefsFile}`;
+    let xml: string;
+    try {
+      xml = this.adb(['exec-out', 'run-as', this.pkg, 'cat', remote]);
+    } catch {
+      xml = '';
+    }
+    if (!xml.includes('<map')) {
+      xml =
+        "<?xml version='1.0' encoding='utf-8' standalone='yes' ?>\n<map>\n</map>\n";
+    }
+    // Fenix writes prefs lazily, so shared_prefs/ may not exist yet on a
+    // freshly-launched app; the `>` redirect below needs the directory present.
+    this.runAs('mkdir -p shared_prefs');
+    // Remove any existing entry for this key, then insert before </map>.
+    const keyRe = new RegExp(
+      `\\s*<string name="${key}">[\\s\\S]*?</string>`,
+      'g'
+    );
+    xml = xml.replace(keyRe, '');
+    const entry = `    <string name="${key}">${xmlEscape(value)}</string>\n`;
+    xml = xml.replace('</map>', `${entry}</map>`);
+
+    // base64 over stdin avoids adb-shell CRLF translation corrupting the XML.
+    const b64 = Buffer.from(xml, 'utf8').toString('base64');
+    this.runAs(`base64 -d > ${remote}`, b64);
+  }
+
+  private launchHome(): void {
+    this.adb(['shell', 'am', 'start', '-n', `${this.pkg}/${HOME_ACTIVITY}`]);
+  }
+
+  private async waitForProcess(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      // `pidof` exits non-zero when no process matches; treat that as "not yet".
+      let pid = '';
+      try {
+        pid = this.adb(['shell', 'pidof', this.pkg]).trim();
+      } catch {
+        pid = '';
+      }
+      if (pid) return;
+      await sleep(1_000);
+    }
+    throw new Error(`${this.pkg} did not start within ${timeoutMs}ms`);
+  }
+
+  /**
+   * Cold-start into the Sync Debug preference screen via a deep link. The Sync
+   * Debug entry is always visible on debug builds (isDebugMenuPersistentlyRevealed
+   * defaults to Config.channel.isDebug).
+   */
+  private async openSyncDebug(): Promise<void> {
+    this.adb([
+      'shell',
+      'am',
+      'start',
+      '-a',
+      'android.intent.action.VIEW',
+      '-d',
+      `${DEEP_LINK_SCHEME}://settings`,
+      this.pkg,
+    ]);
+    await this.waitForProcess(30_000);
+    await sleep(6_000); // Settings screen + first-run init
+    this.dismissBlockingDialogs();
+    await this.tapByText(/^Sync Debug$/, { scroll: true });
+    await sleep(1_500);
+  }
+
+  /** Dismiss known startup dialogs that can steal taps (may be stacked). */
+  private dismissBlockingDialogs(): void {
+    const dismissers = [
+      /^Cancel$/, // "Set as default browser" dialog
+      /^Don.t allow$/, // notification permission (straight or curly apostrophe)
+      /^CLOSE$/, // crash report dialog
+      /^Not now$/,
+    ];
+    for (let pass = 0; pass < 3; pass++) {
+      const nodes = this.dumpUi();
+      const hit = nodes.find((n) => dismissers.some((re) => re.test(n.text)));
+      if (!hit) return;
+      this.tap(hit.cx, hit.cy);
+      debug(`Dismissed dialog button: ${hit.text}`);
+    }
+  }
+
+  /** Poll the UI (re-dumping) until an element matches, then tap it. */
+  private async waitAndTap(re: RegExp, timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const node = this.dumpUi().find(
+        (n) => re.test(n.text) || re.test(n.desc)
+      );
+      if (node) {
+        this.tap(node.cx, node.cy);
+        return;
+      }
+      await sleep(1_500);
+    }
+    throw new Error(`Timed out waiting for UI element matching ${re}`);
+  }
+
+  private async tapByText(
+    re: RegExp,
+    opts: { scroll?: boolean; byDesc?: boolean } = {}
+  ): Promise<void> {
+    const maxScrolls = opts.scroll ? 6 : 0;
+    for (let attempt = 0; attempt <= maxScrolls; attempt++) {
+      const nodes = this.dumpUi();
+      const node = nodes.find((n) => re.test(opts.byDesc ? n.desc : n.text));
+      if (node) {
+        this.tap(node.cx, node.cy);
+        return;
+      }
+      if (attempt < maxScrolls) {
+        this.scrollToReveal();
+        await sleep(700);
+      }
+    }
+    throw new Error(`Could not find UI element matching ${re}`);
+  }
+
+  private dumpUi(): UiNode[] {
+    this.adb(['shell', 'uiautomator', 'dump', '/sdcard/ui.xml']);
+    const xml = this.adb(['exec-out', 'cat', '/sdcard/ui.xml']);
+    const nodes: UiNode[] = [];
+    const nodeRe = /<node[^>]*\/?>/g;
+    let m: RegExpExecArray | null;
+    while ((m = nodeRe.exec(xml)) !== null) {
+      const tag = m[0];
+      const text = attr(tag, 'text');
+      const desc = attr(tag, 'content-desc');
+      const bounds = attr(tag, 'bounds');
+      const b = bounds.match(/\[(\d+),(\d+)\]\[(\d+),(\d+)\]/);
+      if (!b) continue;
+      const cx = Math.floor((Number(b[1]) + Number(b[3])) / 2);
+      const cy = Math.floor((Number(b[2]) + Number(b[4])) / 2);
+      nodes.push({ text, desc, cx, cy });
+    }
+    return nodes;
+  }
+
+  private async waitForLog(re: RegExp, timeoutMs: number): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const log = this.adb(['logcat', '-d']);
+      const line = log.split('\n').find((l) => re.test(l));
+      if (line) return line;
+      await sleep(2_000);
+    }
+    throw new Error(`Timed out waiting for logcat line matching ${re}`);
+  }
+}
+
+function attr(tag: string, name: string): string {
+  const m = tag.match(new RegExp(`${name}="([^"]*)"`));
+  return m ? decodeXml(m[1]) : '';
+}
+
+function decodeXml(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/functional-tests/tests/pairing/CLAUDE.md
+++ b/packages/functional-tests/tests/pairing/CLAUDE.md
@@ -1,0 +1,176 @@
+# Pairing flow tests: running the automated E2E tests
+
+Self-contained guide for an agent to set up, run, and debug the cross-device
+pairing E2E tests in this directory. Everything needed is here.
+(`docs/pairing/README.md` covers
+the same ground framed for developers doing manual, by-hand device testing.)
+
+## What these tests do
+
+Pairing connects a signed-in desktop Firefox (the **authority**) to a mobile
+Firefox (the **supplicant**) over a short-lived channel. The specs drive both
+sides: a Marionette-controlled desktop Firefox as the authority, and a real
+mobile app as the supplicant.
+
+- `pairingFlowAndroid.spec.ts` + `lib/android-supplicant.ts` (adb-driven Fenix).
+- `pairingFlowiOS.spec.ts` (Simulator + XCUITest-driven Firefox iOS).
+
+Both are gated behind env flags (`ANDROID_PAIRING_ENABLED` /
+`IOS_PAIRING_ENABLED`) and skip by default, including in CI. The web-only specs
+(`pairingFlow.spec.ts`, `pairChoice.spec.ts`, the Backbone/negative variants)
+need no mobile device and are unaffected.
+
+The channel server is separate from the FxA stack and defaults to production
+(`wss://channelserver.services.mozilla.com`) even locally, so both sides need
+outbound network to it. The OAuth/account side can be the local stack via the
+mobile app's FxA-server override.
+
+## Prerequisites
+
+- **FxA stack running:** `yarn install` once, then `yarn start` (or `yarn start
+mza` for a faster core subset). Needs Docker; `yarn start infrastructure` if it
+  isn't up. Provides content-server :3030, auth-server :9000; Fenix/iOS client
+  ids are registered in `packages/fxa-auth-server/config/dev.json`.
+- **Playwright's Firefox** (the authority): pulled by `yarn install` in
+  `packages/functional-tests`; if missing, `npx playwright install firefox`.
+  Override the binary with `FIREFOX_BINARY`.
+- **Android:** a booted emulator/device (`adb devices` lists it) with a Fenix
+  debug build that has the Sync Debug pairing hook (`org.mozilla.fenix.debug`;
+  hook landed in Bug 2053454, so a current debug build already has it). Build +
+  install from a `mozilla-firefox/firefox` checkout:
+  ```bash
+  ./mach --no-interactive bootstrap --application-choice mobile_android_artifact_mode
+  ./mach build && ./mach gradle :fenix:installDebug
+  ```
+  For `--project=local` only: run `yarn adb-reverse`, and apply the
+  webchannel-localhost patch (see below).
+- **iOS:** a booted Simulator and a firefox-ios checkout built for testing
+  (`xcodebuild build-for-testing -scheme Fennec -testPlan SyncIntegrationTestPlan
+-destination '<dest>'`); point at it with `FIREFOX_IOS_PROJECT_DIR`.
+
+## Running
+
+Android:
+
+```bash
+yarn adb-reverse                       # local only: bridge FxA ports to the device
+cd packages/functional-tests
+ANDROID_PAIRING_ENABLED=1 npx playwright test pairingFlowAndroid --project=local
+```
+
+iOS:
+
+```bash
+cd packages/functional-tests
+IOS_PAIRING_ENABLED=1 \
+  FIREFOX_IOS_PROJECT_DIR=<firefox-ios checkout> \
+  IOS_DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+  npx playwright test pairingFlowiOS.spec.ts --project=local
+```
+
+Extra flags: `ANDROID_PAIRING_DEBUG=1` / `PAIRING_DEBUG=1` (verbose logs),
+`ANDROID_SERIAL` (target one of several attached devices).
+
+## Targets: local, stage, prod
+
+`--project=local|stage|production` sets `target.contentServerUrl`; the
+supplicant's FxA-server override is pointed at it, so the same spec runs against
+all three.
+
+- **local:** `http://localhost:3030`. Android needs `yarn adb-reverse` plus the
+  webchannel-localhost manifest patch; iOS needs neither (the Simulator shares
+  the host network).
+- **stage:** stage hosts are already in the webchannel allowlist, so no patch.
+  The supplicant loads pages in its own web view and can't inject the `fxa-ci`
+  WAF-bypass header, so confirm stage allows the pairing/oauth endpoints. Never
+  commit the WAF token.
+- **production:** creates real accounts via `testAccountTracker`; a real side
+  effect, use sparingly (e.g. a smoke check).
+
+## webchannel localhost (local only)
+
+Against `--project=local`, the supplicant's final "signed in" handoff runs over
+the FxA WebChannel, and the built-in `fxawebchannel` extension's
+`content_scripts.matches` allowlist does not include `localhost`. Without it,
+`fxawebchannel.js` never injects on `http://localhost:3030`, the `oauth_login`
+message is dropped, and the device never registers (so the device-registration
+assertion fails). Add `localhost` to the template and rebuild:
+
+```
+.../feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.template.json
+```
+
+Edit the **template** (the `.json` is generated from it at build time):
+
+```json
+"matches": [
+  "https://accounts.firefox.com/*", "...",
+  "http://localhost/*",
+  "http://127.0.0.1/*"
+]
+```
+
+Not in-tree yet (tracked separately). Stage/prod are unaffected: their hosts are
+already in the stock allowlist.
+
+## Expected success
+
+The run reports `1 passed`. With `ANDROID_PAIRING_DEBUG=1` the account device
+list shows the paired mobile device as `type=mobile, commands=2`, i.e. it
+registered on the account. The authority reaching `/pair/auth/complete` (not
+`/pair/failure`) is the authoritative signal both sides completed the handshake.
+
+## How the Android driver works (and its gotchas)
+
+`AndroidSupplicant` (`lib/android-supplicant.ts`) drives Fenix over adb: it sets
+the FxA-server override, injects the pairing URL into the Sync Debug hook,
+deep-links to Settings, taps Begin pairing, and taps Confirm in the GeckoView
+custom tab. Authority-side logic is shared via `lib/pairing-helpers.ts`
+(`signInAuthorityViaMarionette`, `startPairingFlow`, `buildAuthorityOAuthUrl`,
+`extractChannelId`) and `lib/pairing-constants.ts` (`SELECTORS`,
+`PAIRING_CLIENT_ID`); the `marionetteAuthority` fixture is in
+`lib/fixtures/pairing.ts`. Reuse these rather than duplicating flow logic.
+
+- Navigate via the `fenix-dev://settings` deep link, not the home menu (its
+  "More options" buttons collide with text matching).
+- `adb shell` re-tokenizes argv, so device commands with spaces/redirects are
+  sent as one quoted string, and pref writes use base64 over stdin.
+- uiautomator can read GeckoView web content, but its a11y tree populates
+  lazily; the Confirm tap polls and nudges with a tiny scroll.
+- Both sides must confirm, and the supplicant must connect to the short-lived
+  channel soon after the authority mints the URL, so `ensureReady` runs before
+  `startPairingFlow`.
+
+## Debugging a failing run
+
+Run with `ANDROID_PAIRING_DEBUG=1` (or `PAIRING_DEBUG=1` for iOS) for verbose
+logs; on failure the Android spec also attaches a screenshot and logcat.
+
+Inspect the supplicant directly:
+
+- **Android app / Kotlin logs:** `adb logcat` (filter
+  `--pid=$(adb shell pidof org.mozilla.fenix.debug)`). Pairing logs appear under
+  `FirefoxAccountStateMachine` and `mozac-fxawebchannel`.
+- **Android web content** (the pairing pages run in GeckoView): enable "Remote
+  debugging via USB" in Fenix, then on desktop Firefox open `about:debugging` →
+  This Firefox → connect the device → Inspect the pairing tab for full DevTools
+  (Console, Network, breakpoints).
+- **iOS:** app logs and Swift breakpoints via Xcode; web content via Safari Web
+  Inspector (Safari → Develop → <device/simulator> → the pairing WKWebView).
+
+Common failure modes:
+
+- **Device never registers / test times out on `local`:** the webchannel-localhost
+  patch is missing. logcat shows `[Firefox WebChannel] fxa_status timed out` and
+  the state machine stalls at `Authenticating` instead of reaching `Connected`.
+  Apply the patch above and rebuild.
+- **Supplicant page shows `Invalid pairing configuration`:** `channel_id` /
+  `channel_key` dropped out of the URL fragment. Inspect the loaded URL's fragment
+  in the remote DevTools/Web Inspector, then the app's URL handling.
+- **Flaky handshake (channel vs approval timing):** expected variance; the spec
+  uses `retries: 2`. A long-running emulator degrades (binder/ANR), so relaunch it
+  fresh.
+- **Fenix crash-loops on launch (`MOZ_CRASH(JNI exception)`):** artifact-mode
+  native/Java version skew. Run `./mach artifact clear-cache`, rebuild, reinstall.
+- **`stage` supplicant requests blocked:** the supplicant can't inject the WAF
+  bypass header (see Targets); use a WAF-exempt stage.

--- a/packages/functional-tests/tests/pairing/pairingFlowAndroid.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowAndroid.spec.ts
@@ -1,0 +1,329 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Android (Fenix) pairing flow E2E test.
+ *
+ * Coordinates Marionette (authority / desktop Firefox) with an Android emulator
+ * (supplicant / Firefox for Android) to exercise the full cross-device pairing
+ * flow. This is the Android counterpart of `pairingFlowiOS.spec.ts`; instead of
+ * XCUITest, the supplicant is driven over `adb` (see `lib/android-supplicant.ts`).
+ *
+ *   Authority (Marionette)          Supplicant (Android emulator)
+ *   ---------------------           -----------------------------
+ *   1. Sign in to FxA via OAuth
+ *   2. FxAccountsPairingFlow.start()
+ *      -> generates QR URL
+ *                                   3. adb injects PAIRING_URL into the
+ *                                      Sync Debug "Pairing (debug)" hook
+ *                                   4. adb navigates Settings -> Sync Debug
+ *                                      -> Begin pairing
+ *                                   5. beginPairingAuthentication runs the
+ *                                      supplicant flow in a custom tab
+ *   6. Navigate to approval page
+ *   7. Click "Yes, approve device"
+ *                                   8. OAuth completes -> device registered
+ *
+ * Prerequisites:
+ *   - FXA stack running (auth :9000, content :3030) and `yarn adb-reverse` run
+ *     so the emulator's localhost reaches the host stack.
+ *   - Android emulator booted and visible to `adb` (ANDROID_SERIAL to target).
+ *   - Fenix debug build with the Sync Debug pairing hook installed
+ *     (org.mozilla.fenix.debug). See docs/pairing/README.md.
+ *
+ * Set ANDROID_PAIRING_ENABLED=1 to run. ANDROID_PAIRING_DEBUG=1 for verbose logs.
+ */
+
+import fs from 'fs';
+import { test, expect } from '../../lib/fixtures/pairing';
+import {
+  signInAuthorityViaMarionette,
+  getSignedInUser,
+  startPairingFlow,
+  buildAuthorityOAuthUrl,
+  extractChannelId,
+  findElementBySelectors,
+  isPairRoutesReact,
+  waitForUrlContaining,
+  sleep,
+} from '../../lib/pairing-helpers';
+import { SELECTORS } from '../../lib/pairing-constants';
+import { AndroidSupplicant } from '../../lib/android-supplicant';
+
+const DEBUG = !!process.env.ANDROID_PAIRING_DEBUG;
+const debug = (msg: string) => DEBUG && console.log(`[android-PAIRING] ${msg}`);
+
+/** True for the Fenix supplicant device registered on the account. */
+function isMobileDevice(d: any): boolean {
+  return d.type === 'mobile' || /Android|Fenix|Firefox/i.test(d.name || '');
+}
+
+/** One-line device summary for the run log, showing connection flags. */
+function formatDevice(d: any): string {
+  const flags = [`type=${d.type}`];
+  if (d.isCurrentDevice) flags.push('current');
+  if (d.pushCallback) flags.push('push=connected');
+  if (d.availableCommands) {
+    flags.push(`commands=${Object.keys(d.availableCommands).length}`);
+  }
+  return `  • ${d.name} [${flags.join(', ')}]`;
+}
+
+/** Poll the account's device list until the Fenix supplicant appears. */
+async function pollForMobileDevice(
+  authClient: { deviceList: (token: string) => Promise<any[]> },
+  sessionToken: string,
+  timeoutMs: number
+): Promise<{ name?: string; type?: string } | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const devices = await authClient.deviceList(sessionToken);
+    const found = devices.find(isMobileDevice);
+    if (found) return found;
+    await new Promise((r) => setTimeout(r, 3_000));
+  } while (Date.now() < deadline);
+  return undefined;
+}
+
+// 5 min — includes emulator cold start (~30s), UI navigation, time for the
+// supplicant to connect to the channel, and the OAuth round trip.
+test.setTimeout(300_000);
+
+test.describe.serial('Android pairing flow', () => {
+  // The supplicant web flow has inherent cross-device timing variance (channel
+  // handshake vs authority approval); retry to absorb transient divergence.
+  test.describe.configure({ retries: 2 });
+
+  let useReactPairRoutes = false;
+  let supplicant: AndroidSupplicant;
+
+  test.beforeAll(async ({ browser, target }) => {
+    if (!process.env.ANDROID_PAIRING_ENABLED) return;
+    useReactPairRoutes = await isPairRoutesReact(browser, target);
+  });
+
+  test.beforeEach(async ({}, testInfo) => {
+    if (!process.env.ANDROID_PAIRING_ENABLED) {
+      testInfo.skip(
+        true,
+        'Set ANDROID_PAIRING_ENABLED=1 to run Android pairing tests'
+      );
+    }
+    supplicant = new AndroidSupplicant();
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (!process.env.ANDROID_PAIRING_ENABLED) return;
+    if (process.env.ANDROID_PAIRING_DEBUG) {
+      try {
+        fs.writeFileSync(
+          testInfo.outputPath('android-logcat-debug.txt'),
+          supplicant.dumpLogcat()
+        );
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (testInfo.status !== testInfo.expectedStatus) {
+      try {
+        const shot = testInfo.outputPath('android-supplicant.png');
+        supplicant.screenshot(shot);
+        await testInfo.attach('android-supplicant.png', {
+          path: shot,
+          contentType: 'image/png',
+        });
+        await testInfo.attach('android-logcat.txt', {
+          body: supplicant.dumpLogcat(),
+          contentType: 'text/plain',
+        });
+      } catch {
+        /* best-effort diagnostics */
+      }
+    }
+    supplicant.forceStop();
+  });
+
+  test('authority generates QR URL and Android supplicant connects', async ({
+    target,
+    testAccountTracker,
+    marionetteAuthority,
+  }) => {
+    const client = marionetteAuthority.client;
+    const useReact = useReactPairRoutes;
+
+    const credentials = await test.step('Create test account', async () => {
+      const creds = await testAccountTracker.signUp();
+      debug(`Account created: ${creds.email}`);
+      return creds;
+    });
+
+    const signedInUser =
+      await test.step('Sign in authority via Marionette', async () => {
+        await signInAuthorityViaMarionette(
+          client,
+          target.contentServerUrl,
+          credentials.email,
+          credentials.password,
+          undefined,
+          useReact
+        );
+        const user = await getSignedInUser(client);
+        expect(user.signedIn).toBe(true);
+        expect(user.email).toBe(credentials.email);
+        return user;
+      });
+
+    // Prepare the supplicant BEFORE creating the channel: pairing channels
+    // are short-lived, so the supplicant must connect soon after the authority
+    // mints the URL. ensureReady (install check, override, first launch) is
+    // the slow part and must not run inside the channel's lifetime.
+    await test.step('Prepare Android supplicant', async () => {
+      await supplicant.ensureReady(target.contentServerUrl);
+    });
+
+    const { pairUrl, channelId } =
+      await test.step('Start pairing flow on authority', async () => {
+        const url = await startPairingFlow(client);
+        debug(`Pair URL: ${url}`);
+        expect(url).toContain('/pair#');
+        expect(url).toContain('channel_id=');
+        const id = extractChannelId(url);
+        expect(id).toBeTruthy();
+        return { pairUrl: url, channelId: id };
+      });
+
+    await test.step('Android supplicant begins pairing', async () => {
+      supplicant.injectPairingUrl(pairUrl);
+      const seenUrl = await supplicant.beginPairing();
+      // The supplicant must have started the flow with OUR pairing URL,
+      // carrying the channel_id — not the empty back-out value.
+      expect(seenUrl).toContain(channelId);
+    });
+
+    await test.step('Authority approves pairing', async () => {
+      expect(signedInUser.uid).toBeTruthy();
+      const authorityOAuthUrl = buildAuthorityOAuthUrl(
+        target.contentServerUrl,
+        {
+          email: credentials.email,
+          uid: signedInUser.uid as string,
+          channelId,
+        },
+        useReact
+      );
+
+      // Give the supplicant time to load its /pair/supp page and connect to
+      // the channel before the authority lands on the approval page. The
+      // supplicant custom tab + channel handshake takes ~15-30s.
+      await supplicant.waitForSupplicantOnChannel(45_000);
+
+      await client.setContext('content');
+      debug(`Navigating authority to: ${authorityOAuthUrl}`);
+      await client.navigate(authorityOAuthUrl);
+
+      const approveBtn = await findElementBySelectors(
+        client,
+        SELECTORS.AUTHORITY_APPROVE,
+        30_000
+      );
+      await client.clickElement(approveBtn);
+      debug('Authority approved pairing');
+    });
+
+    await test.step('Android supplicant confirms pairing', async () => {
+      // After the authority approves, it waits on /pair/auth/wait_for_supp;
+      // the supplicant must confirm on its own /pair/supp/allow screen to
+      // complete the handshake.
+      await supplicant.confirmPairing();
+    });
+
+    // The authority reaching /pair/auth/complete (and not /pair/failure) is
+    // the authoritative signal that the two devices completed the pairing
+    // handshake — both connected to the channel and both confirmed.
+    await test.step('Verify pairing handshake completed', async () => {
+      const finalUrl = await waitForUrlContaining(
+        client,
+        'pair/auth/complete',
+        45_000
+      );
+      expect(finalUrl).not.toContain('pair/failure');
+    });
+
+    // The supplicant registers its device asynchronously after finishing the
+    // OAuth webchannel login. This requires the fxawebchannel extension to
+    // inject on the local stack — the extension manifest must include
+    // http://localhost/* in its content_scripts matches (see docs/pairing/README.md,
+    // "webchannel localhost").
+    await test.step('Verify Android device is registered', async () => {
+      const androidDevice = await pollForMobileDevice(
+        target.authClient,
+        credentials.sessionToken as string,
+        45_000
+      );
+      expect(androidDevice).toBeTruthy();
+
+      // Print the account's full device list so the connected Android device
+      // is visible in the run output.
+      const devices = await target.authClient.deviceList(
+        credentials.sessionToken as string
+      );
+      console.log(
+        '[android-PAIRING] account devices:\n' +
+          devices.map(formatDevice).join('\n')
+      );
+    });
+  });
+
+  test('Android supplicant cancels and is not signed in', async ({
+    target,
+    testAccountTracker,
+    marionetteAuthority,
+  }) => {
+    const client = marionetteAuthority.client;
+    const useReact = useReactPairRoutes;
+
+    const credentials = await test.step('Create test account', async () => {
+      return testAccountTracker.signUp();
+    });
+
+    await test.step('Sign in authority via Marionette', async () => {
+      await signInAuthorityViaMarionette(
+        client,
+        target.contentServerUrl,
+        credentials.email,
+        credentials.password,
+        undefined,
+        useReact
+      );
+      const user = await getSignedInUser(client);
+      expect(user.signedIn).toBe(true);
+    });
+
+    const { pairUrl, channelId } =
+      await test.step('Start pairing flow on authority', async () => {
+        const url = await startPairingFlow(client);
+        expect(url).toContain('/pair#');
+        return { pairUrl: url, channelId: extractChannelId(url) };
+      });
+
+    await test.step('Android supplicant begins then cancels', async () => {
+      await supplicant.ensureReady(target.contentServerUrl);
+      supplicant.injectPairingUrl(pairUrl);
+      const seenUrl = await supplicant.beginPairing();
+      expect(seenUrl).toContain(channelId);
+      // Close the pairing custom tab before the authority approves.
+      supplicant.cancel();
+    });
+
+    await test.step('Verify no Android device registered', async () => {
+      // Give any in-flight registration a chance to (not) happen.
+      await sleep(5_000);
+      const devices = await target.authClient.deviceList(
+        credentials.sessionToken as string
+      );
+      const androidDevice = devices.find(isMobileDevice);
+      expect(androidDevice).toBeFalsy();
+    });
+  });
+});

--- a/packages/functional-tests/tests/pairing/pairingFlowiOS.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowiOS.spec.ts
@@ -1,0 +1,528 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * iOS pairing flow E2E test.
+ *
+ * Coordinates Marionette (authority / desktop Firefox) with an iOS Simulator
+ * (supplicant / Firefox iOS) to exercise the full cross-device pairing flow.
+ *
+ *   Authority (Marionette)          Supplicant (iOS Simulator)
+ *   ---------------------           --------------------------
+ *   1. Sign in to FxA via OAuth
+ *   2. FxAccountsPairingFlow.start()
+ *      -> generates QR URL
+ *                                   3. XCUITest reads PAIRING_URL env var
+ *                                   4. Tap "Scan QR Code" -> URL input fallback
+ *                                   5. Paste URL -> Connect
+ *                                   6. App runs native pairing via WKWebView
+ *   7. Navigate to approval page
+ *   8. Click "Yes, approve device"
+ *                                   9. OAuth complete -> sync starts
+ *
+ * Prerequisites:
+ *   - FXA stack running (auth :9000, content :3030)
+ *   - Firefox binary (FIREFOX_BINARY env)
+ *   - Firefox iOS built for Simulator (xcodebuild build-for-testing)
+ *   - iOS Simulator booted (xcrun simctl boot "iPhone 16")
+ *   - FIREFOX_IOS_PROJECT_DIR env pointing to firefox-ios checkout
+ *
+ * Set PAIRING_DEBUG=1 for verbose debug output.
+ */
+
+import { test, expect } from '../../lib/fixtures/pairing';
+import { spawn, execSync, ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import {
+  signInAuthorityViaMarionette,
+  getSignedInUser,
+  startPairingFlow,
+  buildAuthorityOAuthUrl,
+  extractChannelId,
+  findElementBySelectors,
+  screenshotAuthority,
+  isPairRoutesReact,
+  waitForUrlContaining,
+  captureDiagnostics,
+  sleep,
+} from '../../lib/pairing-helpers';
+import { SELECTORS } from '../../lib/pairing-constants';
+
+const DEBUG = !!process.env.PAIRING_DEBUG;
+const debug = (msg: string) => DEBUG && console.log(`[iOS-PAIRING] ${msg}`);
+
+// Defaults to a firefox-ios checkout sibling to the FxA repo; override with the env var.
+const FIREFOX_IOS_PROJECT_DIR =
+  process.env.FIREFOX_IOS_PROJECT_DIR ||
+  path.resolve(__dirname, '../../../../../firefox-ios');
+const IOS_DESTINATION =
+  process.env.IOS_DESTINATION ||
+  'platform=iOS Simulator,name=iPhone 16,OS=18.0';
+const activeXCUITestProcesses = new Set<ChildProcess>();
+
+/**
+ * Find an existing .xctestrun file from a prior `build-for-testing`.
+ * Returns the path if found, undefined otherwise.
+ */
+function findXctestrun(): string | undefined {
+  try {
+    // Look specifically for the SyncIntegrationTestPlan xctestrun, which
+    // includes PairingTests. Other test plans may not include it.
+    const result = execSync(
+      'find ~/Library/Developer/Xcode/DerivedData/Client-*/Build/Products -maxdepth 1 -name "*SyncIntegration*xctestrun" 2>/dev/null | head -1',
+      { encoding: 'utf8' }
+    ).trim();
+    return result || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Patch the xctestrun file in-place with env vars injected.
+ *
+ * XCUITest runs in a sandboxed process — env vars from the host xcodebuild
+ * process are NOT inherited. We inject them into the xctestrun plist's
+ * EnvironmentVariables section so xcodebuild passes them to the test runner.
+ *
+ * The xctestrun must stay in its original directory because it references
+ * test products via relative paths.
+ */
+function patchXctestrun(
+  xctestrunPath: string,
+  envVars: Record<string, string>
+): void {
+  for (const [key, value] of Object.entries(envVars)) {
+    // Use PlistBuddy to inject each env var into the test target's EnvironmentVariables
+    execSync(
+      `/usr/libexec/PlistBuddy -c "Add :TestConfigurations:0:TestTargets:0:EnvironmentVariables:${key} string ${value}" "${xctestrunPath}" 2>/dev/null || ` +
+        `/usr/libexec/PlistBuddy -c "Set :TestConfigurations:0:TestTargets:0:EnvironmentVariables:${key} ${value}" "${xctestrunPath}"`
+    );
+  }
+  debug(`Patched xctestrun with env vars: ${Object.keys(envVars).join(', ')}`);
+}
+
+/**
+ * Launch the iOS XCUITest that drives the supplicant side of pairing.
+ *
+ * Uses `test-without-building` if a pre-built xctestrun exists (fast),
+ * otherwise falls back to `test` which compiles first (slow).
+ *
+ * Environment variables are injected into the xctestrun plist so they
+ * reach the sandboxed XCUITest runner process.
+ */
+function launchXCUITest(
+  pairingUrl: string,
+  customFxAServer: string,
+  testMethod = 'testPairingWithUrl',
+  logPath?: string
+): { process: ChildProcess; promise: Promise<void>; logPath?: string } {
+  // Require a prebuilt xctestrun. Env vars only reach the sandboxed XCUITest
+  // runner via the xctestrun plist (see patchXctestrun), so a plain
+  // `xcodebuild test` here would not deliver PAIRING_URL/CUSTOM_FXA_SERVER.
+  const xctestrun = findXctestrun();
+  if (!xctestrun) {
+    throw new Error(
+      'No SyncIntegrationTestPlan .xctestrun found. Build the iOS tests first:\n' +
+        `  cd ${FIREFOX_IOS_PROJECT_DIR}\n` +
+        '  xcodebuild build-for-testing -scheme Fennec ' +
+        `-testPlan SyncIntegrationTestPlan -destination '${IOS_DESTINATION}'`
+    );
+  }
+
+  const onlyTesting = `XCUITests/PairingTests/${testMethod}`;
+  patchXctestrun(xctestrun, {
+    PAIRING_URL: pairingUrl,
+    CUSTOM_FXA_SERVER: customFxAServer,
+  });
+  debug(`Using pre-built xctestrun: ${xctestrun}`);
+  const args = [
+    'test-without-building',
+    '-xctestrun',
+    xctestrun,
+    '-destination',
+    IOS_DESTINATION,
+    `-only-testing:${onlyTesting}`,
+  ];
+
+  // Always pipe so we can parse test results; mirror to console in debug mode.
+  if (logPath) {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, `xcodebuild ${args.join(' ')}\n\n`, 'utf8');
+  }
+
+  const proc = spawn('xcodebuild', args, {
+    cwd: FIREFOX_IOS_PROJECT_DIR,
+    env: {
+      ...process.env,
+      PAIRING_URL: pairingUrl,
+      CUSTOM_FXA_SERVER: customFxAServer,
+    },
+    stdio: 'pipe',
+  });
+  activeXCUITestProcesses.add(proc);
+
+  let output = '';
+  proc.stdout?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    if (logPath) fs.appendFileSync(logPath, text);
+    if (DEBUG) process.stdout.write(text);
+  });
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    if (logPath) fs.appendFileSync(logPath, text);
+    if (DEBUG) process.stderr.write(text);
+  });
+
+  const promise = new Promise<void>((resolve, reject) => {
+    proc.on('close', (code) => {
+      activeXCUITestProcesses.delete(proc);
+      // xcodebuild may return exit code 65 even when all tests pass
+      // (infrastructure/coverage issues). Check actual test results.
+      const testsPassed = output.includes("Test Suite 'Selected tests' passed");
+      if (code === 0 || testsPassed) {
+        debug(
+          `xcodebuild exited with code ${code}, tests passed: ${testsPassed}`
+        );
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `xcodebuild exited with code ${code}. ` +
+              `Last 500 chars: ${output.slice(-500)}`
+          )
+        );
+      }
+    });
+    proc.on('error', (err) => {
+      activeXCUITestProcesses.delete(proc);
+      reject(new Error(`Failed to launch xcodebuild: ${err.message}`));
+    });
+  });
+
+  return { process: proc, promise, logPath };
+}
+
+// 4 min — includes xcodebuild launch + 45s wait for iOS app + pairing flow
+test.setTimeout(240_000);
+
+test.describe.serial('iOS pairing flow', () => {
+  test.slow();
+
+  // Captured once per worker so tests can decide whether to append the
+  // ?showReactApp=true suffix without re-reading the config per test.
+  let useReactPairRoutes = false;
+  test.beforeAll(async ({ browser, target }) => {
+    if (!process.env.IOS_PAIRING_ENABLED) return;
+    useReactPairRoutes = await isPairRoutesReact(browser, target);
+  });
+
+  test.beforeEach(async ({ target }, testInfo) => {
+    if (!process.env.IOS_PAIRING_ENABLED) {
+      testInfo.skip(true, 'Set IOS_PAIRING_ENABLED=1 to run iOS pairing tests');
+    }
+
+    // Pre-grant notification permission so the system dialog doesn't block the test
+    try {
+      const bundleId = 'org.mozilla.ios.Fennec';
+      execSync(`xcrun simctl privacy booted grant notifications ${bundleId}`, {
+        stdio: 'pipe',
+      });
+      debug('Pre-granted notification permission for Fennec');
+    } catch {
+      debug('Could not pre-grant notification permission (non-fatal)');
+    }
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    for (const proc of activeXCUITestProcesses) {
+      if (!proc.killed) {
+        proc.kill('SIGTERM');
+      }
+    }
+    activeXCUITestProcesses.clear();
+
+    const iosLogPath = testInfo.outputPath('ios-xcodebuild.log');
+    if (fs.existsSync(iosLogPath)) {
+      await testInfo.attach('ios-xcodebuild.log', {
+        path: iosLogPath,
+        contentType: 'text/plain',
+      });
+    }
+  });
+
+  test('authority generates QR URL and iOS supplicant connects', async ({
+    target,
+    testAccountTracker,
+    marionetteAuthority,
+  }, testInfo) => {
+    const client = marionetteAuthority.client;
+    const useReact = useReactPairRoutes;
+
+    // 1. Create account + sign in authority
+    const credentials = await test.step('Create test account', async () => {
+      const creds = await testAccountTracker.signUp();
+      debug(`Account created: ${creds.email}`);
+      return creds;
+    });
+
+    const signedInUser =
+      await test.step('Sign in authority via Marionette', async () => {
+        await signInAuthorityViaMarionette(
+          client,
+          target.contentServerUrl,
+          credentials.email,
+          credentials.password,
+          undefined,
+          useReact
+        );
+        const user = await getSignedInUser(client);
+        expect(user.signedIn).toBe(true);
+        expect(user.email).toBe(credentials.email);
+        await screenshotAuthority(client, 'iOS', '1-signed-in');
+        return user;
+      });
+
+    // 2. Start pairing flow -> QR URL
+    const { pairUrl, channelId } =
+      await test.step('Start pairing flow on authority', async () => {
+        const url = await startPairingFlow(client);
+        debug(`Pair URL: ${url}`);
+        expect(url).toBeTruthy();
+        expect(url).toContain('/pair#');
+        expect(url).toContain('channel_id=');
+
+        const id = extractChannelId(url);
+        expect(id).toBeTruthy();
+        return { pairUrl: url, channelId: id };
+      });
+
+    // 3. Launch iOS supplicant in background
+    const xcuitest = await test.step('Launch iOS supplicant', async () => {
+      const result = launchXCUITest(
+        pairUrl,
+        target.contentServerUrl,
+        'testPairingWithUrl',
+        testInfo.outputPath('ios-xcodebuild.log')
+      );
+      debug('Launched xcodebuild for iOS supplicant');
+      return result;
+    });
+
+    // 4. Wait for supplicant to connect, then approve on authority
+    await test.step('Authority approves pairing', async () => {
+      expect(signedInUser.uid).toBeTruthy();
+      const authorityOAuthUrl = buildAuthorityOAuthUrl(
+        target.contentServerUrl,
+        {
+          email: credentials.email,
+          uid: signedInUser.uid as string,
+          channelId,
+        },
+        useReact
+      );
+
+      await client.setContext('content');
+
+      // The iOS app needs time to: boot (~10s) + navigate UI (~5s) +
+      // enter URL + tap Connect (~5s) + Rust FxA beginPairingFlow (~10s).
+      // Total ~30-40s. Use 45s to be safe.
+      debug('Waiting 45s for iOS app to boot and connect to channel...');
+      await sleep(45_000);
+
+      debug(`Navigating authority to: ${authorityOAuthUrl}`);
+      await client.navigate(authorityOAuthUrl);
+
+      // Wait for the page to settle and check we're not already at failure
+      await sleep(3_000);
+      const { url: preApproveUrl } = await captureDiagnostics(client);
+      debug(`Authority URL before approve: ${preApproveUrl}`);
+      await screenshotAuthority(client, 'iOS', '2-auth-approve');
+
+      // Dump the page HTML to help debug missing buttons
+      try {
+        const pageHtml = await client.executeScript(
+          'return document.documentElement.outerHTML.substring(0, 5000);',
+          { sandbox: 'default' }
+        );
+        debug(`Authority page HTML (first 5000 chars): ${pageHtml}`);
+      } catch (htmlErr) {
+        debug(`Could not capture page HTML: ${htmlErr}`);
+      }
+
+      // Log all visible buttons on the page
+      try {
+        const buttons = await client.executeScript(
+          `return Array.from(document.querySelectorAll('button, [type="submit"], [data-testid]'))
+              .map(el => ({ tag: el.tagName, text: el.textContent?.trim(), testid: el.dataset?.testid, type: el.type, visible: el.offsetParent !== null }))
+              .slice(0, 20);`,
+          { sandbox: 'default' }
+        );
+        debug(`Authority page buttons: ${JSON.stringify(buttons)}`);
+      } catch (btnErr) {
+        debug(`Could not enumerate buttons: ${btnErr}`);
+      }
+
+      if (preApproveUrl.includes('pair/failure')) {
+        throw new Error(
+          `Authority reached /pair/failure before approve. ` +
+            `Supplicant likely did not connect to channel in time.`
+        );
+      }
+
+      const approveBtn = await findElementBySelectors(
+        client,
+        SELECTORS.AUTHORITY_APPROVE,
+        30_000 // longer timeout — supplicant may still be connecting
+      );
+      await client.clickElement(approveBtn);
+      debug('Authority approved pairing');
+      await screenshotAuthority(client, 'iOS', '3-auth-approved');
+    });
+
+    // 5. Wait for authority to reach completion page
+    await test.step('Verify authority completion', async () => {
+      // After approve, authority should navigate through:
+      //   /pair/auth/allow -> /pair/auth/wait_for_supp -> /pair/auth/complete
+      // Give 30s for the supplicant to complete OAuth.
+      const finalUrl = await waitForUrlContaining(
+        client,
+        'pair/auth/complete',
+        30_000
+      );
+      expect(finalUrl).not.toContain('pair/failure');
+      debug(`Authority completed at: ${finalUrl}`);
+      await screenshotAuthority(client, 'iOS', '4-auth-complete');
+    });
+
+    // 6. Wait for iOS XCUITest to finish
+    await test.step('Wait for iOS XCUITest completion', async () => {
+      await xcuitest.promise;
+      debug('iOS pairing test completed successfully');
+    });
+
+    // 7. Verify the iOS device was registered on the account
+    await test.step('Verify iOS device is signed in', async () => {
+      const devices = await target.authClient.deviceList(
+        credentials.sessionToken
+      );
+      debug(
+        `Account devices: ${JSON.stringify(devices.map((d: any) => ({ name: d.name, type: d.type })))}`
+      );
+      expect(devices.length).toBeGreaterThanOrEqual(2);
+      const iosDevice = devices.find(
+        (d: any) => d.type === 'mobile' || /iOS|iPhone|iPad/i.test(d.name || '')
+      );
+      expect(iosDevice).toBeTruthy();
+      debug(`iOS device found: ${iosDevice.name} (type: ${iosDevice.type})`);
+    });
+  });
+
+  test('iOS supplicant cancels pairing and is not signed in', async ({
+    target,
+    testAccountTracker,
+    marionetteAuthority,
+  }, testInfo) => {
+    const client = marionetteAuthority.client;
+    const useReact = useReactPairRoutes;
+
+    const credentials = await test.step('Create test account', async () => {
+      const creds = await testAccountTracker.signUp();
+      debug(`Account created: ${creds.email}`);
+      return creds;
+    });
+
+    const signedInUser =
+      await test.step('Sign in authority via Marionette', async () => {
+        await signInAuthorityViaMarionette(
+          client,
+          target.contentServerUrl,
+          credentials.email,
+          credentials.password,
+          undefined,
+          useReact
+        );
+        const user = await getSignedInUser(client);
+        expect(user.signedIn).toBe(true);
+        debug(`Authority signed in as ${user.email}`);
+        return user;
+      });
+
+    const { pairUrl, channelId } =
+      await test.step('Start pairing flow on authority', async () => {
+        const url = await startPairingFlow(client);
+        debug(`Pair URL: ${url}`);
+        expect(url).toContain('/pair#');
+        expect(url).toContain('channel_id=');
+        const id = extractChannelId(url);
+        expect(id).toBeTruthy();
+        return { pairUrl: url, channelId: id };
+      });
+
+    // Launch the iOS cancel test first so the app can boot in parallel.
+    const xcuitest = await test.step('Launch iOS cancel test', async () => {
+      const result = launchXCUITest(
+        pairUrl,
+        target.contentServerUrl,
+        'testPairingCancelledByUser',
+        testInfo.outputPath('ios-xcodebuild.log')
+      );
+      debug('Launched xcodebuild for iOS cancel test');
+      return result;
+    });
+
+    // Navigate authority to approval page after giving the iOS app time
+    // to boot. The supplicant connects to the channel, but the handshake
+    // only completes once the authority is on the approval page.
+    await test.step('Authority navigates to approval page', async () => {
+      expect(signedInUser.uid).toBeTruthy();
+      const authorityOAuthUrl = buildAuthorityOAuthUrl(
+        target.contentServerUrl,
+        {
+          email: credentials.email,
+          uid: signedInUser.uid as string,
+          channelId,
+        },
+        useReact
+      );
+
+      // Wait for the iOS app to boot and enter the pairing URL
+      debug('Waiting 45s for iOS app to boot and connect to channel...');
+      await sleep(45_000);
+
+      debug(`Navigating authority to: ${authorityOAuthUrl}`);
+      await client.setContext('content');
+      await client.navigate(authorityOAuthUrl);
+
+      // Wait for the approve button to confirm the page loaded
+      await findElementBySelectors(client, SELECTORS.AUTHORITY_APPROVE, 30_000);
+      debug('Authority approval page loaded');
+      await screenshotAuthority(client, 'iOS-cancel', '1-auth-approve');
+    });
+
+    // Wait for iOS XCUITest to finish (supplicant taps Cancel)
+    await test.step('Wait for iOS XCUITest completion', async () => {
+      await xcuitest.promise;
+      debug('iOS cancel test completed successfully');
+    });
+
+    // Verify the iOS device was NOT registered on the account
+    await test.step('Verify no new device registered', async () => {
+      const devices = await target.authClient.deviceList(
+        credentials.sessionToken
+      );
+      debug(
+        `Account devices: ${JSON.stringify(devices.map((d: any) => ({ name: d.name, type: d.type })))}`
+      );
+      const iosDevice = devices.find(
+        (d: any) => d.type === 'mobile' || /iOS|iPhone|iPad/i.test(d.name || '')
+      );
+      expect(iosDevice).toBeFalsy();
+      debug('No iOS device registered (as expected after cancel)');
+    });
+  });
+});


### PR DESCRIPTION
## Because

- FxA device pairing (QR sign-in) had no automated end-to-end coverage for mobile supplicants, so regressions in the authority/supplicant handshake could only be caught by manual testing.

## This pull request

- Adds `android-supplicant.ts`, an adb-driven Fenix debug driver (device readiness, Sync Debug deep link, pairing-URL injection, tap/swipe/scroll helpers).
- Adds `pairingFlowAndroid.spec.ts`, driving a Marionette desktop authority + Android supplicant to a completed pairing and asserting device registration (`type=mobile, commands=2`).
- Adds `pairingFlowiOS.spec.ts`, orchestrating the iOS supplicant side (Simulator + XCUITest) of the same flow.
- Gates both specs behind `ANDROID_PAIRING_ENABLED` / `IOS_PAIRING_ENABLED` (including in `beforeAll`), so they skip cleanly in CI with no emulator/simulator setup.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14161

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

- Developer setup/debugging docs live in `docs/pairing/README.md` (added in the FXA-13884 PR).
- **How to run (Android):** boot an emulator with a Fenix debug build (Sync Debug pairing hook, Bug 2053454), start the FxA stack, `yarn adb-reverse`, then `ANDROID_PAIRING_ENABLED=1 npx playwright test pairingFlowAndroid --project=local`.
- CI: env-gated, skip by default (no mobile setup needed).
