### PR TITLE
feat(passkeys): request PRF at sign-in to record capability

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.challenge.manager.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.challenge.manager.in.spec.ts
@@ -58,6 +58,7 @@ beforeAll(async () => {
     challengeTimeout: 1000 * 60 * 5,
     requestPrfAtRegistration: false,
     prfSalt: '',
+    requestPrfAtAuthentication: 'off',
   });
 
   const moduleRef = await buildTestModule(redis, config, mockLogger);
@@ -149,6 +150,7 @@ describe('PasskeyChallengeManager (integration)', () => {
         challengeTimeout: 1000,
         requestPrfAtRegistration: false,
         prfSalt: '',
+        requestPrfAtAuthentication: 'off',
       });
 
       const moduleRef = await buildTestModule(redis, shortConfig, mockLogger);

--- a/libs/accounts/passkey/src/lib/passkey.challenge.manager.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.challenge.manager.spec.ts
@@ -37,6 +37,7 @@ function makeConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
     rpId: 'accounts.firefox.com',
     requestPrfAtRegistration: false,
     prfSalt: '',
+    requestPrfAtAuthentication: 'off',
     ...overrides,
   });
 

--- a/libs/accounts/passkey/src/lib/passkey.config.ts
+++ b/libs/accounts/passkey/src/lib/passkey.config.ts
@@ -26,6 +26,18 @@ import type {
 export const MAX_PASSKEY_NAME_LENGTH = 255;
 
 /**
+ * Scope of the PRF-at-authentication request (see
+ * {@link PasskeyConfig.requestPrfAtAuthentication}).
+ *
+ * - `off`: never request PRF at sign-in (kill switch).
+ * - `keys-required`: request PRF only for keys-required (Sync) sign-ins — the
+ *   Phase-2-relevant cohort, lowest blast radius.
+ * - `all`: request PRF for every passkey sign-in, for fuller telemetry.
+ */
+export const PRF_AUTH_SCOPES = ['off', 'keys-required', 'all'] as const;
+export type PrfAuthScope = (typeof PRF_AUTH_SCOPES)[number];
+
+/**
  * Configuration for passkey (WebAuthn) functionality.
  *
  * This configuration is loaded from Convict in auth-server's config/index.ts
@@ -118,6 +130,13 @@ export class PasskeyConfig {
   public prfSalt!: string;
 
   /**
+   * Scope of the PRF request at sign-in. Off by default (kill switch).
+   * @see {@link PrfAuthScope}
+   */
+  @IsIn(PRF_AUTH_SCOPES)
+  public requestPrfAtAuthentication!: PrfAuthScope;
+
+  /**
    * Creates a new PasskeyConfig instance by copying all fields from the
    * provided options object.
    *
@@ -131,6 +150,7 @@ export class PasskeyConfig {
     this.maxPasskeysPerUser = opts.maxPasskeysPerUser;
     this.requestPrfAtRegistration = opts.requestPrfAtRegistration;
     this.prfSalt = opts.prfSalt;
+    this.requestPrfAtAuthentication = opts.requestPrfAtAuthentication;
     this.residentKey = opts.residentKey;
     this.rpId = opts.rpId;
   }

--- a/libs/accounts/passkey/src/lib/passkey.manager.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.in.spec.ts
@@ -36,6 +36,7 @@ describe('PasskeyManager (Integration)', () => {
     challengeTimeout: 30_000,
     requestPrfAtRegistration: false,
     prfSalt: '',
+    requestPrfAtAuthentication: 'off',
   });
 
   const mockMetrics = {

--- a/libs/accounts/passkey/src/lib/passkey.manager.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.spec.ts
@@ -29,6 +29,7 @@ jest.mock('./passkey.repository', () => ({
   insertPasskey: jest.fn(),
   updatePasskeyCounterAndLastUsed: jest.fn(),
   updatePasskeyName: jest.fn(),
+  updatePasskeyPrfEnabled: jest.fn(),
 }));
 
 const mockDb = {} as unknown as AccountDatabase;
@@ -43,6 +44,7 @@ const mockConfig = new PasskeyConfig({
   maxPasskeysPerUser: MOCK_MAX_PASSKEYS_PER_USER,
   requestPrfAtRegistration: false,
   prfSalt: '',
+  requestPrfAtAuthentication: 'off',
 });
 
 const mockMetrics = {
@@ -245,6 +247,36 @@ describe('PasskeyManager', () => {
 
       expect(result).toBe(false);
       expect(PasskeyRepository.updatePasskeyName).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setPasskeyPrfEnabled', () => {
+    const uid = Buffer.alloc(16, 1).toString('hex');
+    const credentialId = Buffer.alloc(32, 2).toString('base64url');
+
+    it('returns true when the repository rolls the flag forward', async () => {
+      (
+        PasskeyRepository.updatePasskeyPrfEnabled as jest.Mock
+      ).mockResolvedValue(1);
+
+      const result = await manager.setPasskeyPrfEnabled(uid, credentialId);
+
+      expect(result).toBe(true);
+      expect(PasskeyRepository.updatePasskeyPrfEnabled).toHaveBeenCalledWith(
+        mockDb,
+        uid,
+        credentialId
+      );
+    });
+
+    it('returns false when no row was updated (already true, not found, or wrong user)', async () => {
+      (
+        PasskeyRepository.updatePasskeyPrfEnabled as jest.Mock
+      ).mockResolvedValue(0);
+
+      const result = await manager.setPasskeyPrfEnabled(uid, credentialId);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/libs/accounts/passkey/src/lib/passkey.manager.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.ts
@@ -21,6 +21,7 @@ import {
   PasskeyRecord,
   updatePasskeyCounterAndLastUsed,
   updatePasskeyName,
+  updatePasskeyPrfEnabled,
 } from './passkey.repository';
 import { PasskeyConfig, MAX_PASSKEY_NAME_LENGTH } from './passkey.config';
 import { AppError } from '@fxa/accounts/errors';
@@ -162,6 +163,28 @@ export class PasskeyManager {
       uid,
       credentialId,
       newName
+    );
+    return rowsUpdated > 0;
+  }
+
+  /**
+   * Roll a passkey's `prfEnabled` flag forward from false to true.
+   *
+   * Monotonic: never flips an already-true flag back to false. Both uid and
+   * credentialId must match to prevent one user from flipping another user's
+   * passkey.
+   *
+   * @returns true if the flag was rolled false→true; false if it was already
+   *   true, the credential was not found, or it belongs to another user.
+   */
+  async setPasskeyPrfEnabled(
+    uid: string,
+    credentialId: string
+  ): Promise<boolean> {
+    const rowsUpdated = await updatePasskeyPrfEnabled(
+      this.db,
+      uid,
+      credentialId
     );
     return rowsUpdated > 0;
   }

--- a/libs/accounts/passkey/src/lib/passkey.provider.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.provider.spec.ts
@@ -15,6 +15,12 @@ import {
   RawPasskeyConfig,
 } from './passkey.provider';
 import Redis from 'ioredis';
+import * as Sentry from '@sentry/nestjs';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+}));
+const mockCaptureMessage = Sentry.captureMessage as jest.Mock;
 
 const VALID_RAW_CONFIG: RawPasskeyConfig = {
   enabled: true,
@@ -26,6 +32,7 @@ const VALID_RAW_CONFIG: RawPasskeyConfig = {
   authenticatorAttachment: '',
   requestPrfAtRegistration: false,
   prfSalt: '',
+  requestPrfAtAuthentication: 'off',
 };
 
 function buildModule(rawPasskeys: unknown) {
@@ -106,6 +113,7 @@ describe('PasskeyConfigProvider', () => {
       expect(config!.residentKey).toBe('required');
       expect(config!.requestPrfAtRegistration).toBe(false);
       expect(config!.prfSalt).toBe('');
+      expect(config!.requestPrfAtAuthentication).toBe('off');
     });
 
     it('copies a configured prfSalt', async () => {
@@ -195,6 +203,33 @@ describe('PasskeyConfigProvider', () => {
         })
       ).rejects.toThrow(
         'property prfSalt has failed the following constraints'
+      );
+    });
+  });
+
+  describe('requestPrfAtAuthentication normalization', () => {
+    beforeEach(() => {
+      mockCaptureMessage.mockClear();
+    });
+
+    it('copies a valid scope through unchanged', async () => {
+      const { config } = await buildModule({
+        ...VALID_RAW_CONFIG,
+        requestPrfAtAuthentication: 'all',
+      });
+      expect(config!.requestPrfAtAuthentication).toBe('all');
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    it('falls back to "off" and reports to Sentry for an invalid value', async () => {
+      const { config } = await buildModule({
+        ...VALID_RAW_CONFIG,
+        requestPrfAtAuthentication: 'sometimes',
+      });
+      expect(config!.requestPrfAtAuthentication).toBe('off');
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('sometimes'),
+        'warning'
       );
     });
   });

--- a/libs/accounts/passkey/src/lib/passkey.provider.ts
+++ b/libs/accounts/passkey/src/lib/passkey.provider.ts
@@ -5,8 +5,9 @@
 import { LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import * as Sentry from '@sentry/nestjs';
 import Redis from 'ioredis';
-import { PasskeyConfig } from './passkey.config';
+import { PasskeyConfig, PRF_AUTH_SCOPES, PrfAuthScope } from './passkey.config';
 import { validateSync } from 'class-validator';
 import type {
   AuthenticatorAttachment,
@@ -32,6 +33,8 @@ export type RawPasskeyConfig = {
   authenticatorAttachment: AuthenticatorAttachment | '';
   requestPrfAtRegistration: boolean;
   prfSalt: string;
+  /** Free-form string; normalized to a valid `PrfAuthScope` by `buildPasskeyConfig`. */
+  requestPrfAtAuthentication: string;
 };
 
 /**
@@ -40,6 +43,9 @@ export type RawPasskeyConfig = {
  * Normalizes `authenticatorAttachment`: an empty string (the Convict
  * no-preference sentinel) is converted to `undefined` so that the
  * WebAuthn library omits the field from registration options entirely.
+ * `requestPrfAtAuthentication` is likewise normalized to a valid scope,
+ * defaulting an unrecognized value to `'off'` (and reporting it) instead of
+ * throwing.
  *
  * @param raw - Raw config values read from Convict.
  * @returns A fully validated {@link PasskeyConfig} instance.
@@ -47,9 +53,26 @@ export type RawPasskeyConfig = {
  *   human-readable list of all validation errors.
  */
 export function buildPasskeyConfig(raw: RawPasskeyConfig): PasskeyConfig {
+  // Default an unrecognized scope to the "off" kill switch (and report it) so a
+  // bad stage/prod value degrades safely instead of crashing startup.
+  const requestPrfAtAuthentication = (
+    PRF_AUTH_SCOPES as readonly string[]
+  ).includes(raw.requestPrfAtAuthentication)
+    ? (raw.requestPrfAtAuthentication as PrfAuthScope)
+    : 'off';
+  if (requestPrfAtAuthentication !== raw.requestPrfAtAuthentication) {
+    Sentry.captureMessage(
+      `Invalid PASSKEYS__REQUEST_PRF_AT_AUTHENTICATION value ${JSON.stringify(
+        raw.requestPrfAtAuthentication
+      )}; defaulting to "off"`,
+      'warning'
+    );
+  }
+
   const passkeyConfig = new PasskeyConfig({
     ...raw,
     authenticatorAttachment: raw.authenticatorAttachment || undefined,
+    requestPrfAtAuthentication,
   });
 
   const errors = validateSync(passkeyConfig, {

--- a/libs/accounts/passkey/src/lib/passkey.repository.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.repository.in.spec.ts
@@ -144,7 +144,11 @@ describe('PasskeyRepository (Integration)', () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
       const passkey = PasskeyFactory({ uid: uidBuffer(uid1), signCount: 0 });
-      await PasskeyRepository.insertPasskey(db, uid1, toNewPasskeyData(passkey));
+      await PasskeyRepository.insertPasskey(
+        db,
+        uid1,
+        toNewPasskeyData(passkey)
+      );
 
       // Wrong uid — WHERE clause should prevent the update
       const success = await PasskeyRepository.updatePasskeyCounterAndLastUsed(
@@ -161,6 +165,115 @@ describe('PasskeyRepository (Integration)', () => {
         passkey.credentialId.toString('base64url')
       );
       expect(found?.signCount).toBe(0);
+    });
+  });
+
+  describe('updatePasskeyPrfEnabled (monotonic)', () => {
+    it('rolls prfEnabled forward from false to true', async () => {
+      const uid = await createTestAccount();
+      const passkey = PasskeyFactory({
+        uid: uidBuffer(uid),
+        prfEnabled: false,
+      });
+      await PasskeyRepository.insertPasskey(db, uid, toNewPasskeyData(passkey));
+
+      const rows = await PasskeyRepository.updatePasskeyPrfEnabled(
+        db,
+        uid,
+        passkey.credentialId.toString('base64url')
+      );
+
+      expect(rows).toBe(1);
+      const found = await PasskeyRepository.findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
+      expect(found?.prfEnabled).toBe(true);
+    });
+
+    it('is a no-op (0 rows) when prfEnabled is already true', async () => {
+      const uid = await createTestAccount();
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid), prfEnabled: true });
+      await PasskeyRepository.insertPasskey(db, uid, toNewPasskeyData(passkey));
+
+      const rows = await PasskeyRepository.updatePasskeyPrfEnabled(
+        db,
+        uid,
+        passkey.credentialId.toString('base64url')
+      );
+
+      expect(rows).toBe(0);
+      const found = await PasskeyRepository.findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
+      expect(found?.prfEnabled).toBe(true);
+    });
+
+    it('does not update when uid does not match the credential owner', async () => {
+      const uid1 = await createTestAccount();
+      const uid2 = await createTestAccount();
+      const passkey = PasskeyFactory({
+        uid: uidBuffer(uid1),
+        prfEnabled: false,
+      });
+      await PasskeyRepository.insertPasskey(
+        db,
+        uid1,
+        toNewPasskeyData(passkey)
+      );
+
+      const rows = await PasskeyRepository.updatePasskeyPrfEnabled(
+        db,
+        uid2,
+        passkey.credentialId.toString('base64url')
+      );
+
+      expect(rows).toBe(0);
+      const found = await PasskeyRepository.findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
+      expect(found?.prfEnabled).toBe(false);
+    });
+    it('does not update when the credential does not match', async () => {
+      const uid = await createTestAccount();
+      const passkey1 = PasskeyFactory({
+        uid: uidBuffer(uid),
+        prfEnabled: false,
+      });
+      const passkey2 = PasskeyFactory({
+        uid: uidBuffer(uid),
+        prfEnabled: false,
+      });
+      await PasskeyRepository.insertPasskey(
+        db,
+        uid,
+        toNewPasskeyData(passkey1)
+      );
+      await PasskeyRepository.insertPasskey(
+        db,
+        uid,
+        toNewPasskeyData(passkey2)
+      );
+
+      const rows = await PasskeyRepository.updatePasskeyPrfEnabled(
+        db,
+        uid,
+        passkey1.credentialId.toString('base64url')
+      );
+      // Should update passkey1 but not passkey2
+      expect(rows).toBe(1);
+      const found1 = await PasskeyRepository.findPasskeyByCredentialId(
+        db,
+        passkey1.credentialId.toString('base64url')
+      );
+      const found2 = await PasskeyRepository.findPasskeyByCredentialId(
+        db,
+        passkey2.credentialId.toString('base64url')
+      );
+      expect(found1?.prfEnabled).toBe(true);
+      expect(found2?.prfEnabled).toBe(false);
     });
   });
 });

