### PR TITLE
feat(auth): Add option to skip access token creation on oauth grants used by Fx

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -215,6 +215,14 @@ const DESCRIPTIONS = {
     - \`grant_type=authorization_code\` and the original authorization request included \`access_type=offline\`.
     - \`grant_type=fxa-credentials\` and the request included \`access_type=offline\`.
   `,
+  refreshTokenOnly: dedent`
+    When true, return a refresh token without minting an access token, deferring
+    access-token creation (and the \`access_token.created\` Glean event it drives)
+    until the client later uses that refresh token to request an access token.
+    Requires an offline grant: \`access_type=offline\` for
+    \`grant_type=fxa-credentials\`, or an authorization code created with
+    \`access_type=offline\` for \`grant_type=authorization_code\`.
+  `,
   refreshTokenId: 'The specific `refresh_token_id` to be destroyed.',
   reminder: 'Indicates that verification originates from a reminder email.',
   resource:

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -183,16 +183,28 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
 // This function does *not* perform any authentication or validation, assuming that
 // the specified grant has been sufficiently vetted by calling code.
 module.exports.generateTokens = async function generateTokens(grant) {
-  // We always generate an access_token.
-  const access = await exports.generateAccessToken(grant);
+  // `refreshTokenOnly` lets a caller obtain a refresh token *without* minting an
+  // access token, deferring access-token creation (and the `access_token.created`
+  // Glean event it drives) until the service is actually used. It requires an
+  // offline grant — otherwise the response would be empty.
+  if (grant.refreshTokenOnly && !grant.offline) {
+    throw OauthError.invalidRequestParameter('refresh_token_only');
+  }
 
-  const result = {
-    access_token: access.jwt_token || access.token.toString('hex'),
-    token_type: access.type,
-    scope: access.scope.toString(),
-  };
-  result.expires_in =
-    grant.ttl || Math.floor((access.expiresAt - Date.now()) / 1000);
+  const result = {};
+  if (grant.refreshTokenOnly) {
+    // Access token intentionally omitted; carry the granted scope through so the
+    // client still learns what the eventual access token will be good for.
+    result.scope = grant.scope.toString();
+  } else {
+    // Always generate an access_token.
+    const access = await exports.generateAccessToken(grant);
+    result.access_token = access.jwt_token || access.token.toString('hex');
+    result.token_type = access.type;
+    result.scope = access.scope.toString();
+    result.expires_in =
+      grant.ttl || Math.floor((access.expiresAt - Date.now()) / 1000);
+  }
   if (grant.authAt) {
     result.auth_at = grant.authAt;
   }
@@ -205,7 +217,16 @@ module.exports.generateTokens = async function generateTokens(grant) {
     result.refresh_token = refresh.token.toString('hex');
   }
   // Maybe also generate an idToken?
-  if (grant.scope && grant.scope.contains(SCOPE_OPENID)) {
+  // The id_token is a separate token whose at_hash claim hashes the access token,
+  // so producing one requires an access token — which a refresh-token-only grant
+  // doesn't mint (hence the !refreshTokenOnly guard). A plain refresh_token grant
+  // has openid excluded from its scope upstream (validateRefreshTokenGrant), so it
+  // doesn't reach here with openid either.
+  if (
+    !grant.refreshTokenOnly &&
+    grant.scope &&
+    grant.scope.contains(SCOPE_OPENID)
+  ) {
     result.id_token = await generateIdToken(grant, result.access_token);
   }
 

--- a/packages/fxa-auth-server/lib/oauth/grant.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/grant.spec.ts
@@ -328,4 +328,48 @@ describe('generateTokens', () => {
     const jwt = decodeJWT(result.id_token);
     expect(jwt.claims.auth_time).toBe(Math.floor(requestedGrant.authAt / 1000));
   });
+
+  describe('refreshTokenOnly', () => {
+    beforeEach(() => {
+      requestedGrant.offline = true;
+      requestedGrant.refreshTokenOnly = true;
+    });
+
+    it('returns the refresh token and scope but no access token', async () => {
+      const result = await generateTokens(requestedGrant);
+      expect(mockDB.generateAccessToken).not.toHaveBeenCalled();
+      expect(result.refresh_token).toBe('refresh_token');
+      expect(result.scope).toBe(
+        'profile:uid profile:email profile:subscriptions'
+      );
+      expect('access_token' in result).toBe(false);
+      expect('token_type' in result).toBe(false);
+      expect('expires_in' in result).toBe(false);
+    });
+
+    it('still returns keys_jwe from the grant', async () => {
+      requestedGrant.keysJwe = 'encrypted-keys';
+      const result = await generateTokens(requestedGrant);
+      expect(result.keys_jwe).toBe('encrypted-keys');
+      expect(result.refresh_token).toBe('refresh_token');
+    });
+
+    it('does not generate an id_token even when the openid scope is requested', async () => {
+      requestedGrant.scope = ScopeSet.fromArray(['openid']);
+      const result = await generateTokens(requestedGrant);
+      expect('id_token' in result).toBe(false);
+      expect('access_token' in result).toBe(false);
+      expect(result.refresh_token).toBe('refresh_token');
+    });
+
+    it('rejects with invalidRequestParameter when the grant is not offline', async () => {
+      requestedGrant.offline = false;
+      await expect(generateTokens(requestedGrant)).rejects.toMatchObject({
+        errno: 109,
+        message: 'Invalid request parameter',
+      });
+      expect(mockDB.generateAccessToken).not.toHaveBeenCalled();
+      expect(mockDB.generateRefreshToken).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -18,6 +18,16 @@
 //   * A long-lived `refresh_token`, via `access_type=offline`
 //   * An OpenID Connect `id_token`, via `scope=openid`
 //
+// Which of those each grant returns:
+//
+//   * `refresh_token` — a fresh `access_token` only (never a new refresh_token).
+//   * token-exchange — an `access_token` + `refresh_token` (the presented
+//     refresh_token is then revoked).
+//   * `authorization_code` / `fxa-credentials` — an `access_token`; add
+//     `access_type=offline` for a `refresh_token` too, or `refresh_token_only=true`
+//     (offline only, `/oauth/token` route only — the legacy `/token` route strips
+//     it) for the `refresh_token` and no `access_token`.
+//
 // And because of the different client authentication methods:
 //
 //   * `client_secret`, provided in either header or request body
@@ -41,7 +51,6 @@ const { config } = require('../../../config');
 const encrypt = require('fxa-shared/auth/encrypt');
 const util = require('../../oauth/util');
 const oauthRouteUtils = require('../utils/oauth');
-const token = require('../../oauth/token');
 const validators = require('../../oauth/validators');
 const { validateRequestedGrant, generateTokens } = require('../../oauth/grant');
 const verifyAssertion = require('../../oauth/assertion');
@@ -266,6 +275,10 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
     requestedGrant.ppidSeed = params.ppid_seed;
     requestedGrant.resource = params.resource;
     requestedGrant.ttl = Math.min(params.ttl, MAX_TTL_S);
+    // Opt-in for the authorization_code / fxa-credentials grants only (the
+    // payload schema exposes the param on just those two). Absent elsewhere,
+    // so this coerces to false for refresh_token / token-exchange grants.
+    requestedGrant.refreshTokenOnly = params.refresh_token_only === true;
     return requestedGrant;
   }
 
@@ -622,14 +635,21 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
       service: oauthClientId,
       uid,
     });
-    glean.oauth.tokenCreated(req, {
-      uid,
-      oauthClientId,
-      reason: params.reason
-        ? `${params.grant_type}:${params.reason}`
-        : params.grant_type,
-      scopes: grant.scope?.toString() || '',
-    });
+    // This event maps to the `access_token.created` Glean event, so only emit it when
+    // an access token was _actually_ minted. A refresh_token_only grant creates no
+    // access token, so it is skipped here; the access token — and this event — come
+    // later when the client uses that refresh token to request an access token via
+    // the refresh_token grant.
+    if (!grant.refreshTokenOnly) {
+      glean.oauth.tokenCreated(req, {
+        uid,
+        oauthClientId,
+        reason: params.reason
+          ? `${params.grant_type}:${params.reason}`
+          : params.grant_type,
+        scopes: grant.scope?.toString() || '',
+      });
+    }
 
     if (tokens.keys_jwe) {
       const serviceTags = getClientServiceTags(req);
@@ -661,6 +681,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
     // Include grant properties needed by the /oauth/token handler for newTokenNotification.
     // These are internal properties that get stripped before returning to the client.
     tokens._clientId = oauthClientId;
+    tokens._uid = uid;
     if (grant.existingDeviceId) {
       tokens._existingDeviceId = grant.existingDeviceId;
     }
@@ -713,6 +734,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
           // Strip internal properties that are only used by /oauth/token handler
           delete result._clientId;
           delete result._existingDeviceId;
+          delete result._uid;
           return result;
         },
       },
@@ -758,6 +780,10 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
               resource: validators.resourceUrl
                 .optional()
                 .description(DESCRIPTION.resource),
+              refresh_token_only: Joi.boolean()
+                .optional()
+                .default(false)
+                .description(DESCRIPTION.refreshTokenOnly),
             }).xor('client_secret', 'code_verifier'),
             // refresh token
             Joi.object({
@@ -782,6 +808,17 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
               access_type: Joi.string()
                 .valid('online', 'offline')
                 .default('online'),
+              refresh_token_only: Joi.boolean()
+                .optional()
+                .default(false)
+                // refresh_token_only only makes sense for an offline grant (it
+                // returns just the refresh token); reject it up front otherwise
+                // rather than failing later in generateTokens.
+                .when('access_type', {
+                  is: 'offline',
+                  otherwise: Joi.valid(false),
+                })
+                .description(DESCRIPTION.refreshTokenOnly),
               // Note: the max allowed TTL is currently configured in oauth-server config,
               // making it hard to know what limit to set here.
               ttl: Joi.number().positive().optional(),
@@ -856,6 +893,17 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
               scope: validators.scope.required(),
               token_type: Joi.string().valid('bearer').required(),
               expires_in: Joi.number().required(),
+            }),
+            // refresh_token_only grant: no access token is minted, so the usual
+            // access_token / token_type / expires_in fields are absent. Only the
+            // refresh_token and scope are returned (with auth_at, keys_jwe, and
+            // session_token included when the grant produced them).
+            Joi.object({
+              refresh_token: validators.refreshToken.required(),
+              scope: validators.scope.required(),
+              auth_at: Joi.number().optional(),
+              keys_jwe: validators.jwe.optional(),
+              session_token: validators.sessionToken.optional(),
             })
           ),
         },
