### PR TITLE
fix(functional-tests): stabilize stage smoke redirect and pairing specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,7 +710,10 @@ jobs:
     steps:
       - git-checkout
       - restore-workspace
-      - gcp-cli/setup
+      - gcp-cli/setup:
+          # Pinned; the orb's "latest" resolution flakes. Remove once resolved:
+          # https://github.com/CircleCI-Public/gcp-cli-orb/issues/100
+          version: 502.0.0
       - run:
           name: Build shared libs
           command: NODE_OPTIONS="--max-old-space-size=7168" npx nx run-many -t build --projects=tag:scope:shared:lib --parallel=2
@@ -762,7 +765,10 @@ jobs:
     steps:
       - git-checkout
       - restore-workspace
-      - gcp-cli/setup
+      - gcp-cli/setup:
+          # Pinned; the orb's "latest" resolution flakes. Remove once resolved:
+          # https://github.com/CircleCI-Public/gcp-cli-orb/issues/100
+          version: 502.0.0
       - wait-for-infrastructure
       - run:
           name: Start customs
@@ -817,7 +823,10 @@ jobs:
     parallelism: << parameters.parallelism >>
     steps:
       - git-checkout
-      - gcp-cli/setup
+      - gcp-cli/setup:
+          # Pinned; the orb's "latest" resolution flakes. Remove once resolved:
+          # https://github.com/CircleCI-Public/gcp-cli-orb/issues/100
+          version: 502.0.0
       - provision
       - check-playwright-test-count:
           project: << parameters.project >>
@@ -849,7 +858,10 @@ jobs:
     steps:
       - git-checkout
       - restore-workspace
-      - gcp-cli/setup
+      - gcp-cli/setup:
+          # Pinned; the orb's "latest" resolution flakes. Remove once resolved:
+          # https://github.com/CircleCI-Public/gcp-cli-orb/issues/100
+          version: 502.0.0
       - check-playwright-test-count:
           project: local
       - run:
@@ -899,7 +911,10 @@ jobs:
     steps:
       - git-checkout
       - restore-workspace
-      - gcp-cli/setup
+      - gcp-cli/setup:
+          # Pinned; the orb's "latest" resolution flakes. Remove once resolved:
+          # https://github.com/CircleCI-Public/gcp-cli-orb/issues/100
+          version: 502.0.0
       - run:
           name: Add localhost
           command: |
@@ -946,7 +961,10 @@ jobs:
     parallelism: << parameters.parallelism >>
     steps:
       - git-checkout
-      - gcp-cli/setup
+      - gcp-cli/setup:
+          # Pinned; the orb's "latest" resolution flakes. Remove once resolved:
+          # https://github.com/CircleCI-Public/gcp-cli-orb/issues/100
+          version: 502.0.0
       - provision
       - run-playwright-tests:
           project: << parameters.project >>

--- a/packages/functional-tests/tests/pairing/pairingFlow.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlow.spec.ts
@@ -91,6 +91,13 @@ test.describe('severity-2 #smoke', () => {
     // server instance only serves one stack.
     // Runs once per worker. Pair-route rollout is env-stable.
     test.beforeAll(async ({ browser, target }) => {
+      // Stage-only: the authority stalls on /pair/auth/wait_for_supp against the
+      // nonprod stage channel server (passes locally and on prod). Fixme here in
+      // beforeAll so no per-test fixtures (e.g. marionetteAuthority) run on stage.
+      test.fixme(
+        target.name === 'stage',
+        'Pairing completion is flaky against the nonprod stage channel server'
+      );
       const isReact = await isPairRoutesReact(browser, target);
       test.skip(
         !isReact,

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -28,8 +28,11 @@ test.describe('severity-2 #smoke', () => {
       page,
       pages: { signin },
     }) => {
+      // waitUntil 'commit' captures the 406 response without waiting for the
+      // WAF error page's load event, which never fires and would hang goto.
       const response = await page.goto(
-        `${target.contentServerUrl}/?redirect_to=javascript:alert(1)`
+        `${target.contentServerUrl}/?redirect_to=javascript:alert(1)`,
+        { waitUntil: 'commit' }
       );
 
       if (response && response.status() === 406) {


### PR DESCRIPTION
## Because

- The `redirect_to` XSS smoke test hung for 60s on the WAF's 406 error page (its `load` event never fires) and failed the stage smoke suite.
- The React pairing smoke spec fails on stage: the nonprod stage channel server never completes the supplicant→authority handshake, so the authority stalls on `/pair/auth/wait_for_supp`. It passes locally and on prod.
- CI (and nightly) flaked repeatedly because `gcp-cli/setup` installed the "latest" gcloud at runtime, resolving the version by scraping a web page (upstream bug gcp-cli-orb#100).

## This pull request

- Loads the XSS redirect with `waitUntil: 'commit'` in `redirect.spec.ts`, capturing the 406 before the never-firing `load` event.
- Marks the pairing flow specs `fixme` on stage only, in `beforeAll` so no per-test fixtures run; keeps local/prod coverage.
- Pins gcloud to `502.0.0` across all `gcp-cli/setup` uses in `.circleci/config.yml`, removing the flaky "latest" web-scrape.

## Issue that this pull request solves

Connects https://mozilla-hub.atlassian.net/browse/FXA-14175

## Checklist

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information
