### PR TITLE
fix(auth): harden email/domain blocklist

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1,12 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import {
-  Account,
-  EmailBlocklist,
-  DomainBlocklist,
-  getAccountCustomerByUid,
-} from 'fxa-shared/db/models/auth';
+import { Account, getAccountCustomerByUid } from 'fxa-shared/db/models/auth';
 import {
   AppStoreSubscription,
   PlayStoreSubscription,
@@ -42,7 +37,11 @@ import {
 } from '../payments/iap/iap-formatter';
 import { StripeHelper } from '../payments/stripe';
 import { AuthClientInfoService, AuthLogger, AuthRequest } from '../types';
-import { deleteAccountIfUnverified, fetchRpCmsData } from './utils/account';
+import {
+  checkBlocklists,
+  deleteAccountIfUnverified,
+  fetchRpCmsData,
+} from './utils/account';
 import {
   isClientAllowedForPasswordless,
   isPasswordlessEligible,
@@ -584,27 +583,7 @@ export class AccountHandler {
   }
 
   private async checkBlocklists(normalizedEmail: string): Promise<void> {
-    const blockedRegex =
-      await EmailBlocklist.findMatchingRegex(normalizedEmail);
-    if (blockedRegex !== null) {
-      this.log.info('account.create.blocked', {
-        domain: normalizedEmail.split('@')[1],
-        blockedRegex,
-        blocker: 'regex',
-      });
-      this.statsd.increment('account.create.blocked', { blocker: 'regex' });
-      throw error.requestBlocked(false);
-    }
-    const blockedDomain =
-      await DomainBlocklist.findMatchingDomain(normalizedEmail);
-    if (blockedDomain !== null) {
-      this.log.info('account.create.blocked', {
-        domain: blockedDomain,
-        blocker: 'domain',
-      });
-      this.statsd.increment('account.create.blocked', { blocker: 'domain' });
-      throw error.requestBlocked(false);
-    }
+    await checkBlocklists(normalizedEmail, this.log, this.statsd);
   }
 
   private async checkEmailDomainValidity(email: string): Promise<boolean> {

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
@@ -38,6 +38,16 @@ jest.mock('./utils/third-party-events', () => {
   });
 });
 
+// Default to "not blocked" so happy paths run without a DB.
+jest.mock('fxa-shared/db/models/auth', () => ({
+  EmailBlocklist: {
+    findMatchingRegex: jest.fn().mockResolvedValue(null),
+  },
+  DomainBlocklist: {
+    findMatchingDomain: jest.fn().mockResolvedValue(null),
+  },
+}));
+
 const mocks = require('../../test/mocks');
 const { getRoute } = require('../../test/routes_helpers');
 const { AppError: error } = require('@fxa/accounts/errors');
@@ -230,6 +240,25 @@ describe('/linked_account', () => {
         expect(mockDB.createSessionToken).toHaveBeenCalledTimes(1);
         expect(result.uid).toBe(UID);
         expect(result.sessionToken).toBeTruthy();
+      });
+
+      it('does not create a new account when the domain is blocklisted', async () => {
+        const { DomainBlocklist } = require('fxa-shared/db/models/auth');
+        mockDB.accountRecord = jest.fn(() =>
+          Promise.reject(error.unknownAccount(mockGoogleUser.email))
+        );
+        (DomainBlocklist.findMatchingDomain as jest.Mock).mockResolvedValueOnce(
+          mockGoogleUser.email.split('@')[1]
+        );
+
+        await expect(runTest(route, mockRequest)).rejects.toMatchObject({
+          errno: error.requestBlocked().errno,
+        });
+        expect(mockDB.createAccount).not.toHaveBeenCalled();
+        expect(mockDB.createLinkedAccount).not.toHaveBeenCalled();
+        (DomainBlocklist.findMatchingDomain as jest.Mock).mockResolvedValue(
+          null
+        );
       });
 
       it('throws thirdPartyAccountError when the Google token endpoint responds non-ok', async () => {

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -18,7 +18,11 @@ import isA from 'joi';
 import DESCRIPTION from '../../docs/swagger/shared/descriptions';
 import { AppError as error } from '@fxa/accounts/errors';
 import { schema as METRICS_CONTEXT_SCHEMA } from '../metrics/context';
-import { notifyAttachedServicesForAccountSession } from './utils/account';
+import {
+  checkBlocklists,
+  notifyAttachedServicesForAccountSession,
+} from './utils/account';
+import { normalizeEmail } from 'fxa-shared/email/helpers';
 import {
   getGooglePublicKey,
   getApplePublicKey,
@@ -473,7 +477,10 @@ export class LinkedAccountHandler {
         }
         // This is a new user creating a new FxA account, we
         // create the FxA account with random password and mark email
-        // verified
+        // verified.
+        // Block creation on a blocklisted email/domain, as other signup paths do.
+        await checkBlocklists(normalizeEmail(email), this.log, this.statsd);
+
         const emailCode = await random.hex(16);
         const authSalt = await random.hex(32);
         const [kA, wrapWrapKb, wrapWrapKbVersion2] = await random.hex(

--- a/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
@@ -490,6 +490,40 @@ describe('/account/passwordless/confirm_code', () => {
     });
   });
 
+  it('does not create a new account when the email matches the regex blocklist', async () => {
+    const { EmailBlocklist } = require('fxa-shared/db/models/auth');
+    mockDB.accountRecord = jest.fn(() =>
+      Promise.reject(error.unknownAccount())
+    );
+    mockDB.createAccount = jest.fn();
+    (EmailBlocklist.findMatchingRegex as jest.Mock).mockResolvedValueOnce(
+      '@example\\.com$'
+    );
+
+    await expect(runTest(route, mockRequest)).rejects.toThrow(
+      error.requestBlocked()
+    );
+    expect(mockDB.createAccount).toHaveBeenCalledTimes(0);
+    (EmailBlocklist.findMatchingRegex as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('does not create a new account when the domain matches the domain blocklist', async () => {
+    const { DomainBlocklist } = require('fxa-shared/db/models/auth');
+    mockDB.accountRecord = jest.fn(() =>
+      Promise.reject(error.unknownAccount())
+    );
+    mockDB.createAccount = jest.fn();
+    (DomainBlocklist.findMatchingDomain as jest.Mock).mockResolvedValueOnce(
+      'example.com'
+    );
+
+    await expect(runTest(route, mockRequest)).rejects.toThrow(
+      error.requestBlocked()
+    );
+    expect(mockDB.createAccount).toHaveBeenCalledTimes(0);
+    (DomainBlocklist.findMatchingDomain as jest.Mock).mockResolvedValue(null);
+  });
+
   it('should create session for existing account with valid code', () => {
     // Primary differs from the signup email; the login notification must use the primary.
     const currentPrimaryEmail = 'current-primary@mozilla.com';
@@ -1674,6 +1708,58 @@ describe('/account/passwordless/resend_code', () => {
         expect(err.errno).toBe(206);
       }
     );
+  });
+
+  it('blocks resend for a new account when the email matches the regex blocklist', async () => {
+    const { EmailBlocklist } = require('fxa-shared/db/models/auth');
+    mockDB.accountRecord = jest.fn(() =>
+      Promise.reject(error.unknownAccount())
+    );
+    (EmailBlocklist.findMatchingRegex as jest.Mock).mockResolvedValueOnce(
+      '@example\\.com$'
+    );
+
+    await expect(runTest(route, mockRequest)).rejects.toThrow(
+      error.requestBlocked()
+    );
+    // No OTP sent to a blocked address.
+    expect(mockOtpManagerDelete).toHaveBeenCalledTimes(0);
+    expect(mockOtpManagerCreate).toHaveBeenCalledTimes(0);
+    (EmailBlocklist.findMatchingRegex as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('blocks resend for a new account when the domain matches the domain blocklist', async () => {
+    const { DomainBlocklist } = require('fxa-shared/db/models/auth');
+    mockDB.accountRecord = jest.fn(() =>
+      Promise.reject(error.unknownAccount())
+    );
+    (DomainBlocklist.findMatchingDomain as jest.Mock).mockResolvedValueOnce(
+      'example.com'
+    );
+
+    await expect(runTest(route, mockRequest)).rejects.toThrow(
+      error.requestBlocked()
+    );
+    expect(mockOtpManagerDelete).toHaveBeenCalledTimes(0);
+    expect(mockOtpManagerCreate).toHaveBeenCalledTimes(0);
+    (DomainBlocklist.findMatchingDomain as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('does not check the blocklist when resending for an existing account', async () => {
+    const { DomainBlocklist } = require('fxa-shared/db/models/auth');
+    mockDB.accountRecord = jest.fn(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        primaryEmail: { email: TEST_EMAIL, isVerified: true },
+        verifierSetAt: 0,
+        emails: [{ email: TEST_EMAIL, isPrimary: true }],
+      })
+    );
+
+    await runTest(route, mockRequest);
+
+    expect(DomainBlocklist.findMatchingDomain).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/fxa-auth-server/lib/routes/passwordless.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.ts
@@ -29,10 +29,10 @@ import {
   isClientAllowedForPasswordless,
   isPasswordlessEligible,
 } from './utils/passwordless';
-import { EmailBlocklist, DomainBlocklist } from 'fxa-shared/db/models/auth';
 import { normalizeEmail } from 'fxa-shared/email/helpers';
 import { RelyingPartyConfigurationManager } from '@fxa/shared/cms';
 import {
+  checkBlocklists,
   getOptionalCmsEmailConfig,
   notifyAttachedServicesForAccountSession,
 } from './utils/account';
@@ -187,27 +187,7 @@ class PasswordlessHandler {
     );
 
     if (isNewAccount) {
-      const normalized = normalizeEmail(email);
-      const blockedRegex = await EmailBlocklist.findMatchingRegex(normalized);
-      if (blockedRegex !== null) {
-        this.log.info('account.create.blocked', {
-          domain: normalized.split('@')[1],
-          blockedRegex,
-          blocker: 'regex',
-        });
-        this.statsd.increment('account.create.blocked', { blocker: 'regex' });
-        throw error.requestBlocked(false);
-      }
-      const blockedDomain =
-        await DomainBlocklist.findMatchingDomain(normalized);
-      if (blockedDomain !== null) {
-        this.log.info('account.create.blocked', {
-          domain: blockedDomain,
-          blocker: 'domain',
-        });
-        this.statsd.increment('account.create.blocked', { blocker: 'domain' });
-        throw error.requestBlocked(false);
-      }
+      await this.checkBlocklists(email);
     }
 
     return this.generateAndSendOtp(
@@ -217,6 +197,11 @@ class PasswordlessHandler {
       isNewAccount,
       false
     );
+  }
+
+  /** Normalize the email and run the shared blocklist check. */
+  private async checkBlocklists(email: string): Promise<void> {
+    await checkBlocklists(normalizeEmail(email), this.log, this.statsd);
   }
 
   async confirmCode(request: AuthRequest) {
@@ -409,6 +394,10 @@ class PasswordlessHandler {
       request
     );
 
+    if (isNewAccount) {
+      await this.checkBlocklists(email);
+    }
+
     // Delete existing code before sending a new one
     const otpKey = account ? account.uid : email;
     await this.otpManager.delete(otpKey);
@@ -531,6 +520,9 @@ class PasswordlessHandler {
     email: string,
     request: AuthRequest
   ): Promise<any> {
+    // Chokepoint: block creation regardless of which OTP path was used.
+    await this.checkBlocklists(email);
+
     const emailCode = await random.hex(16);
     const authSalt = await random.hex(32);
     const [kA, wrapWrapKb, wrapWrapKbVersion2] = await random.hex(32, 32, 32);

--- a/packages/fxa-auth-server/lib/routes/utils/account.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/account.ts
@@ -1,3 +1,4 @@
+import { StatsD } from 'hot-shots';
 import { StripeHelper } from '../../payments/stripe';
 import { AuthLogger, AuthRequest } from '../../types';
 import { AppError as error } from '@fxa/accounts/errors';
@@ -7,6 +8,39 @@ import { RelyingPartyConfigurationManager } from '@fxa/shared/cms';
 import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
 import { DB } from '../../db';
 import { getClientServiceTags } from '../../metrics/client-tags';
+import { EmailBlocklist, DomainBlocklist } from 'fxa-shared/db/models/auth';
+
+/**
+ * Throws `error.requestBlocked` if the (normalized) email matches the
+ * admin-managed regex or domain blocklist. Shared by all account-creation
+ * paths so none can bypass the block.
+ */
+export async function checkBlocklists(
+  normalizedEmail: string,
+  log: AuthLogger,
+  statsd: StatsD
+): Promise<void> {
+  const blockedRegex = await EmailBlocklist.findMatchingRegex(normalizedEmail);
+  if (blockedRegex !== null) {
+    log.info('account.create.blocked', {
+      domain: normalizedEmail.split('@')[1],
+      blockedRegex,
+      blocker: 'regex',
+    });
+    statsd.increment('account.create.blocked', { blocker: 'regex' });
+    throw error.requestBlocked(false);
+  }
+  const blockedDomain =
+    await DomainBlocklist.findMatchingDomain(normalizedEmail);
+  if (blockedDomain !== null) {
+    log.info('account.create.blocked', {
+      domain: blockedDomain,
+      blocker: 'domain',
+    });
+    statsd.increment('account.create.blocked', { blocker: 'domain' });
+    throw error.requestBlocked(false);
+  }
+}
 
 export async function deleteAccountIfUnverified(
   db: DB,


### PR DESCRIPTION
## Because

- The admin-managed email/domain blocklist was not enforced consistently across all account-creation paths

## This pull request

- Extracts the blocklist check into a shared `checkBlocklists` helper (`routes/utils/account.ts`) as the single source of truth, replacing duplicate inline copies.
- Applies the check consistently across the passwordless and third-party account-creation paths, including at the creation chokepoint.
- Adds unit coverage.

## Issue that this pull request solves

Closes: FXA-14112

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

