### PR TITLE
feat(auth-server): copy local email codes to the clipboard

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -87,6 +87,26 @@ This also allows to use temporary throw-away Docker containers to provide these.
 
 See the ["Emails" page in ecosystem platform](https://mozilla.github.io/ecosystem-platform/reference/emails) for docs on our email stack, including styling and l10n guides.
 
+### Local emails and codes
+
+Locally, emails are caught by [`test/mail_helper.js`](test/mail_helper.js) — a fake SMTP server that `yarn start` runs under pm2 as the `inbox` service. Rather than delivering anything, it logs the code or link from each email, so watch it while signing in or signing up:
+
+```sh
+pm2 logs inbox
+```
+
+To skip the copy/paste between terminal and browser, start the stack with `MAIL_HELPER_COPY_CODES=1` (or set in your env) and each code is copied to your clipboard as it arrives:
+
+```sh
+MAIL_HELPER_COPY_CODES=1 yarn start
+```
+
+This covers signin, token, unblock, password reset, MFA, passwordless signup/signin, and recovery phone codes, plus the verification link for the flows that send one instead of a code. It is off by default, requires `pbcopy` (macOS), `xclip` (Linux), or `clip` (Windows), and is silently skipped if the clipboard tool is unavailable.
+
+Note that enabling this puts codes into your system clipboard, where clipboard managers, history tools, and other local processes may pick them up and retain them. These are throwaway codes for local test accounts, but keep the flag off if that tradeoff matters on your machine.
+
+The service reports which mode it is in on startup, so `pm2 logs inbox` will show either `Clipboard copy: enabled (pbcopy)` or `Clipboard copy: disabled`. If it says disabled despite the variable being set in your shell, the pm2 daemon is likely holding an older environment — `pm2 kill` and start the stack again, or restart the one service with `MAIL_HELPER_COPY_CODES=1 pm2 restart inbox --update-env`.
+
 ### Storybook
 
 Storybook is set up in the auth-server for FxA and SubPlat emails. See our "emails" documentation for more info.

--- a/packages/fxa-auth-server/test/mail_helper.js
+++ b/packages/fxa-auth-server/test/mail_helper.js
@@ -5,6 +5,7 @@
 /* eslint-disable no-console */
 
 'use strict';
+const { spawn } = require('child_process');
 const MailParser = require('mailparser').MailParser;
 const simplesmtp = require('simplesmtp');
 const Redis = require('ioredis');
@@ -12,6 +13,43 @@ const config = require('../config').default.getProperties();
 const { RECOVERY_PHONE_REDIS_PREFIX } = require('@fxa/accounts/recovery-phone');
 
 const TEMPLATES_WITH_NO_CODE = new Set(['passwordResetEmail']);
+
+// Set MAIL_HELPER_COPY_CODES=1 to copy each code to the local clipboard as it
+// arrives. Off by default. See "Local emails and codes" in the README.
+const COPY_CODES = process.env.MAIL_HELPER_COPY_CODES === '1';
+const CLIPBOARD_COMMAND = {
+  darwin: ['pbcopy'],
+  linux: ['xclip', ['-selection', 'clipboard']],
+  win32: ['clip'],
+}[process.platform];
+
+function clipboardStatus() {
+  if (!COPY_CODES) {
+    return 'Clipboard copy: disabled (set MAIL_HELPER_COPY_CODES=1 to enable)';
+  }
+  if (!CLIPBOARD_COMMAND) {
+    return `Clipboard copy: unavailable (no clipboard tool known for ${process.platform})`;
+  }
+  return `Clipboard copy: enabled (${CLIPBOARD_COMMAND[0]})`;
+}
+
+// Copies whatever the mail helper just logged — a code, or the verification
+// link for the flows that send one instead.
+function copyToClipboard(value) {
+  if (!COPY_CODES || !value || !CLIPBOARD_COMMAND) {
+    return;
+  }
+  const [command, args = []] = CLIPBOARD_COMMAND;
+  try {
+    const proc = spawn(command, args, { stdio: ['pipe', 'ignore', 'ignore'] });
+    // A missing clipboard binary shouldn't take the mail helper down with it.
+    proc.on('error', () => {});
+    proc.stdin.on('error', () => {});
+    proc.stdin.end(String(value));
+  } catch (err) {
+    // Ignore errors
+  }
+}
 
 // SMS polling
 const redis = new Redis(config.redis);
@@ -39,6 +77,7 @@ async function printMatchingKeys(startUp = false) {
         if (!usersLastSms[uid][code]) {
           if (!startUp) {
             console.log('\x1B[36mRecovery Phone Otp:', code, '\x1B[39m');
+            copyToClipboard(code);
           }
           usersLastSms[uid][code] = true;
         }
@@ -97,23 +136,32 @@ module.exports = (printLogs) => {
 
           if (vsc) {
             console.log('\x1B[34mSignin code', vsc, '\x1B[39m');
+            copyToClipboard(vsc);
           } else if (vc) {
             console.log('\x1B[32m', link || vc, '\x1B[39m');
+            copyToClipboard(link || vc);
           } else if (sc) {
             console.log('\x1B[32mToken code: ', sc, '\x1B[39m');
+            copyToClipboard(sc);
           } else if (rc) {
-            console.log('\x1B[34m', link, '\x1B[39m');
+            console.log('\x1B[34m', link || rc, '\x1B[39m');
+            copyToClipboard(link || rc);
           } else if (uc) {
             console.log('\x1B[36mUnblock code:', uc, '\x1B[39m');
             console.log('\x1B[36mReport link:', rul, '\x1B[39m');
+            copyToClipboard(uc);
           } else if (rpc) {
             console.log('\x1B[36mReset password Otp:', rpc, '\x1B[39m');
+            copyToClipboard(rpc);
           } else if (mfa) {
             console.log('\x1B[36mMfa code:', mfa, '\x1B[39m');
+            copyToClipboard(mfa);
           } else if (plSignup) {
             console.log('\x1B[35mPasswordless signup code:', plSignup, '\x1B[39m');
+            copyToClipboard(plSignup);
           } else if (plSignin) {
             console.log('\x1B[35mPasswordless signin code:', plSignin, '\x1B[39m');
+            copyToClipboard(plSignin);
           } else if (TEMPLATES_WITH_NO_CODE.has(template)) {
             console.log(`Notification email: ${template}`);
           } else {
@@ -198,6 +246,7 @@ module.exports = (printLogs) => {
 
     api.start().then(() => {
       console.log('mail_helper started...');
+      console.log(clipboardStatus());
       printMatchingKeys(true);
       return resolve({
         close() {


### PR DESCRIPTION
## Because

- I'm too lazy to copy/paste and forget to tail inbox pm2 logs

## This pull request

- Adds an opt-in `MAIL_HELPER_COPY_CODES=1` flag to `packages/fxa-auth-server/test/mail_helper.js` that copies each code to the local clipboard as it arrives, so it can be pasted straight into the browser.
- Copies at the point the code is already in hand, covering signin, token, unblock, password reset, MFA, passwordless signup/signin, and the Redis-polled recovery phone OTP.
- Logs `Clipboard copy: enabled (pbcopy)` / `disabled` on startup next to `mail_helper started...`, so a missing env var is diagnosable at a glance rather than looking like a broken feature.
- Documents the `inbox` service and the new flag under a "Local emails and codes" section in `packages/fxa-auth-server/README.md`, which previously had no mention of how to retrieve a code locally.

## Issue that this pull request solves

Closes: N/A

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The flag is off by default, so CI and local functional-test runs are unaffected — `copyCode()` returns immediately unless `MAIL_HELPER_COPY_CODES=1`, and no clipboard process is spawned. It resolves `pbcopy` / `xclip` / `clip` by platform and silently no-ops if the tool is missing, so it cannot take the mail helper down.

No Jira ticket: local dev-tooling only, with no production code path or user-facing behaviour. No pre-merge review skill was run for the same reason.
