### PR TITLE
fix(payments-api): iap support archived prices

### DIFF
--- a/libs/payments/api-server/src/lib/billing-and-subscriptions.service.spec.ts
+++ b/libs/payments/api-server/src/lib/billing-and-subscriptions.service.spec.ts
@@ -358,6 +358,157 @@ describe('BillingAndSubscriptionsService', () => {
       });
     });
 
+    it('falls back to the Google IAP price search when no interval price is found', async () => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockRejectedValue(
+          new AccountCustomerNotFoundError(UID, new Error('not found'))
+        );
+      jest
+        .spyOn(googleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([
+          GoogleIapPurchaseFactory({ sku: 'google_sku' }) as never,
+        ]);
+      const iapPrice = StripePriceFactory({
+        id: 'price_g',
+        product: 'prod_g',
+        recurring: StripePriceRecurringFactory({ interval: 'month' }),
+      });
+      jest
+        .spyOn(productConfigurationManager, 'getIapOfferings')
+        .mockResolvedValue({
+          getIapPageContentByStoreId: (storeId: string) =>
+            IapOfferingFactory({ storeId, stripePlanChoice: iapPrice.id }),
+        } as never);
+      jest
+        .spyOn(priceManager, 'retrieveByInterval')
+        .mockResolvedValue(undefined);
+      const findGoogleSpy = jest
+        .spyOn(priceManager, 'findGoogleIAPPriceByStoreId')
+        .mockResolvedValue(iapPrice);
+      const findAppleSpy = jest
+        .spyOn(priceManager, 'findAppleIAPPriceByStoreId')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(productManager, 'retrieve')
+        .mockResolvedValue(
+          StripeResponseFactory(
+            StripeProductFactory({ id: 'prod_g', name: 'Google IAP Product' })
+          )
+        );
+      jest
+        .spyOn(capabilityManager, 'priceIdsToClientCapabilities')
+        .mockResolvedValue({ [CLIENT_ID]: ['cap'] });
+
+      const result = await service.get({ uid: UID, clientId: CLIENT_ID });
+
+      expect(findGoogleSpy).toHaveBeenCalledWith('google_sku');
+      // A Google store id is routed to the Google search only.
+      expect(findAppleSpy).not.toHaveBeenCalled();
+      expect(result.subscriptions).toHaveLength(1);
+      expect(result.subscriptions[0]).toMatchObject({
+        _subscription_type: 'iap_google',
+        price_id: iapPrice.id,
+        product_id: 'prod_g',
+        product_name: 'Google IAP Product',
+      });
+    });
+
+    it('falls back to the Apple IAP price search when no interval price is found', async () => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockRejectedValue(
+          new AccountCustomerNotFoundError(UID, new Error('not found'))
+        );
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([
+          AppleIapPurchaseFactory({ productId: 'apple.prod' }) as never,
+        ]);
+      const iapPrice = StripePriceFactory({
+        id: 'price_a',
+        product: 'prod_a',
+        recurring: StripePriceRecurringFactory({ interval: 'month' }),
+      });
+      jest
+        .spyOn(productConfigurationManager, 'getIapOfferings')
+        .mockResolvedValue({
+          getIapPageContentByStoreId: (storeId: string) =>
+            IapOfferingFactory({ storeId, stripePlanChoice: iapPrice.id }),
+        } as never);
+      jest
+        .spyOn(priceManager, 'retrieveByInterval')
+        .mockResolvedValue(undefined);
+      const findGoogleSpy = jest
+        .spyOn(priceManager, 'findGoogleIAPPriceByStoreId')
+        .mockResolvedValue(undefined);
+      const findAppleSpy = jest
+        .spyOn(priceManager, 'findAppleIAPPriceByStoreId')
+        .mockResolvedValue(iapPrice);
+      jest
+        .spyOn(productManager, 'retrieve')
+        .mockResolvedValue(
+          StripeResponseFactory(
+            StripeProductFactory({ id: 'prod_a', name: 'Apple IAP Product' })
+          )
+        );
+      jest
+        .spyOn(capabilityManager, 'priceIdsToClientCapabilities')
+        .mockResolvedValue({ [CLIENT_ID]: ['cap'] });
+
+      const result = await service.get({ uid: UID, clientId: CLIENT_ID });
+
+      expect(findAppleSpy).toHaveBeenCalledWith('apple.prod');
+      // A non-Google (Apple) store id is routed to the Apple search only.
+      expect(findGoogleSpy).not.toHaveBeenCalled();
+      expect(result.subscriptions).toHaveLength(1);
+      expect(result.subscriptions[0]).toMatchObject({
+        _subscription_type: 'iap_apple',
+        app_store_product_id: 'apple.prod',
+        product_id: 'prod_a',
+      });
+    });
+
+    it('rejects when neither the interval nor the fallback search finds a price', async () => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockRejectedValue(
+          new AccountCustomerNotFoundError(UID, new Error('not found'))
+        );
+      jest
+        .spyOn(googleIapPurchaseManager, 'getForUser')
+        .mockResolvedValue([
+          GoogleIapPurchaseFactory({ sku: 'google_sku' }) as never,
+        ]);
+      jest
+        .spyOn(productConfigurationManager, 'getIapOfferings')
+        .mockResolvedValue({
+          getIapPageContentByStoreId: (storeId: string) =>
+            IapOfferingFactory({ storeId, stripePlanChoice: 'price_missing' }),
+        } as never);
+      jest
+        .spyOn(priceManager, 'retrieveByInterval')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(priceManager, 'findGoogleIAPPriceByStoreId')
+        .mockResolvedValue(undefined);
+      jest
+        .spyOn(priceManager, 'findAppleIAPPriceByStoreId')
+        .mockResolvedValue(undefined);
+      const productRetrieveSpy = jest.spyOn(productManager, 'retrieve');
+
+      await expect(
+        service.get({ uid: UID, clientId: CLIENT_ID })
+      ).rejects.toThrow('Something went wrong');
+
+      // The product is never retrieved because the storeId is skipped when no
+      // price is found; the failure surfaces later from buildIapPriceInfoMap.
+      expect(productRetrieveSpy).not.toHaveBeenCalled();
+      const loggedError = logger.error.mock.calls[0][0] as Error;
+      expect(loggedError.message).toContain('Stripe price not found');
+      expect(loggedError.message).toContain('storeId=google_sku');
+    });
+
     it('filters out web subs whose price has no capability for the client', async () => {
       const customer = StripeResponseFactory(
         StripeCustomerFactory({

--- a/libs/payments/api-server/src/lib/billing-and-subscriptions.service.ts
+++ b/libs/payments/api-server/src/lib/billing-and-subscriptions.service.ts
@@ -223,10 +223,18 @@ export class BillingAndSubscriptionsService {
           offering.offering.defaultPurchase.stripePlanChoices.map(
             (choice) => choice.stripePlanChoice
           );
-        const price = await this.priceManager.retrieveByInterval(
+        let price = await this.priceManager.retrieveByInterval(
           priceIds,
           offering.interval as unknown as SubplatInterval
         );
+
+        if (!price) {
+          const isGoogle = googleIapPurchases.some((p) => p.sku === storeId);
+          price = isGoogle
+            ? await this.priceManager.findGoogleIAPPriceByStoreId(storeId)
+            : await this.priceManager.findAppleIAPPriceByStoreId(storeId);
+        }
+
         if (!price) {
           continue;
         }

--- a/libs/payments/customer/src/lib/customer.error.ts
+++ b/libs/payments/customer/src/lib/customer.error.ts
@@ -29,6 +29,20 @@ export class PlanIntervalMultiplePlansError extends CustomerError {
   }
 }
 
+export class PlanAppleIAPMultiplePlansError extends CustomerError {
+  constructor(priceIds: string[], storeId: string) {
+    super('Apple storeId has multiple plans', { priceIds, storeId });
+    this.name = 'PlanAppleIAPMultiplePlansError';
+  }
+}
+
+export class PlanGoogleIAPMultiplePlansError extends CustomerError {
+  constructor(priceIds: string[], storeId: string) {
+    super('Google storeId has multiple plans', { priceIds, storeId });
+    this.name = 'PlanGoogleIAPMultiplePlansError';
+  }
+}
+
 export class PriceForCurrencyNotFoundError extends CustomerError {
   constructor(priceId: string, currency: string) {
     super('Price for currency not found', { priceId, currency });
@@ -40,7 +54,7 @@ export class SubscriptionCustomerMismatchError extends CustomerError {
   constructor(
     customerId: string,
     subscriptionCustomerId: string,
-    subscriptionId: string,
+    subscriptionId: string
   ) {
     super('Subscription customer does not match provided customer', {
       customerId,

--- a/libs/payments/customer/src/lib/price.manager.spec.ts
+++ b/libs/payments/customer/src/lib/price.manager.spec.ts
@@ -7,12 +7,15 @@ import { MockLoggerProvider } from '@fxa/shared/log';
 
 import {
   StripeClient,
+  StripeApiSearchResultFactory,
   StripeResponseFactory,
   StripePriceFactory,
   StripePriceRecurringFactory,
   MockStripeConfigProvider,
 } from '@fxa/payments/stripe';
 import {
+  PlanAppleIAPMultiplePlansError,
+  PlanGoogleIAPMultiplePlansError,
   PlanIntervalMultiplePlansError,
   PriceForCurrencyNotFoundError,
 } from './customer.error';
@@ -98,6 +101,152 @@ describe('PriceManager', () => {
           subplatInterval
         )
       ).rejects.toBeInstanceOf(PlanIntervalMultiplePlansError);
+    });
+  });
+
+  describe('findAppleIAPPriceByStoreId', () => {
+    const storeId = 'apple.iap.product';
+
+    it('searches by the appStoreProductIds metadata field', async () => {
+      const mockPrice = StripePriceFactory();
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([mockPrice]))
+        );
+
+      await priceManager.findAppleIAPPriceByStoreId(storeId);
+
+      expect(stripeClient.pricesSearch).toHaveBeenCalledWith(
+        `metadata['appStoreProductIds']:'${storeId}'`
+      );
+    });
+
+    it('escapes a single quote in the storeId before searching', async () => {
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([]))
+        );
+
+      await priceManager.findAppleIAPPriceByStoreId("sku_o'brien");
+
+      expect(stripeClient.pricesSearch).toHaveBeenCalledWith(
+        `metadata['appStoreProductIds']:'sku_o\\'brien'`
+      );
+    });
+
+    it('returns the single matching price', async () => {
+      const mockPrice = StripePriceFactory();
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([mockPrice]))
+        );
+
+      const result = await priceManager.findAppleIAPPriceByStoreId(storeId);
+      expect(result).toEqual(mockPrice);
+    });
+
+    it('returns undefined when no price matches', async () => {
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([]))
+        );
+
+      const result = await priceManager.findAppleIAPPriceByStoreId(storeId);
+      expect(result).toBeUndefined();
+    });
+
+    it('throws PlanAppleIAPMultiplePlansError when multiple prices match', async () => {
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(
+            StripeApiSearchResultFactory([
+              StripePriceFactory(),
+              StripePriceFactory(),
+            ])
+          )
+        );
+
+      await expect(
+        priceManager.findAppleIAPPriceByStoreId(storeId)
+      ).rejects.toBeInstanceOf(PlanAppleIAPMultiplePlansError);
+    });
+  });
+
+  describe('findGoogleIAPPriceByStoreId', () => {
+    const storeId = 'google.play.sku';
+
+    it('searches by the playSkuIds metadata field', async () => {
+      const mockPrice = StripePriceFactory();
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([mockPrice]))
+        );
+
+      await priceManager.findGoogleIAPPriceByStoreId(storeId);
+
+      expect(stripeClient.pricesSearch).toHaveBeenCalledWith(
+        `metadata['playSkuIds']:'${storeId}'`
+      );
+    });
+
+    it('escapes a single quote in the storeId before searching', async () => {
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([]))
+        );
+
+      await priceManager.findGoogleIAPPriceByStoreId("sku_o'brien");
+
+      expect(stripeClient.pricesSearch).toHaveBeenCalledWith(
+        `metadata['playSkuIds']:'sku_o\\'brien'`
+      );
+    });
+
+    it('returns the single matching price', async () => {
+      const mockPrice = StripePriceFactory();
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([mockPrice]))
+        );
+
+      const result = await priceManager.findGoogleIAPPriceByStoreId(storeId);
+      expect(result).toEqual(mockPrice);
+    });
+
+    it('returns undefined when no price matches', async () => {
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(StripeApiSearchResultFactory([]))
+        );
+
+      const result = await priceManager.findGoogleIAPPriceByStoreId(storeId);
+      expect(result).toBeUndefined();
+    });
+
+    it('throws PlanGoogleIAPMultiplePlansError when multiple prices match', async () => {
+      jest
+        .spyOn(stripeClient, 'pricesSearch')
+        .mockResolvedValue(
+          StripeResponseFactory(
+            StripeApiSearchResultFactory([
+              StripePriceFactory(),
+              StripePriceFactory(),
+            ])
+          )
+        );
+
+      await expect(
+        priceManager.findGoogleIAPPriceByStoreId(storeId)
+      ).rejects.toBeInstanceOf(PlanGoogleIAPMultiplePlansError);
     });
   });
 

