### PR TITLE
bug(auth): Remove broken call for legacy customs server to reset

### DIFF
--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -189,13 +189,6 @@ class CustomsClient {
 
   async reset(request, email) {
     await this.resetV2(request, email);
-
-    await this.makeRequest('/passwordReset', {
-      ...this.sanitizePayload({
-        ip: request.app.clientAddress,
-        email: emailNormalization.normalizeEmailAliases(email),
-      }),
-    });
   }
 
   /**

--- a/packages/fxa-auth-server/lib/customs.spec.ts
+++ b/packages/fxa-auth-server/lib/customs.spec.ts
@@ -140,18 +140,13 @@ describe('Customs', () => {
     expect(err.output.statusCode).toBe(400);
   });
 
-  it('posts a sanitized /passwordReset body on reset', async () => {
+  it('does not call the legacy customs server on reset', async () => {
     const customs = new Customs(CUSTOMS_URL_REAL, log, error, statsd);
     global.fetch = jest.fn().mockResolvedValue(customsResponse({}));
 
     await customs.reset(request, email);
 
-    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
-    expect(url).toBe(`${CUSTOMS_URL_REAL}/passwordReset`);
-    expect(JSON.parse(init.body)).toEqual({
-      ip: request.app.clientAddress,
-      email,
-    });
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it('posts ip and action to /checkIpOnly', async () => {
@@ -178,9 +173,6 @@ describe('Customs', () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
 
     await expect(customs.check(request, email, action)).rejects.toMatchObject({
-      errno: error.ERRNO.BACKEND_SERVICE_FAILURE,
-    });
-    await expect(customs.reset(request, email)).rejects.toMatchObject({
       errno: error.ERRNO.BACKEND_SERVICE_FAILURE,
     });
   });
@@ -257,6 +249,7 @@ describe('Customs', () => {
       check: jest.fn(),
       skip: jest.fn(),
       supportsAction: jest.fn(),
+      unblock: jest.fn(),
     };
 
     const customs = new Customs(
@@ -271,6 +264,7 @@ describe('Customs', () => {
       mockRateLimit.check = jest.fn();
       mockRateLimit.skip = jest.fn(() => false);
       mockRateLimit.supportsAction = jest.fn(() => true);
+      mockRateLimit.unblock = jest.fn(async () => Promise.resolve());
       const originalGet = configModule.config.get.bind(configModule.config);
       jest
         .spyOn(configModule.config, 'get')
@@ -443,6 +437,20 @@ describe('Customs', () => {
           ip_email: normalizedIpEmail,
         })
       );
+    });
+
+    it('unblocks the ip and normalized email on reset', async () => {
+      const emailWithAlias = 'user+alias@mozilla.com';
+      const normalizedEmail = 'user@mozilla.com';
+
+      await customs.reset(request, emailWithAlias);
+
+      expect(mockRateLimit.unblock).toHaveBeenCalledTimes(1);
+      expect(mockRateLimit.unblock).toHaveBeenCalledWith({
+        ip,
+        email: normalizedEmail,
+        ip_email: `${ip}_${normalizedEmail}`,
+      });
     });
   });
 


### PR DESCRIPTION
## Because

- We were seeing errors calling legacy customs reset endpoint

## This pull request

- Remove call to that end point

## Issue that this pull request solves

Closes: FXA-14218

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
