### PR TITLE
feat(auth): Add new DAU exclusion field on access token created, add option to opt-out

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -215,6 +215,14 @@ const DESCRIPTIONS = {
     - \`grant_type=authorization_code\` and the original authorization request included \`access_type=offline\`.
     - \`grant_type=fxa-credentials\` and the request included \`access_type=offline\`.
   `,
+  excludeDau: dedent`
+    When true, tag this access-token creation so it is excluded from the daily
+    active users (DAU) signal. The \`access_token.created\` Glean event still fires,
+    with its \`exclude_dau\` field set to true. Use this when the access token does
+    not represent active use of the service — for example, a token created for a
+    signed-in user regardless of whether they are using the service. Accepted on
+    the \`fxa-credentials\` and \`authorization_code\` grants.
+  `,
   refreshTokenId: 'The specific `refresh_token_id` to be destroyed.',
   reminder: 'Indicates that verification originates from a reminder email.',
   resource:

--- a/packages/fxa-auth-server/lib/metrics/glean/index.spec.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.spec.ts
@@ -759,6 +759,30 @@ describe('Glean server side events', () => {
         const metrics = gleanMocks['recordAccessTokenCreated'].mock.calls[0][0];
         expect(metrics['scopes']).toBe('openid,profile');
       });
+
+      it('does not mutate a caller-provided scopes array', async () => {
+        const glean = gleanMetrics(config);
+        const scopes = ['profile', 'openid'];
+        await glean.oauth.tokenCreated(request, { scopes });
+        // sort() must operate on a copy, not the caller's array.
+        expect(scopes).toEqual(['profile', 'openid']);
+      });
+
+      it('passes exclude_dau through when set', async () => {
+        const glean = gleanMetrics(config);
+        await glean.oauth.tokenCreated(request, { excludeDau: true });
+        expect(gleanMocks['recordAccessTokenCreated']).toHaveBeenCalledTimes(1);
+        const metrics = gleanMocks['recordAccessTokenCreated'].mock.calls[0][0];
+        expect(metrics['exclude_dau']).toBe(true);
+      });
+
+      it('defaults exclude_dau to false when omitted', async () => {
+        const glean = gleanMetrics(config);
+        await glean.oauth.tokenCreated(request, { scopes: 'profile' });
+        expect(gleanMocks['recordAccessTokenCreated']).toHaveBeenCalledTimes(1);
+        const metrics = gleanMocks['recordAccessTokenCreated'].mock.calls[0][0];
+        expect(metrics['exclude_dau']).toBe(false);
+      });
     });
 
     describe('tokenChecked', () => {

--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -29,6 +29,7 @@ type MetricsData = {
   oauthClientId?: string;
   scopes?: string | Array<string>;
   platform?: string;
+  excludeDau?: boolean;
 };
 
 type AdditionalMetricsCallback = (
@@ -199,6 +200,29 @@ const extraKeyReasonCb = (metrics: Record<string, any>) => ({
   reason: metrics.reason ?? '',
 });
 
+// `scopes` may arrive as a string[] (e.g. verify.js getScopeValues()) or a
+// space/comma-separated string (token.js ScopeSet.toString()); normalize both to
+// a sorted, comma-separated string.
+const normalizeScopes = (scopes?: string | string[]): string => {
+  if (!scopes) {
+    return '';
+  }
+  // Copy the array before sorting — sort() mutates in place, and a caller may
+  // pass an array they still use (e.g. verify.js getScopeValues()).
+  const list = Array.isArray(scopes)
+    ? [...scopes]
+    : scopes.split(/[,\s]+/).filter(Boolean);
+  return list.sort().join(',');
+};
+
+// Extra metrics for the `access_token.created` event. `exclude_dau` flags a token
+// creation that should be excluded from the DAU signal (defaults to false).
+const accessTokenCreatedMetricsCb: AdditionalMetricsCallback = (metrics) => ({
+  reason: metrics.reason ?? '',
+  scopes: normalizeScopes(metrics.scopes),
+  exclude_dau: metrics.excludeDau === true,
+});
+
 const extraKeySignoutCb = (metrics: Record<string, any>) => ({
   platform: metrics.platform ?? 'unknown',
 });
@@ -278,20 +302,7 @@ export function gleanMetrics(config: ConfigType) {
 
     oauth: {
       tokenCreated: createEventFn('access_token_created', {
-        additionalMetrics: (metrics) => ({
-          reason: metrics.reason ?? '',
-          scopes: metrics.scopes
-            ? // Array: in at least verify.js, getScopeValues() returns string[]
-              Array.isArray(metrics.scopes)
-              ? metrics.scopes.sort().join(',')
-              : // String: in at least token.js, ScopeSet.toString() returns space-separated scopes
-                metrics.scopes
-                  .split(/[,\s]+/)
-                  .filter(Boolean)
-                  .sort()
-                  .join(',')
-            : '',
-        }),
+        additionalMetrics: accessTokenCreatedMetricsCb,
       }),
       tokenChecked: createEventFn('access_token_checked', {
         skipClientIp: true,

--- a/packages/fxa-auth-server/lib/metrics/glean/server_events.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/server_events.ts
@@ -410,6 +410,7 @@ class EventsServerEventLogger {
    * @param {string} utm_term - This metric is similar to the `utm.source`; it is used in the Firefox browser.  For example, if the user started from about:welcome, then the value could be 'aboutwelcome-default-screen'.  The value has a max length of 128 characters with the alphanumeric characters, _ (underscore), forward slash (/), . (period), % (percentage sign), and - (hyphen) in the allowed set of characters..
    * @param {string} reason - additional context-dependent info, e.g. the cause of an error.
    * @param {string} scopes - The OAuth scopes granted for the access token, in a comma-separated list.
+   * @param {boolean} exclude_dau - True when this access-token creation should be excluded from the daily active users (DAU) signal — e.g. a token created for a signed-in user regardless of whether they are using the service. Defaults to false..
    */
   recordAccessTokenCreated({
     user_agent,
@@ -430,6 +431,7 @@ class EventsServerEventLogger {
     utm_term,
     reason,
     scopes,
+    exclude_dau,
   }: {
     user_agent: string;
     ip_address: string;
@@ -449,6 +451,7 @@ class EventsServerEventLogger {
     utm_term: string;
     reason: string;
     scopes: string;
+    exclude_dau: boolean;
   }) {
     const event = {
       category: 'access_token',
@@ -456,6 +459,7 @@ class EventsServerEventLogger {
       extra: {
         reason: String(reason),
         scopes: String(scopes),
+        exclude_dau: String(exclude_dau),
       },
     };
     this.#record({

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -266,6 +266,11 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
     requestedGrant.ppidSeed = params.ppid_seed;
     requestedGrant.resource = params.resource;
     requestedGrant.ttl = Math.min(params.ttl, MAX_TTL_S);
+    // When true, the `access_token.created` Glean event is tagged with
+    // `exclude_dau` so this token creation is excluded from the DAU signal (the
+    // event still fires). Exposed on the authorization_code / fxa-credentials
+    // grants only; absent elsewhere, so it coerces to false.
+    requestedGrant.excludeDau = params.exclude_dau === true;
     return requestedGrant;
   }
 
@@ -622,13 +627,20 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
       service: oauthClientId,
       uid,
     });
+    const reason = params.reason
+      ? `${params.grant_type}:${params.reason}`
+      : params.grant_type;
+    const scopes = grant.scope?.toString() || '';
+    // This maps to the `access_token.created` Glean event which always fires here
+    // because an access token is always created. `exclude_dau` tags the
+    // event so the DAU signal can exclude token creations that we know don't
+    // represent active use of the service.
     glean.oauth.tokenCreated(req, {
       uid,
       oauthClientId,
-      reason: params.reason
-        ? `${params.grant_type}:${params.reason}`
-        : params.grant_type,
-      scopes: grant.scope?.toString() || '',
+      reason,
+      scopes,
+      excludeDau: grant.excludeDau,
     });
 
     if (tokens.keys_jwe) {
@@ -661,6 +673,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
     // Include grant properties needed by the /oauth/token handler for newTokenNotification.
     // These are internal properties that get stripped before returning to the client.
     tokens._clientId = oauthClientId;
+    tokens._uid = uid;
     if (grant.existingDeviceId) {
       tokens._existingDeviceId = grant.existingDeviceId;
     }
@@ -713,6 +726,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
           // Strip internal properties that are only used by /oauth/token handler
           delete result._clientId;
           delete result._existingDeviceId;
+          delete result._uid;
           return result;
         },
       },
@@ -758,6 +772,10 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
               resource: validators.resourceUrl
                 .optional()
                 .description(DESCRIPTION.resource),
+              exclude_dau: Joi.boolean()
+                .optional()
+                .default(false)
+                .description(DESCRIPTION.excludeDau),
             }).xor('client_secret', 'code_verifier'),
             // refresh token
             Joi.object({
@@ -782,6 +800,10 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
               access_type: Joi.string()
                 .valid('online', 'offline')
                 .default('online'),
+              exclude_dau: Joi.boolean()
+                .optional()
+                .default(false)
+                .description(DESCRIPTION.excludeDau),
               // Note: the max allowed TTL is currently configured in oauth-server config,
               // making it hard to know what limit to set here.
               ttl: Joi.number().positive().optional(),
@@ -908,6 +930,11 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
 
         const scopeSet = ScopeSet.fromString(grant.scope);
 
+        // Captured before the internal props are stripped below. Preferred uid
+        // source for grant flows without a session token (e.g. authorization_code,
+        // token-exchange), avoiding a redundant access-token verification.
+        const grantUid = grant._uid;
+
         // Token exchange doesn't provide a session token, and token migration
         // doesn't need a new session token created, so skip those blocks for both.
         const isRefreshTokenUpgrade =
@@ -977,6 +1004,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
               skipEmail: isSilentUpgrade,
               existingDeviceId: grant._existingDeviceId,
               clientId: grant._clientId,
+              uid: grantUid,
             }
           );
         }
@@ -989,17 +1017,18 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
         // Strip internal properties before returning to client
         delete grant._clientId;
         delete grant._existingDeviceId;
+        delete grant._uid;
         delete grant.session_token_id;
 
         // attempt to record metrics, but swallow the error if one is thrown.
         try {
-          let uid = sessionToken && sessionToken.uid;
-
-          // As mentioned in lib/routes/utils/oauth.js, some grant flows won't
-          // have the uid in `credentials`, so we get it from the oauth DB.
+          // Some grant flows (e.g. authorization_code, token-exchange) have no
+          // session token, so fall back to the uid carried on the grant. As a
+          // last resort (should not happen — an access token is always minted),
+          // recover it by verifying the access token.
+          let uid = (sessionToken && sessionToken.uid) || grantUid;
           if (!uid) {
-            const tokenVerify = await token.verify(grant.access_token);
-            uid = tokenVerify.user;
+            uid = (await token.verify(grant.access_token)).user;
           }
 
           await req.emitMetricsEvent('oauth.token.created', {

--- a/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
@@ -38,7 +38,9 @@ const noop = () => {};
 const mockLog = { debug: noop, warn: noop, info: noop, error: noop };
 const mockDb = { touchSessionToken: jest.fn() };
 const mockStatsD = { increment: jest.fn() };
-const mockGlean = { oauth: { tokenCreated: jest.fn() } };
+const mockGlean = {
+  oauth: { tokenCreated: jest.fn() },
+};
 
 const tokenRoutesDepMocks = {
   '../../oauth/assertion': async () => true,
@@ -338,10 +340,6 @@ describe('/token POST', () => {
   });
 
   describe('Glean metrics', () => {
-    beforeEach(() => {
-      mockGlean.oauth.tokenCreated.mockClear();
-    });
-
     it('logs the token created event', async () => {
       const request = {
         app: {},
@@ -359,6 +357,7 @@ describe('/token POST', () => {
         oauthClientId: CLIENT_ID,
         reason: 'authorization_code',
         scopes: '',
+        excludeDau: false,
       });
     });
 
@@ -375,7 +374,9 @@ describe('/token POST', () => {
           scope: ScopeSet.fromString(SMARTWINDOW_SCOPES),
         }),
       }));
-      const mockGleanLocal = { oauth: { tokenCreated: jest.fn() } };
+      const mockGleanLocal = {
+        oauth: { tokenCreated: jest.fn() },
+      };
       const routes = require('./token')({
         ...tokenRoutesArgMocks,
         glean: mockGleanLocal,
@@ -395,6 +396,7 @@ describe('/token POST', () => {
         oauthClientId: CLIENT_ID,
         reason: 'fxa-credentials',
         scopes: SMARTWINDOW_SCOPES,
+        excludeDau: false,
       });
     });
   });
@@ -705,6 +707,96 @@ describe('token exchange grant_type', () => {
 });
 
 describe('/oauth/token POST', () => {
+  describe('exclude_dau input validation', () => {
+    // tokenRoutes[1] is the POST /oauth/token route (tokenRoutes[0] is /token).
+    function v(req: any) {
+      const oauthTokenRoute = tokenRoutes[1];
+      return oauthTokenRoute.config.validate.payload.validate(req);
+    }
+
+    it('accepts exclude_dau=true for the authorization_code grant', () => {
+      const res = v({
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        grant_type: 'authorization_code',
+        code: CODE,
+        exclude_dau: true,
+      });
+      expect(res.error).toBeUndefined();
+      expect(res.value.exclude_dau).toBe(true);
+    });
+
+    it('accepts exclude_dau=true for the fxa-credentials grant', () => {
+      const res = v({
+        client_id: CLIENT_ID,
+        grant_type: 'fxa-credentials',
+        exclude_dau: true,
+      });
+      expect(res.error).toBeUndefined();
+      expect(res.value.exclude_dau).toBe(true);
+    });
+
+    it('defaults exclude_dau to false when omitted', () => {
+      const res = v({
+        client_id: CLIENT_ID,
+        grant_type: 'fxa-credentials',
+      });
+      expect(res.error).toBeUndefined();
+      expect(res.value.exclude_dau).toBe(false);
+    });
+  });
+
+  describe('Glean metrics', () => {
+    it('fires the token created event with exclude_dau false by default', async () => {
+      const request = {
+        app: {},
+        auth: { credentials: { uid: 'abc' } },
+        headers: {},
+        payload: {
+          client_id: CLIENT_ID,
+          grant_type: 'fxa-credentials',
+          access_type: 'offline',
+        },
+        emitMetricsEvent: async () => {},
+      };
+      await tokenRoutes[1].handler(request);
+      expect(mockGlean.oauth.tokenCreated).toHaveBeenCalledTimes(1);
+      expect(mockGlean.oauth.tokenCreated).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({
+          reason: 'fxa-credentials',
+          scopes: 'testo',
+          excludeDau: false,
+        })
+      );
+    });
+
+    it('tags the token created event with excludeDau when exclude_dau is set', async () => {
+      const request = {
+        app: {},
+        auth: { credentials: { uid: 'abc' } },
+        headers: {},
+        payload: {
+          client_id: CLIENT_ID,
+          grant_type: 'fxa-credentials',
+          access_type: 'offline',
+          exclude_dau: true,
+        },
+        emitMetricsEvent: async () => {},
+      };
+      await tokenRoutes[1].handler(request);
+      expect(mockGlean.oauth.tokenCreated).toHaveBeenCalledTimes(1);
+      expect(mockGlean.oauth.tokenCreated).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({
+          reason: 'fxa-credentials',
+          scopes: 'testo',
+          excludeDau: true,
+        })
+      );
+    });
+  });
+
   describe('update session last access time', () => {
     beforeEach(() => {
       mockDb.touchSessionToken.mockClear();
@@ -861,6 +953,7 @@ describe('/oauth/token POST', () => {
           skipEmail: true,
           existingDeviceId: MOCK_DEVICE_ID,
           clientId: FIREFOX_IOS_CLIENT_ID,
+          uid: 'eaf0',
         }
       );
       expect(sessionTokenStub).not.toHaveBeenCalled();
@@ -951,6 +1044,7 @@ describe('/oauth/token POST', () => {
           skipEmail: true,
           existingDeviceId: undefined,
           clientId: FIREFOX_IOS_CLIENT_ID,
+          uid: 'eaf0',
         }
       );
     });

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.js
@@ -32,7 +32,12 @@ module.exports = {
     grant,
     options = {}
   ) {
-    const { skipEmail = false, existingDeviceId, clientId: optionsClientId } = options;
+    const {
+      skipEmail = false,
+      existingDeviceId,
+      clientId: optionsClientId,
+      uid: optionsUid,
+    } = options;
     const fxaMailer = Container.get(FxaMailer);
     const oauthClientInfoService = Container.get(OAuthClientInfoServiceName);
 
@@ -49,10 +54,15 @@ module.exports = {
     }
 
     if (!credentials.uid) {
-      // this can be removed once issue #3000 has been resolved
-      const tokenVerify = await token.verify(grant.access_token);
-      // some grant flows won't have the uid in `credentials`
-      credentials.uid = tokenVerify.user;
+      // Some grant flows (e.g. authorization_code, token-exchange) have no
+      // session token, so fall back to the uid carried on the grant. As a
+      // last resort that's likely not needed, obtain it by verifying the
+      // access token.
+      credentials.uid = optionsUid;
+      if (!credentials.uid) {
+        const tokenVerify = await token.verify(grant.access_token);
+        credentials.uid = tokenVerify.user;
+      }
     }
 
     if (!credentials.refreshTokenId) {

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.spec.ts
@@ -151,13 +151,48 @@ describe('newTokenNotification', () => {
     expect(devices.upsert).toHaveBeenCalledTimes(1);
   });
 
-  it('creates a device and sends an email with token uid', async () => {
+  it('resolves the uid from the uid option when credentials has none', async () => {
+    const MOCK_UID_FROM_OPTION = '11d4847823f24b0f95e1524987cb0391';
     credentials = {};
     request = mockRequest({ credentials });
-    await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
+    await oauthUtils.newTokenNotification(db, mailer, devices, request, grant, {
+      skipEmail: true,
+      uid: MOCK_UID_FROM_OPTION,
+    });
 
-    expect(fxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
     expect(devices.upsert).toHaveBeenCalledTimes(1);
+    expect(devices.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ uid: MOCK_UID_FROM_OPTION }),
+      expect.anything()
+    );
+  });
+
+  it('falls back to verifying the access token when neither credentials nor option supply the uid', async () => {
+    credentials = {};
+    request = mockRequest({ credentials });
+    const grantWithAccessToken = {
+      ...grant,
+      access_token: 'mock_access_token',
+    };
+    await oauthUtils.newTokenNotification(
+      db,
+      mailer,
+      devices,
+      request,
+      grantWithAccessToken,
+      { skipEmail: true }
+    );
+
+    // token.verify mock returns MOCK_UID.
+    expect(devices.upsert).toHaveBeenCalledTimes(1);
+    expect(devices.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ uid: MOCK_UID }),
+      expect.anything()
+    );
   });
 
   it('does nothing for non-NOTIFICATION_SCOPES', async () => {

--- a/packages/fxa-auth-server/test/remote/oauth_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.in.spec.ts
@@ -186,6 +186,29 @@ describe.each(testVersions)(
       expect(devices.length).toBe(1);
     });
 
+    describe('exclude_dau', () => {
+      // The exclude_dau tagging itself is asserted at the unit layer (token.spec
+      // via mockGlean); here we confirm the option is accepted end-to-end and does
+      // not change the token response — an access token and refresh token are still
+      // returned as normal.
+      it('accepts exclude_dau and still returns a normal token response', async () => {
+        const SCOPE = OAUTH_SCOPE_OLD_SYNC;
+        const res = await client.grantOAuthTokensFromSessionToken({
+          grant_type: 'fxa-credentials',
+          client_id: PUBLIC_CLIENT_ID,
+          access_type: 'offline',
+          scope: SCOPE,
+          exclude_dau: true,
+        });
+
+        expect(res.access_token).toBeTruthy();
+        expect(res.refresh_token).toBeTruthy();
+        expect(res.scope).toBe(SCOPE);
+        expect(res.token_type).toBeTruthy();
+        expect(res.expires_in).toBeTruthy();
+      });
+    });
+
     it('successfully propagates `resource` and `clientId` in the ID token `aud` claim', async () => {
       const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
 

--- a/packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
@@ -509,6 +509,13 @@ access_token:
       scopes:
         description: The OAuth scopes granted for the access token, in a comma-separated list
         type: string
+      # A non-PII boolean flag; covered by this event's existing data review.
+      exclude_dau:
+        description: >
+          True when this access-token creation should be excluded from the daily
+          active users (DAU) signal — e.g. a token created for a signed-in user
+          regardless of whether they are using the service. Defaults to false.
+        type: boolean
 login:
   backup_code_success:
     type: event


### PR DESCRIPTION
Because:
* Firefox always creates a Sync-scoped access token even when the user is not using Sync, impacting DAU
* Our grant types always create an access token when a refresh token is created. This is standard oauth, but because Firefox does not immediately need and use the access token given back for fxa-credentials and authorization_code grants, we need to either suppress the access token creation, or suppress the DAU event
* Because it is standard oauth to always return an access token, and because doing something non-standard will add another wrinkle to moving to an oauth standard library later, and because we already have at least one other separate case where we want to suppress a DAU event (FXA-14159), we want to continue creating the access tokens and logging access token created events

This commit:
* Adds a new "exclude_dau" option fxa-credentials and authorization_code oauth token grants so that when passed, we still emit the access token created event, but the new field will make these events filterable
* Passes UID from earlier in the grant flow to avoid a DB call

closes FXA-14206

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

--

This PR would replace #20888. ~I have not tested this locally yet.~ Tested, and I see it coming through with the new option: `"events\":[{\"category\":\"access_token\",\"name\":\"created\",\"extra\":{\"reason\":\"fxa-credentials\",\"scopes\":\"profile\",\"exclude_dau\":\"true\"},` and without: `"extra\":{\"reason\":\"fxa-credentials\",\"scopes\":\"profile\",\"exclude_dau\":\"false\"},`

Note, we have [FXA - 14160](https://mozilla-hub.atlassian.net/browse/FXA-14160) filed for "a better DAU signal" and that is NOT the fix for that ask.