--- a/libs/accounts/passkey/src/lib/passkey.repository.ts
+++ b/libs/accounts/passkey/src/lib/passkey.repository.ts
@@ -275,6 +275,31 @@ export async function updatePasskeyName(
 }
 
 /**
+ * Roll a passkey's `prfEnabled` flag forward from false to true. Monotonic: the
+ * `prfEnabled = false` guard means an already-true flag is never rewritten, so
+ * capability detected on one device can't be erased by a device lacking PRF.
+ * Scoped to both uid and credentialId so one user can't flip another's passkey.
+ *
+ * @returns Rows updated: 1 on a false→true flip, 0 when already true, not found,
+ *   or owned by another user.
+ */
+export async function updatePasskeyPrfEnabled(
+  db: AccountDatabase,
+  uid: string,
+  credentialId: string
+): Promise<number> {
+  const result = await db
+    .updateTable('passkeys')
+    .set({ prfEnabled: 1 })
+    .where('uid', '=', uuidTransformer.to(uid))
+    .where('credentialId', '=', base64urlToBuffer(credentialId))
+    .where('prfEnabled', '=', false)
+    .executeTakeFirst();
+
+  return Number(result.numUpdatedRows);
+}
+
+/**
  * Delete a specific passkey for a user.
  *
  * @param db - Database instance

--- a/libs/accounts/passkey/src/lib/passkey.service.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.spec.ts
@@ -99,6 +99,7 @@ describe('PasskeyService', () => {
     findPasskeyByCredentialId: jest.fn(),
     updatePasskeyAfterAuth: jest.fn(),
     renamePasskey: jest.fn(),
+    setPasskeyPrfEnabled: jest.fn(),
     deletePasskey: jest.fn(),
   };
 
@@ -128,6 +129,7 @@ describe('PasskeyService', () => {
     residentKey: 'required',
     requestPrfAtRegistration: false,
     prfSalt: '',
+    requestPrfAtAuthentication: 'off',
   });
 
   beforeEach(async () => {
@@ -631,6 +633,7 @@ describe('PasskeyService', () => {
       ).toHaveBeenCalledWith(mockConfig, {
         challenge: MOCK_CHALLENGE,
         allowCredentials: [],
+        requestPrf: false,
       });
     });
 
@@ -642,7 +645,7 @@ describe('PasskeyService', () => {
     it('includes user credential IDs in allowCredentials when uid is provided', async () => {
       mockManager.listPasskeysForUser.mockResolvedValue([mockPasskey]);
 
-      await service.generateAuthenticationChallenge(MOCK_UID);
+      await service.generateAuthenticationChallenge({ uid: MOCK_UID });
 
       expect(mockManager.listPasskeysForUser).toHaveBeenCalledWith(MOCK_UID);
       expect(
@@ -650,20 +653,105 @@ describe('PasskeyService', () => {
       ).toHaveBeenCalledWith(mockConfig, {
         challenge: MOCK_CHALLENGE,
         allowCredentials: [MOCK_CREDENTIAL_ID],
+        requestPrf: false,
       });
     });
 
     it('passes empty allowCredentials when user has no passkeys', async () => {
       mockManager.listPasskeysForUser.mockResolvedValue([]);
 
-      await service.generateAuthenticationChallenge(MOCK_UID);
+      await service.generateAuthenticationChallenge({ uid: MOCK_UID });
 
       expect(
         webauthnAdapter.generateWebauthnAuthenticationOptions
       ).toHaveBeenCalledWith(mockConfig, {
         challenge: MOCK_CHALLENGE,
         allowCredentials: [],
+        requestPrf: false,
       });
+    });
+
+    it('requests PRF and increments passkey.authentication.prf.requested under the all scope', async () => {
+      const configAll = new PasskeyConfig({
+        ...mockConfig,
+        requestPrfAtAuthentication: 'all',
+        prfSalt: 'dGVzdC1wcmYtc2FsdA',
+      });
+      const serviceAll = new PasskeyService(
+        mockManager as unknown as PasskeyManager,
+        mockChallengeManager as unknown as PasskeyChallengeManager,
+        configAll,
+        mockMetrics as never,
+        mockLogger as never
+      );
+
+      await serviceAll.generateAuthenticationChallenge({ keysRequired: false });
+
+      expect(
+        webauthnAdapter.generateWebauthnAuthenticationOptions
+      ).toHaveBeenCalledWith(configAll, {
+        challenge: MOCK_CHALLENGE,
+        allowCredentials: [],
+        requestPrf: true,
+      });
+      expect(mockMetrics.increment).toHaveBeenCalledWith(
+        'passkey.authentication.prf.requested'
+      );
+    });
+
+    it('does not request PRF (or increment the metric) when no salt is configured', async () => {
+      const configNoSalt = new PasskeyConfig({
+        ...mockConfig,
+        requestPrfAtAuthentication: 'all',
+        prfSalt: '',
+      });
+      const serviceNoSalt = new PasskeyService(
+        mockManager as unknown as PasskeyManager,
+        mockChallengeManager as unknown as PasskeyChallengeManager,
+        configNoSalt,
+        mockMetrics as never,
+        mockLogger as never
+      );
+
+      await serviceNoSalt.generateAuthenticationChallenge({
+        keysRequired: true,
+      });
+
+      expect(
+        webauthnAdapter.generateWebauthnAuthenticationOptions
+      ).toHaveBeenCalledWith(
+        configNoSalt,
+        expect.objectContaining({ requestPrf: false })
+      );
+      expect(mockMetrics.increment).not.toHaveBeenCalledWith(
+        'passkey.authentication.prf.requested'
+      );
+    });
+
+    it('requests PRF under keys-required scope only when keysRequired is true', async () => {
+      const configKeysRequired = new PasskeyConfig({
+        ...mockConfig,
+        requestPrfAtAuthentication: 'keys-required',
+        prfSalt: 'dGVzdC1wcmYtc2FsdA',
+      });
+      const serviceKeysRequired = new PasskeyService(
+        mockManager as unknown as PasskeyManager,
+        mockChallengeManager as unknown as PasskeyChallengeManager,
+        configKeysRequired,
+        mockMetrics as never,
+        mockLogger as never
+      );
+
+      await serviceKeysRequired.generateAuthenticationChallenge({
+        keysRequired: true,
+      });
+
+      expect(
+        webauthnAdapter.generateWebauthnAuthenticationOptions
+      ).toHaveBeenCalledWith(
+        configKeysRequired,
+        expect.objectContaining({ requestPrf: true })
+      );
     });
   });
 
@@ -883,6 +971,89 @@ describe('PasskeyService', () => {
         'passkey.authentication.failed',
         { reason: 'updateFailed' }
       );
+    });
+
+    describe('PRF roll-forward', () => {
+      it('rolls prfEnabled forward when prfSupported is true and the flag is currently false', async () => {
+        mockManager.setPasskeyPrfEnabled.mockResolvedValue(true);
+
+        const result = await service.verifyAuthenticationResponse(
+          mockResponse,
+          MOCK_CHALLENGE,
+          undefined,
+          true
+        );
+
+        expect(result).toEqual({ uid: MOCK_UID });
+        expect(mockManager.setPasskeyPrfEnabled).toHaveBeenCalledWith(
+          MOCK_UID,
+          MOCK_CREDENTIAL_ID
+        );
+        expect(mockMetrics.increment).toHaveBeenCalledWith(
+          'passkey.authentication.prf.update_applied'
+        );
+      });
+
+      it('does not attempt a roll-forward when prfSupported is false', async () => {
+        await service.verifyAuthenticationResponse(
+          mockResponse,
+          MOCK_CHALLENGE,
+          undefined,
+          false
+        );
+
+        expect(mockManager.setPasskeyPrfEnabled).not.toHaveBeenCalled();
+      });
+
+      it('does not attempt a roll-forward when the flag is already true (in-memory guard)', async () => {
+        mockManager.findPasskeyByCredentialId.mockResolvedValue({
+          ...mockPasskey,
+          prfEnabled: true,
+        });
+
+        await service.verifyAuthenticationResponse(
+          mockResponse,
+          MOCK_CHALLENGE,
+          undefined,
+          true
+        );
+
+        expect(mockManager.setPasskeyPrfEnabled).not.toHaveBeenCalled();
+      });
+
+      it('increments update_noop when the row was already flipped by a concurrent write', async () => {
+        mockManager.setPasskeyPrfEnabled.mockResolvedValue(false);
+
+        await service.verifyAuthenticationResponse(
+          mockResponse,
+          MOCK_CHALLENGE,
+          undefined,
+          true
+        );
+
+        expect(mockMetrics.increment).toHaveBeenCalledWith(
+          'passkey.authentication.prf.update_noop'
+        );
+      });
+
+      it('still returns uid and never fails sign-in when the roll-forward rejects', async () => {
+        mockManager.setPasskeyPrfEnabled.mockRejectedValue(
+          new Error('db down')
+        );
+
+        const result = await service.verifyAuthenticationResponse(
+          mockResponse,
+          MOCK_CHALLENGE,
+          undefined,
+          true
+        );
+
+        expect(result).toEqual({ uid: MOCK_UID });
+        expect(mockMetrics.increment).toHaveBeenCalledWith(
+          'passkey.authentication.prf.update_failed',
+          { reason: 'dbError' }
+        );
+      });
     });
   });
 

--- a/libs/accounts/passkey/src/lib/passkey.service.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.ts
@@ -27,6 +27,7 @@ import {
   generateWebauthnAuthenticationOptions,
   verifyWebauthnAuthenticationResponse,
   UserVerificationRequiredError,
+  shouldRequestPrfAtAuth,
 } from './webauthn-adapter';
 import { AppError } from '@fxa/accounts/errors';
 
@@ -404,13 +405,17 @@ export class PasskeyService {
   /**
    * Generate WebAuthn authentication (assertion) options.
    *
-   * @param uid - Optional user ID. When provided, restricts authentication to
-   *   the user's registered credentials (known-user flow).
+   * @param options.uid - Optional user ID. When provided, restricts
+   *   authentication to the user's registered credentials (known-user flow).
+   * @param options.keysRequired - Whether this sign-in is a keys-required
+   *   (Sync) flow, used to decide whether to request PRF under the
+   *   `keys-required` scope. Defaults to false.
    * @returns WebAuthn authentication options
    */
   async generateAuthenticationChallenge(
-    uid?: string
+    options: { uid?: string; keysRequired?: boolean } = {}
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
+    const { uid, keysRequired = false } = options;
     const challenge =
       await this.challengeManager.generateAuthenticationChallenge();
 
@@ -420,9 +425,15 @@ export class PasskeyService {
       allowCredentials = passkeys.map((p) => p.credentialId);
     }
 
+    const requestPrf = shouldRequestPrfAtAuth(this.config, keysRequired);
+    if (requestPrf) {
+      this.metrics.increment('passkey.authentication.prf.requested');
+    }
+
     return await generateWebauthnAuthenticationOptions(this.config, {
       challenge,
       allowCredentials,
+      requestPrf,
     });
   }
 
