### PR TITLE
fix(payments): return accurate tag version info for payments-api and payments-next

### DIFF
--- a/_dev/docker/mono/build.sh
+++ b/_dev/docker/mono/build.sh
@@ -5,6 +5,9 @@ cd "$DIR/../../.."
 
 VERSION=$1
 
+# Strip known tag prefixes (e.g. subplat-v1.340.3 → v1.340.3)
+VERSION=$(echo "${VERSION}" | sed 's/^subplat-//')
+
 if [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Updating version in package.json to ${VERSION}"
 else

--- a/apps/payments/api/package.json
+++ b/apps/payments/api/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "payments-api",
+  "version": "0.0.0"
+}

--- a/apps/payments/api/src/app/app.controller.spec.ts
+++ b/apps/payments/api/src/app/app.controller.spec.ts
@@ -1,31 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
+const MOCK_VERSION = {
+  version: '1.341.0',
+  commit: 'abc123',
+  source: 'https://github.com/mozilla/fxa',
+};
+
 describe('AppController', () => {
-  let app: TestingModule;
+  let appController: AppController;
 
   beforeAll(async () => {
-    app = await Test.createTestingModule({
+    const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [
+        {
+          provide: AppService,
+          useValue: {
+            __heartbeat__: () => ({}),
+            __lbheartbeat__: () => ({}),
+            __version__: () => MOCK_VERSION,
+          },
+        },
+      ],
     }).compile();
+
+    appController = app.get<AppController>(AppController);
   });
 
   describe('service status endpoints', () => {
     it('__heartbeat__ should return empty object', () => {
-      const appController = app.get<AppController>(AppController);
       expect(appController.__heartbeat__()).toEqual({});
     });
 
     it('__lbheartbeat__ should return empty object', () => {
-      const appController = app.get<AppController>(AppController);
       expect(appController.__lbheartbeat__()).toEqual({});
     });
 
-    it('__version__ should return version object', () => {
-      const appController = app.get<AppController>(AppController);
-      expect(appController.__version__()).toEqual({ version: '0.0.0' });
+    it('__version__ should return version info', () => {
+      expect(appController.__version__()).toEqual(MOCK_VERSION);
     });
   });
 });

--- a/apps/payments/api/src/app/app.service.spec.ts
+++ b/apps/payments/api/src/app/app.service.spec.ts
@@ -1,5 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Test } from '@nestjs/testing';
 import { AppService } from './app.service';
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  const MOCK_VERSION_JSON = {
+    version: {
+      hash: 'abc123',
+      version: '1.341.0',
+      source: 'https://github.com/mozilla/fxa',
+    },
+  };
+  return {
+    ...actual,
+    readFileSync: (filepath: string, encoding: string) => {
+      if (filepath.endsWith('config/version.json')) {
+        return JSON.stringify(MOCK_VERSION_JSON);
+      }
+      return actual.readFileSync(filepath, encoding);
+    },
+  };
+});
 
 describe('AppService', () => {
   let service: AppService;
@@ -21,8 +45,12 @@ describe('AppService', () => {
       expect(service.__lbheartbeat__()).toEqual({});
     });
 
-    it('__version__ should return version object', () => {
-      expect(service.__version__()).toEqual({ version: '0.0.0' });
+    it('__version__ should return version from package.json with commit and source from version.json', () => {
+      expect(service.__version__()).toEqual({
+        version: '0.0.0',
+        commit: 'abc123',
+        source: 'https://github.com/mozilla/fxa',
+      });
     });
   });
 });

