### PR TITLE
fix(payments-ui): Fix circular dependency in assertCartOwnership decorator

### DIFF
--- a/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.spec.ts
+++ b/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment node
+ */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CartUidMismatchError } from '@fxa/payments/cart';
+import { AssertCartOwnership } from './assertCartOwnership.decorator';
+
+const MOCK_SESSION_UID = 'session-uid-abc-123';
+const MOCK_CART_ID = 'cart-id-def-456';
+const MOCK_OTHER_UID = 'other-uid-xyz-789';
+
+const mockGetSessionUid = jest.fn<Promise<string | undefined>, []>();
+
+jest.mock('@fxa/payments/ui-auth', () => ({
+  __esModule: true,
+  getSessionUid: (...args: unknown[]) => mockGetSessionUid(...(args as [])),
+}));
+
+class TestService {
+  cartManager = {
+    fetchCartById: jest.fn(),
+  };
+
+  originalMethodMock = jest.fn();
+
+  @AssertCartOwnership()
+  async decoratedMethod(args: { cartId: string }) {
+    return this.originalMethodMock(args);
+  }
+}
+
+describe('AssertCartOwnership', () => {
+  let service: TestService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new TestService();
+    mockGetSessionUid.mockResolvedValue(MOCK_SESSION_UID);
+  });
+
+  it('calls the original method when the cart has no uid', async () => {
+    service.cartManager.fetchCartById.mockResolvedValue({
+      id: MOCK_CART_ID,
+      uid: null,
+    });
+    service.originalMethodMock.mockResolvedValue('result');
+
+    const result = await service.decoratedMethod({ cartId: MOCK_CART_ID });
+
+    expect(result).toBe('result');
+    expect(service.cartManager.fetchCartById).toHaveBeenCalledWith(
+      MOCK_CART_ID
+    );
+    expect(service.originalMethodMock).toHaveBeenCalledWith({
+      cartId: MOCK_CART_ID,
+    });
+  });
+
+  it('calls the original method when cart uid matches the session uid', async () => {
+    service.cartManager.fetchCartById.mockResolvedValue({
+      id: MOCK_CART_ID,
+      uid: MOCK_SESSION_UID,
+    });
+    service.originalMethodMock.mockResolvedValue('result');
+
+    const result = await service.decoratedMethod({ cartId: MOCK_CART_ID });
+
+    expect(result).toBe('result');
+    expect(service.originalMethodMock).toHaveBeenCalledWith({
+      cartId: MOCK_CART_ID,
+    });
+  });
+
+  it('throws CartUidMismatchError when cart uid does not match the session uid', async () => {
+    service.cartManager.fetchCartById.mockResolvedValue({
+      id: MOCK_CART_ID,
+      uid: MOCK_OTHER_UID,
+    });
+
+    await expect(
+      service.decoratedMethod({ cartId: MOCK_CART_ID })
+    ).rejects.toThrow(CartUidMismatchError);
+    expect(service.originalMethodMock).not.toHaveBeenCalled();
+  });
+
+  it('throws CartUidMismatchError with the cart id and session uid', async () => {
+    service.cartManager.fetchCartById.mockResolvedValue({
+      id: MOCK_CART_ID,
+      uid: MOCK_OTHER_UID,
+    });
+
+    let thrownError: CartUidMismatchError | undefined;
+    try {
+      await service.decoratedMethod({ cartId: MOCK_CART_ID });
+    } catch (err) {
+      thrownError = err as CartUidMismatchError;
+    }
+
+    expect(thrownError).toBeInstanceOf(CartUidMismatchError);
+    expect(thrownError?.name).toBe('CartUidMismatchError');
+    expect(thrownError?.message).toBe('Cart UID does not match session UID');
+  });
+
+  it('allows access when the session uid is undefined and the cart has a uid', async () => {
+    mockGetSessionUid.mockResolvedValue(undefined);
+    service.cartManager.fetchCartById.mockResolvedValue({
+      id: MOCK_CART_ID,
+      uid: MOCK_OTHER_UID,
+    });
+
+    // cart.uid ('other-uid') !== sessionUid (undefined) → should throw
+    await expect(
+      service.decoratedMethod({ cartId: MOCK_CART_ID })
+    ).rejects.toThrow(CartUidMismatchError);
+  });
+
+  it('fetches the cart by the cartId from args', async () => {
+    service.cartManager.fetchCartById.mockResolvedValue({
+      id: MOCK_CART_ID,
+      uid: null,
+    });
+    service.originalMethodMock.mockResolvedValue(undefined);
+
+    await service.decoratedMethod({ cartId: MOCK_CART_ID });
+
+    expect(service.cartManager.fetchCartById).toHaveBeenCalledWith(
+      MOCK_CART_ID
+    );
+  });
+
+  it('propagates errors from fetchCartById', async () => {
+    const dbError = new Error('ECONNREFUSED');
+    service.cartManager.fetchCartById.mockRejectedValue(dbError);
+
+    await expect(
+      service.decoratedMethod({ cartId: MOCK_CART_ID })
+    ).rejects.toThrow(dbError);
+    expect(service.originalMethodMock).not.toHaveBeenCalled();
+  });
+});

--- a/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.ts
+++ b/libs/payments/ui/src/lib/nestapp/assertCartOwnership.decorator.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getSessionUid } from '@fxa/payments/ui-auth';
 import { CartUidMismatchError } from '@fxa/payments/cart';
 
 /**
@@ -15,6 +14,7 @@ export function AssertCartOwnership() {
 
     descriptor.value = async function (this: any, args: any) {
       const cartId = args?.cartId as string;
+      const { getSessionUid } = await import('@fxa/payments/ui-auth');
       const sessionUid = await getSessionUid();
 
       const cart = await this.cartManager.fetchCartById(cartId);


### PR DESCRIPTION
## Because

- The static import of `getSessionUid` from `@fxa/payments/ui-auth` in `assertCartOwnership.decorator.ts` created a circular dependency: decorator → ui-auth → ui/server → app.ts → nextjs-actions.service → decorator.
- This caused a TDZ ReferenceError ("Cannot access 'NextJSActionsService' before initialization") on stage, returning 500 for all SSR pages including /subscriptions/manage.


## This pull request

- Changes the `@fxa/payments/ui-auth` import in the decorator to a dynamic `await import()`, breaking the circular module evaluation chain.
- Adds unit tests for the `AssertCartOwnership` decorator.

## Issue that this pull request solves

Closes: PAY-3828

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
