### PR TITLE
fix(settings): match passkey password-fallback error handling to sign-in

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.test.tsx
@@ -269,23 +269,39 @@ describe('SigninPasskeyFallback container', () => {
       });
     });
 
-    it('renders an error banner when sessionReauth throws', async () => {
+    it('shows the incorrect-password error in the field tooltip and disables Continue', async () => {
       mockSessionReauth.mockRejectedValueOnce({
-        errno: 103,
+        errno: AuthUiErrors.INCORRECT_PASSWORD.errno,
         message: 'Incorrect password',
       });
-      const { getByTestId, findByText } = render();
+      const { getByTestId, findByTestId, queryByRole } = render();
       submitPassword(getByTestId);
-      expect(await findByText(/Incorrect password/i)).toBeInTheDocument();
+      expect(await findByTestId('tooltip')).toHaveTextContent(
+        /Incorrect password/i
+      );
+      expect(queryByRole('alert')).not.toBeInTheDocument();
+      expect(getByTestId('continue-button')).toBeDisabled();
     });
 
-    it('renders an error banner when handleNavigation returns an error', async () => {
-      mockHandleNavigation.mockResolvedValueOnce({
-        error: { errno: 103, message: 'Incorrect password' },
+    it('shows a banner for a non-password reauth error', async () => {
+      mockSessionReauth.mockRejectedValueOnce({
+        errno: AuthUiErrors.UNEXPECTED_ERROR.errno,
+        message: 'Unexpected error',
       });
-      const { getByTestId, findByText } = render();
+      const { getByTestId, findByRole, queryByTestId } = render();
       submitPassword(getByTestId);
-      expect(await findByText(/Incorrect password/i)).toBeInTheDocument();
+      expect(await findByRole('alert')).toBeInTheDocument();
+      expect(queryByTestId('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('shows a banner when handleNavigation returns an error', async () => {
+      mockHandleNavigation.mockResolvedValueOnce({
+        error: { errno: 999, message: 'Nav broke' },
+      });
+      const { getByTestId, findByRole, queryByTestId } = render();
+      submitPassword(getByTestId);
+      expect(await findByRole('alert')).toBeInTheDocument();
+      expect(queryByTestId('tooltip')).not.toBeInTheDocument();
     });
   });
 
@@ -369,7 +385,7 @@ describe('SigninPasskeyFallback container', () => {
       });
     });
 
-    it('fires submit_frontend_error with reason=server_error when handleNavigation returns an error', async () => {
+    it('fires submit_frontend_error with reason=navigation_error when handleNavigation returns an error', async () => {
       mockHandleNavigation.mockResolvedValueOnce({
         error: { errno: 999, message: 'Nav broke' },
       });
@@ -378,7 +394,7 @@ describe('SigninPasskeyFallback container', () => {
       await waitFor(() => {
         expect(
           GleanMetrics.passkeyEnterPassword.submitFrontendError
-        ).toHaveBeenCalledWith({ event: { reason: 'server_error' } });
+        ).toHaveBeenCalledWith({ event: { reason: 'navigation_error' } });
       });
       expect(GleanMetrics.passkeyEnterPassword.success).not.toHaveBeenCalled();
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
@@ -25,7 +25,7 @@ import { SigninLocationState } from '../interfaces';
 import { buildPasskeyAuthSuccessReason } from '../../../lib/passkeys/signin-flow';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
 import { QueryParams } from '../../..';
-import SigninPasskeyFallback from '.';
+import SigninPasskeyFallback, { SigninPasskeyFallbackContinueError } from '.';
 
 // Password step for accounts that signed in with a passkey but still need the
 // account password to unwrap Sync encryption keys.
@@ -51,7 +51,6 @@ const SigninPasskeyFallbackContainer = ({
 
   // Falls back to cached localStorage account so the page survives refresh.
   const signinState = getSigninState(location.state);
-  const [localizedErrorMessage, setLocalizedErrorMessage] = useState('');
 
   const sessionToken = signinState?.sessionToken;
   const email = signinState?.email;
@@ -116,7 +115,9 @@ const SigninPasskeyFallbackContainer = ({
   }, [authClient, config, sessionToken]);
 
   const onContinue = useCallback(
-    async (password: string) => {
+    async (
+      password: string
+    ): Promise<SigninPasskeyFallbackContinueError | undefined> => {
       if (!sessionToken || !email || !uid) {
         navigateWithQuery('/');
         return;
@@ -143,8 +144,10 @@ const SigninPasskeyFallbackContainer = ({
             reason: isIncorrectPassword ? 'incorrect_password' : 'server_error',
           },
         });
-        setLocalizedErrorMessage(getLocalizedErrorMessage(ftlMsgResolver, err));
-        return;
+        return {
+          errno,
+          localizedErrorMessage: getLocalizedErrorMessage(ftlMsgResolver, err),
+        };
       }
 
       const { error: navError } = await handleNavigation({
@@ -172,12 +175,14 @@ const SigninPasskeyFallbackContainer = ({
       });
       if (navError) {
         GleanMetrics.passkeyEnterPassword.submitFrontendError({
-          event: { reason: 'server_error' },
+          event: { reason: 'navigation_error' },
         });
-        setLocalizedErrorMessage(
-          getLocalizedErrorMessage(ftlMsgResolver, navError)
-        );
-        return;
+        return {
+          localizedErrorMessage: getLocalizedErrorMessage(
+            ftlMsgResolver,
+            navError
+          ),
+        };
       }
 
       GleanMetrics.passkeyEnterPassword.success({
@@ -191,6 +196,7 @@ const SigninPasskeyFallbackContainer = ({
           reason: buildPasskeyAuthSuccessReason(passkeySurface, 'withpassword'),
         },
       });
+      return undefined;
     },
     [
       authClient,
@@ -229,7 +235,6 @@ const SigninPasskeyFallbackContainer = ({
       {...{
         email,
         onContinue,
-        localizedErrorMessage,
         avatarData,
         avatarLoading,
         passkeySurface,

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.stories.tsx
@@ -25,13 +25,3 @@ export const Default = () => (
     <SigninPasskeyFallback email="user@example.com" {...handlers} />
   </MemoryRouter>
 );
-
-export const WithError = () => (
-  <MemoryRouter>
-    <SigninPasskeyFallback
-      email="user@example.com"
-      localizedErrorMessage="Incorrect password"
-      {...handlers}
-    />
-  </MemoryRouter>
-);

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../../models/mocks';
 import SigninPasskeyFallback from '.';
 import GleanMetrics from '../../../lib/glean';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
@@ -47,14 +48,119 @@ describe('SigninPasskeyFallback', () => {
     expect(onContinue).toHaveBeenCalledWith('hunter2-the-sequel');
   });
 
-  it('shows a banner when localizedErrorMessage is set', () => {
-    renderWithRouter(
-      <SigninPasskeyFallback
-        email="user@example.com"
-        localizedErrorMessage="Incorrect password"
-      />
-    );
-    expect(screen.getByText('Incorrect password')).toBeInTheDocument();
+  describe('password error handling', () => {
+    const incorrectPassword = {
+      errno: AuthUiErrors.INCORRECT_PASSWORD.errno,
+      localizedErrorMessage: 'Incorrect password',
+    };
+    const passwordField = () => screen.getByTestId('password-input-field');
+    const continueButton = () => screen.getByTestId('continue-button');
+
+    it('shows a validation tooltip and does not call onContinue when submitted empty', async () => {
+      const user = userEvent.setup();
+      const onContinue = jest.fn().mockResolvedValue(undefined);
+      renderWithRouter(
+        <SigninPasskeyFallback
+          email="user@example.com"
+          onContinue={onContinue}
+        />
+      );
+      await user.click(continueButton());
+      expect(await screen.findByTestId('tooltip')).toHaveTextContent(
+        'Valid password required'
+      );
+      expect(onContinue).not.toHaveBeenCalled();
+    });
+
+    it('shows an incorrect-password error in the field tooltip, not the banner', async () => {
+      const user = userEvent.setup();
+      const onContinue = jest.fn().mockResolvedValue(incorrectPassword);
+      renderWithRouter(
+        <SigninPasskeyFallback
+          email="user@example.com"
+          onContinue={onContinue}
+        />
+      );
+      await user.type(passwordField(), 'wrong-password');
+      await user.click(continueButton());
+      expect(await screen.findByTestId('tooltip')).toHaveTextContent(
+        'Incorrect password'
+      );
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('disables Continue after an incorrect password until the field is edited', async () => {
+      const user = userEvent.setup();
+      const onContinue = jest.fn().mockResolvedValue(incorrectPassword);
+      renderWithRouter(
+        <SigninPasskeyFallback
+          email="user@example.com"
+          onContinue={onContinue}
+        />
+      );
+      await user.type(passwordField(), 'wrong-password');
+      await user.click(continueButton());
+      await screen.findByTestId('tooltip');
+      expect(continueButton()).toBeDisabled();
+
+      await user.type(passwordField(), '!');
+      expect(continueButton()).toBeEnabled();
+    });
+
+    it('clears the tooltip when the password is edited', async () => {
+      const user = userEvent.setup();
+      const onContinue = jest.fn().mockResolvedValue(incorrectPassword);
+      renderWithRouter(
+        <SigninPasskeyFallback
+          email="user@example.com"
+          onContinue={onContinue}
+        />
+      );
+      await user.type(passwordField(), 'wrong-password');
+      await user.click(continueButton());
+      expect(await screen.findByTestId('tooltip')).toBeInTheDocument();
+
+      await user.type(passwordField(), '!');
+      expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('does not resubmit the same password until it is edited', async () => {
+      const user = userEvent.setup();
+      const onContinue = jest.fn().mockResolvedValue(incorrectPassword);
+      renderWithRouter(
+        <SigninPasskeyFallback
+          email="user@example.com"
+          onContinue={onContinue}
+        />
+      );
+      await user.type(passwordField(), 'wrong-password');
+      await user.click(continueButton());
+      await screen.findByTestId('tooltip');
+
+      await user.click(continueButton());
+      expect(onContinue).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a non-password error in the banner and keeps Continue enabled', async () => {
+      const user = userEvent.setup();
+      const onContinue = jest.fn().mockResolvedValue({
+        errno: AuthUiErrors.UNEXPECTED_ERROR.errno,
+        localizedErrorMessage: 'Something went wrong',
+      });
+      renderWithRouter(
+        <SigninPasskeyFallback
+          email="user@example.com"
+          onContinue={onContinue}
+        />
+      );
+      await user.type(passwordField(), 'some-password');
+      await user.click(continueButton());
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        'Something went wrong'
+      );
+      expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+      expect(continueButton()).toBeEnabled();
+    });
   });
 
   describe('Glean events', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.tsx
@@ -12,13 +12,21 @@ import Avatar from '../../../components/Settings/Avatar';
 import { Banner } from '../../../components/Banner';
 import InputPassword from '../../../components/InputPassword';
 import GleanMetrics from '../../../lib/glean';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { AccountAvatar } from '../../../lib/interfaces';
 import { PasskeyMetricsSurface } from '../../../lib/passkeys/signin-flow';
+import { useFtlMsgResolver } from '../../../models';
+
+export type SigninPasskeyFallbackContinueError = {
+  errno?: number;
+  localizedErrorMessage: string;
+};
 
 export type SigninPasskeyFallbackProps = {
   email?: string;
-  onContinue?: (password: string) => Promise<void>;
-  localizedErrorMessage?: string;
+  onContinue?: (
+    password: string
+  ) => Promise<SigninPasskeyFallbackContinueError | void>;
   avatarData?: { account: { avatar: AccountAvatar } };
   avatarLoading?: boolean;
   passkeySurface?: PasskeyMetricsSurface;
@@ -33,13 +41,19 @@ export const viewName = 'signin-passkey-fallback';
 const SigninPasskeyFallback = ({
   email,
   onContinue,
-  localizedErrorMessage,
   avatarData,
   avatarLoading,
   passkeySurface = 'emailfirst',
 }: SigninPasskeyFallbackProps) => {
-  const [passwordErrorText, setPasswordErrorText] = useState('');
+  const ftlMsgResolver = useFtlMsgResolver();
+  const [passwordTooltipErrorText, setPasswordTooltipErrorText] = useState('');
+  const [bannerErrorText, setBannerErrorText] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const localizedValidPasswordError = ftlMsgResolver.getMsg(
+    'auth-error-1010',
+    'Valid password required'
+  );
 
   const { handleSubmit, register, watch } = useForm<FormData>({
     mode: 'onTouched',
@@ -67,28 +81,38 @@ const SigninPasskeyFallback = ({
   }, [hasEngaged, passwordValue, passkeySurface]);
 
   const handleContinue = useCallback(
-    async (data: FormData) => {
+    async ({ password }: FormData) => {
+      if (password === '') {
+        setPasswordTooltipErrorText(localizedValidPasswordError);
+        return;
+      }
       if (!onContinue) return;
       GleanMetrics.passkeyEnterPassword.submit({
         event: { reason: passkeySurface },
       });
       setIsSubmitting(true);
       try {
-        await onContinue(data.password);
+        const result = await onContinue(password);
+        if (result) {
+          const { errno, localizedErrorMessage: message } = result;
+          if (errno === AuthUiErrors.INCORRECT_PASSWORD.errno) {
+            setBannerErrorText('');
+            setPasswordTooltipErrorText(message);
+          } else {
+            setBannerErrorText(message);
+          }
+        }
       } finally {
         setIsSubmitting(false);
       }
     },
-    [onContinue, passkeySurface]
+    [onContinue, passkeySurface, localizedValidPasswordError]
   );
 
   return (
     <AppLayout>
-      {localizedErrorMessage && (
-        <Banner
-          type="error"
-          content={{ localizedHeading: localizedErrorMessage }}
-        />
+      {bannerErrorText && (
+        <Banner type="error" content={{ localizedHeading: bannerErrorText }} />
       )}
 
       <FtlMsg id="signin-passkey-fallback-header">
@@ -136,11 +160,12 @@ const SigninPasskeyFallback = ({
             name="password"
             label="Password"
             className="mb-6"
-            errorText={passwordErrorText}
+            errorText={passwordTooltipErrorText}
             anchorPosition="start"
+            tooltipPosition="bottom"
             autoFocus
-            onChange={() => setPasswordErrorText('')}
-            inputRef={register({ required: true })}
+            onChange={() => setPasswordTooltipErrorText('')}
+            inputRef={register()}
             prefixDataTestId="password"
           />
         </FtlMsg>
@@ -150,7 +175,7 @@ const SigninPasskeyFallback = ({
             type="submit"
             className="cta-primary cta-xl w-full"
             data-testid="continue-button"
-            disabled={isSubmitting}
+            disabled={isSubmitting || !!passwordTooltipErrorText}
           >
             Continue
           </button>

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -2857,9 +2857,11 @@ passkey_enter_password:
     extra_keys:
       reason:
         description: |
-          Reason the password entry failed: 'incorrect_password' (sessionReauth
-          rejected the password) or 'server_error' (the request failed for any
-          other reason).
+          Reason the sign-in did not complete after password entry:
+          'incorrect_password' (sessionReauth rejected the password),
+          'server_error' (the sessionReauth request failed for any other
+          reason), or 'navigation_error' (sessionReauth succeeded but the
+          post-reauth Sync/OAuth sign-in handoff failed).
         type: string
   success:
     type: event


### PR DESCRIPTION
## Because

- The passkey "enter password" fallback screen converts noticeably lower (~60%) than the general sign-in password step (~68%). Its error UX had diverged from sign-in: an incorrect password showed in a blocking top banner rather than a coaching inline message, users could keep clicking Continue on the same wrong password (unsure whether it submitted), and editing the field did not clear the error.
- Converging the fallback onto the established sign-in error model targets two of the ticket's hypotheses for the gap: blocking-vs-coaching UX, and repeated Continue clicks.

## This pull request

- Splits error display into two surfaces in `packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.tsx`: password-validation and incorrect-password errors render as an inline field tooltip, while all other errors render in the banner — matching `packages/fxa-settings/src/pages/Signin/index.tsx`.
- Keeps the Continue button disabled after a wrong password until the field is edited, and clears the tooltip on edit, preventing resubmission of the same password.
- Catches an empty submit client-side and shows a "Valid password required" tooltip (`auth-error-1010`) without calling the server.
- Moves error classification out of the container: `onContinue` in `container.tsx` now returns a classified `{ errno?, localizedErrorMessage }` result, and the component owns the tooltip/banner state.
- Relabels the post-reauth navigation-failure metric reason from `server_error` to `navigation_error` and documents it in `packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml`; removes the unreachable `PASSWORD_REQUIRED` (1010) routing branch.
- Updates the component and container tests and the Storybook story to match.

## Issue that this pull request solves

Issue: FXA-14131

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `SigninPasskeyFallback/index.tsx` (two-surface error routing, disable-until-edit) and `container.tsx` (the `onContinue` return contract).
- Suggested review order: `index.tsx` → `container.tsx` → `index.test.tsx` / `container.test.tsx` → `fxa-ui-metrics.yaml`.
- Risky or complex parts: the tooltip-vs-banner routing and disable-until-edit behaviour deliberately mirror the sign-in page (`packages/fxa-settings/src/pages/Signin/index.tsx`) and were validated against it.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

https://github.com/user-attachments/assets/8573ff1a-dc56-45c3-9a4d-1ce5ca0c4058

## Other information (Optional)

- Scope: this delivers the UX / error-handling portion of FXA-14131 only. The incorrect-password rate-limit/attempt changes (tied to blocked sign-ins, FXA-12983, on hold) and the "Forgot password?" UI are tracked separately and are out of scope here — hence `Issue:` rather than `Closes:`.
- The one non-`fxa-settings` file (`packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml`) is a description-only doc update to the existing `submit_frontend_error` metric's free-form `reason` key (adds `navigation_error`) — no new metric or key and no new data collection.