--- a/libs/payments/customer/src/lib/price.manager.ts
+++ b/libs/payments/customer/src/lib/price.manager.ts
@@ -5,21 +5,30 @@
 import { Injectable } from '@nestjs/common';
 
 import { StripeClient, StripePrice } from '@fxa/payments/stripe';
-import { PlanIntervalMultiplePlansError, PriceForCurrencyNotFoundError } from './customer.error';
+import {
+  PlanAppleIAPMultiplePlansError,
+  PlanGoogleIAPMultiplePlansError,
+  PlanIntervalMultiplePlansError,
+  PriceForCurrencyNotFoundError,
+} from './customer.error';
 import { SubplatInterval, type PricingForCurrency } from './types';
 import { doesPriceMatchSubplatInterval } from './util/doesPriceMatchSubplatInterval';
 import { determinePriceUnitAmount } from './util/determinePriceUnitAmount';
+import { escapeStripeSearchValue } from './util/escapeStripeSearchValue';
 
 @Injectable()
 export class PriceManager {
-  constructor(private stripeClient: StripeClient) { }
+  constructor(private stripeClient: StripeClient) {}
 
   async retrieve(priceId: string) {
     const price = await this.stripeClient.pricesRetrieve(priceId);
     return price;
   }
 
-  async retrievePricingForCurrency(priceId: string, currency: string): Promise<PricingForCurrency> {
+  async retrievePricingForCurrency(
+    priceId: string,
+    currency: string
+  ): Promise<PricingForCurrency> {
     const stripeCurrency = currency.toLowerCase();
     const price = await this.retrieve(priceId);
 
@@ -29,13 +38,15 @@ export class PriceManager {
       throw new PriceForCurrencyNotFoundError(priceId, currency);
     }
 
-    const unitAmountForCurrency = determinePriceUnitAmount(currencyOptionForCurrency)
+    const unitAmountForCurrency = determinePriceUnitAmount(
+      currencyOptionForCurrency
+    );
 
     return {
       price,
       unitAmountForCurrency,
       currencyOptionForCurrency,
-    }
+    };
   }
 
   async retrieveByInterval(priceIds: string[], interval: SubplatInterval) {
@@ -46,7 +57,36 @@ export class PriceManager {
         prices.push(price);
       }
     }
-    if (prices.length > 1) throw new PlanIntervalMultiplePlansError(priceIds, interval);
+    if (prices.length > 1)
+      throw new PlanIntervalMultiplePlansError(priceIds, interval);
     return prices.at(0);
+  }
+
+  async findAppleIAPPriceByStoreId(storeId: string) {
+    const query = `metadata['appStoreProductIds']:'${escapeStripeSearchValue(storeId)}'`;
+    const result = await this.stripeClient.pricesSearch(query);
+
+    if (result.data.length > 1) {
+      throw new PlanAppleIAPMultiplePlansError(
+        result.data.map((price) => price.id),
+        storeId
+      );
+    }
+
+    return result.data.at(0);
+  }
+
+  async findGoogleIAPPriceByStoreId(storeId: string) {
+    const query = `metadata['playSkuIds']:'${escapeStripeSearchValue(storeId)}'`;
+    const result = await this.stripeClient.pricesSearch(query);
+
+    if (result.data.length > 1) {
+      throw new PlanGoogleIAPMultiplePlansError(
+        result.data.map((price) => price.id),
+        storeId
+      );
+    }
+
+    return result.data.at(0);
   }
 }

--- a/libs/payments/customer/src/lib/util/escapeStripeSearchValue.spec.ts
+++ b/libs/payments/customer/src/lib/util/escapeStripeSearchValue.spec.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { escapeStripeSearchValue } from './escapeStripeSearchValue';
+
+describe('escapeStripeSearchValue', () => {
+  it('returns an ordinary value unchanged', () => {
+    expect(escapeStripeSearchValue('org.mozilla.ios.FirefoxVPN')).toBe(
+      'org.mozilla.ios.FirefoxVPN'
+    );
+  });
+
+  it('escapes a single quote', () => {
+    expect(escapeStripeSearchValue("sku_o'brien")).toBe("sku_o\\'brien");
+  });
+
+  it('escapes a backslash', () => {
+    expect(escapeStripeSearchValue('sku_a\\b')).toBe('sku_a\\\\b');
+  });
+
+  it('escapes a backslash before a single quote so the quote cannot break out', () => {
+    // A raw "\'" would otherwise let the value smuggle in an escaped quote;
+    // the backslash must itself be escaped first.
+    expect(escapeStripeSearchValue("sku_\\'")).toBe("sku_\\\\\\'");
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(escapeStripeSearchValue('')).toBe('');
+  });
+});

--- a/libs/payments/customer/src/lib/util/escapeStripeSearchValue.ts
+++ b/libs/payments/customer/src/lib/util/escapeStripeSearchValue.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Escape a value for safe embedding inside a single-quoted Stripe search
+ * query string (e.g. `metadata['playSkuIds']:'<value>'`).
+ *
+ * Stripe's search query language treats backslash as the escape character
+ * within quoted string values, so any literal backslash or single quote in
+ * the value must be escaped to prevent it from breaking out of, or altering,
+ * the search expression.
+ *
+ * @see https://docs.stripe.com/search#search-query-language
+ */
+export function escapeStripeSearchValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -9,6 +9,7 @@ export * from './lib/accountCustomer/accountCustomer.types';
 export { StripeAddressFactory } from './lib/factories/address.factory';
 export {
   StripeApiListFactory,
+  StripeApiSearchResultFactory,
   StripeResponseFactory,
 } from './lib/factories/api-list.factory';
 export { StripeCardFactory } from './lib/factories/card.factory';

--- a/libs/payments/stripe/src/lib/factories/api-list.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/api-list.factory.ts
@@ -5,6 +5,7 @@
 import { faker } from '@faker-js/faker';
 import {
   StripeApiList,
+  StripeApiSearchResult,
   StripeResponse,
   type StripeApiListPromise,
 } from '../stripe.client.types';
@@ -16,6 +17,18 @@ export const StripeApiListFactory = <T extends Array<any>>(
   object: 'list',
   url: '/v1/subscriptions',
   has_more: false,
+  data,
+  ...override,
+});
+
+export const StripeApiSearchResultFactory = <T>(
+  data: T[],
+  override?: Partial<StripeApiSearchResult<T>>
+): StripeApiSearchResult<T> => ({
+  object: 'search_result',
+  url: '/v1/prices/search',
+  has_more: false,
+  next_page: null,
   data,
   ...override,
 });

--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -10,6 +10,7 @@ import { Stripe } from 'stripe';
 import {
   StripeApiListFactory,
   StripeApiListPromiseFactory,
+  StripeApiSearchResultFactory,
   StripeResponseFactory,
 } from './factories/api-list.factory';
 import { StripeCustomerFactory } from './factories/customer.factory';
@@ -44,6 +45,8 @@ const mockStripePaymentMethodsAttach =
   mockJestFnGenerator<typeof Stripe.prototype.paymentMethods.attach>();
 const mockStripePricesRetrieve =
   mockJestFnGenerator<typeof Stripe.prototype.prices.retrieve>();
