### PR TITLE
fix(settings): warn (not error) on cancelled/timed-out passkey sign-in

### DIFF
--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -93,7 +93,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.settingsHeading).toBeVisible();
     });
 
-    test('shows an error banner when the user cancels the WebAuthn prompt', async ({
+    test('shows a warning banner when the user cancels the WebAuthn prompt', async ({
       target,
       pages: { page, settings, settingsPasskeyAdd, signin },
       testAccountTracker,
@@ -116,10 +116,10 @@ test.describe('severity-1 #smoke', () => {
           await signin.passkeySigninButton.click();
         },
         async () => {
-          // Match by role to avoid coupling to the exact localized string.
-          await expect(page.getByRole('alert')).toContainText(
-            /Sign-in with passkey failed/i
-          );
+          // A cancelled ceremony now surfaces a warning banner, not the error banner.
+          await expect(
+            page.getByText(/Couldn’t sign in with a passkey/i)
+          ).toBeVisible();
         }
       );
 
@@ -576,6 +576,9 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutPasswordForm(credentials.password);
 
       await page.waitForURL(/inline_totp_setup/);
+      await expect(
+        page.getByRole('heading', { name: /Set up two-step authentication/i })
+      ).toBeVisible();
     });
 
     test('shows the passkey button on prompt=login re-auth and completes sign-in via passkey', async ({

--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.tsx
@@ -62,7 +62,7 @@ const AlternativeAuthOptions = ({
       {separator && (
         <div
           className={`text-sm flex items-center justify-center mt-6 ${
-            errorBanner ? 'mb-3' : 'mb-6'
+            errorBanner ? 'mb-0' : 'mb-6'
           }`}
         >
           <div className="flex-1 h-px bg-grey-300 divide-x"></div>
@@ -75,7 +75,7 @@ const AlternativeAuthOptions = ({
         </div>
       )}
 
-      {errorBanner && <div className="mb-4">{errorBanner}</div>}
+      {errorBanner}
 
       <div className="flex flex-col gap-2.5">
         {renderPasskey && (

--- a/packages/fxa-settings/src/components/Banner/index.test.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.test.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import Banner from './index';
 import { BannerProps } from './interfaces';
 
@@ -74,6 +75,23 @@ describe('Banner Component', () => {
       expect(
         screen.getByRole('button', { name: /Close banner/i })
       ).toHaveAttribute('data-glean-id', 'dismiss-glean-id');
+    });
+
+    it('maps an external link gleanId to the data-glean-id attribute', () => {
+      renderWithLocalizationProvider(
+        <Banner
+          {...getDefaultProps()}
+          link={{
+            url: 'https://example.com/help',
+            localizedText: 'Learn more',
+            gleanId: 'link-glean-id',
+          }}
+        />
+      );
+      expect(screen.getByRole('link', { name: /Learn more/i })).toHaveAttribute(
+        'data-glean-id',
+        'link-glean-id'
+      );
     });
   });
 });

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -89,7 +89,8 @@ export const Banner = ({
             <LinkExternal
               className="text-sm link-blue"
               href={link.url}
-              {...(link.gleanId && { 'data-glean-id': link.gleanId })}
+              {...(link.gleanId && { gleanDataAttrs: { id: link.gleanId } })}
+              onClick={link.onClick}
             >
               {link.localizedText}
             </LinkExternal>

--- a/packages/fxa-settings/src/components/Banner/interfaces.ts
+++ b/packages/fxa-settings/src/components/Banner/interfaces.ts
@@ -63,6 +63,7 @@ export type ExternalLinkProps = {
   url: string;
   localizedText: string;
   gleanId?: string;
+  onClick?: () => void;
   path?: never;
   locationState?: never;
 };

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -896,6 +896,11 @@ const recordEventMetric = (
         reason: gleanPingMetrics?.event?.['reason'] || '',
       });
       break;
+    case 'passkey_get_help_link_click':
+      passkey.getHelpLinkClick.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
     case 'passkey_enter_password_view':
       passkeyEnterPassword.view.record({
         reason: gleanPingMetrics?.event?.['reason'] || '',

--- a/packages/fxa-settings/src/lib/passkeys/en.ftl
+++ b/packages/fxa-settings/src/lib/passkeys/en.ftl
@@ -47,6 +47,17 @@ passkey-registration-error-unexpected = Passkey setup failed. Try again or choos
 
 # Authentication errors
 
+# Shown as a warning (not error) banner when a passkey sign-in is cancelled, no passkey is
+# available on this device, or the authenticator can't satisfy the request. Copy stays neutral and
+# points the user to another way to sign in.
+passkey-authentication-trouble-heading = Couldn’t sign in with a passkey
+# Shown when a passkey sign-in doesn't complete. "Try again" means retry signing in with the
+# passkey; "another sign-in option" means one of the other sign-in methods offered alongside it.
+passkey-authentication-trouble-description = Try again or use another sign-in option.
+# Label for the support link in the passkey sign-in trouble message; opens a SUMO article about
+# using passkeys.
+passkey-authentication-trouble-link = How to use passkeys
+
 # User cancelled or dismissed the browser prompt, or no passkey is available / verification failed
 passkey-authentication-error-not-allowed = Sign-in with passkey failed or is unavailable. Try again or choose another method.
 
@@ -55,6 +66,8 @@ passkey-authentication-error-not-allowed-existing = Passkey setup isn’t availa
 
 # The ceremony timed out before the user responded
 passkey-authentication-error-timeout = Passkey request timed out. Please try again.
+# Shown in a warning (not error) banner when the passkey sign-in ceremony times out.
+passkey-authentication-error-timeout-v2 = Passkey sign-in timed out. Try again.
 
 # Browser or platform does not support passkeys
 passkey-authentication-error-not-supported-v2 = Your browser or device doesn’t support passkeys.

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -14,6 +14,7 @@ import {
   type PasskeySignInIntegration,
 } from './signin-flow';
 import { getCredential, isWebAuthnSupported } from './webauthn';
+import { PASSKEY_SUPPORT_URL, PASSKEY_TROUBLESHOOT_URL } from './constants';
 import { storeAccountData } from '../storage-utils';
 import { AuthUiErrors } from '../auth-errors/auth-errors';
 import GleanMetrics from '../glean';
@@ -73,6 +74,7 @@ jest.mock('../glean', () => ({
     passkey: {
       buttonView: jest.fn(),
       authSuccess: jest.fn(),
+      getHelpLinkClick: jest.fn(),
     },
   },
 }));
@@ -611,22 +613,12 @@ describe('usePasskeySignIn', () => {
     }
   );
 
-  // Locks the contract: each DOMException name maps to its expected FTL id
-  // AND its fallback string. Drift in either lands silently otherwise.
-  // The fallback substrings are stable phrases pulled from webauthn-errors.ts
-  // — robust to minor copy edits, strict on intent.
+  // Device/platform DOMExceptions keep the red error banner. Locks the
+  // contract: each name maps to its expected FTL id AND its fallback string.
+  // Drift in either lands silently otherwise. The fallback substrings are
+  // stable phrases from webauthn-errors.ts — robust to minor copy edits,
+  // strict on intent.
   it.each([
-    [
-      'NotAllowedError',
-      'passkey-authentication-error-not-allowed',
-      'Sign-in with passkey failed',
-    ],
-    [
-      'AbortError',
-      'passkey-authentication-error-not-allowed',
-      'Sign-in with passkey failed',
-    ],
-    ['TimeoutError', 'passkey-authentication-error-timeout', 'timed out'],
     [
       'NotSupportedError',
       'passkey-authentication-error-not-supported-v2',
@@ -644,8 +636,35 @@ describe('usePasskeySignIn', () => {
       'access the authenticator',
     ],
   ])(
-    'categorises WebAuthn DOMException %s and surfaces %s',
+    'shows the error banner for device/platform DOMException %s (%s)',
     async (errorName, expectedFtlId, fallbackSubstring) => {
+      (getCredential as jest.Mock).mockRejectedValue(
+        new DOMException('failed', errorName)
+      );
+      const { args, spies } = buildArgs();
+
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      expect(handleNavigation).not.toHaveBeenCalled();
+      const banner = result.current.errorBanner as React.ReactElement;
+      expect(banner.props.type).toBe('error');
+      expect(spies.ftlMsgResolver.getMsg).toHaveBeenCalledWith(
+        expectedFtlId,
+        expect.stringContaining(fallbackSubstring)
+      );
+    }
+  );
+
+  // A cancelled ceremony (NotAllowedError / AbortError share the 'not_allowed'
+  // reason) surfaces the neutral warning banner with the help link — never the
+  // red error banner, and never Sentry.
+  it.each([['NotAllowedError'], ['AbortError']])(
+    'shows the neutral warning banner for a cancelled ceremony (%s), not the error copy, and does not report to Sentry',
+    async (errorName) => {
       (getCredential as jest.Mock).mockRejectedValue(
         new DOMException('cancelled', errorName)
       );
@@ -658,11 +677,74 @@ describe('usePasskeySignIn', () => {
       });
 
       expect(handleNavigation).not.toHaveBeenCalled();
-      expect(result.current.errorBanner).toBeDefined();
-      expect(spies.ftlMsgResolver.getMsg).toHaveBeenCalledWith(
-        expectedFtlId,
-        expect.stringContaining(fallbackSubstring)
+
+      // The core contract: a neutral warning banner (not the red error banner)
+      // carrying the help link.
+      const banner = result.current.errorBanner as React.ReactElement;
+      expect(banner.props.type).toBe('warning');
+      expect(banner.props.content).toEqual({
+        localizedHeading: 'Couldn’t sign in with a passkey',
+        localizedDescription: 'Try again or use another sign-in option.',
+      });
+      expect(banner.props.link.localizedText).toBe('How to use passkeys');
+      // Never routed to the red error banner copy, and never reported to Sentry.
+      expect(spies.ftlMsgResolver.getMsg).not.toHaveBeenCalledWith(
+        'passkey-authentication-error-not-allowed',
+        expect.anything()
       );
+      expect(Sentry.captureException as jest.Mock).not.toHaveBeenCalled();
+    }
+  );
+
+  // Timeout is transient: its own message, warning style, no help link.
+  it('shows a dedicated warning banner (no help link) on a timed-out ceremony', async () => {
+    (getCredential as jest.Mock).mockRejectedValue(
+      new DOMException('timed out', 'TimeoutError')
+    );
+    const { args } = buildArgs();
+
+    const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+    await act(async () => {
+      await result.current.onClick();
+    });
+
+    const banner = result.current.errorBanner as React.ReactElement;
+    expect(banner.props.type).toBe('warning');
+    expect(banner.props.content).toEqual({
+      localizedHeading: 'Passkey sign-in timed out. Try again.',
+    });
+    expect(banner.props.link).toBeUndefined();
+    expect(GleanMetrics.passkey.getHelpLinkClick).not.toHaveBeenCalled();
+    expect(Sentry.captureException as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  // Email-first sends users to the "what is a passkey" article; the other
+  // surfaces (where the user already has a passkey) go to troubleshooting.
+  it.each([
+    ['emailfirst' as const, PASSKEY_SUPPORT_URL, 'emailfirst'],
+    ['login' as const, PASSKEY_TROUBLESHOOT_URL, 'signin'],
+    ['login_otp' as const, PASSKEY_TROUBLESHOOT_URL, 'otplogin'],
+    ['alternative_auth' as const, PASSKEY_TROUBLESHOOT_URL, 'alternative_auth'],
+  ])(
+    'warning banner links to the right article and records a get-help click for surface=%s',
+    async (surface, expectedUrl, expectedReason) => {
+      (getCredential as jest.Mock).mockRejectedValue(
+        new DOMException('cancelled', 'NotAllowedError')
+      );
+      const { args } = buildArgs({ surface });
+
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+
+      const banner = result.current.errorBanner as React.ReactElement;
+      expect(banner.props.link.url).toBe(expectedUrl);
+
+      banner.props.link.onClick();
+      expect(GleanMetrics.passkey.getHelpLinkClick).toHaveBeenCalledWith({
+        event: { reason: expectedReason },
+      });
     }
   );
 
@@ -960,7 +1042,9 @@ describe('usePasskeySignIn', () => {
       'fires passkey.auth_success with reason=%s on the no-Sync-password branch (surface=%s)',
       async (surface, expectedReason) => {
         const { args } = buildArgs({ surface });
-        const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+        const { result } = renderHook(() => usePasskeySignIn(args), {
+          wrapper,
+        });
         await act(async () => {
           await result.current.onClick();
         });

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -14,6 +14,10 @@ import type AuthClient from 'fxa-auth-client/browser';
 import { FtlMsgResolver } from 'fxa-react/lib/utils';
 
 import Banner from '../../components/Banner';
+import type {
+  BannerContentProps,
+  ExternalLinkProps,
+} from '../../components/Banner/interfaces';
 import { AuthUiErrors } from '../auth-errors/auth-errors';
 import GleanMetrics from '../glean';
 import { useNavigate } from 'react-router';
@@ -35,6 +39,7 @@ import {
   type PublicKeyCredentialJSON,
 } from './';
 import type { PasskeySignInGleanReason } from './webauthn-errors';
+import { PASSKEY_SUPPORT_URL, PASSKEY_TROUBLESHOOT_URL } from './constants';
 
 /**
  * Sign-in surface the user clicked the passkey button on. Drives Glean event
@@ -225,6 +230,17 @@ export interface UsePasskeySignInResult {
   onClick: () => Promise<void>;
 }
 
+/**
+ * The banner the hook surfaces in its `errorBanner` slot: an `error` (red)
+ * banner for a genuine failure, or a `warning` (amber) banner for a benign
+ * outcome (cancelled ceremony or timeout).
+ */
+type PasskeyBannerState = {
+  type: 'error' | 'warning';
+  content: BannerContentProps;
+  link?: ExternalLinkProps;
+};
+
 export function usePasskeySignIn({
   integration,
   authClient,
@@ -238,7 +254,7 @@ export function usePasskeySignIn({
   supportsKeysOptionalLogin,
 }: UsePasskeySignInArgs): UsePasskeySignInResult {
   const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const [banner, setBanner] = useState<PasskeyBannerState | undefined>();
   const inFlight = useRef(false);
   const navigate = useNavigate();
 
@@ -251,29 +267,83 @@ export function usePasskeySignIn({
     }
   }, [isButtonVisible, surface]);
 
-  const errorBanner = useMemo<React.ReactNode | undefined>(
-    () =>
-      errorMessage
-        ? React.createElement(Banner, {
-            type: 'error',
-            content: { localizedHeading: errorMessage },
-          })
-        : undefined,
-    [errorMessage]
-  );
+  const errorBanner = useMemo<React.ReactNode | undefined>(() => {
+    if (!banner) {
+      return undefined;
+    }
+    return React.createElement(Banner, {
+      type: banner.type,
+      content: banner.content,
+      link: banner.link,
+    });
+  }, [banner]);
 
   const setLocalizedError = useCallback(
     (ftlId: string, fallback: string) => {
-      setErrorMessage(ftlMsgResolver.getMsg(ftlId, fallback));
+      setBanner({
+        type: 'error',
+        content: { localizedHeading: ftlMsgResolver.getMsg(ftlId, fallback) },
+      });
     },
     [ftlMsgResolver]
   );
+
+  // Shown when a passkey sign-in is cancelled (dismissed prompt, no passkey on
+  // this device, or the authenticator can't satisfy the request). Points to
+  // help plus another sign-in option.
+  const setWarningBanner = useCallback(() => {
+    setBanner({
+      type: 'warning',
+      content: {
+        localizedHeading: ftlMsgResolver.getMsg(
+          'passkey-authentication-trouble-heading',
+          'Couldn’t sign in with a passkey'
+        ),
+        localizedDescription: ftlMsgResolver.getMsg(
+          'passkey-authentication-trouble-description',
+          'Try again or use another sign-in option.'
+        ),
+      },
+      link: {
+        url:
+          surface === 'emailfirst'
+            ? PASSKEY_SUPPORT_URL
+            : PASSKEY_TROUBLESHOOT_URL,
+        localizedText: ftlMsgResolver.getMsg(
+          'passkey-authentication-trouble-link',
+          'How to use passkeys'
+        ),
+        onClick: () => {
+          try {
+            GleanMetrics.passkey.getHelpLinkClick({
+              event: { reason: toPasskeyMetricsSurface(surface) },
+            });
+          } catch {
+            // A metrics failure must never block the help link.
+          }
+        },
+      },
+    });
+  }, [ftlMsgResolver, surface]);
+
+  // A timed-out ceremony is transient — its own message, warning style, retry.
+  const setTimeoutBanner = useCallback(() => {
+    setBanner({
+      type: 'warning',
+      content: {
+        localizedHeading: ftlMsgResolver.getMsg(
+          'passkey-authentication-error-timeout-v2',
+          'Passkey sign-in timed out. Try again.'
+        ),
+      },
+    });
+  }, [ftlMsgResolver]);
 
   const onClick = useCallback(async () => {
     if (inFlight.current) {
       return;
     }
-    setErrorMessage(undefined);
+    setBanner(undefined);
     const gleanEvents = gleanEventsForSurface(surface);
 
     // Button stays visible even without support — the user may have a passkey
@@ -324,7 +394,14 @@ export function usePasskeySignIn({
             Sentry.captureException
           );
           gleanEvents.submitFrontendError(categorized.gleanReason);
-          setLocalizedError(categorized.ftlId, categorized.fallbackText);
+          // Cancelled and timed-out ceremonies are benign — warn, don't error.
+          if (categorized.gleanReason === 'not_allowed') {
+            setWarningBanner();
+          } else if (categorized.gleanReason === 'timeout') {
+            setTimeoutBanner();
+          } else {
+            setLocalizedError(categorized.ftlId, categorized.fallbackText);
+          }
           finish();
           return;
         }
@@ -492,6 +569,8 @@ export function usePasskeySignIn({
     queryParams,
     flowQueryParams,
     setLocalizedError,
+    setWarningBanner,
+    setTimeoutBanner,
     surface,
     supportsKeysOptionalLogin,
   ]);

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -612,21 +612,6 @@ const SigninPasswordlessCode = ({
         }}
       />
 
-      {showPasskeySignin && (
-        <AlternativeAuthOptions
-          showThirdPartyAuth={false}
-          showPasskeySignin={showPasskeySignin}
-          passkeySignIn={{
-            isLoading: passkey.isLoading,
-            onClick: passkey.onClick,
-          }}
-          errorBanner={passkey.errorBanner}
-          {...{ viewName, flowQueryParams }}
-        />
-      )}
-
-      <TermsPrivacyAgreement legalTerms={integration.getLegalTerms()} />
-
       <div className="mt-6 text-grey-500 text-sm inline-flex gap-1">
         <FtlMsg id="signin-passwordless-code-expired">
           <p>Code expired?</p>
@@ -659,6 +644,21 @@ const SigninPasswordlessCode = ({
           </FtlMsg>
         )}
       </div>
+
+      {showPasskeySignin && (
+        <AlternativeAuthOptions
+          showThirdPartyAuth={false}
+          showPasskeySignin={showPasskeySignin}
+          passkeySignIn={{
+            isLoading: passkey.isLoading,
+            onClick: passkey.onClick,
+          }}
+          errorBanner={passkey.errorBanner}
+          {...{ viewName, flowQueryParams }}
+        />
+      )}
+
+      <TermsPrivacyAgreement legalTerms={integration.getLegalTerms()} />
     </AppLayout>
   );
 };

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -2948,6 +2948,31 @@ passkey:
           'otplogin' and 'alternative_auth' are no-password surfaces, so they
           pair only with 'nopassword'/'createdpassword' (never 'withpassword').
         type: string
+  get_help_link_click:
+    type: event
+    description: |
+      The help link in the passkey sign-in trouble banner was clicked. The
+      banner is shown for a cancelled ceremony (dismissed prompt, no passkey on
+      this device, or the authenticator can't satisfy the request).
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-14171
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: |
+          Sign-in surface the banner was shown on: 'emailfirst', 'signin',
+          'otplogin', or 'alternative_auth'.
+        type: string
 
 account_pref:
   view:

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -181,6 +181,7 @@ export const eventsMap = {
   passkey: {
     buttonView: 'passkey_button_view',
     authSuccess: 'passkey_auth_success',
+    getHelpLinkClick: 'passkey_get_help_link_click',
   },
 
   cad: {

--- a/packages/fxa-shared/metrics/glean/web/passkey.ts
+++ b/packages/fxa-shared/metrics/glean/web/passkey.ts
@@ -48,3 +48,23 @@ export const buttonView = new EventMetricType<{
   },
   ['reason']
 );
+
+/**
+ * The help link in the passkey sign-in trouble banner was clicked. The
+ * banner is shown for a cancelled ceremony (dismissed prompt, no passkey on
+ * this device, or the authenticator can't satisfy the request).
+ *
+ * Generated from `passkey.get_help_link_click`.
+ */
+export const getHelpLinkClick = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'passkey',
+    name: 'get_help_link_click',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);


### PR DESCRIPTION
## Because

- Cancelling a passkey sign-in — or letting it time out — is a benign, expected outcome, but the UI showed a **red error banner** (`role="alert"`) with no path forward (a passkey can't be enrolled from a sign-in screen). That over-alarms users and inflates the perceived passkey error rate.

## This pull request

- Shows an amber **warning** banner (`role="status"`) instead of the red error banner for a **cancelled** ceremony — *"Couldn’t sign in with a passkey"* + a *"How to use passkeys"* link — and a separate warning banner for a **timeout** (*"Passkey sign-in timed out. Try again."*). Genuine device/platform and unexpected errors keep the error banner.
- Routes the help link to the passkey **how-to** article on email-first, and the **troubleshooting** article on the other sign-in surfaces.
- Adds a `passkey.get_help_link_click` Glean event (`reason` = surface), fired when the help link is used; adds an `onClick` passthrough on `Banner`'s external link.
- Moves the passwordless-OTP *"Code expired?"* prompt to directly below the **Confirm** button.

## Issue that this pull request solves

Closes: FXA-14171

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Screenshots (Optional)

<img width="480" height="693" alt="image" src="https://github.com/user-attachments/assets/3b2f3610-3ef1-476d-b1bb-f6e5e43615c7" />

## How to review (Optional)

- Key files: `lib/passkeys/signin-flow.ts` (banner routing by `gleanReason`); `components/Banner/{index,interfaces}.ts` (link `onClick`); `metrics/glean/fxa-ui-metrics.yaml` + `web/passkey.ts` (new event); `SigninPasswordlessCode/index.tsx` (layout).
- Risky/complex: the `NotAllowedError`/`AbortError`/`TimeoutError` → banner routing; the new Glean metric.

## Other information (Optional)

- **New Glean metric** (`passkey.get_help_link_click`) — needs the standard metrics notification/data-review sign-off.
- `AbortError` is grouped with `NotAllowedError` (same "ceremony cancelled" reason).
- Broad passkey error-copy standardization (FXA-13897/FXA-13942) is a **fast-follow**: this PR reuses the existing timeout wording as a `-v2` string and leaves the rest of `ERROR_MAP` copy + Learn-more links to that work.

