### PR TITLE
fix(payments-next): [f010] prompt=none failure redirects to unvalidated callback-url cookie

### DIFF
--- a/apps/payments/next/app/[locale]/auth/error/page.tsx
+++ b/apps/payments/next/app/[locale]/auth/error/page.tsx
@@ -8,6 +8,7 @@ import mozillaIcon from '@fxa/shared/assets/images/moz-logo-bw-rgb.svg';
 import Link from 'next/link';
 import { cookies } from 'next/headers';
 import { BaseButton, ButtonVariant } from '@fxa/payments/ui';
+import { getSafeRedirectUrl } from '@fxa/payments/ui-auth';
 import { config } from '../../../../config';
 import { getApp } from '@fxa/payments/ui/server';
 
@@ -18,9 +19,16 @@ export default async function AuthErrorPage({
 }) {
   const cookieStore = await cookies();
   const resolvedSearchParams = await searchParams;
-  const redirectUrl =
+  const rawRedirectUrl =
     cookieStore.get('__Secure-authjs.callback-url')?.value ||
     cookieStore.get('authjs.callback-url')?.value;
+
+  const redirectUrl = rawRedirectUrl
+    ? getSafeRedirectUrl(rawRedirectUrl, config.paymentsNextHostedUrl, [
+        config.contentServerUrl,
+        config.paymentsNextHostedUrl,
+      ])
+    : undefined;
   const supportUrl = config.supportUrl;
   const l10n = getApp().getL10n();
   const errorMessage = Array.isArray(resolvedSearchParams?.error)

--- a/apps/payments/next/app/api/auth/callback/fxa/route.ts
+++ b/apps/payments/next/app/api/auth/callback/fxa/route.ts
@@ -2,6 +2,8 @@ import { NextRequest } from 'next/server';
 import { GET as AuthJsGET } from '../../../../../auth';
 import { redirect } from 'next/navigation';
 import { getApp } from '@fxa/payments/ui/server';
+import { getSafeRedirectUrl } from '@fxa/payments/ui-auth';
+import { config } from 'apps/payments/next/config';
 
 export { POST } from '../../../../../auth';
 
@@ -55,7 +57,12 @@ export async function GET(request: NextRequest) {
       cookieStore.get('authjs.callback-url');
     if (redirectUrl?.value) {
       getApp().getEmitterService().emit('auth', { type: 'prompt_none_fail' });
-      redirect(redirectUrl.value);
+      redirect(
+        getSafeRedirectUrl(redirectUrl.value, config.paymentsNextHostedUrl, [
+          config.contentServerUrl,
+          config.paymentsNextHostedUrl,
+        ])
+      );
     }
   }
 

--- a/libs/payments/ui-auth/src/index.ts
+++ b/libs/payments/ui-auth/src/index.ts
@@ -6,5 +6,6 @@ export { setupAuth, getAuthInstance } from './lib/auth';
 export type { UiAuthOptions } from './lib/auth';
 export { authConfig } from './lib/auth.config';
 export { AuthError, UnauthenticatedError } from './lib/auth.error';
+export { getSafeRedirectUrl } from './lib/getSafeRedirectUrl';
 export { getSessionUid, requireSessionUid } from './lib/session';
 export { SessionFactory } from './lib/session.factory';

--- a/libs/payments/ui-auth/src/lib/auth.ts
+++ b/libs/payments/ui-auth/src/lib/auth.ts
@@ -5,6 +5,7 @@
 import NextAuth, { customFetch } from 'next-auth';
 import { authConfig } from './auth.config';
 import { AuthError } from './auth.error';
+import { getSafeRedirectUrl } from './getSafeRedirectUrl';
 import { singleton } from './singleton';
 import { getApp } from '@fxa/payments/ui/server';
 
@@ -107,18 +108,10 @@ export function setupAuth(opts: UiAuthOptions) {
         };
       },
       async redirect({ url, baseUrl }) {
-        if (url.startsWith('/')) return `${baseUrl}${url}`;
-
-        const urlOrigin = new URL(url).origin;
-        if (
-          urlOrigin === baseUrl ||
-          urlOrigin === opts.contentServerUrl ||
-          urlOrigin === opts.paymentsNextHostedUrl
-        ) {
-          return url;
-        }
-
-        return baseUrl;
+        return getSafeRedirectUrl(url, baseUrl, [
+          opts.contentServerUrl,
+          opts.paymentsNextHostedUrl,
+        ]);
       },
     },
     events: {

--- a/libs/payments/ui-auth/src/lib/getSafeRedirectUrl.test.ts
+++ b/libs/payments/ui-auth/src/lib/getSafeRedirectUrl.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getSafeRedirectUrl } from './getSafeRedirectUrl';
+
+describe('getSafeRedirectUrl', () => {
+  const baseUrl = 'https://payments.example.com';
+  const contentServerUrl = 'https://accounts.example.com';
+  const allowedOrigins = [contentServerUrl, baseUrl];
+
+  it('resolves same-origin relative paths against baseUrl', () => {
+    expect(getSafeRedirectUrl('/checkout', baseUrl, allowedOrigins)).toBe(
+      `${baseUrl}/checkout`
+    );
+  });
+
+  it('returns a url whose origin equals baseUrl', () => {
+    const url = `${baseUrl}/success?foo=bar`;
+    expect(getSafeRedirectUrl(url, baseUrl, allowedOrigins)).toBe(url);
+  });
+
+  it('returns a url whose origin is on the allow-list', () => {
+    const url = `${contentServerUrl}/settings`;
+    expect(getSafeRedirectUrl(url, baseUrl, allowedOrigins)).toBe(url);
+  });
+
+  it('falls back to baseUrl for a disallowed origin', () => {
+    expect(
+      getSafeRedirectUrl('https://evil.example', baseUrl, allowedOrigins)
+    ).toBe(baseUrl);
+  });
+
+  it('falls back to baseUrl for a tossed sibling-subdomain origin', () => {
+    expect(
+      getSafeRedirectUrl(
+        'https://evil.firefox.com',
+        baseUrl,
+        allowedOrigins
+      )
+    ).toBe(baseUrl);
+  });
+
+  it('falls back to baseUrl for a malformed url', () => {
+    expect(getSafeRedirectUrl('not a url', baseUrl, allowedOrigins)).toBe(
+      baseUrl
+    );
+  });
+
+  it('neutralizes protocol-relative urls by prefixing baseUrl', () => {
+    expect(
+      getSafeRedirectUrl('//evil.example', baseUrl, allowedOrigins)
+    ).toBe(`${baseUrl}//evil.example`);
+  });
+});

