### PR TITLE
fix(auth): add rate-limit rules for passkey MFA OTP request/verify

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -151,11 +151,13 @@ mfaOtpCodeRequestForEmail              : uid              : 10          : 5 minu
 mfaOtpCodeRequestFor2fa                : uid              : 10          : 5 minutes       : 15 minutes   : block
 mfaOtpCodeRequestForPassword           : uid              : 10          : 5 minutes       : 15 minutes   : block
 mfaOtpCodeRequestForRecoveryKey        : uid              : 10          : 5 minutes       : 15 minutes   : block
+mfaOtpCodeRequestForPasskey            : uid              : 10          : 5 minutes       : 15 minutes   : block
 # Verify Code rate limits
 mfaOtpCodeVerifyForEmail               : uid              : 5           : 5 minutes       : 15 minutes   : block
 mfaOtpCodeVerifyFor2fa                 : uid              : 5           : 5 minutes       : 15 minutes   : block
 mfaOtpCodeVerifyForPassword            : uid              : 5           : 5 minutes       : 15 minutes   : block
 mfaOtpCodeVerifyForRecoveryKey         : uid              : 5           : 5 minutes       : 15 minutes   : block
+mfaOtpCodeVerifyForPasskey             : uid              : 5           : 5 minutes       : 15 minutes   : block
 
 #
 # Passkey Authentication


### PR DESCRIPTION
## Because

- Brings the passkey MFA OTP step-up actions under dedicated rate-limit rules, consistent with the other MFA actions. Details in FXA-14213 (internal).

## This pull request

- Adds `block` rate-limit rules for the `mfaOtpCodeRequestForPasskey` and `mfaOtpCodeVerifyForPasskey` customs actions in `packages/fxa-auth-server/config/rate-limit-rules.txt`, mirroring the existing `email`/`2fa`/`password`/`recovery_key` MFA-dialog rules.

## Issue that this pull request solves

Closes: FXA-14213

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Applies to local and stage; the corresponding production rule is tracked separately.