+const mockStripePricesSearch =
+  mockJestFnGenerator<typeof Stripe.prototype.prices.search>();
 const mockStripeProductsRetrieve =
   mockJestFnGenerator<typeof Stripe.prototype.products.retrieve>();
 const mockStripePromotionCodesList =
@@ -88,6 +91,7 @@ jest.mock('stripe', () => {
       },
       prices: {
         retrieve: mockStripePricesRetrieve,
+        search: mockStripePricesSearch,
       },
       products: {
         retrieve: mockStripeProductsRetrieve,
@@ -396,6 +400,55 @@ describe('StripeClient', () => {
 
       const result = await stripeClient.pricesRetrieve(mockPrice.id);
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('pricesSearch', () => {
+    it('returns the matching prices from Stripe', async () => {
+      const mockPrice = StripePriceFactory();
+      const mockResponse = StripeResponseFactory(
+        StripeApiSearchResultFactory([mockPrice])
+      );
+
+      mockStripePricesSearch.mockResolvedValue(mockResponse);
+
+      const result = await stripeClient.pricesSearch(
+        `metadata['playSkuIds']:'sku_123'`
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('passes the query along and expands currency_options', async () => {
+      const query = `metadata['appStoreProductIds']:'apple.prod'`;
+      const mockResponse = StripeResponseFactory(
+        StripeApiSearchResultFactory([StripePriceFactory()])
+      );
+
+      mockStripePricesSearch.mockResolvedValue(mockResponse);
+
+      await stripeClient.pricesSearch(query);
+
+      expect(mockStripePricesSearch).toHaveBeenCalledWith({
+        query,
+        expand: ['data.currency_options'],
+      });
+    });
+
+    it('merges caller-supplied params with the query and expand', async () => {
+      const query = `metadata['playSkuIds']:'sku_123'`;
+      const mockResponse = StripeResponseFactory(
+        StripeApiSearchResultFactory([StripePriceFactory()])
+      );
+
+      mockStripePricesSearch.mockResolvedValue(mockResponse);
+
+      await stripeClient.pricesSearch(query, { limit: 5 });
+
+      expect(mockStripePricesSearch).toHaveBeenCalledWith({
+        limit: 5,
+        query,
+        expand: ['data.currency_options'],
+      });
     });
   });
 

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -23,6 +23,7 @@ import {
   StripeSubscription,
   StripeUpcomingInvoice,
   type StripeSetupIntent,
+  StripeApiSearchResult,
 } from './stripe.client.types';
 import { StripeConfig } from './stripe.config';
 import { STRIPE_API_VERSION } from './stripe.constants';
@@ -369,6 +370,24 @@ export class StripeClient {
       expand: ['currency_options'],
     });
     return result as StripeResponse<StripePrice>;
+  }
+
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('pricesSearch', args[0], args[1]),
+    strategy: (_: any, context: StripeClient) =>
+      new CacheFirstStrategy(undefined, undefined, context.log),
+    ttlSeconds: 600,
+    client: new MemoryAdapter(),
+  })
+  @CaptureTimingWithStatsD()
+  async pricesSearch(query: string, params?: Stripe.PriceSearchParams) {
+    const result = await this.stripe.prices.search({
+      ...params,
+      query,
+      expand: ['data.currency_options'],
+    });
+    return result as StripeResponse<StripeApiSearchResult<StripePrice>>;
   }
 
   @Cacheable({

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -413,6 +413,7 @@ export type StripeConfirmationToken = NegotiateExpanded<
 >;
 
 export type StripeAddress = Stripe.Address;
+export type StripeApiSearchResult<T> = Stripe.ApiSearchResult<T>;
 export type StripeApiList<T> = Stripe.ApiList<T>;
 export type StripeApiListPromise<T> = Stripe.ApiListPromise<T>;
 export type StripeResponse<T> = Stripe.Response<T>;


### PR DESCRIPTION
## Because

- `GET /billing-and-subscriptions` could not resolve IAP Stripe price for legacy archived prices.

## This pull request

- If Stripe price could not be resolved using prices configured in default Strapi purchase, then search for Stripe price using the IAP storeId configured in Strapi.

## Issue that this pull request solves

Closes: #PAY-3836

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
