### PR TITLE
ci(functional-tests): reserve node 0 for serialized phone tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,16 @@ commands:
           name: Running Playwright tests
           # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/
           command: |
+            # #phone tests run serially on node 0 (see run-phone-tests-serialized),
+            # so when they're excluded here reserve node 0 out of the split.
+            RESERVE_PHONE_NODE=false
+            if [[ "<< parameters.grep_invert >>" == *"#phone"* && "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]]; then
+              RESERVE_PHONE_NODE=true
+            fi
+            if [[ "$RESERVE_PHONE_NODE" == "true" && "${CIRCLE_NODE_INDEX:-0}" == "0" ]]; then
+              echo "Node 0 is reserved for serialized #phone tests; skipping split tests on this node."
+              exit 0
+            fi
             if [[ "<< parameters.project >>" == "production" ]]; then
               GREP="--grep=\"severity-1\""
             elif [[ "<< parameters.project >>" == "stage" ]]; then
@@ -367,7 +377,12 @@ commands:
             else
               GREP_INVERT=""
             fi
-            echo "targeting project << parameters.project >> $GREP $GREP_INVERT"
+            # Redistribute the split across the remaining nodes (shifted by one).
+            SPLIT_ARGS=""
+            if [[ "$RESERVE_PHONE_NODE" == "true" ]]; then
+              SPLIT_ARGS="--total=$((CIRCLE_NODE_TOTAL - 1)) --index=$((CIRCLE_NODE_INDEX - 1))"
+            fi
+            echo "targeting project << parameters.project >> $GREP $GREP_INVERT $SPLIT_ARGS"
             npx nx build fxa-auth-client
             cd packages/functional-tests/<< parameters.test_dir >>
             TEST_FILES=$(circleci tests glob "./**/*.spec.ts")
@@ -377,7 +392,8 @@ commands:
               --command="xargs yarn playwright test --project=<< parameters.project >> $GREP $GREP_INVERT --pass-with-no-tests" \
               --verbose \
               --split-by=timings \
-              --timings-type=classname
+              --timings-type=classname \
+              $SPLIT_ARGS
           environment:
             NODE_OPTIONS: --dns-result-order=ipv4first
             ACCOUNTS_DOMAIN: << pipeline.parameters.accounts-domain >>
@@ -388,7 +404,9 @@ commands:
             UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
             PLAYWRIGHT_FAIL_FAST: << parameters.fail_fast >>
 
-  # DRY helper to run phone-tagged tests in a single worker on node 0
+  # Runs phone-tagged tests in a single worker on node 0. When these tests are
+  # excluded from the split (grep_invert includes #phone), run-playwright-tests
+  # keeps node 0 out of the split so it only runs these serial tests.
   run-phone-tests-serialized:
     parameters:
       project:


### PR DESCRIPTION
Because:
- Node 0 was doing double duty: running the serialized #phone tests AND receiving its share of the timings-based split, making it the long pole that gated the whole functional-test job.

This commit:
- Makes `run-playwright-tests` reserve node 0 for the serialized #phone tests whenever #phone is grep-inverted out of the split and there is more than one node. Node 0 then skips the split (its phone tests already ran) and the split is redistributed across the remaining nodes via `--total`/`--index` shifted down by one.
- Infers the reservation from the existing `grep_invert: '#phone'` signal rather than a separate flag, so payments and single-node smoke jobs (which run no phone tests) keep the full split unchanged.
- Uses `exit 0` (not step halt) so node 0 still stores/uploads its phone-test artifacts.

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.