### PR TITLE
bug(auth): Fix polluted sentry bread crumbs

### DIFF
--- a/libs/accounts/rate-limit/src/lib/bq-writer.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/bq-writer.spec.ts
@@ -6,8 +6,20 @@ import * as Sentry from '@sentry/node';
 import { RateLimitBqWriter, BqWriterConfig } from './bq-writer';
 import { RateLimitCheckEvent } from './models';
 
+const mockCallLog: string[] = [];
+
 jest.mock('@sentry/node', () => ({
-  captureException: jest.fn(),
+  captureException: jest.fn(() => {
+    mockCallLog.push('captureException');
+  }),
+  withIsolationScope: jest.fn(
+    (callback: (scope: { clear(): void }) => Promise<void>) => {
+      mockCallLog.push('scope:enter');
+      return callback({
+        clear: () => mockCallLog.push('scope:clear'),
+      }).finally(() => mockCallLog.push('scope:exit'));
+    }
+  ),
 }));
 
 describe('RateLimitBqWriter', () => {
@@ -29,9 +41,13 @@ describe('RateLimitBqWriter', () => {
   });
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    mockCallLog.length = 0;
     jest.useFakeTimers();
     mockTable = {
-      insert: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockImplementation(async () => {
+        mockCallLog.push('insert');
+      }),
     };
     config = {
       projectId: 'test-project',
@@ -120,6 +136,86 @@ describe('RateLimitBqWriter', () => {
 
     expect(mockTable.insert).toHaveBeenCalledWith([
       expect.objectContaining({ action: 'remaining' }),
+    ]);
+  });
+
+  it('inserts inside a freshly cleared isolation scope', async () => {
+    writer.write(createEvent());
+
+    await writer.flush();
+
+    expect(mockCallLog).toEqual([
+      'scope:enter',
+      'scope:clear',
+      'insert',
+      'scope:exit',
+    ]);
+  });
+
+  it('reports insert failures from inside the isolation scope', async () => {
+    mockTable.insert.mockImplementation(async () => {
+      mockCallLog.push('insert');
+      throw new Error('BQ unavailable');
+    });
+    writer.write(createEvent());
+
+    await writer.flush();
+
+    expect(mockCallLog).toEqual([
+      'scope:enter',
+      'scope:clear',
+      'insert',
+      'captureException',
+      'scope:exit',
+    ]);
+  });
+
+  it('never has two inserts in flight at once', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    mockTable.insert.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Yield twice so an unserialized second insert would overlap this one.
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight -= 1;
+    });
+
+    writer.write(createEvent({ action: 'first' }));
+    const firstFlush = writer.flush();
+    writer.write(createEvent({ action: 'second' }));
+    const secondFlush = writer.flush();
+    await Promise.all([firstFlush, secondFlush]);
+
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('sends events buffered during an in-flight insert on the next flush', async () => {
+    let releaseFirstInsert!: () => void;
+    mockTable.insert.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirstInsert = resolve;
+        })
+    );
+
+    writer.write(createEvent({ action: 'first' }));
+    const firstFlush = writer.flush();
+    // Let the chained flush start; the first insert is now pending.
+    await Promise.resolve();
+
+    writer.write(createEvent({ action: 'second' }));
+    const secondFlush = writer.flush();
+
+    releaseFirstInsert();
+    await Promise.all([firstFlush, secondFlush]);
+
+    expect(mockTable.insert).toHaveBeenNthCalledWith(1, [
+      expect.objectContaining({ action: 'first' }),
+    ]);
+    expect(mockTable.insert).toHaveBeenNthCalledWith(2, [
+      expect.objectContaining({ action: 'second' }),
     ]);
   });
 

--- a/libs/accounts/rate-limit/src/lib/bq-writer.ts
+++ b/libs/accounts/rate-limit/src/lib/bq-writer.ts
@@ -27,6 +27,7 @@ export interface BqWriterConfig {
 export class RateLimitBqWriter {
   private buffer: RateLimitCheckEvent[] = [];
   private timer: NodeJS.Timeout | null = null;
+  private flushChain: Promise<void> = Promise.resolve();
   private readonly tableRef: Table;
 
   /**
@@ -57,20 +58,45 @@ export class RateLimitBqWriter {
     }
   }
 
-  /** Send buffered events to BigQuery. Catches all errors. */
+  /**
+   * Send buffered events to BigQuery. Catches all errors.
+   *
+   * Flushes are serialized: the timer and a batch-size trigger must not
+   * splice the buffer concurrently, or two inserts race over the same rows.
+   */
   async flush(): Promise<void> {
+    this.flushChain = this.flushChain.then(() => this.flushOnce());
+    return this.flushChain;
+  }
+
+  /**
+   * Perform a single insert. Only ever called from the flush chain, so at
+   * most one is in flight at a time.
+   *
+   * flushOnce never rejects — the try/catch covers the insert — so the chain
+   * cannot be poisoned. If that ever changes, flush() needs a .catch() guard.
+   */
+  private async flushOnce(): Promise<void> {
     if (this.buffer.length === 0) {
       return;
     }
 
     const batch = this.buffer.splice(0);
-    try {
-      await this.tableRef.insert(batch);
-    } catch (err) {
-      // Never throw — BQ failures must not affect auth
-      this.statsd?.increment('rate_limit.bq_writer.flush_error');
-      Sentry.captureException(err);
-    }
+
+    // Run the insert in a throwaway isolation scope. Sentry's httpIntegration
+    // records a breadcrumb for the outgoing insertAll call on whichever
+    // isolation scope is active when the request is made. Without this other
+    // Sentry captures get polluted with these insertAll bread crumbs.
+    await Sentry.withIsolationScope(async (scope) => {
+      scope.clear();
+      try {
+        await this.tableRef.insert(batch);
+      } catch (err) {
+        // Never throw — BQ failures must not affect auth
+        this.statsd?.increment('rate_limit.bq_writer.flush_error');
+        Sentry.captureException(err);
+      }
+    });
   }
 
   /** Drain remaining events and stop the flush timer. */

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -572,6 +572,16 @@ async function run(config) {
         });
       }
 
+      // Drain before statsd closes — a failed flush increments a statsd metric.
+      try {
+        await bqWriter?.shutdown();
+      } catch (e) {
+        log.warn('shutdown', {
+          message:
+            'Rate limit BQ writer did not shut down cleanly. ' + e.message,
+        });
+      }
+
       try {
         statsd.close();
       } catch (e) {


### PR DESCRIPTION
## Because

- We were seeing Sentry breadcrumbs being polluted with bqwrite insert all crumbs.

## This pull request

- Isolates the sentry scope in bq-writer

## Issue that this pull request solves

Closes: FXA-14252

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