@@ -907,6 +955,10 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
         }
 
         const scopeSet = ScopeSet.fromString(grant.scope);
+
+        // Captured before the internal props are stripped below. Used as the uid
+        // source when there's no access token to verify (refresh_token_only).
+        const grantUid = grant._uid;
 
         // Token exchange doesn't provide a session token, and token migration
         // doesn't need a new session token created, so skip those blocks for both.
@@ -977,6 +1029,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
               skipEmail: isSilentUpgrade,
               existingDeviceId: grant._existingDeviceId,
               clientId: grant._clientId,
+              uid: grantUid,
             }
           );
         }
@@ -989,18 +1042,14 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
         // Strip internal properties before returning to client
         delete grant._clientId;
         delete grant._existingDeviceId;
+        delete grant._uid;
         delete grant.session_token_id;
 
         // attempt to record metrics, but swallow the error if one is thrown.
         try {
-          let uid = sessionToken && sessionToken.uid;
-
-          // As mentioned in lib/routes/utils/oauth.js, some grant flows won't
-          // have the uid in `credentials`, so we get it from the oauth DB.
-          if (!uid) {
-            const tokenVerify = await token.verify(grant.access_token);
-            uid = tokenVerify.user;
-          }
+          // Some grant flows (e.g. authorization_code, token-exchange) have no
+          // session token, so fall back to the uid carried on the grant.
+          const uid = (sessionToken && sessionToken.uid) || grantUid;
 
           await req.emitMetricsEvent('oauth.token.created', {
             grantType: req.payload.grant_type,

--- a/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
@@ -705,6 +705,78 @@ describe('token exchange grant_type', () => {
 });
 
 describe('/oauth/token POST', () => {
+  describe('refresh_token_only input validation', () => {
+    // tokenRoutes[1] is the POST /oauth/token route (tokenRoutes[0] is /token).
+    function v(req: any) {
+      const oauthTokenRoute = tokenRoutes[1];
+      return oauthTokenRoute.config.validate.payload.validate(req);
+    }
+
+    it('accepts refresh_token_only=true for the authorization_code grant', () => {
+      const res = v({
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        grant_type: 'authorization_code',
+        code: CODE,
+        refresh_token_only: true,
+      });
+      expect(res.error).toBeUndefined();
+      expect(res.value.refresh_token_only).toBe(true);
+    });
+
+    it('accepts refresh_token_only=true for the fxa-credentials grant', () => {
+      const res = v({
+        client_id: CLIENT_ID,
+        grant_type: 'fxa-credentials',
+        access_type: 'offline',
+        refresh_token_only: true,
+      });
+      expect(res.error).toBeUndefined();
+      expect(res.value.refresh_token_only).toBe(true);
+    });
+
+    it('defaults refresh_token_only to false when omitted', () => {
+      const res = v({
+        client_id: CLIENT_ID,
+        grant_type: 'fxa-credentials',
+      });
+      expect(res.error).toBeUndefined();
+      expect(res.value.refresh_token_only).toBe(false);
+    });
+
+    it('rejects refresh_token_only=true for fxa-credentials without access_type=offline', () => {
+      // access_type defaults to 'online', so the credentials alternative rejects
+      // refresh_token_only=true (contrast with the offline case accepted above).
+      const res = v({
+        client_id: CLIENT_ID,
+        grant_type: 'fxa-credentials',
+        refresh_token_only: true,
+      });
+      expect(res.error).toBeDefined();
+      expect(res.error.isJoi).toBe(true);
+      expect(res.error.name).toBe('ValidationError');
+    });
+  });
+
+  describe('Glean metrics', () => {
+    it('does not log the token created event for a refresh_token_only grant', async () => {
+      const request = {
+        app: {},
+        auth: { credentials: { uid: 'abc' } },
+        headers: {},
+        payload: {
+          client_id: CLIENT_ID,
+          grant_type: 'fxa-credentials',
+          access_type: 'offline',
+          refresh_token_only: true,
+        },
+        emitMetricsEvent: async () => {},
+      };
+      await tokenRoutes[1].handler(request);
+      expect(mockGlean.oauth.tokenCreated).not.toHaveBeenCalled();
+    });
+  });
+
   describe('update session last access time', () => {
     beforeEach(() => {
       mockDb.touchSessionToken.mockClear();
@@ -861,6 +933,7 @@ describe('/oauth/token POST', () => {
           skipEmail: true,
           existingDeviceId: MOCK_DEVICE_ID,
           clientId: FIREFOX_IOS_CLIENT_ID,
+          uid: 'eaf0',
         }
       );
       expect(sessionTokenStub).not.toHaveBeenCalled();
@@ -951,6 +1024,7 @@ describe('/oauth/token POST', () => {
           skipEmail: true,
           existingDeviceId: undefined,
           clientId: FIREFOX_IOS_CLIENT_ID,
+          uid: 'eaf0',
         }
       );
     });

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.js
@@ -10,7 +10,6 @@ const {
   OAUTH_SCOPE_OLD_SYNC,
   MAX_NEW_ACCOUNT_AGE,
 } = require('fxa-shared/oauth/constants');
-const token = require('../../oauth/token');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const { Container } = require('typedi');
 const { FxaMailer } = require('../../senders/fxa-mailer');
@@ -32,7 +31,12 @@ module.exports = {
     grant,
     options = {}
   ) {
-    const { skipEmail = false, existingDeviceId, clientId: optionsClientId } = options;
+    const {
+      skipEmail = false,
+      existingDeviceId,
+      clientId: optionsClientId,
+      uid: optionsUid,
+    } = options;
     const fxaMailer = Container.get(FxaMailer);
     const oauthClientInfoService = Container.get(OAuthClientInfoServiceName);
 
@@ -49,10 +53,10 @@ module.exports = {
     }
 
     if (!credentials.uid) {
-      // this can be removed once issue #3000 has been resolved
-      const tokenVerify = await token.verify(grant.access_token);
-      // some grant flows won't have the uid in `credentials`
-      credentials.uid = tokenVerify.user;
+      // Some grant flows don't carry the uid in `credentials` (e.g. the mobile
+      // authorization_code flow has no session token). The caller passes it
+      // through from the validated grant via the `uid` option.
+      credentials.uid = optionsUid;
     }
 
     if (!credentials.refreshTokenId) {

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.spec.ts
@@ -10,19 +10,7 @@ const MOCK_REFRESH_TOKEN_2 =
   '00661392cf69b0be709fbd3122d0726bb32247b476b2a28451345e7a5555cec7';
 const MOCK_REFRESH_TOKEN_ID_2 =
   '0e4f2255bed0ae53af401150488e69f22beae103b7d6857a5194df00c9827d19';
-const OAUTH_CLIENT_ID = '3c49430b43dfba77';
-const MOCK_CHECK_RESPONSE = {
-  user: MOCK_UID,
-  client_id: OAUTH_CLIENT_ID,
-  scope: ['https://identity.mozilla.com/apps/oldsync', 'openid'],
-};
 const MOCK_DEVICE_ID = 'a72ed885e66cb9c96a12fde247112daa';
-
-jest.mock('../../oauth/token', () => ({
-  verify: async function () {
-    return MOCK_CHECK_RESPONSE;
-  },
-}));
 
 jest.mock('../../oauth/client', () => ({
   getClientById: async function () {
@@ -151,13 +139,22 @@ describe('newTokenNotification', () => {
     expect(devices.upsert).toHaveBeenCalledTimes(1);
   });
 
-  it('creates a device and sends an email with token uid', async () => {
+  it('resolves the uid from the uid option when credentials has none', async () => {
+    const MOCK_UID_FROM_OPTION = '11d4847823f24b0f95e1524987cb0391';
     credentials = {};
     request = mockRequest({ credentials });
-    await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
+    await oauthUtils.newTokenNotification(db, mailer, devices, request, grant, {
+      skipEmail: true,
+      uid: MOCK_UID_FROM_OPTION,
+    });
 
-    expect(fxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
     expect(devices.upsert).toHaveBeenCalledTimes(1);
+    expect(devices.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ uid: MOCK_UID_FROM_OPTION }),
+      expect.anything()
+    );
   });
 
   it('does nothing for non-NOTIFICATION_SCOPES', async () => {

--- a/packages/fxa-auth-server/test/remote/oauth_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.in.spec.ts
@@ -186,6 +186,76 @@ describe.each(testVersions)(
       expect(devices.length).toBe(1);
     });
 
+    describe('refresh_token_only', () => {
+      it('returns a refresh token but no access token for an offline fxa-credentials grant', async () => {
+        const SCOPE = OAUTH_SCOPE_OLD_SYNC;
+        const res = await client.grantOAuthTokensFromSessionToken({
+          grant_type: 'fxa-credentials',
+          client_id: PUBLIC_CLIENT_ID,
+          access_type: 'offline',
+          scope: SCOPE,
+          refresh_token_only: true,
+        });
+
+        expect(res.refresh_token).toBeTruthy();
+        expect(res.scope).toBe(SCOPE);
+        expect(res.auth_at).toBeTruthy();
+        expect(res.access_token).toBeUndefined();
+        expect(res.token_type).toBeUndefined();
+        expect(res.expires_in).toBeUndefined();
+      });
+
+      it('returns a refresh token but no access token or id token for an offline authorization_code grant', async () => {
+        // openid is included specifically to prove the id_token is skipped when
+        // no access token is minted (its at_hash binds to the access token).
+        const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
+        let res = await client.createAuthorizationCode({
+          client_id: PUBLIC_CLIENT_ID,
+          state: 'abc',
+          code_challenge: MOCK_CODE_CHALLENGE,
+          code_challenge_method: 'S256',
+          scope: SCOPE,
+          access_type: 'offline',
+        });
+        expect(res.code).toBeTruthy();
+
+        res = await client.grantOAuthTokens({
+          client_id: PUBLIC_CLIENT_ID,
+          code: res.code,
+          code_verifier: MOCK_CODE_VERIFIER,
+          refresh_token_only: true,
+        });
+
+        expect(res.refresh_token).toBeTruthy();
+        expect(res.scope).toBe(SCOPE);
+        expect(res.auth_at).toBeTruthy();
+        expect(res.access_token).toBeUndefined();
+        expect(res.token_type).toBeUndefined();
+        expect(res.expires_in).toBeUndefined();
+        expect(res.id_token).toBeUndefined();
+      });
+
+      it('rejects refresh_token_only when the grant is not offline', async () => {
+        // Guards against a non-rejecting call silently passing the catch block.
+        expect.assertions(2);
+        try {
+          await client.grantOAuthTokensFromSessionToken({
+            grant_type: 'fxa-credentials',
+            client_id: PUBLIC_CLIENT_ID,
+            scope: OAUTH_SCOPE_OLD_SYNC,
+            refresh_token_only: true,
+          });
+          throw new Error('should have thrown');
+        } catch (err: any) {
+          // The oauth-layer OauthError.invalidRequestParameter is translated to
+          // an AppError at the HTTP boundary (errno 107), which also drops the
+          // parameter name from the response body.
+          expect(err.code).toBe(400);
+          expect(err.errno).toBe(error.ERRNO.INVALID_PARAMETER);
+        }
+      });
+    });
+
     it('successfully propagates `resource` and `clientId` in the ID token `aud` claim', async () => {
       const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
 


### PR DESCRIPTION
Because:
* Firefox always creates a Sync-scoped access token even when the user is not using Sync, impacting DAU
* Our grant types always create an access token when a refresh token is created, and Firefox needs the ability to create a refresh token without immediately creating an access token

This commit:
* Adds a refresh_token_only option for fxa-credentials and authorization_code oauth token grants so that when passed, we do not create an access token automatically
* Skips the Glean access token created event for this

closes FXA-14206

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

---

I manually tested this by:
* Signing into Desktop Sync on `main` and on this branch, seeing no change in the login requests/tokens received (uses the auth code flow which gets a refresh + access back, and then `fxa-credentials` to grab access tokens)
* Sending a POST request via `fxa-credentials` with `refresh_token_only` and seeing the request lack an access token response