--- a/libs/payments/ui-auth/src/lib/getSafeRedirectUrl.ts
+++ b/libs/payments/ui-auth/src/lib/getSafeRedirectUrl.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function getSafeRedirectUrl(
+  url: string,
+  baseUrl: string,
+  allowedOrigins: string[]
+): string {
+  if (url.startsWith('/')) return `${baseUrl}${url}`;
+  try {
+    const urlOrigin = new URL(url).origin;
+    if (urlOrigin === baseUrl || allowedOrigins.includes(urlOrigin)) {
+      return url;
+    }
+  } catch {
+    // Malformed URL - fall through to baseUrl.
+  }
+  return baseUrl;
+}


### PR DESCRIPTION
## Because

* The prompt=none login_required branch and the auth error page redirected to the authjs.callback-url cookie without validation, bypassing NextAuth's redirect allow-list. A cookie tossed from a sibling *.firefox.com subdomain could force an open redirect to an attacker-controlled URL.

## This pull request

* Adds a shared getSafeRedirectUrl helper that validates redirect origins against the NextAuth allow-list, and applies it in the callback route, the auth error page, and the existing redirect callback.

## Issue that this pull request solves

Closes #[PAY-3803](https://mozilla-hub.atlassian.net/browse/PAY-3803)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3803]: https://mozilla-hub.atlassian.net/browse/PAY-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