### PR TITLE
bug(rate-limit): Fix value for blockDurationSeconds.

### DIFF
--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -813,6 +813,50 @@ describe('rate-limit', () => {
       );
     });
 
+    it('reports blockDurationSeconds in seconds, matching the block duration', async () => {
+      mockIncr.mockResolvedValue(6); // exceeds maxAttempts of 5
+      redis.set = jest.fn().mockResolvedValue('OK');
+
+      rateLimit = new RateLimit(
+        // 5 minute block duration => 300 seconds
+        { rules: parseConfigRules(['test:ip:5:1 minute:5 minutes:block']) },
+        redis,
+        statsd,
+        { write: mockWrite }
+      );
+
+      await rateLimit.check('test', { ip: '1.2.3.4' });
+
+      // The block's duration is already in seconds, so it must be reported
+      // as-is (300), not divided by 1000.
+      expect(mockWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          wasBlocked: true,
+          blockDurationSeconds: 300,
+        })
+      );
+    });
+
+    it('reports blockDurationSeconds as undefined when no block is triggered', async () => {
+      mockIncr.mockResolvedValue(1); // under maxAttempts of 5
+
+      rateLimit = new RateLimit(
+        { rules: parseConfigRules(['test:ip:5:1 minute:5 minutes:block']) },
+        redis,
+        statsd,
+        { write: mockWrite }
+      );
+
+      await rateLimit.check('test', { ip: '1.2.3.4' });
+
+      expect(mockWrite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          wasBlocked: false,
+          blockDurationSeconds: undefined,
+        })
+      );
+    });
+
     it('calls bqWriter.write on skip() with wasSkipped true', () => {
       rateLimit = new RateLimit(
         { rules: {}, ignoreIPs: ['127.0.0.1'] },

--- a/libs/accounts/rate-limit/src/lib/rate-limit.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.ts
@@ -265,7 +265,7 @@ export class RateLimit {
       wasBlocked: result != null,
       blockPolicy: result?.policy,
       blockDurationSeconds: result
-        ? Math.round(result.duration / 1000)
+        ? result.duration
         : undefined,
       wasSkipped,
       usedDefaultRule: firstRule?.isDefault ?? false,


### PR DESCRIPTION
## Because

- The `blockDurationSeconds` wasn't reporting the correct value.

## This pull request

- Removes the division by 1000. The value is already in seconds.

## Issue that this pull request solves

Closes: FXA-14167

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