--- a/apps/payments/api/src/app/app.service.ts
+++ b/apps/payments/api/src/app/app.service.ts
@@ -1,9 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Injectable } from '@nestjs/common';
+import cp from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+// Version-reading logic is intentionally self-contained per app (not shared)
+// payments-api and payments-next are deployed as separate containers.
+const UNKNOWN = 'unknown';
+
+// build.sh patches package.json with the git tag version, matching version.json.
+const version = require('../../package.json').version;
+let commitHash = UNKNOWN;
+let sourceRepo = UNKNOWN;
+
+try {
+  const versionJsonPath = path.join(process.cwd(), 'config', 'version.json');
+  const info = JSON.parse(fs.readFileSync(versionJsonPath, 'utf-8'));
+  commitHash = info.version.hash;
+  sourceRepo = info.version.source;
+} catch {
+  /* ignore, fall back to git */
+}
+
+if (commitHash === UNKNOWN) {
+  try {
+    commitHash = cp.execSync('git rev-parse HEAD').toString().trim();
+  } catch {
+    commitHash = UNKNOWN;
+  }
+}
+
+if (sourceRepo === UNKNOWN) {
+  try {
+    sourceRepo = cp
+      .execSync('git config --get remote.origin.url')
+      .toString()
+      .trim();
+  } catch {
+    sourceRepo = UNKNOWN;
+  }
+}
+
+// No l10n field — payments-api is a pure backend API with no localization.
+export interface VersionInfo {
+  version: string;
+  commit: string;
+  source: string;
+}
 
 @Injectable()
 export class AppService {
-  constructor() {}
-
   __heartbeat__() {
     return {};
   }
@@ -12,9 +61,7 @@ export class AppService {
     return {};
   }
 
-  __version__() {
-    return {
-      version: '0.0.0',
-    };
+  __version__(): VersionInfo {
+    return { commit: commitHash, version, source: sourceRepo };
   }
 }

--- a/apps/payments/next/app/%5F_version__/route.ts
+++ b/apps/payments/next/app/%5F_version__/route.ts
@@ -2,10 +2,68 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import cp from 'child_process';
+import fs from 'fs';
+import path from 'path';
 import { NextResponse } from 'next/server';
 
+// force-dynamic uses Node.js runtime (not edge), so fs and child_process are available.
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
-  return NextResponse.json({ version: process.env.version });
+// Version-reading logic is intentionally self-contained per app (not shared)
+// payments-api and payments-next are deployed as separate containers.
+const UNKNOWN = 'unknown';
+// build.sh patches package.json with the git tag version, matching version.json.
+const version = require('../../package.json').version;
+
+let commitHash = UNKNOWN;
+let sourceRepo = UNKNOWN;
+let l10n: string | undefined;
+
+try {
+  const versionJsonPath = path.join(process.cwd(), 'config', 'version.json');
+  const info = JSON.parse(fs.readFileSync(versionJsonPath, 'utf-8'));
+  commitHash = info.version.hash;
+  sourceRepo = info.version.source;
+} catch {
+  /* ignore, fall back to git */
+}
+
+if (commitHash === UNKNOWN) {
+  try {
+    commitHash = cp.execSync('git rev-parse HEAD').toString().trim();
+  } catch {
+    commitHash = UNKNOWN;
+  }
+}
+
+if (sourceRepo === UNKNOWN) {
+  try {
+    sourceRepo = cp
+      .execSync('git config --get remote.origin.url')
+      .toString()
+      .trim();
+  } catch {
+    sourceRepo = UNKNOWN;
+  }
+}
+
+try {
+  l10n = fs
+    .readFileSync(
+      path.join(process.cwd(), 'public', 'locales', 'git-head.txt'),
+      'utf-8'
+    )
+    .trim();
+} catch {
+  /* git-head.txt doesn't exist in dev */
+}
+
+export async function GET() {
+  return NextResponse.json({
+    commit: commitHash,
+    version,
+    ...(l10n ? { l10n } : {}),
+    source: sourceRepo,
+  });
 }


### PR DESCRIPTION
## Because

- Version currently reflects "0.0.0" when tagged

## This pull request

- Updates version information

## Issue that this pull request solves

Closes: PAY-3808

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## Screenshot
Auth, payments-next, payments-api
<img width="1303" height="274" alt="Screenshot 2026-07-17 at 3 10 49 PM" src="https://github.com/user-attachments/assets/6be59e4c-f8ec-4c18-8e08-bbfcd7e7e541" />
