### PR TITLE
fix(functional-tests): register WAF bypass header on the browser context

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -17,8 +17,11 @@ import { BaseTarget } from '../targets/base';
 import { TestAccountTracker } from '../testAccountTracker';
 import { PasskeyPage } from '../../pages/passkey';
 import { GleanEventsHelper } from '../glean';
+import { addWafBypassHeader } from '../waf';
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname, basename } from 'path';
+
+export { addWafBypassHeader };
 
 // The DEBUG env is used to debug without the playwright inspector, like in vscode
 // see .vscode/launch.json
@@ -34,42 +37,6 @@ export type TestOptions = {
   gleanEventsHelper: GleanEventsHelper;
 };
 export type WorkerOptions = { targetName: TargetName; target: ServerTarget };
-
-const CI_WAF_TOKEN = process.env.CI_WAF_TOKEN;
-
-/**
- * Adds a route handler that injects the WAF bypass header on requests to
- * FXA-owned domains only, leaving third-party origins (Stripe, hCaptcha)
- * untouched. No-op when CI_WAF_TOKEN is unset.
- */
-export async function addWafBypassHeader(page: Page, target: BaseTarget) {
-  if (!CI_WAF_TOKEN) {
-    if (target.name === 'stage' || target.name === 'production') {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `⚠ CI_WAF_TOKEN is not set for target "${target.name}". Requests may be blocked by the WAF.`
-      );
-    }
-    return;
-  }
-  const fxaDomains = [
-    new URL(target.contentServerUrl).host,
-    new URL(target.authServerUrl).host,
-    new URL(target.paymentsNextUrl).host,
-    new URL(target.relierUrl).host,
-  ];
-  const pattern = new RegExp(
-    fxaDomains.map((d) => d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
-  );
-  await page.route(pattern, async (route) => {
-    await route.continue({
-      headers: {
-        ...route.request().headers(),
-        'fxa-ci': CI_WAF_TOKEN,
-      },
-    });
-  });
-}
 
 export const test = base.extend<TestOptions, WorkerOptions>({
   targetName: ['local', { scope: 'worker', option: true }],

--- a/packages/functional-tests/lib/waf.ts
+++ b/packages/functional-tests/lib/waf.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Page } from '@playwright/test';
+import { BaseTarget } from './targets/base';
+
+const CI_WAF_TOKEN = process.env.CI_WAF_TOKEN;
+
+/**
+ * Adds a route handler that injects the WAF bypass header on requests to
+ * FXA-owned domains only, leaving third-party origins (Stripe, hCaptcha)
+ * untouched. No-op when CI_WAF_TOKEN is unset.
+ *
+ * Registered on the browser context, so it also covers pages opened later
+ * (e.g. `context().newPage()` in ConfigPage.getConfig), not just this page.
+ */
+export async function addWafBypassHeader(page: Page, target: BaseTarget) {
+  if (!CI_WAF_TOKEN) {
+    if (target.name === 'stage' || target.name === 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `⚠ CI_WAF_TOKEN is not set for target "${target.name}". Requests may be blocked by the WAF.`
+      );
+    }
+    return;
+  }
+  const fxaDomains = [
+    new URL(target.contentServerUrl).host,
+    new URL(target.authServerUrl).host,
+    new URL(target.paymentsNextUrl).host,
+    new URL(target.relierUrl).host,
+  ];
+  const pattern = new RegExp(
+    fxaDomains.map((d) => d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  );
+  await page.context().route(pattern, async (route) => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        'fxa-ci': CI_WAF_TOKEN,
+      },
+    });
+  });
+}

--- a/packages/functional-tests/pages/config.ts
+++ b/packages/functional-tests/pages/config.ts
@@ -9,7 +9,8 @@ export class ConfigPage extends BaseLayout {
 
   async getConfig() {
     if (!this.config) {
-      // Create a new page
+      // Create a new page. The WAF bypass header is registered on the browser
+      // context (see addWafBypassHeader), so this page inherits it.
       const page = await this.page.context().newPage();
 
       await page.goto(this.baseUrl);


### PR DESCRIPTION
## Because

- On stage/production the content-server root sits behind Fastly's bot "Client Challenge"; functional tests need the `fxa-ci` bypass header to reach the app.
- `addWafBypassHeader` used `page.route()` (per-page), so pages opened outside the fixtures didn't inherit it. 

## This pull request

- Registers the WAF bypass route on the **browser context** (`page.context().route`) instead of the page, so every page in the context — including `getConfig`'s `newPage` — inherits it, while keeping the FXA-domain scoping that avoids leaking the token to third-party origins (Stripe, hCaptcha).

## Issue that this pull request solves

Closes https://mozilla-hub.atlassian.net/browse/FXA-14175

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test (stage, requires `CI_WAF_TOKEN`):**
1. `cd packages/functional-tests`
2. `CI_WAF_TOKEN=<token> npx playwright test --project=stage tests/settings/passkey.spec.ts tests/cms/cms.spec.ts`
3. Suites that previously timed out in the `getConfig` `beforeEach` now pass (verified: `settings/passkey` 5/5, `cms` 6/6 on Playwright 1.61.1).