### PR TITLE
fix(payments-next): [f008] Apple IAP status never updated — entitlement persists after expiry (libs/ stack)

### DIFF
--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.repository.spec.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.repository.spec.ts
@@ -17,6 +17,7 @@ import {
   deletePurchasesByUserId,
 } from './apple-iap-purchase.repository';
 import { FirestoreAppleIapPurchaseRecordFactory } from '../factories';
+import { SubscriptionStatus } from 'app-store-server-api';
 
 jest.mock('@google-cloud/firestore');
 
@@ -118,6 +119,38 @@ describe('Apple IAP Purchase Repository', () => {
       await expect(
         updatePurchase(mockDb, mockPurchaseRecord.originalTransactionId, {})
       ).rejects.toThrow('Must provide at least one update param');
+    });
+
+    it('persists the full record including status and expiresDate on a refresh', async () => {
+      const refresh = FirestoreAppleIapPurchaseRecordFactory({
+        status: SubscriptionStatus.Expired,
+        expiresDate: 1_700_000_000_000,
+      });
+      await updatePurchase(
+        mockDb,
+        mockPurchaseRecord.originalTransactionId,
+        refresh
+      );
+      expect(mockDoc.update).toHaveBeenCalledWith(refresh);
+    });
+
+    it('persists status and expiresDate on a partial update', async () => {
+      await updatePurchase(mockDb, mockPurchaseRecord.originalTransactionId, {
+        status: SubscriptionStatus.Expired,
+        expiresDate: 1_700_000_000_000,
+      });
+      expect(mockDoc.update).toHaveBeenCalledWith({
+        status: SubscriptionStatus.Expired,
+        expiresDate: 1_700_000_000_000,
+      });
+    });
+
+    it('drops undefined fields from a partial update', async () => {
+      await updatePurchase(mockDb, mockPurchaseRecord.originalTransactionId, {
+        userId: 'updated-user',
+        verifiedAt: undefined,
+      });
+      expect(mockDoc.update).toHaveBeenCalledWith({ userId: 'updated-user' });
     });
   });
 

--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.repository.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.repository.ts
@@ -6,6 +6,7 @@ import { CollectionReference } from '@google-cloud/firestore';
 import { APPLE_APP_STORE_FORM_OF_PAYMENT } from '../constants';
 import { TransactionType } from 'app-store-server-api';
 import type { FirestoreAppleIapPurchaseRecord } from '../types';
