### PR TITLE
fix(auth): Exclude unauthorized Desktop VPN access tokens from DAU

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1450,6 +1450,30 @@ const convictConf = convict({
         env: 'FXA_ACCOUNT_ACTIVITY_UPDATE_AFTER',
       },
     },
+    // FXA-14159 bandaid: Firefox Desktop mints a VPN-scoped access token for
+    // every signed-in user via the fxa-credentials grant, inflating VPN's
+    // services-DAU. When enabled, the token endpoint consults accountAuthorizations
+    // for real VPN consent and, when absent, tags the access_token_created Glean
+    // event with exclude_dau so the DAU rollup filters it (the token is still
+    // granted). The lookup is per-uid rollout-gated and Redis-cached to protect
+    // the OAuth DB. Remove these configs and all associated code once 1) Desktop
+    // moves to refresh tokens (~Fx 155), 2) VPN stops using the fxa-credentials grant
+    // for this, and 3) when we are OK with dropping this for older browser versions.
+    // This does still overcount some users, see FXA-14159 comments.
+    vpnInDesktopDauBandaid: {
+      rolloutRate: {
+        doc: 'Fraction (0-1) of eligible fxa-credentials grants for which the accountAuthorizations lookup runs, bucketed deterministically per-uid. 0 disables the bandaid; ramp per-env (e.g. 0.2 -> 0.5 -> 1).',
+        format: Number,
+        default: 0,
+        env: 'OAUTH_DESKTOP_VPN_DAU_FIX_ROLLOUT_RATE',
+      },
+      cacheTtl: {
+        doc: 'How long the per-uid VPN authorization result (positive and negative) is cached in Redis before the OAuth DB is consulted again.',
+        format: 'duration',
+        default: '12 hours',
+        env: 'OAUTH_DESKTOP_VPN_DAU_FIX_CACHE_TTL',
+      },
+    },
     accountAuthorizations: {
       // Shadow-table migration of accountAuthorizations scope -> scopeId FK
       // (FXA-14169). Both flags default off; nothing changes on deploy.

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -395,6 +395,19 @@ class OauthDB extends ConnectedServicesDb {
     };
   }
 
+  // True iff a consent row exists for the exact (uid, scope, service, clientId).
+  // Used by the VPN-in-Desktop DAU bandaid (FXA-14159) to decide whether a VPN
+  // token creation for the Firefox Desktop client should count toward DAU.
+  async hasConsentForScopeAndClient(uid, scope, service, clientId) {
+    await this.ready();
+    return this.mysql._hasConsentForScopeAndClient(
+      uid,
+      scope,
+      service,
+      clientId
+    );
+  }
+
   // True iff the user has any prior consent for this service (any scope/client).
   // Used for the browser-service grain of the first-authorization signal.
   async hasConsentForService(uid, service) {

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -222,6 +222,13 @@ const QUERY_ACCOUNT_CONSENT_FIND_SIGNIN =
 // same service.
 const QUERY_HAS_CONSENT_FOR_SCOPE =
   'SELECT 1 FROM accountAuthorizations WHERE uid=? AND scope=? AND service=? LIMIT 1';
+// Full-PK existence check for the VPN-in-Desktop DAU bandaid (FXA-14159).
+// Adds clientId to QUERY_HAS_CONSENT_FOR_SCOPE so a VPN consent recorded for a
+// different client (e.g. Mobile or the standalone VPN app) does not count as
+// Desktop authorization. A complete PK match — the fastest lookup this table
+// supports.
+const QUERY_HAS_CONSENT_FOR_SCOPE_AND_CLIENT =
+  'SELECT 1 FROM accountAuthorizations WHERE uid=? AND scope=? AND service=? AND clientId=? LIMIT 1';
 // Existence checks for the first-authorization signal (FXA-13784). Bounded by
 // the user's rows (PK prefix on uid) with a LIMIT 1 early-out — cheaper than
 // fetching all of a user's consents and filtering in JS.
@@ -826,6 +833,19 @@ class MysqlStore extends MysqlOAuthShared {
       buf(uid),
       scope,
       service,
+    ]);
+    return rows.length > 0;
+  }
+
+  // True iff a consent row exists for the exact (uid, scope, service, clientId).
+  // Used by the VPN-in-Desktop DAU bandaid (FXA-14159) to confirm the user
+  // authorized VPN for this specific client before counting the token.
+  async _hasConsentForScopeAndClient(uid, scope, service, clientId) {
+    const rows = await this._read(QUERY_HAS_CONSENT_FOR_SCOPE_AND_CLIENT, [
+      buf(uid),
+      scope,
+      service,
+      buf(clientId),
     ]);
     return rows.length > 0;
   }

--- a/packages/fxa-auth-server/lib/oauth/vpn-in-desktop-dau-bandaid.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/vpn-in-desktop-dau-bandaid.spec.ts
@@ -1,0 +1,330 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import fxaShared from 'fxa-shared';
+
+import {
+  shouldExcludeFromDau,
+  ScopeSetLike,
+  VpnInDesktopDauBandaidOauthDB,
+  VpnInDesktopDauBandaidPolicy,
+  VpnInDesktopDauBandaidRedis,
+} from './vpn-in-desktop-dau-bandaid';
+
+const ScopeSet = (
+  fxaShared as { oauth: { scopes: { fromArray(v: string[]): ScopeSetLike } } }
+).oauth.scopes;
+
+const VPN_SCOPE = 'https://identity.mozilla.com/apps/vpn';
+const DESKTOP_CLIENT_ID = '5882386c6d801776';
+const OTHER_CLIENT_ID = '1b1a3e44c54fbb58';
+const TTL_SECONDS = 43_200;
+
+const UID = '0123456789abcdef0123456789abcdef';
+// sha256(UID), first 4 bytes big-endian / 2^32. A hardcoded literal (not
+// recomputed from the SUT) so a change to the bucketing algorithm moves the
+// real bucket off this value and fails the boundary tests below, instead of
+// shifting both sides in lockstep.
+const UID_BUCKET = 0.24489958654157817;
+
+describe('shouldExcludeFromDau', () => {
+  let oauthDB: jest.Mocked<VpnInDesktopDauBandaidOauthDB>;
+  let redis: jest.Mocked<VpnInDesktopDauBandaidRedis>;
+  let statsd: { increment: jest.Mock };
+  let log: { warn: jest.Mock };
+
+  const vpnScopeSet = () => ScopeSet.fromArray([VPN_SCOPE, 'profile']);
+
+  function makePolicy(
+    overrides: Partial<VpnInDesktopDauBandaidPolicy> = {}
+  ): VpnInDesktopDauBandaidPolicy {
+    return {
+      clientId: DESKTOP_CLIENT_ID,
+      scope: VPN_SCOPE,
+      rolloutRate: 1,
+      cacheTtlSeconds: TTL_SECONDS,
+      ...overrides,
+    };
+  }
+
+  function deps() {
+    return { oauthDB, redis, statsd, log };
+  }
+
+  beforeEach(() => {
+    oauthDB = {
+      getServiceForCanonicalScope: jest.fn(),
+      hasConsentForScopeAndClient: jest.fn(),
+    };
+    oauthDB.getServiceForCanonicalScope.mockReturnValue('vpn');
+    oauthDB.hasConsentForScopeAndClient.mockResolvedValue(false);
+    redis = { get: jest.fn(), set: jest.fn() };
+    redis.get.mockResolvedValue(null);
+    redis.set.mockResolvedValue('OK');
+    statsd = { increment: jest.fn() };
+    log = { warn: jest.fn() };
+  });
+
+  describe('ineligible requests return false before any Redis or DB access', () => {
+    it('returns false when the client is not the configured VPN client', async () => {
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: OTHER_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(redis.get).not.toHaveBeenCalled();
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the requested scopes do not include the VPN scope', async () => {
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: ScopeSet.fromArray(['profile']),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(redis.get).not.toHaveBeenCalled();
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the scope set is null', async () => {
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: null,
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+    });
+
+    it('returns false when rolloutRate is 0 (feature disabled)', async () => {
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy({ rolloutRate: 0 }),
+      });
+      expect(result).toBe(false);
+      expect(redis.get).not.toHaveBeenCalled();
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('per-uid rollout bucketing', () => {
+    it('performs the lookup for a uid whose bucket is below rolloutRate', async () => {
+      await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy({ rolloutRate: UID_BUCKET + 1e-9 }),
+      });
+      expect(oauthDB.hasConsentForScopeAndClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the lookup for a uid whose bucket is at or above rolloutRate', async () => {
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy({ rolloutRate: UID_BUCKET - 1e-9 }),
+      });
+      expect(result).toBe(false);
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+    });
+
+    it('buckets a given uid consistently across repeated calls', async () => {
+      // UID_BUCKET (~0.245) is below 0.5, so the lookup runs on every call;
+      // a non-deterministic gate would drop one of the two.
+      const args = {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy({ rolloutRate: 0.5 }),
+      };
+      await shouldExcludeFromDau(deps(), args);
+      await shouldExcludeFromDau(deps(), args);
+      expect(oauthDB.hasConsentForScopeAndClient).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Redis cache', () => {
+    it('returns false without a DB call when the cache holds an authorized result', async () => {
+      redis.get.mockResolvedValue('1');
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+    });
+
+    it('returns true without a DB call when the cache holds an unauthorized result', async () => {
+      redis.get.mockResolvedValue('0');
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(true);
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+    });
+
+    it('reads the cache under a per-uid key', async () => {
+      await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(redis.get).toHaveBeenCalledWith(`vpnInDesktopDau:${UID}`);
+    });
+  });
+
+  describe('cache miss -> DB lookup', () => {
+    it('queries consent with the exact (uid, scope, service, clientId) key', async () => {
+      await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(oauthDB.hasConsentForScopeAndClient).toHaveBeenCalledWith(
+        UID,
+        VPN_SCOPE,
+        'vpn',
+        DESKTOP_CLIENT_ID
+      );
+    });
+
+    it('returns false and caches "1" when the user has authorized VPN', async () => {
+      oauthDB.hasConsentForScopeAndClient.mockResolvedValue(true);
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(redis.set).toHaveBeenCalledWith(
+        `vpnInDesktopDau:${UID}`,
+        '1',
+        'EX',
+        TTL_SECONDS
+      );
+    });
+
+    it('returns true and caches "0" when the user has not authorized VPN', async () => {
+      oauthDB.hasConsentForScopeAndClient.mockResolvedValue(false);
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(true);
+      expect(redis.set).toHaveBeenCalledWith(
+        `vpnInDesktopDau:${UID}`,
+        '0',
+        'EX',
+        TTL_SECONDS
+      );
+    });
+
+    it('floors a fractional cacheTtlSeconds to an integer for the Redis EX arg', async () => {
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy({ cacheTtlSeconds: 90.5 }),
+      });
+      expect(result).toBe(true);
+      expect(redis.set).toHaveBeenCalledWith(
+        `vpnInDesktopDau:${UID}`,
+        '0',
+        'EX',
+        90
+      );
+    });
+
+    it('skips the cache write when cacheTtlSeconds rounds down to 0', async () => {
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy({ cacheTtlSeconds: 0.9 }),
+      });
+      expect(result).toBe(true);
+      expect(redis.set).not.toHaveBeenCalled();
+    });
+
+    it('returns false and increments a metric when the scope has no known service', async () => {
+      oauthDB.getServiceForCanonicalScope.mockReturnValue(undefined);
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(oauthDB.hasConsentForScopeAndClient).not.toHaveBeenCalled();
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'oauth.vpnInDesktopDau.unknown_service'
+      );
+    });
+
+    it('works without a Redis client, querying the DB directly', async () => {
+      oauthDB.hasConsentForScopeAndClient.mockResolvedValue(false);
+      const result = await shouldExcludeFromDau(
+        { oauthDB, redis: undefined, statsd, log },
+        {
+          uid: UID,
+          clientId: DESKTOP_CLIENT_ID,
+          scopeSet: vpnScopeSet(),
+          policy: makePolicy(),
+        }
+      );
+      expect(result).toBe(true);
+      expect(oauthDB.hasConsentForScopeAndClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fail-open on error', () => {
+    it('returns false and increments a metric when the DB lookup rejects', async () => {
+      oauthDB.hasConsentForScopeAndClient.mockRejectedValue(
+        new Error('ECONNREFUSED')
+      );
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'oauth.vpnInDesktopDau.error'
+      );
+    });
+
+    it('returns false when the Redis read rejects', async () => {
+      redis.get.mockRejectedValue(new Error('redis timeout'));
+      const result = await shouldExcludeFromDau(deps(), {
+        uid: UID,
+        clientId: DESKTOP_CLIENT_ID,
+        scopeSet: vpnScopeSet(),
+        policy: makePolicy(),
+      });
+      expect(result).toBe(false);
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'oauth.vpnInDesktopDau.error'
+      );
+    });
+  });
+});

--- a/packages/fxa-auth-server/lib/oauth/vpn-in-desktop-dau-bandaid.ts
+++ b/packages/fxa-auth-server/lib/oauth/vpn-in-desktop-dau-bandaid.ts
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// VPN-in-Desktop DAU bandaid (FXA-14159).
+//
+// Firefox Desktop mints a VPN-scoped access token for every signed-in user via
+// the fxa-credentials grant, regardless of whether the user actually uses VPN.
+// Each mint fires the server-side `access_token_created` Glean event, which
+// feeds the services-DAU rollup, so VPN's Desktop DAU is inflated to ~every
+// signed-in Desktop user.
+//
+// This helper decides whether a given fxa-credentials token creation should be
+// EXCLUDED from that DAU signal (the token is always granted either way). It is
+// excluded when the request is Firefox Desktop requesting the VPN scope AND the
+// user has no VPN consent row for that client in accountAuthorizations.
+//
+// THIS IS A BANDAID, NOT THE FIX. The real fix lives in Firefox Desktop, which
+// must stop minting a VPN access token for users who haven't used VPN.
+//
+// The `/oauth/token` path is hot and the OAuth DB has seen connection spikes,
+// so the accountAuthorizations lookup is (a) gated by a deterministic
+// per-uid rollout fraction and (b) cached per-uid in Redis. Negative results
+// (the majority: signed-in users who don't use VPN) are cached too — that is
+// what shields the DB.
+//
+// Fail-open: any unexpected error returns false (keep the current behavior,
+// count the token). The bandaid must never break or slow a grant, and failing
+// open cannot undercount.
+
+import crypto from 'crypto';
+import { StatsD } from 'hot-shots';
+import { Logger } from 'mozlog';
+
+const CACHE_KEY_PREFIX = 'vpnInDesktopDau:';
+const UINT32_SPACE = 0x1_0000_0000;
+
+export interface VpnInDesktopDauBandaidPolicy {
+  /** OAuth client_id (hex) subject to the bandaid. Firefox Desktop. */
+  clientId: string;
+  /** Canonical VPN scope (must be a key of oauthServer.exchange.serviceScopes). */
+  scope: string;
+  /** Fraction 0-1 of eligible grants for which the lookup runs. 0 disables. */
+  rolloutRate: number;
+  /** Redis TTL, in seconds, for the cached authorization result. */
+  cacheTtlSeconds: number;
+}
+
+export interface ScopeSetLike {
+  contains(scope: string): boolean;
+}
+
+export interface VpnInDesktopDauBandaidOauthDB {
+  getServiceForCanonicalScope(scope: string): string | undefined;
+  hasConsentForScopeAndClient(
+    uid: string,
+    scope: string,
+    service: string,
+    clientId: string
+  ): Promise<boolean>;
+}
+
+export interface VpnInDesktopDauBandaidRedis {
+  get(key: string): Promise<string | null>;
+  // Variadic tail mirrors ioredis (e.g. 'EX', ttlSeconds) via the FxaRedis wrapper.
+  set(
+    key: string,
+    value: string,
+    ...args: (string | number)[]
+  ): Promise<unknown>;
+}
+
+export interface VpnInDesktopDauBandaidDeps {
+  oauthDB: VpnInDesktopDauBandaidOauthDB;
+  redis?: VpnInDesktopDauBandaidRedis;
+  // Only the methods this module uses, picked from the real collaborator types
+  // so a minimal mock satisfies them without re-declaring the contract.
+  statsd?: Pick<StatsD, 'increment'>;
+  log?: Pick<Logger, 'warn'>;
+}
+
+export interface VpnInDesktopDauBandaidParams {
+  /** Grant user id, hex. */
+  uid: string;
+  /** Grant client_id, hex. */
+  clientId: string;
+  scopeSet: ScopeSetLike | null | undefined;
+  policy: VpnInDesktopDauBandaidPolicy;
+}
+
+/**
+ * Deterministic per-uid bucket in [0, 1). Same uid always maps to the same
+ * value, so a user is consistently inside or outside the rollout — stable DAU
+ * measurement and a meaningful per-uid cache.
+ */
+function rolloutBucket(uid: string): number {
+  const digest = crypto.createHash('sha256').update(uid).digest();
+  return digest.readUInt32BE(0) / UINT32_SPACE;
+}
+
+/**
+ * Returns true when this token creation should be tagged `exclude_dau` (i.e.
+ * excluded from the DAU signal). Never throws.
+ *
+ * Cheap constant checks short-circuit before any Redis/DB access, so only
+ * Firefox-Desktop + VPN + in-rollout fxa-credentials grants ever touch Redis or
+ * the OAuth DB.
+ */
+export async function shouldExcludeFromDau(
+  deps: VpnInDesktopDauBandaidDeps,
+  params: VpnInDesktopDauBandaidParams
+): Promise<boolean> {
+  const { oauthDB, redis, statsd, log } = deps;
+  const { uid, clientId, scopeSet, policy } = params;
+
+  try {
+    // Only the configured client (Firefox Desktop) requesting the VPN scope.
+    if (clientId !== policy.clientId) {
+      return false;
+    }
+    if (!scopeSet?.contains(policy.scope)) {
+      return false;
+    }
+
+    // Rollout gate. Disabled, or this uid falls outside the current fraction.
+    if (!(policy.rolloutRate > 0) || rolloutBucket(uid) >= policy.rolloutRate) {
+      return false;
+    }
+
+    // Keyed by uid alone: the client and scope are fixed constants for this
+    // bandaid, so they don't need to be part of the key.
+    const cacheKey = `${CACHE_KEY_PREFIX}${uid}`;
+
+    if (redis) {
+      const cached = await redis.get(cacheKey);
+      if (cached === '1') {
+        return false; // authorized -> count
+      }
+      if (cached === '0') {
+        return true; // not authorized -> exclude
+      }
+    }
+
+    const service = oauthDB.getServiceForCanonicalScope(policy.scope);
+    if (!service) {
+      // Misconfiguration: the scope isn't owned by a known service, so we can't
+      // form the consent key. Fail open rather than guess.
+      statsd?.increment('oauth.vpnInDesktopDau.unknown_service');
+      return false;
+    }
+
+    const authorized = await oauthDB.hasConsentForScopeAndClient(
+      uid,
+      policy.scope,
+      service,
+      policy.clientId
+    );
+
+    // Redis `SET ... EX` requires an integer TTL; avoid fractional cacheTtlSeconds
+    // by rounding down.
+    const cacheTtlSeconds = Math.floor(policy.cacheTtlSeconds);
+    if (redis && cacheTtlSeconds > 0) {
+      // Fire-and-forget: the cache write isn't needed to answer this request,
+      // so the grant response shouldn't wait on a Redis round-trip. A dropped
+      // write just means the next request re-queries the DB.
+      Promise.resolve(
+        redis.set(cacheKey, authorized ? '1' : '0', 'EX', cacheTtlSeconds)
+      ).catch(() =>
+        statsd?.increment('oauth.vpnInDesktopDau.cache_write_failed')
+      );
+    }
+
+    return !authorized;
+  } catch (err) {
+    statsd?.increment('oauth.vpnInDesktopDau.error');
+    log?.warn('oauth.vpnInDesktopDau.error', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -87,7 +87,8 @@ module.exports = function (
     mailer,
     devicesImpl,
     statsd,
-    glean
+    glean,
+    authServerCacheRedis
   );
   const oauthRoutes = oauth.map((route) => ({
     path: route.path,

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -1,6 +1,15 @@
 const oauthDB = require('../../oauth/db');
 
-module.exports = (log, config, db, mailer, devices, statsd, glean) => {
+module.exports = (
+  log,
+  config,
+  db,
+  mailer,
+  devices,
+  statsd,
+  glean,
+  authServerCacheRedis
+) => {
   const routes = [
     require('./authorization')({ log, oauthDB, config, statsd }),
     require('./authorized-clients/destroy')({ oauthDB }),
@@ -11,7 +20,16 @@ module.exports = (log, config, db, mailer, devices, statsd, glean) => {
     require('./introspect')({ oauthDB }),
     require('./jwks')(),
     require('./key_data')({ log, oauthDB, statsd }),
-    require('./token')({ log, oauthDB, db, mailer, devices, statsd, glean }),
+    require('./token')({
+      log,
+      oauthDB,
+      db,
+      mailer,
+      devices,
+      statsd,
+      glean,
+      authServerCacheRedis,
+    }),
     require('./verify')({ log, glean }),
   ].flat();
 

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -97,6 +97,23 @@ const ACCOUNT_ACTIVITY_UPDATE_AFTER_MS = config.get(
   'oauthServer.accountActivity.updateAfter'
 );
 
+// VPN-in-Desktop DAU bandaid (FXA-14159).
+const vpnInDesktopDauBandaid = require('../../oauth/vpn-in-desktop-dau-bandaid');
+// The client and scope the bandaid targets are fixed product facts, not
+// operational knobs, so they're constants rather than config: Firefox Desktop
+// is the only client that mints a VPN token for every signed-in user, and the
+// VPN scope is its canonical scope (a key of oauthServer.exchange.serviceScopes).
+const FIREFOX_DESKTOP_CLIENT_ID = '5882386c6d801776';
+const VPN_SCOPE = 'https://identity.mozilla.com/apps/vpn';
+const VPN_IN_DESKTOP_DAU_POLICY = {
+  clientId: FIREFOX_DESKTOP_CLIENT_ID,
+  scope: VPN_SCOPE,
+  rolloutRate: config.get('oauthServer.vpnInDesktopDauBandaid.rolloutRate'),
+  // Convict 'duration' yields milliseconds; Redis EX wants seconds.
+  cacheTtlSeconds:
+    config.get('oauthServer.vpnInDesktopDauBandaid.cacheTtl') / 1000,
+};
+
 // These scopes are used to request a one-off exchange of claims or credentials,
 // but they don't make sense to use on an ongoing basis via refresh tokens.
 const SCOPES_TO_EXCLUDE_FROM_REFRESH_TOKEN_GRANTS = ScopeSet.fromArray([
@@ -236,7 +253,16 @@ const PAYLOAD_SCHEMA = Joi.object({
   resource: validators.resourceUrl.optional().description(DESCRIPTION.resource),
 });
 
-module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
+module.exports = ({
+  log,
+  oauthDB,
+  db,
+  mailer,
+  devices,
+  statsd,
+  glean,
+  authServerCacheRedis,
+}) => {
   async function validateGrantParameters(client, params) {
     let requestedGrant;
     switch (params.grant_type) {
@@ -631,6 +657,27 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
       ? `${params.grant_type}:${params.reason}`
       : params.grant_type;
     const scopes = grant.scope?.toString() || '';
+
+    // VPN-in-Desktop DAU bandaid (FXA-14159): Firefox Desktop mints a VPN token
+    // for every signed-in user via fxa-credentials. When the user hasn't
+    // actually authorized VPN for this client, tag the event `exclude_dau` so
+    // the DAU rollup filters it. The token is still granted. Don't override a
+    // client-supplied exclude_dau=true.
+    if (params.grant_type === GRANT_FXA_ASSERTION && !grant.excludeDau) {
+      const exclude = await vpnInDesktopDauBandaid.shouldExcludeFromDau(
+        { oauthDB, redis: authServerCacheRedis, statsd, log },
+        {
+          uid,
+          clientId: oauthClientId,
+          scopeSet: grant.scope,
+          policy: VPN_IN_DESKTOP_DAU_POLICY,
+        }
+      );
+      if (exclude) {
+        grant.excludeDau = true;
+      }
+    }
+
     // This maps to the `access_token.created` Glean event which always fires here
     // because an access token is always created. `exclude_dau` tags the
     // event so the DAU signal can exclude token creations that we know don't

--- a/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
@@ -137,6 +137,54 @@ describe('accountAuthorizations repository', () => {
     expect(await db.listAccountConsentsByUid(id)).toHaveLength(2);
   });
 
+  describe('hasConsentForScopeAndClient (VPN-in-Desktop DAU bandaid)', () => {
+    it('returns true for the exact (uid, scope, service, clientId)', async () => {
+      const id = track(newUid());
+      await seed({
+        uid: id,
+        scope: VPN_SCOPE,
+        service: 'vpn',
+        clientId: DESKTOP,
+      });
+      expect(
+        await db.hasConsentForScopeAndClient(id, VPN_SCOPE, 'vpn', DESKTOP)
+      ).toBe(true);
+    });
+
+    it('returns false when only the clientId differs', async () => {
+      const id = track(newUid());
+      // VPN authorized on another client (e.g. iOS) must not count as Desktop.
+      await seed({ uid: id, scope: VPN_SCOPE, service: 'vpn', clientId: IOS });
+      expect(
+        await db.hasConsentForScopeAndClient(id, VPN_SCOPE, 'vpn', DESKTOP)
+      ).toBe(false);
+    });
+
+    it('returns false when the scope differs', async () => {
+      const id = track(newUid());
+      await seed({
+        uid: id,
+        scope: OLDSYNC_SCOPE,
+        service: 'vpn',
+        clientId: DESKTOP,
+      });
+      expect(
+        await db.hasConsentForScopeAndClient(id, VPN_SCOPE, 'vpn', DESKTOP)
+      ).toBe(false);
+    });
+
+    it('returns false for a uid with no consent rows', async () => {
+      expect(
+        await db.hasConsentForScopeAndClient(
+          newUid(),
+          VPN_SCOPE,
+          'vpn',
+          DESKTOP
+        )
+      ).toBe(false);
+    });
+  });
+
   it('records one row per scope from a single multi-scope upsert', async () => {
     const id = track(newUid());
     const now = Date.now();

--- a/packages/fxa-auth-server/test/remote/oauth_token_route.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_token_route.in.spec.ts
@@ -17,6 +17,12 @@ const CODE_WITHOUT_KEYS = 'f0f0f0';
 const mockDb = { touchSessionToken: jest.fn() };
 const mockStatsD = { increment: jest.fn() };
 const mockGlean = { oauth: { tokenCreated: jest.fn() } };
+const mockAuthServerCacheRedis = { get: jest.fn(), set: jest.fn() };
+// The vpn-in-desktop-dau-bandaid helper's own decision logic is unit-tested in
+// lib/oauth/vpn-in-desktop-dau-bandaid.spec.ts; here we mock it at the module
+// boundary to verify token.js applies its result to the Glean event and still
+// returns the token.
+const mockShouldExcludeFromDau = jest.fn();
 
 const tokenRoutesDepMocks = {
   '../../oauth/assertion': async () => true,
@@ -35,7 +41,12 @@ const tokenRoutesDepMocks = {
       }
       return t;
     },
-    validateRequestedGrant: () => ({ offline: true, scope: 'testo' }),
+    validateRequestedGrant: () => ({
+      offline: true,
+      scope: 'testo',
+      userId: buf(UID),
+      clientId: buf(CLIENT_ID),
+    }),
   },
   '../../oauth/util': {
     makeAssertionJWT: async () => ({}),
@@ -76,6 +87,7 @@ const tokenRoutesArgMocks = {
   devices: {},
   statsd: mockStatsD,
   glean: mockGlean,
+  authServerCacheRedis: mockAuthServerCacheRedis,
 };
 
 // Captured at module scope so beforeAll's set and afterAll's remove use the
@@ -115,6 +127,9 @@ beforeAll(() => {
     '../../lib/oauth/util',
     () => tokenRoutesDepMocks['../../oauth/util']
   );
+  jest.doMock('../../lib/oauth/vpn-in-desktop-dau-bandaid', () => ({
+    shouldExcludeFromDau: mockShouldExcludeFromDau,
+  }));
   const tokenRouteFactory = require('../../lib/routes/oauth/token');
   tokenRoutes = tokenRouteFactory(tokenRoutesArgMocks);
 });
@@ -177,6 +192,63 @@ describe('/token POST (integration)', () => {
         output: { statusCode: 503 },
         errno: 202, // Disabled client
       });
+    });
+  });
+
+  describe('VPN-in-Desktop DAU bandaid', () => {
+    function fxaCredentialsRequest(overrides: any = {}) {
+      return {
+        headers: {},
+        emitMetricsEvent: jest.fn(),
+        payload: {
+          client_id: NON_DISABLED_CLIENT_ID,
+          grant_type: 'fxa-credentials',
+          assertion: 'unused-mocked-assertion',
+          ...overrides,
+        },
+      };
+    }
+
+    it('tags the Glean event with excludeDau when the helper says to exclude', async () => {
+      mockShouldExcludeFromDau.mockResolvedValue(true);
+      const request = fxaCredentialsRequest();
+      await route.config.handler(request);
+      expect(mockShouldExcludeFromDau).toHaveBeenCalledTimes(1);
+      expect(mockGlean.oauth.tokenCreated).toHaveBeenCalledWith(request, {
+        uid: UID,
+        oauthClientId: CLIENT_ID,
+        reason: 'fxa-credentials',
+        scopes: 'testo',
+        excludeDau: true,
+      });
+    });
+
+    it('leaves excludeDau false when the helper says to count', async () => {
+      mockShouldExcludeFromDau.mockResolvedValue(false);
+      const request = fxaCredentialsRequest();
+      await route.config.handler(request);
+      expect(mockShouldExcludeFromDau).toHaveBeenCalledTimes(1);
+      expect(mockGlean.oauth.tokenCreated).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({ excludeDau: false })
+      );
+    });
+
+    it('still returns the granted token when the helper excludes it from DAU', async () => {
+      mockShouldExcludeFromDau.mockResolvedValue(true);
+      const result = await route.config.handler(fxaCredentialsRequest());
+      expect(result).toMatchObject({ refresh_token: '00ff' });
+    });
+
+    it('does not consult the helper when the client already supplied exclude_dau=true', async () => {
+      mockShouldExcludeFromDau.mockResolvedValue(false);
+      const request = fxaCredentialsRequest({ exclude_dau: true });
+      await route.config.handler(request);
+      expect(mockShouldExcludeFromDau).not.toHaveBeenCalled();
+      expect(mockGlean.oauth.tokenCreated).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({ excludeDau: true })
+      );
     });
   });
 });


### PR DESCRIPTION
Because:
 - Firefox Desktop mints a VPN-scoped access token for every signed-in user via the fxa-credentials grant, so every signed-in user fires the access_token_created Glean event and inflates VPN's services-DAU.

This commit:
 - Reads accountAuthorizations on fxa-credentials + Firefox Desktop + VPN scope grants to check whether the user actually authorized VPN for that client; when they have not, tags the event exclude_dau so the DAU rollup filters it. The token is always granted.
 - Gates the lookup behind a per-uid rollout rate and caches the result in Redis (default 12h) to keep this hot path off the OAuth DB.
 - Adds associated configs

closes FXA-14159

---

Confirmed checking auth-server Glean logs + our redis instance that 1) the bandaid works, 2) the redis cache works, 3) clearing the cache, next time it reads from the table.