### PR TITLE
fix(payments-api): transform string to boolean before validation

### DIFF
--- a/apps/payments/api/src/config/index.ts
+++ b/apps/payments/api/src/config/index.ts
@@ -1,10 +1,5 @@
-import { Type } from 'class-transformer';
-import {
-  IsBoolean,
-  IsDefined,
-  IsOptional,
-  ValidateNested,
-} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsDefined, ValidateNested } from 'class-validator';
 
 import { CurrencyConfig } from '@fxa/payments/currency';
 import { MeteringConfig } from '@fxa/entitlements/metering';
@@ -96,8 +91,12 @@ export class RootConfig {
   @IsDefined()
   public readonly meteringConfig!: Partial<MeteringConfig>;
 
-  /** Serve interactive Swagger UI at /api-docs. Off by default; enable for local dev. */
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return value;
+  })
   @IsBoolean()
-  @IsOptional()
-  public readonly swaggerUi: boolean = false;
+  @IsDefined()
+  public readonly swaggerUi!: boolean;
 }


### PR DESCRIPTION
## Because

- payments-api fails to start up due to swagger_ui config failing boolean validation, since it is a string.

## This pull request

- Transform the string value provided by dotenv loader to a boolean before validation.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
