### PR TITLE
fix(dau): Use new 'exclude_dau' option for signin flow Settings client_id access tokens

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -3224,6 +3224,7 @@ export default class AuthClient {
       access_type?: string;
       scope?: string;
       ttl?: number;
+      exclude_dau?: boolean;
     } = {},
     headers?: Headers
   ) {
@@ -3236,6 +3237,7 @@ export default class AuthClient {
         client_id: clientId,
         scope: options.scope,
         ttl: options.ttl,
+        exclude_dau: options.exclude_dau,
       },
       headers
     );

--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -4,7 +4,6 @@
 
 import * as assert from 'assert';
 import AuthClient from '../server';
-import * as crypto from '../lib/crypto';
 
 // TODO: Use proper mocks when we move to jest. Not going to add sinon dep just for this...
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -89,6 +88,50 @@ describe('lib/client', () => {
         'ABCD1234'
       );
       assert.notEqual(lastInit?.credentials, 'include');
+    });
+  });
+
+  describe('createOAuthToken', () => {
+    let httpsClient: AuthClient;
+    let originalFetch: typeof globalThis.fetch;
+    let lastBody: Record<string, any> | undefined;
+    // valid-length hex so HAWK credential derivation succeeds
+    const sessionToken = 'a'.repeat(64);
+
+    before(() => {
+      httpsClient = new AuthClient('https://localhost:9000');
+    });
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      lastBody = undefined;
+      globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+        lastBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response('{"access_token":"token"}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('forwards exclude_dau to /oauth/token when set', async () => {
+      await httpsClient.createOAuthToken(sessionToken, 'ea3ca969f8c6bb0d', {
+        scope: 'profile:avatar',
+        exclude_dau: true,
+      });
+      assert.equal(lastBody?.exclude_dau, true);
+    });
+
+    it('omits exclude_dau from the payload when not set', async () => {
+      await httpsClient.createOAuthToken(sessionToken, 'ea3ca969f8c6bb0d', {
+        scope: 'profile:avatar',
+      });
+      // cleanStringify drops null/undefined, so the key is absent entirely
+      assert.ok(lastBody && !('exclude_dau' in lastBody));
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/container.tsx
@@ -3,20 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useNavigate, useLocation } from 'react-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  Integration,
-  useAuthClient,
-  useConfig,
-  useFtlMsgResolver,
-} from '../../../models';
+import { useCallback, useEffect, useMemo } from 'react';
+import { Integration, useAuthClient, useFtlMsgResolver } from '../../../models';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import { PROFILE_OAUTH_TOKEN_TTL_SECONDS } from '../../../lib/oauth';
+import { useSigninAvatar } from '../useSigninAvatar';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import GleanMetrics from '../../../lib/glean';
-import { AccountAvatar } from '../../../lib/interfaces';
 import OAuthDataError from '../../../components/OAuthDataError';
 import AppLayout from '../../../components/AppLayout';
 import VerificationMethods from '../../../constants/verification-methods';
@@ -37,7 +31,6 @@ const SigninPasskeyFallbackContainer = ({
   flowQueryParams: QueryParams;
 }) => {
   const authClient = useAuthClient();
-  const config = useConfig();
   const ftlMsgResolver = useFtlMsgResolver();
   const navigateWithQuery = useNavigateWithQuery();
   const navigate = useNavigate();
@@ -61,58 +54,7 @@ const SigninPasskeyFallbackContainer = ({
     [flowQueryParams]
   );
 
-  // Mirrors Signin/container.tsx's avatar fetch: mint a profile:avatar-scoped
-  // OAuth token, GET /v1/avatar from the profile server, fall back to default
-  // on any failure.
-  const [avatarData, setAvatarData] = useState<
-    { account: { avatar: AccountAvatar } } | undefined
-  >(undefined);
-  const [avatarLoading, setAvatarLoading] = useState(true);
-
-  useEffect(() => {
-    if (
-      !sessionToken ||
-      !config?.servers?.profile?.url ||
-      !config?.oauth?.clientId
-    ) {
-      setAvatarLoading(false);
-      return;
-    }
-    let cancelled = false;
-    authClient
-      .createOAuthToken(sessionToken, config.oauth.clientId, {
-        scope: 'profile:avatar',
-        ttl: PROFILE_OAUTH_TOKEN_TTL_SECONDS,
-      })
-      .then(({ access_token }) =>
-        fetch(`${config.servers.profile.url}/v1/avatar`, {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${access_token}`,
-            'Content-Type': 'application/json',
-          },
-        })
-      )
-      .then((response) => {
-        if (!response.ok) throw new Error('Failed to fetch avatar');
-        return response.json();
-      })
-      .then((data: { id: string; url: string; avatar?: string }) => {
-        if (cancelled) return;
-        setAvatarData({
-          account: { avatar: { id: data.id, url: data.avatar || data.url } },
-        });
-      })
-      .catch(() => {
-        if (!cancelled) setAvatarData(undefined);
-      })
-      .finally(() => {
-        if (!cancelled) setAvatarLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [authClient, config, sessionToken]);
+  const { avatarData, avatarLoading } = useSigninAvatar(sessionToken);
 
   const onContinue = useCallback(
     async (

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -69,7 +69,7 @@ import {
   StoredAccountData,
 } from '../../lib/storage-utils';
 import { cachedSignIn, ensureCanLinkAcountOrRedirect } from './utils';
-import { PROFILE_OAUTH_TOKEN_TTL_SECONDS } from '../../lib/oauth';
+import { useSigninAvatar } from './useSigninAvatar';
 import OAuthDataError from '../../components/OAuthDataError';
 import { AppLayout } from '../../components/AppLayout';
 
@@ -340,59 +340,7 @@ const SigninContainer = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Avatar state - fetched directly from profile server
-  const [avatarData, setAvatarData] = useState<
-    { account: { avatar: { id: string; url: string } } } | undefined
-  >(undefined);
-  const [avatarLoading, setAvatarLoading] = useState(true);
-
-  // Fetch avatar on mount from profile server (requires OAuth token)
-  useEffect(() => {
-    if (
-      sessionToken &&
-      config?.servers?.profile?.url &&
-      config?.oauth?.clientId
-    ) {
-      // Get OAuth token with profile:avatar scope (required by profile server)
-      authClient
-        .createOAuthToken(sessionToken, config.oauth.clientId, {
-          scope: 'profile:avatar',
-          ttl: PROFILE_OAUTH_TOKEN_TTL_SECONDS,
-        })
-        .then(({ access_token }) => {
-          return fetch(`${config.servers.profile.url}/v1/avatar`, {
-            method: 'GET',
-            headers: {
-              Authorization: `Bearer ${access_token}`,
-              'Content-Type': 'application/json',
-            },
-          });
-        })
-        .then((response) => {
-          if (!response.ok) throw new Error('Failed to fetch avatar');
-          return response.json();
-        })
-        .then((data: { id: string; url: string; avatar?: string }) => {
-          setAvatarData({
-            account: {
-              avatar: {
-                id: data.id,
-                url: data.avatar || data.url,
-              },
-            },
-          });
-        })
-        .catch(() => {
-          // Avatar fetch failed, use default
-          setAvatarData(undefined);
-        })
-        .finally(() => {
-          setAvatarLoading(false);
-        });
-    } else {
-      setAvatarLoading(false);
-    }
-  }, [authClient, config, sessionToken]);
+  const { avatarData, avatarLoading } = useSigninAvatar(sessionToken);
 
   // For Firefox non-Sync flows, validate the cached session token before rendering.
   // This is because if users "sign out" from the browser menu, FxA doesn't know

--- a/packages/fxa-settings/src/pages/Signin/useSigninAvatar.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/useSigninAvatar.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import * as ModelsModule from '../../models';
+import { useSigninAvatar } from './useSigninAvatar';
+
+jest.mock('../../models', () => ({
+  useAuthClient: jest.fn(),
+  useConfig: jest.fn(),
+}));
+
+const CLIENT_ID = 'ea3ca969f8c6bb0d';
+const SESSION_TOKEN = 'deadbeef';
+const mockCreateOAuthToken = jest.fn();
+
+const mockConfig = {
+  servers: { profile: { url: 'http://localhost:1111' } },
+  oauth: { clientId: CLIENT_ID },
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockCreateOAuthToken.mockResolvedValue({ access_token: 'access-token' });
+  (ModelsModule.useAuthClient as jest.Mock).mockReturnValue({
+    createOAuthToken: mockCreateOAuthToken,
+  });
+  (ModelsModule.useConfig as jest.Mock).mockReturnValue(mockConfig);
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve({ id: 'avatar-id', url: 'https://example.com/a.png' }),
+  }) as jest.Mock;
+});
+
+describe('useSigninAvatar', () => {
+  it('mints a profile:avatar token tagged exclude_dau when a session exists', async () => {
+    renderHook(() => useSigninAvatar(SESSION_TOKEN));
+
+    await waitFor(() =>
+      expect(mockCreateOAuthToken).toHaveBeenCalledWith(
+        SESSION_TOKEN,
+        CLIENT_ID,
+        expect.objectContaining({ scope: 'profile:avatar', exclude_dau: true })
+      )
+    );
+  });
+
+  it('does not mint a token when there is no session', async () => {
+    const { result } = renderHook(() => useSigninAvatar(undefined));
+
+    await waitFor(() => expect(result.current.avatarLoading).toBe(false));
+    expect(mockCreateOAuthToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/useSigninAvatar.ts
+++ b/packages/fxa-settings/src/pages/Signin/useSigninAvatar.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useState } from 'react';
+import { useAuthClient, useConfig } from '../../models';
+import { PROFILE_OAUTH_TOKEN_TTL_SECONDS } from '../../lib/oauth';
+
+export type SigninAvatarData =
+  | { account: { avatar: { id: string; url: string } } }
+  | undefined;
+
+/**
+ * Fetches the user's avatar for display on signin pages.
+ *
+ * The profile server is only reachable over its HTTP API, which requires an
+ * OAuth token, so this mints a short-lived `profile:avatar`-scoped token. That
+ * token does NOT represent a real relying-party sign-in — it's minted purely to
+ * render an avatar — so it's tagged `exclude_dau: true` to keep it out of the
+ * services DAU signal (FXA-14226 bandaid). The proper fix, avoiding the mint
+ * entirely when the avatar isn't rendered, is tracked in FXA-14160.
+ *
+ * Resolves `avatarLoading: false` immediately when there is no session token or
+ * no profile/oauth config (nothing to fetch). Any fetch failure falls back to
+ * the default avatar (`avatarData: undefined`).
+ */
+export const useSigninAvatar = (sessionToken?: string) => {
+  const authClient = useAuthClient();
+  const config = useConfig();
+  const [avatarData, setAvatarData] = useState<SigninAvatarData>(undefined);
+  const [avatarLoading, setAvatarLoading] = useState(true);
+
+  useEffect(() => {
+    if (
+      !sessionToken ||
+      !config?.servers?.profile?.url ||
+      !config?.oauth?.clientId
+    ) {
+      setAvatarLoading(false);
+      return;
+    }
+    const { clientId } = config.oauth;
+    const profileUrl = config.servers.profile.url;
+    let cancelled = false;
+
+    const fetchAvatar = async () => {
+      try {
+        const { access_token } = await authClient.createOAuthToken(
+          sessionToken,
+          clientId,
+          {
+            scope: 'profile:avatar',
+            ttl: PROFILE_OAUTH_TOKEN_TTL_SECONDS,
+            exclude_dau: true,
+          }
+        );
+        const response = await fetch(`${profileUrl}/v1/avatar`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${access_token}`,
+            'Content-Type': 'application/json',
+          },
+        });
+        if (!response.ok) throw new Error('Failed to fetch avatar');
+        const data: { id: string; url: string; avatar?: string } =
+          await response.json();
+        if (!cancelled) {
+          setAvatarData({
+            account: { avatar: { id: data.id, url: data.avatar || data.url } },
+          });
+        }
+      } catch {
+        if (!cancelled) setAvatarData(undefined);
+      } finally {
+        if (!cancelled) setAvatarLoading(false);
+      }
+    };
+
+    fetchAvatar();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authClient, config, sessionToken]);
+
+  return { avatarData, avatarLoading };
+};


### PR DESCRIPTION
Because:
* We want to move away from the oauth access token created event for DAU, but for now it's what we use. The GraphQL removal increased the number of profile-scoped access tokens we create, which are attributed to the Settings clie nt_id, and have increased our DAU estimates
* Cached sign-in now always creates an access token. We only want to 'count' users towards DAU for Settings if they are inside Settings

This commit:
* Adds a bandaid patch to pass the 'exclude_dau' option to our oauth/token endpoint during Signin flows so these events can be filtered for DAU
* Adds a shared hook for avatar calls since there was some code duplication

closes FXA-14226
ref FXA-14135

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

---

`glean-server-event` auth-logs with this change:
```"events\":[{\"category\":\"access_token\",\"name\":\"created\",\"extra\":{\"reason\":\"fxa-credentials\",\"scopes\":\"profile:avatar\",\"exclude_dau\":\"true\"}```

<img width="1287" height="735" alt="image" src="https://github.com/user-attachments/assets/52d80222-c1af-488f-8bd6-6880b3d4a233" />
