### PR TITLE
bug(auth-server): Let FxA's front-end turn off the server-sent signin OTP

### DIFF
--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { EmailHeader, EmailType } from '../../lib/email';
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
@@ -120,6 +121,154 @@ test.describe('severity-2 #smoke', () => {
 
       // Verify logged in on Settings page
       await expect(settings.settingsHeading).toBeVisible();
+    });
+
+    test('forced signin confirmation sends exactly one verifyLoginCode email', async ({
+      target,
+      pages: { page, settings, signin, signinTokenCode },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'depends on SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX, which only matches sync*@restmail.net locally'
+      );
+      // A "dormant" account: the primary email is verified, but the auth-server
+      // forces sign-in confirmation, so the session is created unverified and
+      // signin lands on /signin_token_code. The `sync` prefix is what matches
+      // the forced-confirmation regex.
+      const credentials = await testAccountTracker.signUpSync();
+      await target.emailClient.clear(credentials.email);
+
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await expect(page).toHaveURL(/signin_token_code/);
+
+      // Read the code from the header rather than using `getVerifyLoginCode`,
+      // which clears the whole inbox and would destroy the evidence this test
+      // exists to count.
+      const code = await target.emailClient.waitForEmail(
+        credentials.email,
+        EmailType.verifyLoginCode,
+        EmailHeader.signinCode
+      );
+      await signinTokenCode.fillOutCodeForm(code);
+      await expect(settings.settingsHeading).toBeVisible();
+
+      // `newDeviceLogin` is sent by /session/verify_code, strictly after both
+      // possible senders of the code email and through the same mailer. Waiting
+      // for it is a causal barrier rather than an arbitrary sleep: once it
+      // arrives, any duplicate has had at least as long to arrive.
+      await target.emailClient.waitForEmail(
+        credentials.email,
+        EmailType.newDeviceLogin
+      );
+
+      expect(
+        await target.emailClient.countEmailsByType(
+          credentials.email,
+          EmailType.verifyLoginCode
+        ),
+        'signin should send one confirmation code email, not one per sender (FXA-14109)'
+      ).toBe(1);
+    });
+
+    test('unverified signin keeps the server-sent verifyLoginCode email', async ({
+      target,
+      syncBrowserPages: { confirmSignupCode, page, signin },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUpSync({
+        lang: 'en',
+        preVerified: 'false',
+      });
+      await target.emailClient.clear(credentials.email);
+
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await expect(page).toHaveURL(/confirm_signup_code/);
+      await expect(confirmSignupCode.heading).toBeVisible();
+
+      // Barrier: the client's `/session/resend_code` sends `verifyShortCode` on
+      // this path regardless of the flag, so it arrives whether or not the
+      // server-sent email was silenced. Waiting on it means a missing
+      // `verifyLoginCode` surfaces as the count assertion below rather than as
+      // an opaque EmailTimeout.
+      await target.emailClient.waitForEmail(
+        credentials.email,
+        EmailType.verifyShortCode,
+        EmailHeader.shortCode
+      );
+
+      // The unverified-account path must keep its server-sent `verifyLoginCode`.
+      // `sendSigninVerificationEmail` is deliberately scoped to the unverified-
+      // *session* path; widening it to the shared `sendVerifyLoginCodeEmail`
+      // helper silences this email, leaving the user with only the
+      // `verifyShortCode` above — a different template (FXA-14109).
+      expect(
+        await target.emailClient.countEmailsByType(
+          credentials.email,
+          EmailType.verifyLoginCode
+        ),
+        'the signup path must keep its server-sent verifyLoginCode email'
+      ).toBe(1);
+    });
+
+    test('servicesWithEmailVerification RP gets exactly one verifyLoginCode email', async ({
+      target,
+      pages: { page, signin, signinTokenCode },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'depends on SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX, which only matches sync*@restmail.net locally'
+      );
+      // `32aaeb6f1c21316a` is in `servicesWithEmailVerification`, the config list
+      // that makes the auth-server send the code even for RP flows that would
+      // otherwise skip the code screen. That combination — server would send,
+      // front-end must also route to the code screen — is the case most at risk
+      // of ending up with zero emails if the two sides disagree (FXA-14109).
+      const credentials = await testAccountTracker.signUpSync();
+      await target.emailClient.clear(credentials.email);
+
+      const params = new URLSearchParams({
+        client_id: '32aaeb6f1c21316a',
+        redirect_uri: 'http://localhost:3035/api/auth/callback/fxa',
+        scope: 'https://identity.mozilla.com/account/subscriptions',
+        response_type: 'code',
+        state: 'fakestate',
+        code_challenge_method: 'S256',
+        code_challenge: '2oc_C4v1qHeefWAGu5LI5oDG1oX4FV_Itc148D8_oQI',
+      });
+      await page.goto(`${target.contentServerUrl}/authorization?${params}`);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await expect(page).toHaveURL(/signin_token_code/);
+
+      const code = await target.emailClient.waitForEmail(
+        credentials.email,
+        EmailType.verifyLoginCode,
+        EmailHeader.signinCode
+      );
+      await signinTokenCode.fillOutCodeForm(code);
+
+      // Deliberately no assertion on where the browser lands — the RP redirect
+      // target may not be running locally. Verification completes server-side
+      // when the code is submitted, so newDeviceLogin still sends and remains a
+      // valid barrier.
+      await target.emailClient.waitForEmail(
+        credentials.email,
+        EmailType.newDeviceLogin
+      );
+
+      expect(
+        await target.emailClient.countEmailsByType(
+          credentials.email,
+          EmailType.verifyLoginCode
+        ),
+        'an RP in servicesWithEmailVerification should get exactly one code email'
+      ).toBe(1);
     });
 
     test('with bounced email', async ({

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -116,6 +116,11 @@ export type SignInOptions = {
   metricsContext?: MetricsContext;
   postPasswordUpgrade?: boolean;
   skipPasswordUpgrade?: boolean;
+  // Whether the server should send the sign-in verification code email. Defaults
+  // to true when omitted. Pass false only if the caller sends the code itself
+  // (via `sessionResendVerifyCode`) when it presents the code entry screen,
+  // otherwise no code reaches the user.
+  sendSigninVerificationEmail?: boolean;
 };
 
 export type SignedInAccountData = {

--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -240,6 +240,14 @@ const DESCRIPTIONS = {
     'Opaque URL-encoded string to be included in the verification link as a query parameter.',
   scope:
     'A space-separated list of scope values that the user has authorized, or is held by the granted access token that the connecting client will be granted. The requested scope will be provided by the connecting client as part of its authorization request, but may be pruned by the user in a confirmation dialog before being sent to this endpoint.',
+  sendSigninVerificationEmail: dedent`
+    Whether the server should send the sign-in verification code email. Defaults to
+    \`true\` when omitted, so clients integrating with this API directly keep receiving
+    it — including those that render their own verification UI, which this send exists
+    for. Set to \`false\` if the caller sends the code itself (via \`/session/resend_code\`)
+    when it presents the code entry screen, as FxA's own web front-end does. Applies
+    only to the \`verifyLoginCode\` email; link-based confirmation emails are unaffected.
+  `,
   sendVerifyEmail:
     'Boolean indicating whether a verification email should be sent.',
   service: 'Opaque alphanumeric token to be included in verification links.',

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -2976,6 +2976,10 @@ export const accountRoutes = (
             verificationMethod: validators.verificationMethod
               .optional()
               .description(DESCRIPTION.verificationMethod),
+            sendSigninVerificationEmail: isA
+              .boolean()
+              .optional()
+              .description(DESCRIPTION.sendSigninVerificationEmail),
           }),
         },
         response: {

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -152,6 +152,9 @@ module.exports = function (
             metricsContext: METRICS_CONTEXT_SCHEMA,
             originalLoginEmail: validators.email().optional(),
             verificationMethod: validators.verificationMethod.optional(),
+            // Reauth shares `sendSigninNotifications` with /account/login, so it
+            // honours the same flag for clients that send the code themselves.
+            sendSigninVerificationEmail: isA.boolean().optional(),
           }),
         },
         response: {

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -310,6 +310,16 @@ module.exports = (
       const isUnverifiedAccount = !accountRecord.primaryEmail.isVerified;
       const wantsKeys = requestHelper.wantsKeys(request);
 
+      // Defaults to sending. Everyone who omits the flag keeps the server-sent
+      // copy — including the RPs that render their own verification UI against
+      // this API, which is the reason this send exists in the first place. Our
+      // own web front-end passes `false` and sends the code itself via
+      // `/session/resend_code`, so the send is coupled to the navigation that
+      // actually prompts for it. Applies only to the unverified-*session* code
+      // email; see `sendVerifySessionEmail` for why. See FXA-14109.
+      const sendSigninVerificationEmail =
+        request.payload.sendSigninVerificationEmail !== false;
+
       let sessions;
 
       const { deviceId, flowId, flowBeginTime } =
@@ -479,7 +489,19 @@ module.exports = (
             return await sendVerifyLoginEmail();
           case 'email-2fa':
           case 'email-otp':
-            // Sends an email containing a code that can verify a login
+            // Sends an email containing a code that can verify a login.
+            // Scoped to this path deliberately. The unverified-account path
+            // (`sendVerifyAccountEmail`) must keep sending even when the flag is
+            // false, because the client's stand-in — `/session/resend_code` —
+            // sends a *different* template (`verifyShortCode`) when the primary
+            // email is unverified. Turning this off there would silently change
+            // which email a signing-up user receives (FXA-14109).
+            if (!sendSigninVerificationEmail) {
+              log.info('account.token.code.suppressed', {
+                uid: accountRecord.uid,
+              });
+              return;
+            }
             return await sendVerifyLoginCodeEmail();
           case 'email-captcha':
             // `email-captcha` is a custom verification method used only for

--- a/packages/fxa-auth-server/lib/routes/utils/signin.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.spec.ts
@@ -1335,6 +1335,117 @@ describe('sendSigninNotifications', () => {
     });
   });
 
+  // FXA-14109: defaults to sending, so direct API consumers that never set the
+  // flag keep the server send whatever UI they render. Our own web front-end
+  // passes false and sends the OTP itself via /session/resend_code when it shows
+  // the code entry screen, so the user gets one email rather than two.
+  describe('sendSigninVerificationEmail', () => {
+    beforeEach(() => {
+      mocks.mockOAuthClientInfo();
+      sessionToken.tokenVerified = false;
+      request.payload.service = '32aaeb6f1c21316a';
+    });
+
+    it('sends the code email when the flag is omitted, preserving behavior for direct API consumers', async () => {
+      await sendSigninNotifications(
+        request,
+        accountRecord,
+        sessionToken,
+        'email-otp'
+      );
+
+      expect(fxaMailer.sendVerifyLoginCodeEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends the code email when the flag is explicitly true', async () => {
+      request.payload.sendSigninVerificationEmail = true;
+
+      await sendSigninNotifications(
+        request,
+        accountRecord,
+        sessionToken,
+        'email-otp'
+      );
+
+      expect(fxaMailer.sendVerifyLoginCodeEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not send the code email for an unverified session when the flag is false', async () => {
+      request.payload.sendSigninVerificationEmail = false;
+
+      await sendSigninNotifications(
+        request,
+        accountRecord,
+        sessionToken,
+        'email-otp'
+      );
+
+      expect(fxaMailer.sendVerifyLoginCodeEmail).not.toHaveBeenCalled();
+      expect(mailer.sendVerifyLoginCodeEmail).not.toHaveBeenCalled();
+    });
+
+    // The flag is scoped to the unverified-session path. For an unverified
+    // account the client's stand-in (`/session/resend_code`) sends a different
+    // template (`verifyShortCode`), so honouring the flag here would change
+    // which email a signing-up user receives rather than just deduplicating.
+    it('still sends the code email for an unverified account when the flag is false', async () => {
+      accountRecord.primaryEmail.isVerified = false;
+      request.payload.sendSigninVerificationEmail = false;
+
+      await sendSigninNotifications(
+        request,
+        accountRecord,
+        sessionToken,
+        'email-otp'
+      );
+
+      expect(fxaMailer.sendVerifyLoginCodeEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit the email.tokencode.sent metric when the flag is false', async () => {
+      request.emitMetricsEvent = jest.fn(() => Promise.resolve());
+      request.payload.sendSigninVerificationEmail = false;
+
+      await sendSigninNotifications(
+        request,
+        accountRecord,
+        sessionToken,
+        'email-otp'
+      );
+
+      expect(request.emitMetricsEvent).not.toHaveBeenCalledWith(
+        'email.tokencode.sent'
+      );
+    });
+
+    it('still sends the link-based confirmation email when the flag is false', async () => {
+      request.payload.sendSigninVerificationEmail = false;
+
+      await sendSigninNotifications(
+        request,
+        accountRecord,
+        sessionToken,
+        'email'
+      );
+
+      expect(fxaMailer.sendVerifyLoginEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('still sends the account verification email when the flag is false and no OTP method is requested', async () => {
+      accountRecord.primaryEmail.isVerified = false;
+      request.payload.sendSigninVerificationEmail = false;
+
+      await sendSigninNotifications(
+        request,
+        accountRecord,
+        sessionToken,
+        undefined
+      );
+
+      expect(fxaMailer.sendVerifyEmail).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('when using CMS for emails', () => {
     it('uses CMS content for verifyLoginCode email', () => {
       sessionToken.tokenVerified = false;

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
@@ -292,6 +292,19 @@ describe('signin unblock container', () => {
     expect(tryFinalizeUpgrade).toHaveBeenCalledTimes(1);
   });
 
+  // FXA-14109: handleNavigation sends the OTP as it routes to the code screen,
+  // so the auth-server must not send its own copy or the user gets two emails.
+  it('turns off the server-sent verification email', async () => {
+    await render();
+
+    await act(async () => {
+      await currentPageProps?.signinWithUnblockCode(MOCK_UNBLOCK_CODE);
+    });
+
+    const options = mockAuthClient.signInWithAuthPW.mock.calls[0]?.[2];
+    expect(options?.sendSigninVerificationEmail).toBe(false);
+  });
+
   it('handles signin with correct code and failure when looking up credential status', async () => {
     jest.spyOn(global.console, 'warn');
     // Mock credential status to fail

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -82,17 +82,23 @@ export const SigninUnblockContainer = ({
     const service = integration.getService();
     const clientId = integration.getClientId();
 
-    const options: SignInOptions = signInOptions ?? {
-      verificationMethod: VerificationMethods.EMAIL_OTP,
-      keys: integration.wantsKeys(),
-      // See oauth_client_info in the auth-server for details on service/clientId
-      // Sending up the clientId when the user is not signing in to the browser
-      // is used to show the correct service name in emails
-      ...(isFirefoxService(service) ? { service } : { service: clientId }),
-      unblockCode,
-      metricsContext: queryParamsToMetricsContext(
-        flowQueryParams as unknown as Record<string, string>
-      ),
+    const options: SignInOptions = {
+      ...(signInOptions ?? {
+        verificationMethod: VerificationMethods.EMAIL_OTP,
+        keys: integration.wantsKeys(),
+        // See oauth_client_info in the auth-server for details on service/clientId
+        // Sending up the clientId when the user is not signing in to the browser
+        // is used to show the correct service name in emails
+        ...(isFirefoxService(service) ? { service } : { service: clientId }),
+        unblockCode,
+        metricsContext: queryParamsToMetricsContext(
+          flowQueryParams as unknown as Record<string, string>
+        ),
+      }),
+      // We own the verification email in this flow: `handleNavigation` sends it
+      // as it routes to the code screen, so the server must not send its own
+      // copy (FXA-14109).
+      sendSigninVerificationEmail: false,
     };
 
     // Get credentials with the correct key version

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -703,6 +703,20 @@ describe('signin container', () => {
       expect(options?.service).toBeUndefined();
     });
 
+    // FXA-14109: handleNavigation sends the OTP as it routes to the code screen,
+    // so the auth-server must not send its own copy or the user gets two emails.
+    it('turns off the server-sent verification email', async () => {
+      render();
+      await waitFor(() => expect(currentSigninProps).toBeDefined());
+      await act(async () => {
+        await currentSigninProps?.beginSigninHandler(MOCK_EMAIL, MOCK_PASSWORD);
+      });
+
+      const options = (mockAuthClient.signInWithAuthPW as jest.Mock).mock
+        .calls[0]?.[2];
+      expect(options?.sendSigninVerificationEmail).toBe(false);
+    });
+
     describe('showInlineRecoveryKeySetup', () => {
       beforeEach(() => {
         mockSyncDesktopV3Integration();

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -738,6 +738,10 @@ export async function trySignIn(
         metricsContext: options.metricsContext,
         unblockCode: options.unblockCode,
         originalLoginEmail: options.originalLoginEmail,
+        // We own the verification email in this flow: `handleNavigation` sends it
+        // as it routes to the code screen, so the server must not send its own
+        // copy (FXA-14109).
+        sendSigninVerificationEmail: false,
       }
     );
 

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -397,7 +397,9 @@ describe('Signin utils', () => {
         const result = await handleNavigation(navigationOptions);
 
         expect(result.error).toBeUndefined();
-        expect(sessionResendVerifyCode).toHaveBeenCalledWith(MOCK_SESSION_TOKEN);
+        expect(sessionResendVerifyCode).toHaveBeenCalledWith(
+          MOCK_SESSION_TOKEN
+        );
         expect(mockNavigate).toHaveBeenCalledWith(
           '/confirm_signup_code',
           expect.any(Object)

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -297,8 +297,15 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
     // (/signin_token_code for an unverified session, or /confirm_signup_code for an
     // unverified email) and we know their session isn't fully verified, then send them
     // an otp code. Sending here couples the email with the actual navigation action.
+    // For /signin_token_code this is the only send: the login/reauth calls that
+    // reach here pass `sendSigninVerificationEmail: false` so the auth-server does
+    // not send its own copy, and the cached-signin paths perform no server-side
+    // login at all. /confirm_signup_code is unchanged from before — the server
+    // still sends there, because this resend produces a different template
+    // (`verifyShortCode`) for an unverified primary email (FXA-14109).
     if (
-      (to?.includes('signin_token_code') || to?.includes('confirm_signup_code')) &&
+      (to?.includes('signin_token_code') ||
+        to?.includes('confirm_signup_code')) &&
       navigationOptions.signinData.sessionToken &&
       navigationOptions.signinData.verificationMethod ===
         VerificationMethods.EMAIL_OTP
@@ -332,7 +339,8 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
         return { error };
       }
       if (to) {
-        performNavigation({ navigate,
+        performNavigation({
+          navigate,
           to,
           locationState,
           shouldHardNavigate,
@@ -368,7 +376,8 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
     if (navigationOptions.performNavigation !== false) {
       const { to, locationState, shouldHardNavigate } =
         await getNonOAuthNavigationTarget(navigationOptions);
-      performNavigation({ navigate,
+      performNavigation({
+        navigate,
         to,
         locationState,
         shouldHardNavigate,
@@ -409,7 +418,8 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
       if (to === '/post_verify/service_welcome') {
         navigate(to, { state: { origin: 'signin' }, replace: true });
       } else {
-        performNavigation({ navigate,
+        performNavigation({
+          navigate,
           to,
           locationState,
           shouldHardNavigate,


### PR DESCRIPTION
## Because:
- Dormant accounts signing in through Settings received two identical OTP verification emails. The auth-server sends one from `sendSigninNotifications` during `/account/login`, and `handleNavigation` sends a second via `sessionResendVerifyCode` as it routes to the code screen.

- The decision was made in #20601 to move the code sending logic to front end. In theory this stopped the code from being sent when a user was never prompted for one. In practice we had this 'dormant' account state that wasn't accounted for, and had no test coverage. As a result, the change wasn't full proof.

## This PR:
- Adds an optional `sendSigninVerificationEmail` payload flag to `/account/login` and `/session/reauth`. **It defaults to `true` when omitted**, so the safe default is the existing behavior — a client (ie front end) has to opt out deliberately. This makes the API level change non-breaking and backwards compatible.

- For this `sendSigninVerificationEmail` flag, FxA will now provide `false` — the fxa-settings password and unblock sign-in paths, which reach `handleNavigation` and send the code themselves. `handleNavigation` is restored to sending unconditionally and is once again the sole sender on `/signin_token_code` for our web UI.

## Issue that this pull request solves

Closes: FXA-14109, FXA-12972

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

To test manually, do the following comparison:

 1. Check out main
 2. Set your dev.json in auth server follows 
<img width="364" height="128" alt="image" src="https://github.com/user-attachments/assets/d262f6fb-5930-44b9-91c0-557606e26851" />

 3. Go to http://localhost:30303, and create an account. Be sure to set a password!
 4. Run `yarn firefox` to spin up a Firefox instance where sync is pointed at local host.
 5. Wait at least 1 minute since you created that account in step 3.
 6. Try signing in. You'll see two emails. The trigger here is the fact the account was created more than 1 minute ago.

Now checkout this branch and repeat the steps. You'll see only one email is sent.

- Key files: `lib/routes/utils/signin.js` (`sendVerifySessionEmail`, where the gate sits), `pages/Signin/utils.ts` (`handleNavigation`).


Manual testing is a good idea for this PR, because automated testing is not possible at the time of writing due to the requirement that we have a 'dormant' account. The back to back comparison described above is the best way to ensure this is actually working. 

## Screenshots (Optional)

N/A — no user interface change.

## Other information (Optional)

Claude Called this out specifically as the risky part! "A flow where the server *would* have sent but our front-end does not land on a code screen would leave the user with no email. Each server-send branch (`wantsKeys`, no service, service in `servicesWithEmailVerification`, `passwordChangeRequired`) maps to a `handleNavigation` branch that routes to a code screen. **`service=vpn` is the one to watch**, since it is in `servicesWithEmailVerification`."

As far as I can tell, this not an issue. Legacy clients like the VPN app itself will fallback to the old behavior, because of the nature of the `sendSigninVerificationEmail` flag. When it is not defined, we default to true state, which ensures the original behavior is preserved. And all web flows that direct users to the `/signin_token_code` page will now trigger an email send from the front end as this navigation decision is made. 
