### PR TITLE
fix(payments-next): [f003] restartCart resurrects ineligible carts into checkout-able START state

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -259,6 +259,16 @@ export class CartEligibilityMismatchError extends CartError {
   }
 }
 
+export class CartEligibilityStatusNotAllowedError extends CartError {
+  constructor(cartId: string, eligibilityStatus: CartEligibilityStatus) {
+    super('Cart eligibility status not allowed for checkout', {
+      cartId,
+      eligibilityStatus,
+    });
+    this.name = 'CartEligibilityStatusNotAllowedError';
+  }
+}
+
 export class CartFreeTrialMismatchError extends CartError {
   constructor(
     cartId: string,

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -1285,9 +1285,12 @@ describe('CartService', () => {
       jest
         .spyOn(productConfigurationManager, 'retrieveStripePrice')
         .mockResolvedValue(mockPrice);
+      jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
+        subscriptionEligibilityResult: EligibilityStatus.CREATE,
+      });
     });
 
-    it('fetches old cart and creates new cart with same details', async () => {
+    it('fetches old cart and creates new cart with same details and re-validated eligibility', async () => {
       jest
         .spyOn(promotionCodeManager, 'assertValidPromotionCodeNameForPrice')
         .mockResolvedValue(undefined);
@@ -1299,6 +1302,12 @@ describe('CartService', () => {
       const result = await cartService.restartCart(mockOldCart.id);
 
       expect(cartManager.fetchCartById).toHaveBeenCalledWith(mockOldCart.id);
+      expect(eligibilityService.checkEligibility).toHaveBeenCalledWith(
+        mockOldCart.interval,
+        mockOldCart.offeringConfigId,
+        mockOldCart.uid,
+        mockAccountCustomer.stripeCustomerId
+      );
       expect(cartManager.createCart).toHaveBeenCalledWith({
         uid: mockOldCart.uid,
         interval: mockOldCart.interval,
@@ -1308,9 +1317,38 @@ describe('CartService', () => {
         currency: mockOldCart.currency,
         stripeCustomerId: mockAccountCustomer.stripeCustomerId,
         amount: mockOldCart.amount,
-        eligibilityStatus: mockOldCart.eligibilityStatus,
+        eligibilityStatus: CartEligibilityStatus.CREATE,
         isFreeTrial: mockOldCart.isFreeTrial,
       });
+      expect(result).toEqual(mockNewCart);
+    });
+
+    it('creates a FAIL error cart when the user is no longer eligible', async () => {
+      jest
+        .spyOn(promotionCodeManager, 'assertValidPromotionCodeNameForPrice')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(cartManager, 'createErrorCart')
+        .mockResolvedValue(mockNewCart);
+      jest.spyOn(cartManager, 'createCart').mockResolvedValue(mockNewCart);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(eligibilityService, 'checkEligibility')
+        .mockResolvedValue({
+          subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
+        });
+
+      const result = await cartService.restartCart(mockOldCart.id);
+
+      expect(cartManager.createErrorCart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
+        }),
+        CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT
+      );
+      expect(cartManager.createCart).not.toHaveBeenCalled();
       expect(result).toEqual(mockNewCart);
     });
 

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -621,7 +621,16 @@ export class CartService {
         );
       }
 
-      return await this.cartManager.createCart({
+      const eligibility = await this.eligibilityService.checkEligibility(
+        oldCart.interval as SubplatInterval,
+        oldCart.offeringConfigId,
+        oldCart.uid,
+        accountCustomer?.stripeCustomerId
+      );
+      const cartEligibilityStatus =
+        handleEligibilityStatusMap[eligibility.subscriptionEligibilityResult];
+
+      const createCartParams: SetupCart = {
         uid: oldCart.uid,
         interval: oldCart.interval,
         offeringConfigId: oldCart.offeringConfigId,
@@ -631,9 +640,38 @@ export class CartService {
         couponCode: oldCart.couponCode || undefined,
         stripeCustomerId: accountCustomer?.stripeCustomerId || undefined,
         amount: oldCart.amount,
-        eligibilityStatus: oldCart.eligibilityStatus,
+        eligibilityStatus: cartEligibilityStatus,
         isFreeTrial: oldCart.isFreeTrial,
-      });
+      };
+
+      if (eligibility.subscriptionEligibilityResult === EligibilityStatus.SAME) {
+        return this.cartManager.createErrorCart(
+          createCartParams,
+          CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME
+        );
+      }
+
+      if (cartEligibilityStatus === CartEligibilityStatus.INVALID) {
+        return this.cartManager.createErrorCart(
+          createCartParams,
+          CartErrorReasonId.CART_ELIGIBILITY_STATUS_INVALID
+        );
+      }
+
+      if (cartEligibilityStatus === CartEligibilityStatus.DOWNGRADE) {
+        return this.cartManager.createErrorCart(
+          createCartParams,
+          CartErrorReasonId.CART_ELIGIBILITY_STATUS_DOWNGRADE
+        );
+      }
+
+      if (cartEligibilityStatus === CartEligibilityStatus.BLOCKED_IAP) {
+        return this.cartManager.createErrorCart(
+          createCartParams,
+          CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT
+        );
+      }
+      return await this.cartManager.createCart(createCartParams);
     });
   }
 

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -99,6 +99,7 @@ import {
 } from '@fxa/shared/notifier';
 import {
   CartEligibilityMismatchError,
+  CartEligibilityStatusNotAllowedError,
   CartFreeTrialMismatchError,
   CartTotalMismatchError,
   CartAccountNotFoundError,
@@ -516,6 +517,25 @@ describe('CheckoutService', () => {
         await expect(
           checkoutService.prePaySteps(mockCart, mockCart.uid)
         ).rejects.toBeInstanceOf(CartEligibilityMismatchError);
+      });
+
+      it('rejects a disallowed eligibility status even when it matches the cart', async () => {
+        const mockCart = StripeResponseFactory(
+          ResultCartFactory({
+            uid: uid,
+            couponCode: faker.string.uuid(),
+            stripeCustomerId: mockCustomer.id,
+            eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
+            amount: mockInvoicePreview.subtotal,
+          })
+        );
+        jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
+          subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
+        });
+
+        await expect(
+          checkoutService.prePaySteps(mockCart, mockCart.uid)
+        ).rejects.toBeInstanceOf(CartEligibilityStatusNotAllowedError);
       });
 
       it('throws cart free trial mismatch error when cart promised a trial but user is no longer eligible', async () => {

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -52,6 +52,7 @@ import { NotifierService } from '@fxa/shared/notifier';
 import {
   CartTotalMismatchError,
   CartEligibilityMismatchError,
+  CartEligibilityStatusNotAllowedError,
   CartFreeTrialMismatchError,
   CartAccountNotFoundError,
   CartUidNotFoundError,
@@ -60,6 +61,7 @@ import {
   CartUidMismatchError,
 } from './cart.error';
 import { CartManager } from './cart.manager';
+import { CartEligibilityStatus } from '@fxa/shared/db/mysql/account';
 import { ResultCart } from './cart.types';
 import {
   handleEligibilityStatusMap,
@@ -251,6 +253,16 @@ export class CheckoutService {
       throw new CartEligibilityMismatchError(
         cart.id,
         cart.eligibilityStatus,
+        cartEligibilityStatus
+      );
+    }
+
+    if (
+      cartEligibilityStatus !== CartEligibilityStatus.CREATE &&
+      cartEligibilityStatus !== CartEligibilityStatus.UPGRADE
+    ) {
+      throw new CartEligibilityStatusNotAllowedError(
+        cart.id,
         cartEligibilityStatus
       );
     }


### PR DESCRIPTION
## Because

* restartCart copied the old cart's eligibilityStatus into a new START cart without re-running eligibility, letting a blocked user revive a FAIL cart and check out.
* prePaySteps only compared live vs stored eligibility, so a matching-but-disallowed status (e.g. BLOCKED_IAP == BLOCKED_IAP) passed the guard.

## This pull request

* Re-runs checkEligibility in restartCart and, using a similar pattern to setupCart, routes disallowed statuses to a FAIL error cart
* Adds a prePaySteps guard that rejects any status other than CREATE/UPGRADE.


## Issue that this pull request solves

Closes #[PAY-3802](https://mozilla-hub.atlassian.net/browse/PAY-3802)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3802]: https://mozilla-hub.atlassian.net/browse/PAY-3802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