### PR TITLE
fix(payments-ui): use @fxa/payments/cart alias in assertCartOwnership

### DIFF
--- a/libs/payments/cart/src/index.ts
+++ b/libs/payments/cart/src/index.ts
@@ -6,7 +6,10 @@ export * from './lib/cart.factories';
 export * from './lib/cart.manager';
 export * from './lib/cart.service';
 export * from './lib/cart.utils';
-export { CartInvalidStateForActionError } from './lib/cart.error';
+export {
+  CartInvalidStateForActionError,
+  CartUidMismatchError,
+} from './lib/cart.error';
 export * from './lib/checkout.service';
 export * from './lib/checkout.error';
 export * from './lib/checkout.types';

--- a/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.ts
+++ b/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.ts
@@ -3,18 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getSessionUid } from '@fxa/payments/ui-auth';
-import { CartUidMismatchError } from 'libs/payments/cart/src/lib/cart.error';
+import { CartUidMismatchError } from '@fxa/payments/cart';
 
 /**
  * Throws CartUidMismatchError before the decorated method runs when the cart has
  * a uid and it does not match the current session uid.
  */
 export function AssertCartOwnership() {
-  return function (
-    _target: any,
-    _key: string,
-    descriptor: PropertyDescriptor
-  ) {
+  return function (_target: any, _key: string, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
 
     descriptor.value = async function (this: any, args: any) {


### PR DESCRIPTION
## Because

- Webpack's production bundler evaluated NextJSActionsService before its class definition completed, triggering a ReferenceError that 500'd all payments-next routes on stage.

## This pull request

- Exports CartUidMismatchError from the @fxa/payments/cart
- Replaces the import with the @fxa/payments/cart alias

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.
