### PR TITLE
feat(admin): add remove-passkey admin actions

### DIFF
--- a/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
@@ -151,6 +151,18 @@ describe('support agents', () => {
           AdminPanelGroup.SupportAgentStage
         )
       ).true;
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.RemovePasskeys,
+          AdminPanelGroup.AdminProd
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.RemovePasskeys,
+          AdminPanelGroup.AdminStage
+        )
+      ).true;
     });
 
     it('looks up group', () => {
@@ -246,6 +258,12 @@ describe('support agents', () => {
       expect(
         guard.allow(
           AdminPanelFeature.DeleteRecoveryPhone,
+          AdminPanelGroup.SupportAgentStage
+        )
+      ).false;
+      expect(
+        guard.allow(
+          AdminPanelFeature.RemovePasskeys,
           AdminPanelGroup.SupportAgentStage
         )
       ).false;

--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -49,6 +49,7 @@ export enum AdminPanelFeature {
   UnsubscribeFromMailingLists = 'UnsubscribeFromMailingLists',
   RateLimiting = 'RateLimiting',
   DeleteRecoveryPhone = 'DeleteRecoveryPhone',
+  RemovePasskeys = 'RemovePasskeys',
   EmailBlocklist = 'EmailBlocklist',
   ManageWafTokens = 'ManageWafTokens',
   DomainBlocklist = 'DomainBlocklist',
@@ -213,6 +214,10 @@ const defaultAdminPanelPermissions: Permissions = {
   },
   [AdminPanelFeature.DeleteRecoveryPhone]: {
     name: 'Delete Recovery Phone',
+    level: PermissionLevel.Admin,
+  },
+  [AdminPanelFeature.RemovePasskeys]: {
+    name: 'Remove Passkeys',
     level: PermissionLevel.Admin,
   },
   [AdminPanelFeature.EmailBlocklist]: {

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { Account, AccountProps } from './index';
 import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
 import { IClientConfig } from '../../../../interfaces';
 import { mockConfigBuilder } from '../../../lib/config';
+import { adminApi } from '../../../lib/api';
 
 const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
 const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
@@ -34,6 +36,7 @@ jest.mock('../../../lib/api', () => ({
     editLocale: jest.fn(),
     unlinkAccount: jest.fn(),
     clearEmailBounce: jest.fn(),
+    removePasskey: jest.fn(),
     recordSecurityEvent: jest.fn().mockResolvedValue(true),
   },
 }));
@@ -232,6 +235,7 @@ it('displays passkeys with authenticator name', () => {
     passkeys: [
       {
         name: 'iPhone Face ID',
+        credentialId: 'aphonecredentialid',
         createdAt: 1589467100316,
         lastUsedAt: null,
         aaguid: '00000000-0000-0000-0000-000000000000',
@@ -241,6 +245,7 @@ it('displays passkeys with authenticator name', () => {
       },
       {
         name: 'YubiKey 5',
+        credentialId: 'ayubikeycredentialid',
         createdAt: 1589467200000,
         lastUsedAt: 1700000000000,
         aaguid: 'fa2b99dc-9e39-4257-8f92-4a30d23c4118',
@@ -263,6 +268,7 @@ it('displays passkeys with never-used date', () => {
     passkeys: [
       {
         name: 'iPhone Face ID',
+        credentialId: 'aphonecredentialid',
         createdAt: 1589467100316,
         lastUsedAt: null,
         aaguid: '00000000-0000-0000-0000-000000000000',
@@ -283,6 +289,7 @@ it('displays passkeys with last-used date', () => {
     passkeys: [
       {
         name: 'YubiKey 5',
+        credentialId: 'ayubikeycredentialid',
         createdAt: 1589467200000,
         lastUsedAt: 1700000000000,
         aaguid: 'fa2b99dc-9e39-4257-8f92-4a30d23c4118',
@@ -295,6 +302,149 @@ it('displays passkeys with last-used date', () => {
   const { getByTestId } = render(<Account {...withPasskey} />);
 
   expect(getByTestId('passkey-last-used-at')).toHaveTextContent('2023-11');
+});
+
+const passkeyFixture = {
+  name: 'iPhone Face ID',
+  credentialId: 'aphonecredentialid',
+  createdAt: 1589467100316,
+  lastUsedAt: null,
+  aaguid: '00000000-0000-0000-0000-000000000000',
+  authenticatorName: undefined,
+  backupState: true,
+  prfEnabled: false,
+};
+
+it('does not render a per-passkey remove button for a support agent', () => {
+  // The default mocked user is a support agent; RemovePasskeys is Admin-only.
+  render(<Account {...{ ...accountResponse, passkeys: [passkeyFixture] }} />);
+
+  expect(
+    screen.queryByRole('button', { name: /remove passkey/i })
+  ).not.toBeInTheDocument();
+});
+
+it('removes a single passkey by credentialId when an admin confirms', async () => {
+  const allowSpy = jest
+    .spyOn(AdminPanelGuard.prototype, 'allow')
+    .mockReturnValue(true);
+  const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+  (adminApi.removePasskey as jest.Mock).mockResolvedValue(true);
+  // recordSecurityEvent is fire-and-forget (.catch); it must return a promise.
+  (adminApi.recordSecurityEvent as jest.Mock).mockResolvedValue(true);
+  const onCleared = jest.fn();
+
+  try {
+    const user = userEvent.setup();
+    render(
+      <Account
+        {...{ ...accountResponse, onCleared, passkeys: [passkeyFixture] }}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Remove passkey iPhone Face ID' })
+    );
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Remove the passkey "iPhone Face ID" for "hey@happy.com"? This cannot be undone.'
+    );
+
+    await waitFor(() => {
+      expect(adminApi.removePasskey).toHaveBeenCalledWith(
+        accountResponse.uid,
+        'aphonecredentialid'
+      );
+      expect(adminApi.recordSecurityEvent).toHaveBeenCalledWith(
+        accountResponse.uid,
+        'account.passkey.removed'
+      );
+      expect(alertSpy).toHaveBeenCalledWith('The passkey has been removed.');
+      expect(onCleared).toHaveBeenCalled();
+    });
+  } finally {
+    allowSpy.mockRestore();
+    confirmSpy.mockRestore();
+    alertSpy.mockRestore();
+  }
+});
+
+it('does not record the event or clear when no passkey was removed', async () => {
+  const allowSpy = jest
+    .spyOn(AdminPanelGuard.prototype, 'allow')
+    .mockReturnValue(true);
+  const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+  (adminApi.removePasskey as jest.Mock).mockResolvedValue(false);
+  const onCleared = jest.fn();
+
+  try {
+    const user = userEvent.setup();
+    render(
+      <Account
+        {...{ ...accountResponse, onCleared, passkeys: [passkeyFixture] }}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Remove passkey iPhone Face ID' })
+    );
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('No passkey was removed.');
+    });
+    expect(adminApi.recordSecurityEvent).not.toHaveBeenCalled();
+    expect(onCleared).not.toHaveBeenCalled();
+  } finally {
+    allowSpy.mockRestore();
+    confirmSpy.mockRestore();
+    alertSpy.mockRestore();
+  }
+});
+
+it('targets the clicked passkey by its own credentialId with multiple passkeys', async () => {
+  const allowSpy = jest
+    .spyOn(AdminPanelGuard.prototype, 'allow')
+    .mockReturnValue(true);
+  const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+  (adminApi.removePasskey as jest.Mock).mockResolvedValue(true);
+  (adminApi.recordSecurityEvent as jest.Mock).mockResolvedValue(true);
+
+  const secondPasskey = {
+    ...passkeyFixture,
+    name: 'YubiKey 5',
+    credentialId: 'ayubikeycredentialid',
+  };
+
+  try {
+    const user = userEvent.setup();
+    render(
+      <Account
+        {...{ ...accountResponse, passkeys: [passkeyFixture, secondPasskey] }}
+      />
+    );
+
+    expect(
+      screen.getAllByRole('button', { name: /remove passkey/i })
+    ).toHaveLength(2);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Remove passkey YubiKey 5' })
+    );
+
+    await waitFor(() => {
+      expect(adminApi.removePasskey).toHaveBeenCalledWith(
+        accountResponse.uid,
+        'ayubikeycredentialid'
+      );
+    });
+  } finally {
+    allowSpy.mockRestore();
+    confirmSpy.mockRestore();
+    alertSpy.mockRestore();
+  }
 });
 
 it('displays secondary emails', async () => {

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -122,6 +122,30 @@ export const Account = ({
     }
   };
 
+  const handleRemovePasskey = async (credentialId: string, name: string) => {
+    if (
+      !window.confirm(
+        `Remove the passkey "${name}" for "${primaryEmail.email}"? This cannot be undone.`
+      )
+    ) {
+      return;
+    }
+    try {
+      const removed = await adminApi.removePasskey(uid, credentialId);
+      if (!removed) {
+        window.alert('No passkey was removed.');
+        return;
+      }
+      adminApi
+        .recordSecurityEvent(uid, 'account.passkey.removed')
+        .catch(() => {});
+      window.alert('The passkey has been removed.');
+      onCleared();
+    } catch {
+      window.alert('Error removing passkey.');
+    }
+  };
+
   function highlight(val: string) {
     return query === val ? 'bg-yellow-100' : undefined;
   }
@@ -327,10 +351,11 @@ export const Account = ({
               'Backup State',
               'PRF Enabled',
               'Authenticator',
+              'Action',
             ]}
           >
             {passkeys.map((passkey: PasskeyType) => (
-              <TableRowXHeader key={`${passkey.name}-${passkey.createdAt}`}>
+              <TableRowXHeader key={passkey.credentialId}>
                 <td data-testid="passkey-name">{passkey.name}</td>
                 <td data-testid="passkey-created-at">
                   {getFormattedDate(passkey.createdAt)}
@@ -348,6 +373,21 @@ export const Account = ({
                 </td>
                 <td data-testid="passkey-authenticator-name">
                   {passkey.authenticatorName || 'Unknown'}
+                </td>
+                <td>
+                  <Guard features={[AdminPanelFeature.RemovePasskeys]}>
+                    <button
+                      className="p-1 text-red-700 border-2 rounded border-grey-100 bg-grey-10 hover:border-grey-10 hover:bg-grey-50 hover:text-red-700"
+                      type="button"
+                      data-testid={`remove-passkey-${passkey.credentialId}`}
+                      aria-label={`Remove passkey ${passkey.name}`}
+                      onClick={() =>
+                        handleRemovePasskey(passkey.credentialId, passkey.name)
+                      }
+                    >
+                      Remove
+                    </button>
+                  </Guard>
                 </td>
               </TableRowXHeader>
             ))}
@@ -502,6 +542,7 @@ export const Account = ({
           has2FA: totps && totps.some((x) => x.enabled),
           hasRecoveryPhone:
             recoveryPhone && recoveryPhone.some((x) => x.exists),
+          hasPasskeys: passkeys && passkeys.length > 0,
         }}
       />
     </>

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.test.tsx
@@ -47,6 +47,7 @@ jest.mock('../../../lib/api', () => ({
     enableAccount: jest.fn(),
     remove2FA: jest.fn(),
     deleteRecoveryPhone: jest.fn(),
+    removePasskeys: jest.fn(),
     recordSecurityEvent: jest.fn(),
   },
 }));
@@ -78,6 +79,7 @@ const defaultProps = {
   onCleared: jest.fn(),
   has2FA: true,
   hasRecoveryPhone: true,
+  hasPasskeys: true,
 };
 
 function renderDangerZone(props: Partial<typeof defaultProps> = {}) {
@@ -199,6 +201,91 @@ describe('DangerZone Component', () => {
     });
   });
 
+  describe('Remove All Passkeys', () => {
+    it('renders remove passkeys button when account has passkeys', () => {
+      renderDangerZone();
+
+      expect(screen.getByText('Remove All Passkeys')).toBeInTheDocument();
+      expect(
+        screen.getByText("Delete all of the account's passkeys.")
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('remove-all-passkeys')).toBeInTheDocument();
+    });
+
+    it('does not render remove passkeys button when account has no passkeys', () => {
+      renderDangerZone({ hasPasskeys: false });
+
+      expect(screen.queryByText('Remove All Passkeys')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('remove-all-passkeys')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not remove passkeys when the admin cancels the confirmation', async () => {
+      mockConfirm.mockReturnValue(false);
+
+      renderDangerZone();
+
+      await user.click(screen.getByTestId('remove-all-passkeys'));
+
+      expect(mockConfirm).toHaveBeenCalledWith(
+        'Are you sure you want to remove ALL passkeys for "test@example.com"? This cannot be undone.'
+      );
+      expect(adminApi.removePasskeys).not.toHaveBeenCalled();
+    });
+
+    it('removes passkeys and records a security event when the admin confirms', async () => {
+      mockConfirm.mockReturnValue(true);
+      (adminApi.removePasskeys as jest.Mock).mockResolvedValue(true);
+
+      renderDangerZone();
+
+      await user.click(screen.getByTestId('remove-all-passkeys'));
+
+      await waitFor(() => {
+        expect(adminApi.removePasskeys).toHaveBeenCalledWith('test-uid-123');
+        expect(adminApi.recordSecurityEvent).toHaveBeenCalledWith(
+          'test-uid-123',
+          'account.passkey.removed'
+        );
+        expect(mockAlert).toHaveBeenCalledWith(
+          "The account's passkeys have been removed."
+        );
+        expect(defaultProps.onCleared).toHaveBeenCalled();
+      });
+    });
+
+    it('does not record the event or clear when no passkeys were removed', async () => {
+      mockConfirm.mockReturnValue(true);
+      (adminApi.removePasskeys as jest.Mock).mockResolvedValue(false);
+
+      renderDangerZone();
+
+      await user.click(screen.getByTestId('remove-all-passkeys'));
+
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith('No passkeys were removed.');
+      });
+      expect(adminApi.recordSecurityEvent).not.toHaveBeenCalled();
+      expect(defaultProps.onCleared).not.toHaveBeenCalled();
+    });
+
+    it('shows an error alert when removePasskeys fails', async () => {
+      mockConfirm.mockReturnValue(true);
+      (adminApi.removePasskeys as jest.Mock).mockRejectedValue(
+        new Error('Network error')
+      );
+
+      renderDangerZone();
+
+      await user.click(screen.getByTestId('remove-all-passkeys'));
+
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith('Error removing passkeys.');
+      });
+    });
+  });
+
   describe('Component Rendering', () => {
     it('renders danger zone section', () => {
       renderDangerZone();
@@ -213,6 +300,7 @@ describe('DangerZone Component', () => {
       expect(screen.getByTestId('disable-account')).toBeInTheDocument();
       expect(screen.getByTestId('remove-2fa')).toBeInTheDocument();
       expect(screen.getByTestId('delete-recovery-phone')).toBeInTheDocument();
+      expect(screen.getByTestId('remove-all-passkeys')).toBeInTheDocument();
       expect(
         screen.getByTestId('unsubscribe-from-mailing-lists')
       ).toBeInTheDocument();
@@ -231,6 +319,9 @@ describe('DangerZone Component', () => {
       expect(screen.queryByTestId('remove-2fa')).not.toBeInTheDocument();
       expect(
         screen.queryByTestId('delete-recovery-phone')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('remove-all-passkeys')
       ).not.toBeInTheDocument();
       expect(
         screen.queryByTestId('unsubscribe-from-mailing-lists')

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.tsx
@@ -17,6 +17,7 @@ type DangerZoneProps = {
   onCleared: Function;
   has2FA?: boolean | null;
   hasRecoveryPhone?: boolean | null;
+  hasPasskeys?: boolean | null;
 };
 
 const DangerZoneAction = ({
@@ -65,6 +66,7 @@ export const DangerZone = ({
   onCleared,
   has2FA,
   hasRecoveryPhone,
+  hasPasskeys,
 }: DangerZoneProps) => {
   const [unverifyLoading, setUnverifyLoading] = useState(false);
 
@@ -159,6 +161,30 @@ export const DangerZone = ({
     }
   };
 
+  const handleRemovePasskeys = async () => {
+    if (
+      !window.confirm(
+        `Are you sure you want to remove ALL passkeys for "${email.email}"? This cannot be undone.`
+      )
+    ) {
+      return;
+    }
+    try {
+      const removed = await adminApi.removePasskeys(uid);
+      if (!removed) {
+        window.alert('No passkeys were removed.');
+        return;
+      }
+      adminApi
+        .recordSecurityEvent(uid, 'account.passkey.removed')
+        .catch(() => {});
+      window.alert("The account's passkeys have been removed.");
+      onCleared();
+    } catch {
+      window.alert('Error removing passkeys.');
+    }
+  };
+
   // define loading messages
   const loadingMessage = 'Please wait a moment...';
   let unverifyMessage = '';
@@ -175,6 +201,7 @@ export const DangerZone = ({
           AdminPanelFeature.UnsubscribeFromMailingLists,
           AdminPanelFeature.Remove2FA,
           AdminPanelFeature.DeleteRecoveryPhone,
+          AdminPanelFeature.RemovePasskeys,
         ]}
       >
         <h3 className="mt-0 mb-1 bg-red-600 font-medium h-8 pb-8 pl-2 pt-1 rounded-sm text-lg text-white">
@@ -238,6 +265,17 @@ export const DangerZone = ({
             buttonHandler={handleDeleteRecoveryPhone}
             buttonText="Delete"
             buttonTestId="delete-recovery-phone"
+          />
+        </Guard>
+      )}
+      {hasPasskeys && (
+        <Guard features={[AdminPanelFeature.RemovePasskeys]}>
+          <DangerZoneAction
+            header="Remove All Passkeys"
+            description="Delete all of the account's passkeys."
+            buttonHandler={handleRemovePasskeys}
+            buttonText="Remove All"
+            buttonTestId="remove-all-passkeys"
           />
         </Guard>
       )}

--- a/packages/fxa-admin-panel/src/lib/api.ts
+++ b/packages/fxa-admin-panel/src/lib/api.ts
@@ -141,6 +141,20 @@ export const adminApi = {
     });
   },
 
+  removePasskeys(uid: string): Promise<boolean> {
+    return apiFetch('/api/account/remove-passkeys', {
+      method: 'POST',
+      body: JSON.stringify({ uid }),
+    });
+  },
+
+  removePasskey(uid: string, credentialId: string): Promise<boolean> {
+    return apiFetch('/api/account/remove-passkey', {
+      method: 'POST',
+      body: JSON.stringify({ uid, credentialId }),
+    });
+  },
+
   recordSecurityEvent(uid: string, name: string): Promise<boolean> {
     return apiFetch('/api/account/record-security-event', {
       method: 'POST',

--- a/packages/fxa-admin-server/src/database/database.service.ts
+++ b/packages/fxa-admin-server/src/database/database.service.ts
@@ -80,13 +80,23 @@ export class DatabaseService implements OnModuleDestroy {
       metrics
     );
 
+    // Align the connection with the utf8mb4 storage charset; it
+    // otherwise defaults to utf8mb3.
     this.knex = knex({
-      connection: { typeCast: typeCasting, ...dbConfig.fxa },
+      connection: {
+        typeCast: typeCasting,
+        ...dbConfig.fxa,
+        charset: 'UTF8MB4_BIN',
+      },
       client: 'mysql',
     });
 
     this.knexOauth = knex({
-      connection: { typeCast: typeCasting, ...dbConfig.fxa_oauth },
+      connection: {
+        typeCast: typeCasting,
+        ...dbConfig.fxa_oauth,
+        charset: 'UTF8MB4_BIN',
+      },
       client: 'mysql',
     });
 

--- a/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
+++ b/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
@@ -17,6 +17,7 @@ export enum EventNames {
   DeleteRecoveryPhone = 'delete-recovery-phone',
   DeleteAccounts = 'delete-accounts',
   ResetAccounts = 'reset-accounts',
+  RemovePasskeys = 'remove-passkeys',
 }
 
 /**

--- a/packages/fxa-admin-server/src/rest/account/account.controller.spec.ts
+++ b/packages/fxa-admin-server/src/rest/account/account.controller.spec.ts
@@ -29,19 +29,26 @@ import {
 import { BasketService } from '../../newsletters/basket.service';
 import { SubscriptionsService } from '../../subscriptions/subscriptions.service';
 import { AccountDeleteStatus, AccountResetStatus } from '../../types';
+import { uuidTransformer } from '../../database/transformers';
 import { AccountController } from './account.controller';
+
+// AccountController imports SentryTraced from @sentry/nestjs, whose module init
+// does not run under Jest; stub the decorator to a no-op.
+jest.mock('@sentry/nestjs', () => ({ SentryTraced: () => () => undefined }));
 
 describe('AccountController', () => {
   let controller: AccountController;
   let eventLogging: DeepMocked<EventLoggingService>;
   let emailService: DeepMocked<EmailService>;
   let cloudTask: DeepMocked<CloudTasks>;
+  let notifier: DeepMocked<NotifierService>;
 
-  // The account-lookup query builder. `first` (email locator) and `findOne`
-  // (uid locator) are the terminal calls that decide whether an account was
-  // found; the `givenAccount` helper below points both at a test-defined value.
-  // Chain methods return `this`, so they can't be typed against the builder
-  // without a circular reference — plain jest.Mocks keep it simple.
+  // The account-lookup query builder (resetAccounts/deleteAccounts). `first`
+  // (email locator) and `findOne` (uid locator) are the terminal calls that
+  // decide whether an account was found; the `givenAccount` helper below points
+  // both at a test-defined value. Chain methods return `this`, so they can't be
+  // typed against the builder without a circular reference — plain jest.Mocks
+  // keep it simple.
   let accountQuery: {
     select: jest.Mock;
     innerJoin: jest.Mock;
@@ -50,7 +57,20 @@ describe('AccountController', () => {
     first: jest.Mock;
   };
 
+  // The passkeys-table query mock (removePasskeys/removePasskey). db.knex
+  // returns it, and it is awaited directly (no terminal call), so it is
+  // thenable and resolves to `passkeyDeleteCount`.
+  let knexMock: jest.Mock;
+  let passkeyQuery: {
+    delete: jest.Mock;
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    then: jest.Mock;
+  };
+  let passkeyDeleteCount: number;
+
   const MOCK_UID = 'f9416ce3703e4916a4cd6b1e665a3f1a';
+  const MOCK_CREDENTIAL_ID = 'AQIDBAUGBwgJCg';
   const EMAIL_LOCATOR = 'user@example.com';
   const NO_ACCOUNT_LOCATOR = 'nobody@example.com';
   const MOCK_USER = 'admin@mozilla.com';
@@ -71,6 +91,7 @@ describe('AccountController', () => {
     eventLogging = createMock<EventLoggingService>();
     emailService = createMock<EmailService>();
     cloudTask = createMock<CloudTasks>();
+    notifier = createMock<NotifierService>();
 
     accountQuery = {
       select: jest.fn().mockReturnThis(),
@@ -81,8 +102,21 @@ describe('AccountController', () => {
     };
     givenAccount(undefined); // default: no account found
 
+    // Passkey deletes go through db.knex('passkeys'); default to a hit.
+    passkeyDeleteCount = 2;
+    passkeyQuery = {
+      delete: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) =>
+        Promise.resolve(passkeyDeleteCount).then(resolve)
+      ),
+    };
+    knexMock = jest.fn().mockReturnValue(passkeyQuery);
+
     const db = createMock<DatabaseService>({
       account: { query: jest.fn().mockReturnValue(accountQuery) } as any,
+      knex: knexMock as any,
     });
 
     const stub = (provide: any): Provider => ({ provide, useValue: {} });
@@ -93,6 +127,7 @@ describe('AccountController', () => {
         { provide: EventLoggingService, useValue: eventLogging },
         { provide: EmailService, useValue: emailService },
         { provide: CloudTasksService, useValue: cloudTask },
+        { provide: NotifierService, useValue: notifier },
         { provide: MozLoggerService, useValue: createMock<MozLoggerService>() },
         { provide: DatabaseService, useValue: db },
         {
@@ -102,7 +137,6 @@ describe('AccountController', () => {
         stub(CartManager),
         stub(SubscriptionsService),
         stub(BasketService),
-        stub(NotifierService),
         stub(FirestoreService),
         stub(ProfileClient),
         stub(FidoMdsService),
@@ -260,6 +294,85 @@ describe('AccountController', () => {
           },
         ]);
       });
+    });
+  });
+
+  describe('removePasskeys', () => {
+    it('deletes from the passkeys table scoped to the given uid', async () => {
+      await controller.removePasskeys(MOCK_UID);
+      expect(knexMock).toHaveBeenCalledWith('passkeys');
+      expect(passkeyQuery.delete).toHaveBeenCalled();
+      expect(passkeyQuery.where).toHaveBeenCalledWith(
+        'uid',
+        uuidTransformer.to(MOCK_UID)
+      );
+    });
+
+    it('returns true when passkeys were removed', async () => {
+      expect(await controller.removePasskeys(MOCK_UID)).toBe(true);
+    });
+
+    it('logs a remove-passkeys event', async () => {
+      await controller.removePasskeys(MOCK_UID);
+      expect(eventLogging.onEvent).toHaveBeenCalledWith(
+        EventNames.RemovePasskeys
+      );
+    });
+
+    it('emits a profileDataChange notification when passkeys were removed', async () => {
+      await controller.removePasskeys(MOCK_UID);
+      expect(notifier.send).toHaveBeenCalledWith({
+        event: 'profileDataChange',
+        data: { ts: expect.any(Number), uid: MOCK_UID },
+      });
+    });
+
+    it('returns false when the account has no passkeys', async () => {
+      passkeyDeleteCount = 0;
+      expect(await controller.removePasskeys(MOCK_UID)).toBe(false);
+    });
+
+    it('does not notify when the account has no passkeys', async () => {
+      passkeyDeleteCount = 0;
+      await controller.removePasskeys(MOCK_UID);
+      expect(notifier.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removePasskey', () => {
+    it('deletes a single passkey scoped to uid and credentialId', async () => {
+      await controller.removePasskey(MOCK_UID, MOCK_CREDENTIAL_ID);
+      expect(knexMock).toHaveBeenCalledWith('passkeys');
+      expect(passkeyQuery.where).toHaveBeenCalledWith(
+        'uid',
+        uuidTransformer.to(MOCK_UID)
+      );
+      expect(passkeyQuery.andWhere).toHaveBeenCalledWith(
+        'credentialId',
+        Buffer.from(MOCK_CREDENTIAL_ID, 'base64url')
+      );
+    });
+
+    it('returns true when the passkey was removed', async () => {
+      expect(await controller.removePasskey(MOCK_UID, MOCK_CREDENTIAL_ID)).toBe(
+        true
+      );
+    });
+
+    it('notifies when the passkey was removed', async () => {
+      await controller.removePasskey(MOCK_UID, MOCK_CREDENTIAL_ID);
+      expect(notifier.send).toHaveBeenCalledWith({
+        event: 'profileDataChange',
+        data: { ts: expect.any(Number), uid: MOCK_UID },
+      });
+    });
+
+    it('returns false and skips notification when no matching passkey exists', async () => {
+      passkeyDeleteCount = 0;
+      expect(await controller.removePasskey(MOCK_UID, MOCK_CREDENTIAL_ID)).toBe(
+        false
+      );
+      expect(notifier.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-admin-server/src/rest/account/account.controller.ts
+++ b/packages/fxa-admin-server/src/rest/account/account.controller.ts
@@ -114,11 +114,12 @@ const RECOVERYKEY_COLUMNS = [
 const RECOVERYPHONES_COLUMNS = ['phoneNumber'];
 const LINKEDACCOUNT_COLUMNS = ['uid', 'authAt', 'providerId', 'enabled'];
 
-// credentialId, publicKey, signCount, and backupEligible are intentionally
-// excluded from the admin view because they expose sensitive cryptographic
-// material.
+// Columns exposed to the admin panel. credentialId lets a single
+// passkey be targeted for removal; other credential fields are
+// intentionally excluded.
 const PASSKEY_COLUMNS = [
   'name',
+  'credentialId',
   'createdAt',
   'lastUsedAt',
   'aaguid',
@@ -394,6 +395,64 @@ export class AccountController {
           uid,
         },
       });
+    }
+
+    return deleted;
+  }
+
+  /**
+   * Fires the profileDataChange notification after a passkey removal so
+   * downstream profile caches are invalidated.
+   */
+  private async notifyPasskeyRemoved(uid: string) {
+    await this.notifier.send({
+      event: 'profileDataChange',
+      data: {
+        ts: Date.now() / 1000,
+        uid,
+      },
+    });
+  }
+
+  @Features(AdminPanelFeature.RemovePasskeys)
+  @AuditLog()
+  @Post('remove-passkeys')
+  public async removePasskeys(@Body('uid') uid: string): Promise<boolean> {
+    this.eventLogging.onEvent(EventNames.RemovePasskeys);
+
+    const rowsDeleted = await this.db
+      .knex('passkeys')
+      .delete()
+      .where('uid', uuidTransformer.to(uid));
+
+    const deleted = rowsDeleted > 0;
+
+    if (deleted) {
+      await this.notifyPasskeyRemoved(uid);
+    }
+
+    return deleted;
+  }
+
+  @Features(AdminPanelFeature.RemovePasskeys)
+  @AuditLog()
+  @Post('remove-passkey')
+  public async removePasskey(
+    @Body('uid') uid: string,
+    @Body('credentialId') credentialId: string
+  ): Promise<boolean> {
+    this.eventLogging.onEvent(EventNames.RemovePasskeys);
+
+    const rowsDeleted = await this.db
+      .knex('passkeys')
+      .delete()
+      .where('uid', uuidTransformer.to(uid))
+      .andWhere('credentialId', Buffer.from(credentialId, 'base64url'));
+
+    const deleted = rowsDeleted > 0;
+
+    if (deleted) {
+      await this.notifyPasskeyRemoved(uid);
     }
 
     return deleted;
@@ -903,6 +962,7 @@ export class AccountController {
       rows.map(
         async (row: {
           name: string;
+          credentialId: Buffer;
           createdAt: number;
           lastUsedAt: number | null;
           aaguid: Buffer;
@@ -917,7 +977,12 @@ export class AccountController {
             : await this.mds.getAuthenticatorName(
                 bufferToUuidString(row.aaguid)
               );
-          return { ...row, aaguid, authenticatorName };
+          return {
+            ...row,
+            credentialId: row.credentialId.toString('base64url'),
+            aaguid,
+            authenticatorName,
+          };
         }
       )
     );

--- a/packages/fxa-admin-server/src/types.ts
+++ b/packages/fxa-admin-server/src/types.ts
@@ -98,6 +98,7 @@ export interface RecoveryPhone {
 
 export interface Passkey {
   name: string;
+  credentialId: string;
   createdAt: number;
   lastUsedAt: number | null;
   aaguid: string;


### PR DESCRIPTION
## Because

- The admin panel had no action to remove passkeys from an account. This adds
  Admin-only tooling to do so, for support and account-management workflows.

## This pull request

- Adds an Admin-only `RemovePasskeys` guard feature.
- Adds admin-server endpoints to remove all passkeys and a single passkey by
  `credentialId`; both are audited and record an `account.passkey.removed`
  security event.
- Surfaces `credentialId` in the admin passkey read to target a single passkey.
- Adds admin-panel per-passkey Remove buttons and a Remove All Passkeys action.

## Issue that this pull request solves

Closes: FXA-14212

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review

- Key files: `admin-panel-guard.ts`, `account.controller.ts`, `Account/index.tsx`, `DangerZone/index.tsx`.
- `credentialId` is a non-secret WebAuthn handle (sent to clients on every auth); the Admin-only gate is enforced on both client and server.