@@ -433,6 +444,8 @@ export class PasskeyService {
    * @param challenge - The challenge that was issued for this authentication.
    * @param expectedUid - Optional expected user ID. When provided, verifies that
    * the authenticating passkey belongs to this user.
+   * @param prfSupported - Whether the browser returned a PRF output at `get()`;
+   * when true, rolls `prfEnabled` forward false→true.
    * @returns Authentication result containing the uid of the authenticated user.
    * @throws {AppError} passkeyNotFound if the credential is not registered.
    * @throws {AppError} passkeyChallengeExpired if the challenge is invalid or expired.
@@ -442,7 +455,8 @@ export class PasskeyService {
   async verifyAuthenticationResponse(
     response: AuthenticationResponseJSON,
     challenge: string,
-    expectedUid?: string
+    expectedUid?: string,
+    prfSupported?: boolean
   ): Promise<AuthenticationResult> {
     const credentialId = response.id;
 
@@ -537,6 +551,27 @@ export class PasskeyService {
 
     this.metrics.increment('passkey.authentication.success');
     this.log?.log('passkey.authenticated', { uid });
+
+    // Best-effort roll-forward of newly detected PRF capability; a failure must
+    // never fail a verified sign-in. The guard skips a write when already set.
+    if (prfSupported && !passkey.prfEnabled) {
+      try {
+        const applied = await this.passkeyManager.setPasskeyPrfEnabled(
+          uid,
+          credentialId
+        );
+        this.metrics.increment(
+          applied
+            ? 'passkey.authentication.prf.update_applied'
+            : 'passkey.authentication.prf.update_noop'
+        );
+      } catch (err) {
+        Sentry.captureException(err);
+        this.metrics.increment('passkey.authentication.prf.update_failed', {
+          reason: 'dbError',
+        });
+      }
+    }
 
     return { uid };
   }

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -10,6 +10,7 @@ import {
   verifyWebauthnAuthenticationResponse,
   extractPrfEnabled,
   UserVerificationRequiredError,
+  shouldRequestPrfAtAuth,
 } from './webauthn-adapter';
 import { PasskeyConfig } from './passkey.config';
 import { VirtualAuthenticator } from './virtual-authenticator';
@@ -29,6 +30,7 @@ function testConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
     challengeTimeout: 30_000,
     requestPrfAtRegistration: false,
     prfSalt: '',
+    requestPrfAtAuthentication: 'off',
     ...overrides,
   });
 }