+import { stripUndefined } from '../util';
 
 /**
  * Creates a purchase record in the database.
@@ -99,10 +100,32 @@ export async function updatePurchase(
   update: Partial<Omit<FirestoreAppleIapPurchaseRecord, 'id'>>
 ): Promise<void> {
   // Re-build properties for type-safety (Typescript allows wider type to be applied to narrower object type)
-  const _update: typeof update = {};
-  if (update.userId !== undefined) _update.userId = update.userId;
+  const _update = stripUndefined({
+    userId: update.userId,
+    autoRenewStatus: update.autoRenewStatus,
+    autoRenewProductId: update.autoRenewProductId,
+    bundleId: update.bundleId,
+    environment: update.environment,
+    inAppOwnershipType: update.inAppOwnershipType,
+    originalPurchaseDate: update.originalPurchaseDate,
+    originalTransactionId: update.originalTransactionId,
+    productId: update.productId,
+    status: update.status,
+    transactionId: update.transactionId,
+    type: update.type,
+    verifiedAt: update.verifiedAt,
+    currency: update.currency,
+    price: update.price,
+    storefront: update.storefront,
+    expiresDate: update.expiresDate,
+    purchaseDate: update.purchaseDate,
+    renewalCurrency: update.renewalCurrency,
+    renewalPrice: update.renewalPrice,
+    latestNotificationType: update.latestNotificationType,
+    formOfPayment: update.formOfPayment,
+  });
 
-  if (Object.values(_update).length === 0) {
+  if (Object.keys(_update).length === 0) {
     throw new Error('Must provide at least one update param');
   }
 

--- a/libs/payments/iap/src/lib/apple/subscription-purchase.spec.ts
+++ b/libs/payments/iap/src/lib/apple/subscription-purchase.spec.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { SubscriptionStatus } from 'app-store-server-api';
+import { FirestoreAppleIapPurchaseRecordFactory } from '../factories';
+import { AppStoreSubscriptionPurchase } from './subscription-purchase';
+
+const MOCK_NOW = 1_700_000_000_000;
+const ONE_MINUTE = 60_000;
+
+describe('AppStoreSubscriptionPurchase', () => {
+  describe('isEntitlementActive', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(MOCK_NOW);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    const buildPurchase = (
+      override: Parameters<typeof FirestoreAppleIapPurchaseRecordFactory>[0]
+    ) =>
+      AppStoreSubscriptionPurchase.fromFirestoreObject(
+        FirestoreAppleIapPurchaseRecordFactory(override)
+      );
+
+    it('returns true for an active subscription with a future expiry', () => {
+      const purchase = buildPurchase({
+        status: SubscriptionStatus.Active,
+        expiresDate: MOCK_NOW + ONE_MINUTE,
+      });
+      expect(purchase.isEntitlementActive()).toBe(true);
+    });
+
+    it('returns false for an active subscription whose expiry has passed', () => {
+      const purchase = buildPurchase({
+        status: SubscriptionStatus.Active,
+        expiresDate: MOCK_NOW - ONE_MINUTE,
+      });
+      expect(purchase.isEntitlementActive()).toBe(false);
+    });
+
+    it('returns true for a grace-period subscription despite a past expiry', () => {
+      const purchase = buildPurchase({
+        status: SubscriptionStatus.InBillingGracePeriod,
+        expiresDate: MOCK_NOW - ONE_MINUTE,
+      });
+      expect(purchase.isEntitlementActive()).toBe(true);
+    });
+
+    it('returns false for an expired subscription with a future expiry', () => {
+      const purchase = buildPurchase({
+        status: SubscriptionStatus.Expired,
+        expiresDate: MOCK_NOW + ONE_MINUTE,
+      });
+      expect(purchase.isEntitlementActive()).toBe(false);
+    });
+
+    it('returns true for an active subscription with no expiry set', () => {
+      const record = FirestoreAppleIapPurchaseRecordFactory({
+        status: SubscriptionStatus.Active,
+      });
+      delete (record as { expiresDate?: number }).expiresDate;
+      const purchase = AppStoreSubscriptionPurchase.fromFirestoreObject(record);
+      expect(purchase.isEntitlementActive()).toBe(true);
+    });
+  });
+});

--- a/libs/payments/iap/src/lib/apple/subscription-purchase.ts
+++ b/libs/payments/iap/src/lib/apple/subscription-purchase.ts
@@ -219,10 +219,13 @@ export class AppStoreSubscriptionPurchase {
   }
 
   isEntitlementActive() {
-    return [
-      SubscriptionStatus.Active,
-      SubscriptionStatus.InBillingGracePeriod,
-    ].includes(this.status);
+    if (this.status === SubscriptionStatus.InBillingGracePeriod) {
+      return true;
+    }
+    return (
+      this.status === SubscriptionStatus.Active &&
+      (this.expiresDate === undefined || this.expiresDate > Date.now())
+    );
   }
 
   willRenew() {

--- a/libs/payments/iap/src/lib/google/google-iap-purchase.repository.spec.ts
+++ b/libs/payments/iap/src/lib/google/google-iap-purchase.repository.spec.ts
@@ -115,6 +115,39 @@ describe('Google IAP Purchase Repository', () => {
         updatePurchase(mockDb, mockPurchaseRecord.purchaseToken, {})
       ).rejects.toThrow('Must provide at least one update param');
     });
+
+    it('persists paymentState and expiryTimeMillis on a refresh', async () => {
+      const refresh = FirestoreGoogleIapPurchaseRecordFactory({
+        paymentState: 0,
+        expiryTimeMillis: 1_700_000_000_000,
+      });
+      await updatePurchase(mockDb, mockPurchaseRecord.purchaseToken, refresh);
+      expect(mockDoc.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentState: refresh.paymentState,
+          expiryTimeMillis: refresh.expiryTimeMillis,
+        })
+      );
+    });
+
+    it('persists the replacedByAnotherPurchase flag on a partial update', async () => {
+      await updatePurchase(mockDb, mockPurchaseRecord.purchaseToken, {
+        replacedByAnotherPurchase: true,
+        userId: 'replaced-placeholder',
+      });
+      expect(mockDoc.update).toHaveBeenCalledWith({
+        replacedByAnotherPurchase: true,
+        userId: 'replaced-placeholder',
+      });
+    });
+
+    it('drops undefined fields from a partial update', async () => {
+      await updatePurchase(mockDb, mockPurchaseRecord.purchaseToken, {
+        userId: 'updated-user',
+        cancelReason: undefined,
+      });
+      expect(mockDoc.update).toHaveBeenCalledWith({ userId: 'updated-user' });
+    });
   });
 
   describe('deletePurchasesByUserId', () => {

--- a/libs/payments/iap/src/lib/google/google-iap-purchase.repository.ts
+++ b/libs/payments/iap/src/lib/google/google-iap-purchase.repository.ts
@@ -6,6 +6,7 @@ import { CollectionReference } from '@google-cloud/firestore';
 import { GOOGLE_PLAY_FORM_OF_PAYMENT } from '../constants';
 import type { FirestoreGoogleIapPurchaseRecord } from '../types';
 import { SkuType } from './types';
+import { stripUndefined } from '../util';
 
 /**
  * Creates a Google IAP purchase record in the database.
@@ -99,13 +100,34 @@ export async function updatePurchase(
   id: string,
   update: Partial<Omit<FirestoreGoogleIapPurchaseRecord, 'id'>>
 ): Promise<void> {
-  const _update: typeof update = {};
+  const _update = stripUndefined({
+    purchaseToken: update.purchaseToken,
+    startTimeMillis: update.startTimeMillis,
+    orderId: update.orderId,
+    kind: update.kind,
+    formOfPayment: update.formOfPayment,
+    developerPayload: update.developerPayload,
+    skuType: update.skuType,
+    priceCurrencyCode: update.priceCurrencyCode,
+    priceAmountMicros: update.priceAmountMicros,
+    countryCode: update.countryCode,
+    replacedByAnotherPurchase: update.replacedByAnotherPurchase,
+    packageName: update.packageName,
+    paymentState: update.paymentState,
+    sku: update.sku,
+    userId: update.userId,
+    acknowledgementState: update.acknowledgementState,
+    userCancellationTimeMillis: update.userCancellationTimeMillis,
+    cancelReason: update.cancelReason,
+    autoRenewing: update.autoRenewing,
+    cancelSurveyResult: update.cancelSurveyResult,
+    isMutable: update.isMutable,
+    expiryTimeMillis: update.expiryTimeMillis,
+    verifiedAt: update.verifiedAt,
+    latestNotificationType: update.latestNotificationType,
+  });
 
-  if (update.userId !== undefined) _update.userId = update.userId;
-  if (update.formOfPayment !== undefined)
-    _update.formOfPayment = update.formOfPayment;
-
-  if (Object.values(_update).length === 0) {
+  if (Object.keys(_update).length === 0) {
     throw new Error('Must provide at least one update param');
   }
 

--- a/libs/payments/iap/src/lib/util.ts
+++ b/libs/payments/iap/src/lib/util.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function stripUndefined<T extends Record<string, unknown>>(
+  obj: T
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined)
+  ) as Partial<T>;
+}


### PR DESCRIPTION
## Because
* updatePurchase() only wrote userId, silently dropping status/expiresDate/etc., so an expired or refunded Apple IAP sub stayed cached as Active forever and isEntitlementActive() kept reporting the user as entitled.

## This pull request

* Extends updatePurchase() (Apple + Google) to persist every record field via a new stripUndefined() helper, so a refresh converges to the provider's status.
* Updates isEntitlementActive() to also require expiresDate > Date.now()

## Issue that this pull request solves

Closes #[PAY-3801](https://mozilla-hub.atlassian.net/browse/PAY-3801)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3801]: https://mozilla-hub.atlassian.net/browse/PAY-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