### PR TITLE
fix(functional-tests): Fix failing payments functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ process.yml
 
 # Next.js
 .next
+next-env.d.ts
 
 
 tmp

--- a/apps/payments/next/next-env.d.ts
+++ b/apps/payments/next/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./build/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
@@ -328,6 +328,34 @@ describe('CheckoutForm', () => {
       expect(mockCheckoutCartWithStripe).not.toHaveBeenCalled();
       expect(mockRouterPush).not.toHaveBeenCalled();
     });
+
+    it('finalizes the cart with an error and routes to error when checkoutCartWithStripe rejects', async () => {
+      mockElementsSubmit.mockResolvedValue({ error: undefined });
+      mockCreateConfirmationToken.mockResolvedValue({
+        confirmationToken: { id: 'ctoken_123' },
+      });
+      mockCheckoutCartWithStripe.mockRejectedValue(
+        new Error('version mismatch')
+      );
+      mockFinalizeCartWithError.mockResolvedValue(undefined);
+
+      const user = userEvent.setup();
+      render(<CheckoutForm {...baseProps} />);
+      fireStripeReady();
+      await user.click(screen.getByTestId('consent-checkbox'));
+      fireStripeChange({ complete: true, value: { type: 'card' } });
+
+      await user.click(screen.getByRole('button', { name: /Subscribe Now/i }));
+
+      await waitFor(() => {
+        expect(mockFinalizeCartWithError).toHaveBeenCalledWith(
+          'cart-id',
+          'basic-error'
+        );
+      });
+
+      expect(mockRouterPush).toHaveBeenCalledWith('./error');
+    });
   });
 
   describe('PayPal payment path', () => {

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -25,12 +25,7 @@ import {
   useRouter,
   useSearchParams,
 } from 'next/navigation';
-import {
-  useEffect,
-  useMemo,
-  useState,
-  useContext,
-} from 'react';
+import { useEffect, useMemo, useState, useContext } from 'react';
 
 import type { Interval } from '@fxa/payments/metrics/client';
 import { BaseButton, ButtonVariant, CheckoutCheckbox } from '@fxa/payments/ui';
@@ -85,10 +80,10 @@ interface CheckoutFormProps {
     };
     paymentInfo?: {
       type:
-      | Stripe.PaymentMethod.Type
-      | 'google_iap'
-      | 'apple_iap'
-      | 'external_paypal';
+        | Stripe.PaymentMethod.Type
+        | 'google_iap'
+        | 'apple_iap'
+        | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;
@@ -154,13 +149,13 @@ export function CheckoutForm({
     () =>
       isCancelInterstitialOffer
         ? {
-          offeringId: (params.offeringId as string) ?? undefined,
-          interval: (params.interval as Interval) ?? undefined,
-          utmSource: searchParams.get('utm_source') ?? undefined,
-          utmMedium: searchParams.get('utm_medium') ?? undefined,
-          utmCampaign: searchParams.get('utm_campaign') ?? undefined,
-          nimbusUserId: searchParams.get('nimbus_user_id') ?? undefined,
-        }
+            offeringId: (params.offeringId as string) ?? undefined,
+            interval: (params.interval as Interval) ?? undefined,
+            utmSource: searchParams.get('utm_source') ?? undefined,
+            utmMedium: searchParams.get('utm_medium') ?? undefined,
+            utmCampaign: searchParams.get('utm_campaign') ?? undefined,
+            nimbusUserId: searchParams.get('nimbus_user_id') ?? undefined,
+          }
         : null,
     [isCancelInterstitialOffer, params.interval, searchParams]
   );
@@ -246,13 +241,22 @@ export function CheckoutForm({
         });
       }
 
-      await checkoutCartWithPaypal(
-        cart.id,
-        cart.version,
-        getAttributionParams(searchParams),
-        params,
-        Object.fromEntries(searchParams)
-      );
+      try {
+        await checkoutCartWithPaypal(
+          cart.id,
+          cart.version,
+          getAttributionParams(searchParams),
+          params,
+          Object.fromEntries(searchParams)
+        );
+      } catch {
+        await finalizeCartWithError(cart.id, CartErrorReasonId.BASIC_ERROR);
+        const queryParamString = searchParams.toString()
+          ? `?${searchParams.toString()}`
+          : '';
+        router.push('./error' + queryParamString);
+        return;
+      }
 
       const queryParamString = searchParams.toString()
         ? `?${searchParams.toString()}`
@@ -265,25 +269,37 @@ export function CheckoutForm({
     // Trigger form validation and wallet collection
     const { error: submitError } = await elements.submit();
     if (submitError) {
+      if (submitError.type !== 'validation_error') {
+        await finalizeCartWithError(cart.id, CartErrorReasonId.BASIC_ERROR);
+        const queryParamString = searchParams.toString()
+          ? `?${searchParams.toString()}`
+          : '';
+        router.push('./error' + queryParamString);
+        return;
+      }
       setLoading(false);
       return;
     }
 
     const paymentElement = elements.getElement(PaymentElement);
     if (!paymentElement) {
-      setLoading(false);
+      await finalizeCartWithError(cart.id, CartErrorReasonId.BASIC_ERROR);
+      const queryParamString = searchParams.toString()
+        ? `?${searchParams.toString()}`
+        : '';
+      router.push('./error' + queryParamString);
       return;
     }
 
     const confirmationTokenParams: ConfirmationTokenCreateParams | undefined =
       !isSavedPaymentMethod
         ? {
-          payment_method_data: {
-            billing_details: {
-              email: sessionEmail || undefined,
+            payment_method_data: {
+              billing_details: {
+                email: sessionEmail || undefined,
+              },
             },
-          },
-        }
+          }
         : undefined;
 
     // Create the ConfirmationToken using the details collected by the Payment Element
@@ -317,15 +333,24 @@ export function CheckoutForm({
       });
     }
 
-    await checkoutCartWithStripe(
-      cart.id,
-      cart.version,
-      confirmationToken.id,
-      selectedPaymentMethod,
-      getAttributionParams(searchParams),
-      params,
-      Object.fromEntries(searchParams)
-    );
+    try {
+      await checkoutCartWithStripe(
+        cart.id,
+        cart.version,
+        confirmationToken.id,
+        selectedPaymentMethod,
+        getAttributionParams(searchParams),
+        params,
+        Object.fromEntries(searchParams)
+      );
+    } catch {
+      await finalizeCartWithError(cart.id, CartErrorReasonId.BASIC_ERROR);
+      const queryParamString = searchParams.toString()
+        ? `?${searchParams.toString()}`
+        : '';
+      router.push('./error' + queryParamString);
+      return;
+    }
 
     const queryParamString = searchParams.toString()
       ? `?${searchParams.toString()}`

--- a/packages/functional-tests/lib/fixtures/payments.ts
+++ b/packages/functional-tests/lib/fixtures/payments.ts
@@ -2,46 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page } from '@playwright/test';
-import { test as standardTest, expect, addWafBypassHeader } from './standard';
+import { test as standardTest, expect } from './standard';
 import { create as createPaymentPages } from '../../pages/payments';
-import { BaseTarget } from '../targets/base';
 
 export type PaymentPOMS = ReturnType<typeof createPaymentPages>;
 
 export { expect };
 
-const WAF_BYPASS_TOKEN = process.env.WAF_BYPASS_TOKEN;
-
-/**
- * Adds a route handler that injects the WAF bypass header on requests to
- * the payments-next domain only. No-op when WAF_BYPASS_TOKEN is unset.
- */
-async function addPaymentsWafBypassHeader(page: Page, target: BaseTarget) {
-  if (!WAF_BYPASS_TOKEN) return;
-  const paymentsHost = new URL(target.paymentsNextUrl).host;
-  const pattern = new RegExp(
-    paymentsHost.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  );
-  await page.route(pattern, async (route) => {
-    await route.continue({
-      headers: {
-        ...route.request().headers(),
-        'fxa-ci': WAF_BYPASS_TOKEN,
-      },
-    });
-  });
-}
-
 export const test = standardTest.extend<{
   paymentPages: PaymentPOMS;
 }>({
-  page: async ({ page, target }, use) => {
-    await addWafBypassHeader(page, target);
-    await addPaymentsWafBypassHeader(page, target);
-    await use(page);
-  },
-
   paymentPages: async ({ target, page }, use) => {
     const paymentPages = createPaymentPages(page, target);
     await use(paymentPages);

--- a/packages/functional-tests/pages/payments/checkout.ts
+++ b/packages/functional-tests/pages/payments/checkout.ts
@@ -321,6 +321,11 @@ export class CheckoutPage extends BasePaymentPage {
         timeout: 5_000,
       });
       await this.stripeLinkCheckbox.click();
+      // Let Stripe re-validate after toggling Link — it briefly marks
+      // the form incomplete while updating internal state. No observable
+      // DOM signal exists outside the cross-origin iframe.
+      // eslint-disable-next-line playwright/no-wait-for-timeout
+      await this.page.waitForTimeout(500);
     } catch {
       // Stripe Link checkbox not shown — no action needed
     }

--- a/packages/functional-tests/pages/payments/upgrade.ts
+++ b/packages/functional-tests/pages/payments/upgrade.ts
@@ -71,10 +71,9 @@ export class UpgradePage extends BasePaymentPage {
     }
     // If still on /processing or /start, wait for a real terminal state
     if (/\/(processing|start)(\/|$|\?)/.test(url)) {
-      await expect(this.page).toHaveURL(
-        /\/(success|error)(\/|$|\?)/,
-        { timeout }
-      );
+      await expect(this.page).toHaveURL(/\/(success|error)(\/|$|\?)/, {
+        timeout,
+      });
       const resolvedUrl = this.page.url();
       if (/\/error(\/|$|\?)/.test(resolvedUrl)) {
         throw new Error(
@@ -82,8 +81,9 @@ export class UpgradePage extends BasePaymentPage {
         );
       }
     }
-    await expect(this.page).toHaveURL(/\/success(\/|$|\?)/, { timeout: 30_000 });
+    await expect(this.page).toHaveURL(/\/success(\/|$|\?)/, {
+      timeout: 30_000,
+    });
     await expect(this.successHeading).toBeVisible({ timeout: 30_000 });
   }
-
 }

--- a/packages/functional-tests/scripts/start-payments-services.sh
+++ b/packages/functional-tests/scripts/start-payments-services.sh
@@ -21,6 +21,9 @@ NODE_OPTIONS="--max-old-space-size=7168" NODE_ENV=test npx nx run-many \
     fxa-profile-server \
     payments-next
 
+# Spawn the pm2 daemon before concurrent `pm2 start` calls to avoid deadlock.
+npx pm2 ping
+
 NODE_OPTIONS="--max-old-space-size=7168" NODE_ENV=test npx nx run-many \
     -t start \
     --parallel=2 \


### PR DESCRIPTION
## Because

- The WAF refactor moved WAF bypass to the browser context and already covers paymentsNextUrl, but payments.ts wasn't cleaned up

## This pull request

- Removes redundant page override and addPaymentsWafBypassHeader function from payments.ts
- Handles checkoutCartWithStripe rejection to prevent page from silently sticking on /start
- Route Stripe element errors to error page instead of silently staying on /start
- Reduce flakiness

## Issue that this pull request solves

Closes: PAY-3838

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.