@@ -492,6 +494,77 @@ describe('generateWebauthnAuthenticationOptions', () => {
     expect(options.allowCredentials).toEqual([
       expect.objectContaining({ id: credId }),
     ]);
+  });
+
+  it('requests the PRF extension with the configured salt when requestPrf is true and a salt is set', async () => {
+    const options = await generateWebauthnAuthenticationOptions(
+      testConfig({ prfSalt: TEST_PRF_SALT }),
+      {
+        challenge: randomBytes(32).toString('base64url'),
+        allowCredentials: [],
+        requestPrf: true,
+      }
+    );
+
+    expect(options.extensions).toEqual(
+      expect.objectContaining({ prf: { eval: { first: TEST_PRF_SALT } } })
+    );
+  });
+
+  it('omits the PRF extension when requestPrf is true but no salt is configured', async () => {
+    const options = await generateWebauthnAuthenticationOptions(
+      testConfig({ prfSalt: '' }),
+      {
+        challenge: randomBytes(32).toString('base64url'),
+        allowCredentials: [],
+        requestPrf: true,
+      }
+    );
+
+    expect(options.extensions ?? {}).not.toHaveProperty('prf');
+  });
+
+  it('omits the PRF extension when requestPrf is false even with a salt', async () => {
+    const options = await generateWebauthnAuthenticationOptions(
+      testConfig({ prfSalt: TEST_PRF_SALT }),
+      {
+        challenge: randomBytes(32).toString('base64url'),
+        allowCredentials: [],
+        requestPrf: false,
+      }
+    );
+
+    expect(options.extensions ?? {}).not.toHaveProperty('prf');
+  });
+});
+
+describe('shouldRequestPrfAtAuth', () => {
+  const withScope = (scope: PasskeyConfig['requestPrfAtAuthentication']) =>
+    testConfig({ requestPrfAtAuthentication: scope, prfSalt: TEST_PRF_SALT });
+
+  it('never requests PRF under the "off" scope', () => {
+    expect(shouldRequestPrfAtAuth(withScope('off'), true)).toBe(false);
+    expect(shouldRequestPrfAtAuth(withScope('off'), false)).toBe(false);
+  });
+
+  it('always requests PRF under the "all" scope', () => {
+    expect(shouldRequestPrfAtAuth(withScope('all'), true)).toBe(true);
+    expect(shouldRequestPrfAtAuth(withScope('all'), false)).toBe(true);
+  });
+
+  it('requests PRF under "keys-required" only for a keys-required sign-in', () => {
+    expect(shouldRequestPrfAtAuth(withScope('keys-required'), true)).toBe(true);
+    expect(shouldRequestPrfAtAuth(withScope('keys-required'), false)).toBe(
+      false
+    );
+  });
+
+  it('never requests PRF when no salt is configured, even under "all"', () => {
+    const noSalt = testConfig({
+      requestPrfAtAuthentication: 'all',
+      prfSalt: '',
+    });
+    expect(shouldRequestPrfAtAuth(noSalt, true)).toBe(false);
   });
 });
 

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -26,6 +26,30 @@ import { uuidTransformer } from '@fxa/shared/db/mysql/core';
 import { PasskeyConfig } from './passkey.config';
 
 /**
+ * Whether to request the PRF extension at sign-in. Requires a configured salt
+ * (an empty PRF eval is rejected by some authenticators, FXA-13991) and honours
+ * the scope; `keysRequired` only matters under the `keys-required` scope. This
+ * is the single gate — the returned boolean matches the options actually built.
+ */
+export function shouldRequestPrfAtAuth(
+  config: Pick<PasskeyConfig, 'requestPrfAtAuthentication' | 'prfSalt'>,
+  keysRequired: boolean
+): boolean {
+  if (!config.prfSalt) {
+    return false;
+  }
+  switch (config.requestPrfAtAuthentication) {
+    case 'all':
+      return true;
+    case 'keys-required':
+      return keysRequired;
+    case 'off':
+    default:
+      return false;
+  }
+}
+
+/**
  * A credential to exclude from a registration ceremony. When forwarded to the
  * authenticator, the browser surfaces a native "already registered" prompt
  * instead of completing the ceremony.
@@ -231,6 +255,8 @@ export interface AuthenticationOptionsInput {
    * Pass an empty array for usernameless/discoverable flows.
    */
   allowCredentials: string[];
+  /** When true (and a `prfSalt` is configured), request the PRF extension. */
+  requestPrf?: boolean;
 }
 
 /**
@@ -253,6 +279,16 @@ export async function generateWebauthnAuthenticationOptions(
       input.allowCredentials.length > 0
         ? input.allowCredentials.map((id) => ({ id }))
         : undefined,
+    // `eval` (single salt) fits the discoverable flow; an allow-listed ceremony
+    // could use `evalByCredential`. Gated on a salt like registration — an empty
+    // eval breaks Windows Hello (FXA-13991). Cast: bundled type predates PRF.
+    ...(input.requestPrf && config.prfSalt
+      ? {
+          extensions: {
+            prf: { eval: { first: config.prfSalt } },
+          } as AuthenticationExtensionsClientInputs,
+        }
+      : {}),
   });
 }
 

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -3713,12 +3713,24 @@ export default class AuthClient {
    * `allowCredentials` so the browser uses discoverable credentials, which
    * prevents account enumeration.
    *
+   * @param options.keysRequired Hints that this is a keys-required (Sync)
+   *   sign-in, so the server may request PRF under the keys-required scope.
    * @param headers Optional additional headers
    */
   async beginPasskeyAuthentication(
+    options: { keysRequired?: boolean } = {},
     headers?: Headers
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
-    return this.request('POST', '/passkey/authentication/start', {}, headers);
+    const payload =
+      options.keysRequired === undefined
+        ? {}
+        : { keysRequired: options.keysRequired };
+    return this.request(
+      'POST',
+      '/passkey/authentication/start',
+      payload,
+      headers
+    );
   }
 
   /**
@@ -3734,6 +3746,9 @@ export default class AuthClient {
    *   the login is not yet complete here and the server defers its login
    *   notifications/metrics until keys are available. The caller owns this
    *   decision, based on the browser's keys-optional capability.
+   * @param options.prfSupported Whether the browser returned a PRF output at
+   *   `get()`; rolls `prfEnabled` forward server-side. Omit when PRF wasn't
+   *   requested. Never the PRF output itself.
    * @param headers Optional additional headers
    */
   async completePasskeyAuthentication(
@@ -3742,6 +3757,7 @@ export default class AuthClient {
     options: {
       keysRequired: boolean;
       service?: string;
+      prfSupported?: boolean;
       metricsContext?: MetricsContext;
     },
     headers?: Headers
@@ -3751,12 +3767,16 @@ export default class AuthClient {
       challenge: string;
       keysRequired: boolean;
       service?: string;
+      prfSupported?: boolean;
       metricsContext?: MetricsContext;
     } = {
       response,
       challenge,
       keysRequired: options.keysRequired,
       ...(options.service ? { service: options.service } : {}),
+      ...(options.prfSupported !== undefined
+        ? { prfSupported: options.prfSupported }
+        : {}),
       ...(options.metricsContext
         ? { metricsContext: options.metricsContext }
         : {}),

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -470,6 +470,7 @@
     "registrationEnabled": true,
     "authenticationEnabled": true,
     "requestPrfAtRegistration": true,
+    "requestPrfAtAuthentication": "all",
     "prfSalt": "dGVzdC1wcmYtc2FsdA",
     "rpId": "localhost",
     "allowedOrigins": ["http://localhost:3030"]

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2737,6 +2737,12 @@ const convictConf = convict({
       env: 'PASSKEYS__PRF_SALT',
       format: String,
     },
+    requestPrfAtAuthentication: {
+      default: 'off',
+      doc: 'Scope of the WebAuthn PRF request at sign-in. "off" (kill switch) never requests PRF; "keys-required" requests it only for keys-required (Sync) sign-ins; "all" requests it for every passkey sign-in. Validated/normalized in buildPasskeyConfig (invalid → "off"); String format here so a bad value cannot crash startup.',
+      env: 'PASSKEYS__REQUEST_PRF_AT_AUTHENTICATION',
+      format: String,
+    },
   },
   twilio: {
     credentialMode: {

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -1092,7 +1092,19 @@ describe('passkeys routes', () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         mockPasskeyService.generateAuthenticationChallenge
-      ).toHaveBeenCalledWith();
+      ).toHaveBeenCalledWith({ keysRequired: undefined });
+    });
+
+    it('forwards the keysRequired hint from the payload to the service', async () => {
+      await runTest('/passkey/authentication/start', {
+        auth: { credentials: {} },
+        payload: { keysRequired: true },
+        app: { ua: {} },
+      });
+
+      expect(
+        mockPasskeyService.generateAuthenticationChallenge
+      ).toHaveBeenCalledWith({ keysRequired: true });
     });
 
     it('records glean.passkey.authenticationStarted with the request', async () => {
@@ -1154,7 +1166,12 @@ describe('passkeys routes', () => {
 
       expect(
         mockPasskeyService.verifyAuthenticationResponse
-      ).toHaveBeenCalledWith(payload.response, payload.challenge);
+      ).toHaveBeenCalledWith(
+        payload.response,
+        payload.challenge,
+        undefined,
+        undefined
+      );
       expect(db.createPasskeyVerifiedSessionToken).toHaveBeenCalledWith(
         expect.objectContaining({ uid: UID })
       );
@@ -1164,6 +1181,23 @@ describe('passkeys routes', () => {
         verified: true,
         hasPassword: true,
       });
+    });
+
+    it('forwards prfSupported from the payload to verifyAuthenticationResponse', async () => {
+      await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload: { ...payload, prfSupported: true },
+      });
+
+      expect(
+        mockPasskeyService.verifyAuthenticationResponse
+      ).toHaveBeenCalledWith(
+        payload.response,
+        payload.challenge,
+        undefined,
+        true
+      );
     });
 
     it('sets hasPassword false for passwordless accounts', async () => {

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -382,13 +382,21 @@ export class PasskeyHandler {
    * browser. No email or uid is accepted in the request body — discoverable
    * credentials only.
    *
-   * @param request - Unauthenticated Hapi request.
+   * @param request - Unauthenticated Hapi request. An optional `keysRequired`
+   *   flag in the payload lets the server decide, under the `keys-required`
+   *   PRF scope, whether to request the PRF extension in the returned options.
    * @returns WebAuthn authentication options to pass to `navigator.credentials.get`.
    */
   async authenticationStart(request: AuthRequest) {
     await this.customs.checkIpOnly(request, 'passkeyAuthStart');
 
-    const options = await this.service.generateAuthenticationChallenge();
+    const { keysRequired } = (request.payload ?? {}) as {
+      keysRequired?: boolean;
+    };
+
+    const options = await this.service.generateAuthenticationChallenge({
+      keysRequired,
+    });
 
     this.glean.passkey.authenticationStarted(request);
 
@@ -403,24 +411,29 @@ export class PasskeyHandler {
    * with flags the UI needs to drive the post-login flow.
    *
    * @param request - Unauthenticated Hapi request containing `response`,
-   *   `challenge`, and optional `service` / `keysRequired` in the payload.
+   *   `challenge`, and optional `service` / `keysRequired` / `prfSupported` in
+   *   the payload.
    * @returns Session token, uid, `verified`, and `hasPassword`.
    */
   async authenticationFinish(request: AuthRequest) {
     await this.customs.checkIpOnly(request, 'passkeyAuthFinish');
 
-    const { response, challenge, service, keysRequired } = request.payload as {
-      response: AuthenticationResponseJSON;
-      challenge: string;
-      service?: string;
-      keysRequired: boolean;
-    };
+    const { response, challenge, service, keysRequired, prfSupported } =
+      request.payload as {
+        response: AuthenticationResponseJSON;
+        challenge: string;
+        service?: string;
+        keysRequired: boolean;
+        prfSupported?: boolean;
+      };
 
     let uid: string;
     try {
       ({ uid } = await this.service.verifyAuthenticationResponse(
         response,
-        challenge
+        challenge,
+        undefined,
+        prfSupported
       ));
     } catch (err) {
       await recordSecurityEvent('account.passkey.authentication_failure', {
@@ -906,6 +919,12 @@ export const passkeyRoutes = (
         ...PASSKEYS_API_DOCS.PASSKEY_AUTHENTICATION_START_POST,
         pre: [{ method: authenticationEnabledCheck }],
         auth: false,
+        validate: {
+          payload: isA.object({
+            // Hint for the keys-required PRF scope; omitted = not keys-required.
+            keysRequired: isA.boolean().optional(),
+          }),
+        },
         response: {
           schema: isA.object({
             challenge: isA.string().required(),
@@ -949,16 +968,17 @@ export const passkeyRoutes = (
                     signature: base64urlString(1024).required(),
                     userHandle: base64urlString(128).optional(),
                   })
-                  .unknown(true)
                   .required(),
               })
-              .unknown(true)
               .required(),
             challenge: base64urlChallenge().required(),
             service: validators.service.optional(),
             // When true, this login still needs Sync-scoped keys obtained via a
             // follow-up step, so the server defers login notifications/metrics.
             keysRequired: isA.boolean().required(),
+            // Whether the browser returned a PRF output at get(); rolls
+            // prfEnabled forward. Never the PRF output itself.
+            prfSupported: isA.boolean().optional(),
             metricsContext: METRICS_CONTEXT_SCHEMA,
           }),
         },

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -13,6 +13,7 @@ import * as event from 'fxa-shared/metrics/glean/web/event';
 import * as reg from 'fxa-shared/metrics/glean/web/reg';
 import * as login from 'fxa-shared/metrics/glean/web/login';
 import * as accountPref from 'fxa-shared/metrics/glean/web/accountPref';
+import * as passkey from 'fxa-shared/metrics/glean/web/passkey';
 import * as accountBanner from 'fxa-shared/metrics/glean/web/accountBanner';
 import * as deleteAccount from 'fxa-shared/metrics/glean/web/deleteAccount';
 import * as thirdPartyAuth from 'fxa-shared/metrics/glean/web/thirdPartyAuth';
@@ -829,6 +830,36 @@ describe('lib/glean', () => {
         sinon.assert.calledWith(setEventNameStub, 'passkey_auth_success');
         sinon.assert.calledOnce(setEventReasonStub);
         sinon.assert.calledWith(setEventReasonStub, reason);
+      });
+
+      it('submits passkey_signin_prf_support with the supported extra', async () => {
+        const spy = sandbox.spy(passkey.signinPrfSupport, 'record');
+        GleanMetrics.passkey.signinPrfSupport({
+          event: { supported: 'present' },
+        });
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'passkey_signin_prf_support');
+        sinon.assert.calledOnceWithExactly(spy, {
+          supported: 'present',
+        });
+      });
+
+      it('submits passkey_signin_retry_without_prf_request with reason and outcome', async () => {
+        const spy = sandbox.spy(passkey.signinRetryWithoutPrfRequest, 'record');
+        GleanMetrics.passkey.signinRetryWithoutPrfRequest({
+          event: { reason: 'UnknownError', outcome: 'success' },
+        });
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'passkey_signin_retry_without_prf_request'
+        );
+        sinon.assert.calledOnceWithExactly(spy, {
+          reason: 'UnknownError',
+          outcome: 'success',
+        });
       });
     });
 

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -901,6 +901,17 @@ const recordEventMetric = (
         reason: gleanPingMetrics?.event?.['reason'] || '',
       });
       break;
+    case 'passkey_signin_prf_support':
+      passkey.signinPrfSupport.record({
+        supported: gleanPingMetrics?.event?.['supported'] || '',
+      });
+      break;
+    case 'passkey_signin_retry_without_prf_request':
+      passkey.signinRetryWithoutPrfRequest.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+        outcome: gleanPingMetrics?.event?.['outcome'] || '',
+      });
+      break;
     case 'passkey_enter_password_view':
       passkeyEnterPassword.view.record({
         reason: gleanPingMetrics?.event?.['reason'] || '',

--- a/packages/fxa-settings/src/lib/passkeys/prf-fallback.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/prf-fallback.test.ts
@@ -4,12 +4,16 @@
 
 import {
   createCredentialWithPrfFallback,
+  getCredentialWithPrfFallback,
+  extractPrfSupport,
   isRetriableWithoutPrf,
   stripPrfExtension,
+  stripPrfResults,
 } from './prf-fallback';
-import { createCredential } from './webauthn';
+import { createCredential, getCredential } from './webauthn';
 import type {
   PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
   PublicKeyCredentialJSON,
 } from './webauthn';
 
@@ -18,6 +22,9 @@ import type {
 jest.mock('./webauthn');
 const mockCreateCredential = createCredential as jest.MockedFunction<
   typeof createCredential
+>;
+const mockGetCredential = getCredential as jest.MockedFunction<
+  typeof getCredential
 >;
 
 const PRF_SALT = 'dGVzdC1wcmYtc2FsdA';
@@ -291,5 +298,138 @@ describe('createCredentialWithPrfFallback', () => {
     );
 
     expect(onPrfFallback).not.toHaveBeenCalled();
+  });
+});
+
+const requestOptionsWithPrf: PublicKeyCredentialRequestOptionsJSON = {
+  challenge: 'Y2hhbGxlbmdl',
+  userVerification: 'required',
+  extensions: { prf: { eval: { first: PRF_SALT } } },
+};
+
+const assertionResult: PublicKeyCredentialJSON = {
+  id: 'bW9jay1pZA',
+  rawId: 'bW9jay1yYXctaWQ',
+  type: 'public-key',
+  response: {
+    clientDataJSON: 'bW9jay1jbGllbnQtZGF0YQ',
+    authenticatorData: 'bW9jay1hdXRoLWRhdGE',
+    signature: 'bW9jay1zaWduYXR1cmU',
+  },
+  clientExtensionResults: {},
+};
+
+const assertionWithPrfOutput: PublicKeyCredentialJSON = {
+  ...assertionResult,
+  clientExtensionResults: { prf: { results: { first: new ArrayBuffer(32) } } },
+};
+
+describe('getCredentialWithPrfFallback', () => {
+  it('returns the credential from the first attempt without retrying on success', async () => {
+    mockGetCredential.mockResolvedValueOnce(assertionWithPrfOutput);
+
+    const result = await getCredentialWithPrfFallback(requestOptionsWithPrf);
+
+    expect(result).toBe(assertionWithPrfOutput);
+    expect(mockGetCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once without PRF on a retriable UnknownError', async () => {
+    mockGetCredential
+      .mockRejectedValueOnce(new DOMException('transient', 'UnknownError'))
+      .mockResolvedValueOnce(assertionResult);
+
+    const result = await getCredentialWithPrfFallback(requestOptionsWithPrf);
+
+    expect(result).toBe(assertionResult);
+    expect(mockGetCredential).toHaveBeenCalledTimes(2);
+    const [retriedOptions] = mockGetCredential.mock.calls[1];
+    expect(retriedOptions.extensions ?? {}).not.toHaveProperty('prf');
+  });
+
+  it('does not retry when the options carried no PRF extension', async () => {
+    const noPrf: PublicKeyCredentialRequestOptionsJSON = {
+      ...requestOptionsWithPrf,
+      extensions: undefined,
+    };
+    mockGetCredential.mockRejectedValueOnce(
+      new DOMException('transient', 'UnknownError')
+    );
+
+    await expect(getCredentialWithPrfFallback(noPrf)).rejects.toThrow(
+      'transient'
+    );
+    expect(mockGetCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a user-cancel (NotAllowedError) and rethrows it', async () => {
+    const cancel = new DOMException('cancelled', 'NotAllowedError');
+    mockGetCredential.mockRejectedValueOnce(cancel);
+
+    await expect(
+      getCredentialWithPrfFallback(requestOptionsWithPrf)
+    ).rejects.toBe(cancel);
+    expect(mockGetCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the retry outcome to onPrfFallback', async () => {
+    const onPrfFallback = jest.fn();
+    mockGetCredential
+      .mockRejectedValueOnce(new DOMException('transient', 'UnknownError'))
+      .mockResolvedValueOnce(assertionResult);
+
+    await getCredentialWithPrfFallback(
+      requestOptionsWithPrf,
+      undefined,
+      onPrfFallback
+    );
+
+    expect(onPrfFallback).toHaveBeenCalledWith({
+      reason: 'UnknownError',
+      outcome: 'success',
+    });
+  });
+});
+
+describe('extractPrfSupport', () => {
+  it('returns true when the get() output carries a PRF result', () => {
+    expect(extractPrfSupport(assertionWithPrfOutput)).toBe(true);
+  });
+
+  it('returns false when there is no PRF result', () => {
+    expect(extractPrfSupport(assertionResult)).toBe(false);
+  });
+
+  it('returns false when prf is present but results are absent', () => {
+    expect(
+      extractPrfSupport({
+        ...assertionResult,
+        clientExtensionResults: { prf: {} },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('stripPrfResults', () => {
+  it('removes the prf results from clientExtensionResults', () => {
+    const stripped = stripPrfResults(assertionWithPrfOutput);
+    expect(stripped.clientExtensionResults).not.toHaveProperty('prf');
+  });
+
+  it('preserves other clientExtensionResults entries', () => {
+    const stripped = stripPrfResults({
+      ...assertionResult,
+      clientExtensionResults: {
+        prf: { results: { first: new ArrayBuffer(8) } },
+        credProps: { rk: true },
+      },
+    });
+    expect(stripped.clientExtensionResults).toEqual({
+      credProps: { rk: true },
+    });
+  });
+
+  it('returns the same reference when there is no prf result', () => {
+    expect(stripPrfResults(assertionResult)).toBe(assertionResult);
   });
 });

--- a/packages/fxa-settings/src/lib/passkeys/prf-fallback.ts
+++ b/packages/fxa-settings/src/lib/passkeys/prf-fallback.ts
@@ -4,8 +4,11 @@
 
 import {
   createCredential,
+  getCredential,
   DEFAULT_TIMEOUT_MS,
+  type AuthenticationExtensionsJSON,
   type PublicKeyCredentialCreationOptionsJSON,
+  type PublicKeyCredentialRequestOptionsJSON,
   type PublicKeyCredentialJSON,
 } from './webauthn';
 import { WebAuthnErrorType } from './webauthn-errors';
@@ -34,14 +37,15 @@ export function isRetriableWithoutPrf(error: unknown): boolean {
 }
 
 /**
- * Returns the creation options with the PRF extension removed, preserving any
- * other extensions. Used to retry registration without PRF when an
- * authenticator rejects the PRF eval. Returns the original object unchanged
- * (same reference) when there is no PRF extension to strip.
+ * Returns WebAuthn options with the PRF extension removed, preserving any other
+ * extensions. Works for both creation (registration) and request
+ * (authentication) options — the retry drops PRF when an authenticator rejects
+ * the PRF eval. Returns the original object unchanged (same reference) when
+ * there is no PRF extension to strip.
  */
-export function stripPrfExtension(
-  options: PublicKeyCredentialCreationOptionsJSON
-): PublicKeyCredentialCreationOptionsJSON {
+export function stripPrfExtension<
+  T extends { extensions?: AuthenticationExtensionsJSON },
+>(options: T): T {
   if (!options.extensions?.prf) {
     return options;
   }
@@ -54,6 +58,43 @@ export function stripPrfExtension(
         ? remainingExtensions
         : undefined,
   };
+}
+
+/**
+ * True when the browser returned a PRF output at `get()`. At authentication the
+ * browser returns the PRF _output_ (`prf.results.first`), not the `prf.enabled`
+ * boolean seen at creation, so its presence is the support signal. Reads
+ * presence only — never the output value itself.
+ */
+export function extractPrfSupport(
+  credential: Pick<PublicKeyCredentialJSON, 'clientExtensionResults'>
+): boolean {
+  const prf = (
+    credential.clientExtensionResults as {
+      prf?: { results?: { first?: unknown } };
+    }
+  ).prf;
+  return prf?.results?.first != null;
+}
+
+/**
+ * Returns the credential with any PRF extension results removed from
+ * `clientExtensionResults`, so the PRF output never reaches the server.
+ *
+ * Binary PRF outputs are `ArrayBuffer`s that already drop out when the
+ * credential is JSON-stringified for the wire, but this makes the guarantee
+ * explicit and independent of that serialisation quirk. Returns the original
+ * object unchanged (same reference) when there is no PRF result to strip.
+ */
+export function stripPrfResults(
+  credential: PublicKeyCredentialJSON
+): PublicKeyCredentialJSON {
+  const results = credential.clientExtensionResults as { prf?: unknown };
+  if (!results.prf) {
+    return credential;
+  }
+  const { prf: _prf, ...rest } = results;
+  return { ...credential, clientExtensionResults: rest };
 }
 
 /**
@@ -117,6 +158,58 @@ export async function createCredentialWithPrfFallback(
             stripPrfExtension(options),
             remaining,
             externalSignal
+          );
+          onPrfFallback?.({ reason, outcome: 'success' });
+          return credential;
+        } catch (retryError) {
+          onPrfFallback?.({ reason, outcome: 'failure' });
+          throw retryError;
+        }
+      }
+    }
+    throw error;
+  }
+}
+
+/**
+ * Runs the authentication ceremony, silently retrying once without the PRF
+ * extension if the first attempt fails in a way PRF could have caused.
+ *
+ * The authentication analog of {@link createCredentialWithPrfFallback}: PRF is
+ * requested at sign-in only to detect capability (never to block sign-in), so a
+ * PRF-attributable failure must fall back to a normal, PRF-free assertion. Only
+ * an `UnknownError` triggers the retry, so a user cancel (`NotAllowedError`) or
+ * a timeout (`TimeoutError`) is non-retriable and never causes a re-prompt.
+ *
+ * Only retries when the original options actually carried a PRF extension —
+ * otherwise stripping is a no-op and the same error would recur. The retry is
+ * bounded by what remains of the original `timeoutMs` budget so the two
+ * attempts together never exceed a single timeout window.
+ *
+ * When the retry fires, `onPrfFallback` is invoked exactly once with the
+ * triggering error name and the retry outcome — purely for telemetry.
+ */
+export async function getCredentialWithPrfFallback(
+  options: PublicKeyCredentialRequestOptionsJSON,
+  timeoutMs?: number,
+  onPrfFallback?: (info: PrfFallbackInfo) => void
+): Promise<PublicKeyCredentialJSON> {
+  const startedAt = Date.now();
+  try {
+    return await getCredential(options, timeoutMs);
+  } catch (error) {
+    if (isRetriableWithoutPrf(error) && options.extensions?.prf) {
+      const budget = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const remaining = Math.max(0, budget - (Date.now() - startedAt));
+      // With no budget left, a retry (timeoutMs=0) would abort immediately and
+      // throw a TimeoutError that masks the original error, so rethrow the
+      // original unchanged instead.
+      if (remaining > 0) {
+        const reason = (error as DOMException).name;
+        try {
+          const credential = await getCredential(
+            stripPrfExtension(options),
+            remaining
           );
           onPrfFallback?.({ reason, outcome: 'success' });
           return credential;

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -75,6 +75,8 @@ jest.mock('../glean', () => ({
       buttonView: jest.fn(),
       authSuccess: jest.fn(),
       getHelpLinkClick: jest.fn(),
+      signinPrfSupport: jest.fn(),
+      signinRetryWithoutPrfRequest: jest.fn(),
     },
   },
 }));
@@ -1252,6 +1254,104 @@ describe('usePasskeySignIn', () => {
           accountHasTotp: true,
         })
       );
+    });
+  });
+
+  describe('PRF at sign-in', () => {
+    const optionsWithPrf = {
+      challenge: CHALLENGE,
+      userVerification: 'required',
+      extensions: { prf: { eval: { first: 'c2FsdA' } } },
+    };
+    const credentialWithPrf = {
+      ...MOCK_CREDENTIAL,
+      clientExtensionResults: {
+        prf: { results: { first: new ArrayBuffer(32) } },
+      },
+    };
+
+    it('passes the keysRequired hint to beginPasskeyAuthentication', async () => {
+      const { args, spies } = buildArgs({
+        integration: {
+          isSync: () => false,
+          isFirefoxNonSync: () => false,
+          isFirefoxMobileClient: () => false,
+          requiresPasswordForLogin: () => true,
+        } as unknown as PasskeySignInIntegration,
+      });
+
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(spies.beginPasskeyAuthentication).toHaveBeenCalledWith({
+        keysRequired: true,
+      });
+    });
+
+    it('records present support and sends prfSupported=true in the finish request when the output is present', async () => {
+      const { args, spies } = buildArgs();
+      spies.beginPasskeyAuthentication.mockResolvedValue(optionsWithPrf);
+      (getCredential as jest.Mock).mockResolvedValue(credentialWithPrf);
+
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(GleanMetrics.passkey.signinPrfSupport).toHaveBeenCalledWith({
+        event: { supported: 'present' },
+      });
+      const [, , options] = spies.completePasskeyAuthentication.mock.calls[0];
+      expect(options.prfSupported).toBe(true);
+    });
+
+    it('strips the PRF output from the credential before sending it to the server', async () => {
+      const { args, spies } = buildArgs();
+      spies.beginPasskeyAuthentication.mockResolvedValue(optionsWithPrf);
+      (getCredential as jest.Mock).mockResolvedValue(credentialWithPrf);
+
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      const [sentCredential] =
+        spies.completePasskeyAuthentication.mock.calls[0];
+      expect(sentCredential.clientExtensionResults).not.toHaveProperty('prf');
+    });
+
+    it('records absent support and sends prfSupported=false when no output is present', async () => {
+      const { args, spies } = buildArgs();
+      spies.beginPasskeyAuthentication.mockResolvedValue(optionsWithPrf);
+      (getCredential as jest.Mock).mockResolvedValue(MOCK_CREDENTIAL);
+
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(GleanMetrics.passkey.signinPrfSupport).toHaveBeenCalledWith({
+        event: { supported: 'absent' },
+      });
+      const [, , options] = spies.completePasskeyAuthentication.mock.calls[0];
+      expect(options.prfSupported).toBe(false);
+    });
+
+    it('omits prfSupported and the support event when the server did not request PRF', async () => {
+      const { args, spies } = buildArgs();
+      // Default beginPasskeyAuthentication returns options without extensions.
+      (getCredential as jest.Mock).mockResolvedValue(MOCK_CREDENTIAL);
+
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(GleanMetrics.passkey.signinPrfSupport).not.toHaveBeenCalled();
+      const [, , options] = spies.completePasskeyAuthentication.mock.calls[0];
+      expect(options).not.toHaveProperty('prfSupported');
     });
   });
 });

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -33,11 +33,15 @@ import { resolveServiceOrClientId } from '../../models/integrations/utils';
 import { queryParamsToMetricsContext } from '../metrics';
 import type { QueryParams } from '../..';
 import {
-  getCredential,
   handleWebAuthnError,
   isWebAuthnSupported,
   type PublicKeyCredentialJSON,
 } from './';
+import {
+  extractPrfSupport,
+  getCredentialWithPrfFallback,
+  stripPrfResults,
+} from './prf-fallback';
 import type { PasskeySignInGleanReason } from './webauthn-errors';
 import { PASSKEY_SUPPORT_URL, PASSKEY_TROUBLESHOOT_URL } from './constants';
 
@@ -374,18 +378,39 @@ export function usePasskeySignIn({
     setIsLoading(true);
     gleanEvents.submit();
 
+    // True when this login still needs Sync-scoped keys that a follow-up
+    // password step will provide. Computed up front so it can also hint the
+    // server whether to request PRF under the keys-required scope; reused below
+    // to route to the password step.
+    const keysRequired = integration.requiresPasswordForLogin(
+      supportsKeysOptionalLogin
+    );
+
     try {
       // Discoverable credentials only — the Signin page's email field is
       // intentionally ignored. The browser surfaces all credentials for the
-      // RP and the user picks one.
-      const challengeOptions = await authClient.beginPasskeyAuthentication();
+      // RP and the user picks one. The keysRequired hint lets the server decide
+      // whether to attach the PRF extension to the returned options.
+      const challengeOptions = await authClient.beginPasskeyAuthentication({
+        keysRequired,
+      });
 
       // Isolated try/catch so a network-layer TypeError (e.g. fetch failure)
       // from surrounding auth-client calls can't be miscategorised as a
       // WebAuthn error.
       let credential: PublicKeyCredentialJSON;
       try {
-        credential = await getCredential(challengeOptions);
+        // If the server attached PRF and the first attempt fails in a way PRF
+        // could have caused, retry once without PRF (never blocks sign-in).
+        credential = await getCredentialWithPrfFallback(
+          challengeOptions,
+          undefined,
+          ({ reason, outcome }) => {
+            GleanMetrics.passkey.signinRetryWithoutPrfRequest({
+              event: { reason, outcome },
+            });
+          }
+        );
       } catch (err) {
         if (err instanceof DOMException || err instanceof TypeError) {
           const categorized = handleWebAuthnError(
@@ -408,22 +433,30 @@ export function usePasskeySignIn({
         throw err;
       }
 
+      // Read support (presence only) before stripping the output from the
+      // credential; only meaningful when the server requested PRF.
+      const prfRequested = !!challengeOptions.extensions?.prf;
+      const prfSupported = prfRequested && extractPrfSupport(credential);
+      if (prfRequested) {
+        GleanMetrics.passkey.signinPrfSupport({
+          event: { supported: prfSupported ? 'present' : 'absent' },
+        });
+      }
+      credential = stripPrfResults(credential);
+
       const serviceForRequest = resolvePasskeyService(integration);
       const metricsContext = queryParamsToMetricsContext(flowQueryParams);
 
-      const keysRequired = integration.requiresPasswordForLogin(
-        supportsKeysOptionalLogin
-      );
       const completion = await authClient.completePasskeyAuthentication(
         credential,
         challengeOptions.challenge,
         {
           ...(serviceForRequest ? { service: serviceForRequest } : {}),
-          // True when this login still needs Sync-scoped keys that a
-          // follow-up password step will provide. The server uses it to
-          // defer its login metrics/email framing until keys exist; the
-          // client uses the same value below to route to that step.
+          // The server uses keysRequired to defer its login metrics/email
+          // framing until keys exist; the client uses the same value below to
+          // route to that step.
           keysRequired,
+          ...(prfRequested ? { prfSupported } : {}),
           metricsContext,
         }
       );

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -2973,6 +2973,64 @@ passkey:
           Sign-in surface the banner was shown on: 'emailfirst', 'signin',
           'otplogin', or 'alternative_auth'.
         type: string
+  signin_prf_support:
+    type: event
+    description: |
+      Records whether the WebAuthn PRF extension produced an output at passkey
+      sign-in (`navigator.credentials.get()`), i.e. whether the credential
+      supports PRF on this device. Early telemetry ahead of passwordless Sync
+      (Phase 2) to learn the true PRF capability of the passkey base, which the
+      registration-time `prfEnabled` flag under-reports. Only the presence of
+      the PRF output is recorded — never the output itself.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-14085
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      supported:
+        description: |
+          Whether the PRF output was present: "present" or "absent". The
+          sign-in device's OS is available separately via Glean's built-in
+          `client_info.os`, so it is not duplicated here.
+        type: string
+  signin_retry_without_prf_request:
+    type: event
+    description: |
+      A passkey sign-in's first WebAuthn attempt failed in a way the optional
+      PRF extension could have caused (e.g. Windows Hello UnknownError,
+      FXA-13991), so the ceremony silently retried once without PRF. Mirrors
+      `account_pref.passkey_create_retry_without_prf_request` for the sign-in
+      (`navigator.credentials.get()`) path.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-14085
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: |
+          The DOMException name of the first-attempt error that triggered the
+          retry (e.g. UnknownError).
+        type: string
+      outcome:
+        description: |
+          Whether the retry without PRF succeeded: "success" or "failure".
+        type: string
 
 account_pref:
   view:

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -23,7 +23,10 @@ export const stringEventPropertyNames = [
 
 // String event extras passed to specific events but not backed by a global
 // `event`-module metric, so they are not set globally in populateMetrics.
-export const stringEventExtraPropertyNames = ['mobile_device_count'] as const;
+export const stringEventExtraPropertyNames = [
+  'mobile_device_count',
+  'supported',
+] as const;
 
 export type PropertyNameStringT = typeof stringEventPropertyNames;
 export type PropertyNameString =
@@ -182,6 +185,8 @@ export const eventsMap = {
     buttonView: 'passkey_button_view',
     authSuccess: 'passkey_auth_success',
     getHelpLinkClick: 'passkey_get_help_link_click',
+    signinPrfSupport: 'passkey_signin_prf_support',
+    signinRetryWithoutPrfRequest: 'passkey_signin_retry_without_prf_request',
   },
 
   cad: {

--- a/packages/fxa-shared/metrics/glean/web/passkey.ts
+++ b/packages/fxa-shared/metrics/glean/web/passkey.ts
@@ -68,3 +68,49 @@ export const getHelpLinkClick = new EventMetricType<{
   },
   ['reason']
 );
+
+/**
+ * Records whether the WebAuthn PRF extension produced an output at passkey
+ * sign-in (`navigator.credentials.get()`), i.e. whether the credential
+ * supports PRF on this device. Early telemetry ahead of passwordless Sync
+ * (Phase 2) to learn the true PRF capability of the passkey base, which the
+ * registration-time `prfEnabled` flag under-reports. Only the presence of
+ * the PRF output is recorded — never the output itself.
+ *
+ * Generated from `passkey.signin_prf_support`.
+ */
+export const signinPrfSupport = new EventMetricType<{
+  supported?: string;
+}>(
+  {
+    category: 'passkey',
+    name: 'signin_prf_support',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['supported']
+);
+
+/**
+ * A passkey sign-in's first WebAuthn attempt failed in a way the optional
+ * PRF extension could have caused (e.g. Windows Hello UnknownError,
+ * FXA-13991), so the ceremony silently retried once without PRF. Mirrors
+ * `account_pref.passkey_create_retry_without_prf_request` for the sign-in
+ * (`navigator.credentials.get()`) path.
+ *
+ * Generated from `passkey.signin_retry_without_prf_request`.
+ */
+export const signinRetryWithoutPrfRequest = new EventMetricType<{
+  outcome?: string;
+  reason?: string;
+}>(
+  {
+    category: 'passkey',
+    name: 'signin_retry_without_prf_request',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['outcome', 'reason']
+);


### PR DESCRIPTION
## Because

- Phase 2 (passwordless Sync) will unwrap Sync keys using the WebAuthn PRF
  extension at sign-in. Ahead of that we need to learn the true PRF capability
  of the existing passkey base as an early telemetry signal.
- The registration-time `prfEnabled` flag is an incomplete, false-negative
  signal: it reads "no" for passkeys created before PRF-at-create was enabled,
  for platforms that only expose PRF at authentication, and for capability that
  appears later via an OS update. PRF capability is not fixed at creation for
  synced/platform passkeys, so evaluating at sign-in is the only way to learn
  the real capability of the base.

## This pull request

- Adds a scope-aware, default-off flag `PASSKEYS__REQUEST_PRF_AT_AUTHENTICATION`
  (`off` / `keys-required` / `all`) in `packages/fxa-auth-server/config/index.ts`
  and `libs/accounts/passkey/src/lib/passkey.config.ts`, and requests the PRF
  extension in `generateWebauthnAuthenticationOptions`
  (`libs/accounts/passkey/src/lib/webauthn-adapter.ts`) using the same static
  salt as registration. The scope decision is threaded via an optional
  `keysRequired` hint on `POST /passkey/authentication/start`.
- In `packages/fxa-settings/src/lib/passkeys/signin-flow.ts`, detects PRF
  support from the `get()` output, strips the output (`stripPrfResults` in
  `prf-fallback.ts`) so it never reaches the server, and sends only a
  `prfSupported` boolean on `authentication/finish`. Adds a silent no-PRF retry
  (`getCredentialWithPrfFallback`).
- Rolls `prfEnabled` forward false→true inside the verified
  `verifyAuthenticationResponse` flow
  (`libs/accounts/passkey/src/lib/passkey.service.ts`) — monotonic
  (`updatePasskeyPrfEnabled` in `passkey.repository.ts`) and best-effort, so a
  failure never blocks a verified sign-in.
- Adds client Glean events (`passkey.signin_prf_support`,
  `passkey.signin_retry_without_prf_request`) and server StatsD
  (`passkey.prf.signin.*`) to back the kill switch.

## Issue that this pull request solves

Closes: FXA-14085

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `webauthn-adapter.ts` (PRF eval + scope helper),
  `passkey.service.ts` (roll-forward in the verify path), `signin-flow.ts` +
  `prf-fallback.ts` (detect / strip / retry), and `routes/passkeys.ts` (start
  hint + finish `prfSupported`).
- Suggested review order: config/adapter → service roll-forward → route → client.
- Risky or complex parts: PRF-output containment (must never reach the server)
  and the monotonic, best-effort roll-forward.

## Screenshots (Optional)

No user-facing UI changes.

## Other information (Optional)

- **Recording approach differs from the ticket's suggestion.** Rather than a
  new session-token `PATCH /passkey/{credentialId}/prf-enabled` endpoint, this
  records capability via a `prfSupported` boolean on the existing
  `authentication/finish` request — smaller surface, no extra round trip, and no
  ownership re-check needed since the assertion already proves credential control.
- **Rollout:** the flag ships `off`; the intended first enablement is
  `keys-required` (Sync flows, lowest blast radius), widening to `all` later for
  fuller population telemetry.
