### PR TITLE
fix(auth-server): stop converter.spec leaking a real Firestore client

### DIFF
--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/converter.spec.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/converter.spec.ts
@@ -5,8 +5,6 @@
 import fs from 'fs';
 import { Container } from 'typedi';
 
-import { AuthFirestore, AuthLogger, AppConfig } from '../../lib/types';
-import { setupFirestore } from '../../lib/firestore-db';
 import { PaymentConfigManager } from '../../lib/payments/configuration/manager';
 import { ProductConfig } from 'fxa-shared/subscriptions/configuration/product';
 import { PlanConfig } from 'fxa-shared/subscriptions/configuration/plan';
@@ -354,31 +352,10 @@ describe('StripeProductsAndPlansConverter', () => {
     let paymentConfigManager: any;
     let converter: any;
 
-    const mockConfig = {
-      authFirestore: {
-        prefix: 'mock-fxa-',
-      },
-      subscriptions: {
-        playApiServiceAccount: {
-          credentials: {
-            clientEmail: 'mock-client-email',
-          },
-          keyFile: 'mock-private-keyfile',
-        },
-        productConfigsFirestore: {
-          schemaValidation: {
-            cdnUrlRegex: ['^http'],
-          },
-        },
-      },
-    };
-
     beforeEach(() => {
-      const firestore = setupFirestore(mockConfig as any);
-      Container.set(AuthFirestore, firestore);
-      Container.set(AuthLogger, {});
-      Container.set(AppConfig, mockConfig);
-      paymentConfigManager = new PaymentConfigManager();
+      // A real PaymentConfigManager can't be used here: its constructor kicks off
+      // an un-awaited Firestore load() and snapshot listeners that outlive the spec.
+      paymentConfigManager = { validateProductConfig: jest.fn() };
       Container.set(PaymentConfigManager, paymentConfigManager);
       converter = new StripeProductsAndPlansConverter({
         log: mockLog,
@@ -447,31 +424,10 @@ describe('StripeProductsAndPlansConverter', () => {
     let paymentConfigManager: any;
     let converter: any;
 
-    const mockConfig = {
-      authFirestore: {
-        prefix: 'mock-fxa-',
-      },
-      subscriptions: {
-        playApiServiceAccount: {
-          credentials: {
-            clientEmail: 'mock-client-email',
-          },
-          keyFile: 'mock-private-keyfile',
-        },
-        productConfigsFirestore: {
-          schemaValidation: {
-            cdnUrlRegex: ['^http'],
-          },
-        },
-      },
-    };
-
     beforeEach(() => {
-      const firestore = setupFirestore(mockConfig as any);
-      Container.set(AuthFirestore, firestore);
-      Container.set(AuthLogger, {});
-      Container.set(AppConfig, mockConfig);
-      paymentConfigManager = new PaymentConfigManager();
+      // A real PaymentConfigManager can't be used here: its constructor kicks off
+      // an un-awaited Firestore load() and snapshot listeners that outlive the spec.
+      paymentConfigManager = { validatePlanConfig: jest.fn() };
       Container.set(PaymentConfigManager, paymentConfigManager);
       converter = new StripeProductsAndPlansConverter({
         log: mockLog,


### PR DESCRIPTION
## Because

- Nightly `Unit Test` fails on `fxa-auth-server:test-unit`, and Jest misattributes it to a **passing** test in `lib/routes/oauth/index.spec.ts`.
- `converter.spec.ts` built a real Firestore client and `PaymentConfigManager`. With no `keyFilename`/`credentials` in `mockConfig`, `setupFirestore` aimed at the `localhost:9090` emulator — which the unit-test job doesn't run.
- The constructor's un-awaited `load()` and uncancelled snapshot listeners fail *after* the spec ends. `AuthLogger` was `{}`, so the handler died on `this.log.error is not a function`, killing the run with `exit status 130`.

## This pull request

- Replaces the real `PaymentConfigManager` in the `writeToFileProductConfig` and `writeToFilePlanConfig` blocks of `converter.spec.ts` with a plain mock of the validate method each test already stubs.
- Removes the orphaned `setupFirestore`, `AuthFirestore`, `AuthLogger`, and `AppConfig` imports and the `mockConfig` fixtures that only fed that constructor.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14251

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:** run the spec with `--detectOpenHandles`:

```bash
cd packages/fxa-auth-server && VERIFIER_VERSION=0 NODE_ENV=dev npx jest \
  --selectProjects unit --ci --maxWorkers=1 --detectOpenHandles \
  scripts/stripe-products-and-plans-to-firestore-documents/converter.spec.ts
```

On `main` it passes 16, then hangs and crashes. Here: 16 pass, exit 0, no open handles. `scripts/**` plus the OAuth spec: 326 passed.

**Nightly only** because `scripts/test-ci.sh` narrows the run via `--findRelatedTests` when `JEST_AFFECTED_BASE` is set, and only PR workflows set it.