### PR TITLE
bug(auth-client): fix "Incorrect email case" on password checks

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1408,7 +1408,13 @@ export default class AuthClient {
     headers?: Headers
   ): Promise<any> {
     const email = normalizeEmails(emailInput);
-    const credentials = await crypto.getCredentials(email.original, password);
+    // Salt the first attempt with the primary email; the INCORRECT_EMAIL_CASE
+    // handler below re-derives with the signup email (`error.email`). See
+    // `sessionReauth` for why the v1 salt is ambiguous.
+    const credentials = await crypto.getCredentials(
+      options.skipCaseError ? email.original : email.primary,
+      password
+    );
     const payload = {
       email: email.primary,
       authPW: credentials.authPW,
@@ -1430,7 +1436,7 @@ export default class AuthClient {
         options.skipCaseError = true;
 
         return this.accountDestroy(
-          { ...error, original: error.email },
+          { ...email, original: error.email },
           password,
           options,
           sessionToken,
@@ -1635,7 +1641,15 @@ export default class AuthClient {
     headers?: Headers
   ): Promise<SessionReauthedAccountData> {
     const email = normalizeEmails(emailInput);
-    const credentials = await crypto.getCredentials(email.original, password);
+    // For an account whose signup email differs from its current primary, the v1
+    // verifier may be salted with either address. Salt the first attempt with the
+    // primary (the address the user authenticates with); the INCORRECT_EMAIL_CASE
+    // handler below re-derives with the signup email (`error.email`). When the two
+    // addresses match (the common case) this is unchanged.
+    const credentials = await crypto.getCredentials(
+      options.skipCaseError ? email.original : email.primary,
+      password
+    );
 
     try {
       const accountData = await this.sessionReauthWithAuthPW(
@@ -1657,13 +1671,6 @@ export default class AuthClient {
         !options.skipCaseError
       ) {
         options.skipCaseError = true;
-
-        // This is quite confusing. If you look at the server side, the following option is
-        // actually checked against the account's primary email. If it doesn't match, then there
-        // is a failure. The assumption here is that the calling code passed in the primary email
-        // instead of the original email. So the email in the error is the actual original email,
-        // and the email initially provided is the primary email... which may or may not be equal
-        // the original email on the account...
         options.originalLoginEmail = email.primary;
 
         return this.sessionReauth(
@@ -2009,102 +2016,92 @@ export default class AuthClient {
     headers?: Headers
   ): Promise<SignedInAccountData> {
     const email = normalizeEmails(emailInput);
-    const oldCredentials = await this.sessionReauth(
-      sessionToken,
-      email,
-      oldPassword,
-      {
-        keys: true,
-      },
-      headers
-    );
+    // The v1 salt may be either address (see `sessionReauth`), so try the primary
+    // first. This loops rather than reusing `sessionReauth`'s retry because the
+    // reauth and the `/mfa/password/change` payload must share one salt per attempt.
+    const saltCandidates =
+      email.primary === email.original
+        ? [email.original]
+        : [email.primary, email.original];
 
-    const oldCredentialsAuth = await crypto.getCredentials(
-      email.original,
-      oldPassword
-    );
-    const oldAuthPW = oldCredentialsAuth.authPW;
+    let lastError: any;
+    for (let i = 0; i < saltCandidates.length; i++) {
+      const saltEmail = saltCandidates[i];
+      try {
+        const oldCredentials = await crypto.getCredentials(
+          saltEmail,
+          oldPassword
+        );
 
-    const keys = await this.accountKeys(
-      oldCredentials.keyFetchToken!,
-      oldCredentials.unwrapBKey!,
-      headers
-    );
-
-    const newCredentials = await crypto.getCredentials(
-      email.original,
-      newPassword
-    );
-
-    const wrapKb = crypto.unwrapKB(keys.kB, newCredentials.unwrapBKey);
-    const authPW = newCredentials.authPW;
-
-    let payload: {
-      email: string;
-      oldAuthPW: string;
-      authPW: string;
-      wrapKb: string;
-      authPWVersion2?: string;
-      wrapKbVersion2?: string;
-      clientSalt?: string;
-    } = {
-      email: email.original,
-      oldAuthPW,
-      authPW,
-      wrapKb,
-    };
-
-    if (this.keyStretchVersion === 2) {
-      const v2Payload = await this.createPasswordChangeV2Payload(
-        email,
-        newPassword,
-        keys,
-        newCredentials,
-        wrapKb,
-        headers
-      );
-      payload = {
-        ...payload,
-        authPWVersion2: v2Payload.authPWVersion2,
-        wrapKbVersion2: v2Payload.wrapKbVersion2,
-        clientSalt: v2Payload.clientSalt,
-      };
-    }
-
-    try {
-      const accountData = await this.jwtPost(
-        '/mfa/password/change',
-        jwt,
-        payload,
-        headers
-      );
-
-      return accountData;
-    } catch (error: any) {
-      if (
-        error &&
-        error.email &&
-        error.errno === ERRORS.INCORRECT_EMAIL_CASE &&
-        !options.skipCaseError
-      ) {
-        options.skipCaseError = true;
-        Sentry.addBreadcrumb({
-          category: 'passwordChangeJWT',
-          message: 'Unexpected incorrect email case!',
-        });
-        return await this.passwordChangeWithJWT(
-          jwt,
-          { ...email, original: error.email },
-          oldPassword,
-          newPassword,
+        const reauth = await this.sessionReauthWithAuthPW(
           sessionToken,
-          options,
+          email,
+          oldCredentials.authPW,
+          { keys: true },
           headers
         );
-      } else {
+
+        const keys = await this.accountKeys(
+          reauth.keyFetchToken!,
+          oldCredentials.unwrapBKey,
+          headers
+        );
+
+        const newCredentials = await crypto.getCredentials(
+          saltEmail,
+          newPassword
+        );
+        const wrapKb = crypto.unwrapKB(keys.kB, newCredentials.unwrapBKey);
+
+        let payload: {
+          email: string;
+          oldAuthPW: string;
+          authPW: string;
+          wrapKb: string;
+          authPWVersion2?: string;
+          wrapKbVersion2?: string;
+          clientSalt?: string;
+        } = {
+          email: email.original,
+          oldAuthPW: oldCredentials.authPW,
+          authPW: newCredentials.authPW,
+          wrapKb,
+        };
+
+        if (this.keyStretchVersion === 2) {
+          const v2Payload = await this.createPasswordChangeV2Payload(
+            email,
+            newPassword,
+            keys,
+            newCredentials,
+            wrapKb,
+            headers
+          );
+          payload = {
+            ...payload,
+            authPWVersion2: v2Payload.authPWVersion2,
+            wrapKbVersion2: v2Payload.wrapKbVersion2,
+            clientSalt: v2Payload.clientSalt,
+          };
+        }
+
+        return await this.jwtPost(
+          '/mfa/password/change',
+          jwt,
+          payload,
+          headers
+        );
+      } catch (error: any) {
+        const hasNextCandidate = i < saltCandidates.length - 1;
+        if (hasNextCandidate && error?.errno === ERRORS.INCORRECT_EMAIL_CASE) {
+          lastError = error;
+          continue;
+        }
         throw error;
       }
     }
+    // Unreachable while `saltCandidates` is non-empty.
+    throw lastError;
   }
 
   async createPassword(

--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -4,6 +4,7 @@
 
 import * as assert from 'assert';
 import AuthClient from '../server';
+import * as crypto from '../lib/crypto';
 
 // TODO: Use proper mocks when we move to jest. Not going to add sinon dep just for this...
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -269,6 +270,266 @@ describe('lib/client', () => {
         assert.equal(caught?.errno, 114);
         assert.equal(caught?.retryAfter, 30);
       });
+    });
+  });
+
+  describe('v1 credential salt fallback (signup email !== primary email)', () => {
+    let saltClient: AuthClient;
+    let originalFetch: typeof globalThis.fetch;
+    let calls: Array<{ url: string; body: any }>;
+    let responses: Array<() => Response>;
+
+    const sessionToken = '00'.repeat(32);
+    const password = 'hunter2hunter2';
+    const signupEmail = 'signup@example.com';
+    const primaryEmail = 'primary@example.com';
+
+    const emailCaseError = (correctedEmail: string) =>
+      new Response(
+        JSON.stringify({
+          errno: 120,
+          code: 400,
+          error: 'Bad Request',
+          message: 'Incorrect email case',
+          email: correctedEmail,
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    const ok = (json: Record<string, any> = {}) =>
+      new Response(JSON.stringify(json), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    before(() => {
+      saltClient = new AuthClient('http://localhost:9000');
+    });
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      calls = [];
+      responses = [];
+      globalThis.fetch = (async (url: string, init?: RequestInit) => {
+        calls.push({
+          url: String(url),
+          body: init?.body ? JSON.parse(init.body as string) : undefined,
+        });
+        const next = responses.shift();
+        return next ? next() : ok();
+      }) as typeof globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('sessionReauth: falls back to the signup email salt after INCORRECT_EMAIL_CASE', async () => {
+      responses = [() => emailCaseError(signupEmail), () => ok({ uid: 'abc' })];
+
+      const result = await saltClient.sessionReauth(
+        sessionToken,
+        { primary: primaryEmail, original: signupEmail },
+        password
+      );
+
+      assert.equal(calls.length, 2);
+      // The account is always identified by its primary email; only the salt varies.
+      assert.equal(calls[0].body.email, primaryEmail);
+      assert.equal(calls[1].body.email, primaryEmail);
+      // First attempt derives authPW from the primary, the retry from the signup email.
+      const primaryAuthPW = (
+        await crypto.getCredentials(primaryEmail, password)
+      ).authPW;
+      const signupAuthPW = (await crypto.getCredentials(signupEmail, password))
+        .authPW;
+      assert.equal(calls[0].body.authPW, primaryAuthPW);
+      assert.equal(calls[1].body.authPW, signupAuthPW);
+      assert.notEqual(calls[0].body.authPW, calls[1].body.authPW);
+      assert.equal((result as any).uid, 'abc');
+    });
+
+    it('sessionReauth: primary-salted account (signup !== primary) succeeds on the first attempt with no fallback', async () => {
+      // The reported-bug population: the verifier is salted with the primary
+      // email (e.g. a password reset that followed a primary-email swap). The
+      // primary-salted first attempt succeeds, so there is no second request.
+      responses = [() => ok({ uid: 'abc' })];
+
+      const result = await saltClient.sessionReauth(
+        sessionToken,
+        { primary: primaryEmail, original: signupEmail },
+        password
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].body.email, primaryEmail);
+      const primaryAuthPW = (
+        await crypto.getCredentials(primaryEmail, password)
+      ).authPW;
+      assert.equal(calls[0].body.authPW, primaryAuthPW);
+      assert.equal((result as any).uid, 'abc');
+    });
+
+    it('sessionReauth: makes a single request for a normal account (signup === primary)', async () => {
+      responses = [() => ok({ uid: 'abc' })];
+
+      const result = await saltClient.sessionReauth(
+        sessionToken,
+        primaryEmail,
+        password
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].body.email, primaryEmail);
+      // The salt is the primary email, which is also the signup email here.
+      const primaryAuthPW = (
+        await crypto.getCredentials(primaryEmail, password)
+      ).authPW;
+      assert.equal(calls[0].body.authPW, primaryAuthPW);
+      assert.equal((result as any).uid, 'abc');
+    });
+
+    it('sessionReauth: does not fall back on a non-email-case error', async () => {
+      responses = [
+        () =>
+          new Response(
+            JSON.stringify({
+              errno: 103,
+              code: 400,
+              message: 'Incorrect password',
+            }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+          ),
+      ];
+
+      let caught: any;
+      try {
+        await saltClient.sessionReauth(
+          sessionToken,
+          { primary: primaryEmail, original: signupEmail },
+          password
+        );
+      } catch (e) {
+        caught = e;
+      }
+
+      assert.equal(calls.length, 1);
+      assert.equal(caught?.errno, 103);
+    });
+
+    it('accountDestroy: falls back to the signup email salt after INCORRECT_EMAIL_CASE', async () => {
+      responses = [() => emailCaseError(signupEmail), () => ok({})];
+
+      await saltClient.accountDestroy(
+        { primary: primaryEmail, original: signupEmail },
+        password,
+        {},
+        sessionToken
+      );
+
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0].body.email, primaryEmail);
+      assert.equal(calls[1].body.email, primaryEmail);
+      const primaryAuthPW = (
+        await crypto.getCredentials(primaryEmail, password)
+      ).authPW;
+      const signupAuthPW = (await crypto.getCredentials(signupEmail, password))
+        .authPW;
+      assert.equal(calls[0].body.authPW, primaryAuthPW);
+      assert.equal(calls[1].body.authPW, signupAuthPW);
+    });
+
+    it('passwordChangeWithJWT: falls back to the signup email salt, and the change payload keeps the signup email', async () => {
+      // Stub the key-bundle fetch/derivation so the test can focus on the salt
+      // fallback rather than a real /account/keys crypto bundle.
+      const origAccountKeys = saltClient.accountKeys;
+      (saltClient as any).accountKeys = async () => ({
+        kA: '11'.repeat(32),
+        kB: '22'.repeat(32),
+      });
+
+      try {
+        responses = [
+          () => emailCaseError(signupEmail), // reauth attempt 1 (primary salt) fails
+          () => ok({ keyFetchToken: '33'.repeat(32) }), // reauth attempt 2 (signup salt) ok
+          () => ok({ uid: 'abc' }), // /mfa/password/change
+        ];
+
+        const result = await saltClient.passwordChangeWithJWT(
+          'fake.jwt.token',
+          { primary: primaryEmail, original: signupEmail },
+          password,
+          'newpassword9newpassword9',
+          sessionToken
+        );
+
+        const primaryAuthPW = (
+          await crypto.getCredentials(primaryEmail, password)
+        ).authPW;
+        const signupAuthPW = (
+          await crypto.getCredentials(signupEmail, password)
+        ).authPW;
+
+        // reauth (fails) -> reauth (ok) -> change.
+        assert.equal(calls.length, 3);
+        // Both reauth attempts identify by the primary email; the salt flips
+        // primary -> signup between them.
+        assert.ok(calls[0].url.includes('/session/reauth'));
+        assert.equal(calls[0].body.email, primaryEmail);
+        assert.equal(calls[0].body.authPW, primaryAuthPW);
+        assert.ok(calls[1].url.includes('/session/reauth'));
+        assert.equal(calls[1].body.email, primaryEmail);
+        assert.equal(calls[1].body.authPW, signupAuthPW);
+        // The change payload keeps the signup email (so the server's match against
+        // accounts.email holds) with the matching signup-derived oldAuthPW.
+        assert.ok(calls[2].url.includes('/mfa/password/change'));
+        assert.equal(calls[2].body.email, signupEmail);
+        assert.equal(calls[2].body.oldAuthPW, signupAuthPW);
+        assert.equal((result as any).uid, 'abc');
+      } finally {
+        (saltClient as any).accountKeys = origAccountKeys;
+      }
+    });
+
+    it('passwordChangeWithJWT: primary-salted account (signup !== primary) succeeds on the first attempt with no fallback', async () => {
+      // The reported-bug population: the verifier is salted with the primary
+      // email. The primary-salted reauth succeeds immediately, and the change
+      // payload keeps the signup email with the primary-derived oldAuthPW.
+      const origAccountKeys = saltClient.accountKeys;
+      (saltClient as any).accountKeys = async () => ({
+        kA: '11'.repeat(32),
+        kB: '22'.repeat(32),
+      });
+
+      try {
+        responses = [
+          () => ok({ keyFetchToken: '33'.repeat(32) }), // reauth attempt 1 (primary salt) ok
+          () => ok({ uid: 'abc' }), // /mfa/password/change
+        ];
+
+        const result = await saltClient.passwordChangeWithJWT(
+          'fake.jwt.token',
+          { primary: primaryEmail, original: signupEmail },
+          password,
+          'newpassword9newpassword9',
+          sessionToken
+        );
+
+        const primaryAuthPW = (
+          await crypto.getCredentials(primaryEmail, password)
+        ).authPW;
+
+        // reauth (ok) -> change; no fallback.
+        assert.equal(calls.length, 2);
+        assert.ok(calls[0].url.includes('/session/reauth'));
+        assert.equal(calls[0].body.email, primaryEmail);
+        assert.equal(calls[0].body.authPW, primaryAuthPW);
+        assert.ok(calls[1].url.includes('/mfa/password/change'));
+        assert.equal(calls[1].body.email, signupEmail);
+        assert.equal(calls[1].body.oldAuthPW, primaryAuthPW);
+        assert.equal((result as any).uid, 'abc');
+      } finally {
+        (saltClient as any).accountKeys = origAccountKeys;
+      }
     });
   });
 });


### PR DESCRIPTION
## Because

- When an account's signup email (`accounts.email`) differs from its current
  primary email, the current-password check derived v1 credentials from the
  signup email — but the stored verifier may be salted with the primary email
  (e.g. after a password reset that followed a primary-email change). The
  mismatch surfaced to users as an "Incorrect email case" error, blocking
  Change Password, Create Recovery Key, and Delete Account with no self-serve
  workaround.

## This pull request

- Salts the first current-password derivation attempt with the primary email
  (the address the user authenticates with) and falls back to the signup email
  on `INCORRECT_EMAIL_CASE`, in `sessionReauth`, `accountDestroy`, and
  `passwordChangeWithJWT` (`packages/fxa-auth-client/lib/client.ts`). Accounts
  where the two emails match are unaffected (single attempt).
- Fixes a latent retry bug in `accountDestroy` where the retry spread the
  server error object into the email input, resolving the payload email to the
  signup address instead of the primary.
- Adds unit tests in `packages/fxa-auth-client/test/client.ts` covering the
  primary→signup fallback, the single-request happy path, and non-email-case
  errors not retrying.

## Issue that this pull request solves

Closes: FXA-14223

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the salt selection in `sessionReauth` /
  `accountDestroy` (conditional) and `passwordChangeWithJWT` (candidate loop).
- Suggested review order: `sessionReauth` first (shared pattern), then
  `passwordChangeWithJWT`, then the tests.
- Risky or complex parts: the salt is intentionally decoupled from each route's
  identity email — reauth identifies the account by the primary, while the
  `/mfa/password/change` payload keeps the signup email so the server's
  `emailsMatch(email, accounts.email)` check still holds.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This appears to come from swapping primary email from signup email at different points and changing passwords. Since the verify hash is tied to the email, the swap can cause issues. To that, I ran though these cases to make sure, and on the Population B, I was able to see the page 'errored' calling /reauth, then re-attempted the /reauth call with the other email

```
Population A — password never touched after the swap (signup-salted):
1. Sign up with A@x.com → verifier salted with A (signup).
2. Set password
3. Add B@y.com, verify, make it primary. (Password untouched → still salted with A.)
4. Change password → needs salt A (signup). ✅ FXA-14117 handles this; the functional test covers it.

Population B — password reset after the swap (primary-salted):
1. Sign up with A@x.com → verifier salted with A (signup).
2. Set password
3. Add B@y.com, verify, make it primary.
5. Sign out,
6. Reset the password (via B@y.com) → verifier re-salted with B (primary).
7. Change password again → needs salt B (primary), but FXA-14117 sent A (signup) → mismatch → "Incorrect email case." but should succeed
```

I then forced the account into Population B by relabeling its signup email in the DB `UPDATE accounts SET email/normalizedEmail` to a throwaway address, leaving the emails primary untouched. So, signup ≠ primary with the v1 verifier still salted with the primary email (no verifier rewrite needed).