### PR TITLE
fix(payments-next): [ccsec f020] PayPal charge races invoice finalization due to missing await

### DIFF
--- a/libs/payments/customer/src/lib/invoice.manager.spec.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.spec.ts
@@ -454,6 +454,13 @@ describe('InvoiceManager', () => {
   });
 
   describe('processNonZeroInvoice', () => {
+    class MockStripeError extends Error {
+      raw: { message: string };
+      constructor(message: string) {
+        super(message);
+        this.raw = { message };
+      }
+    }
     it('successfully processes non-zero invoice', async () => {
       const mockPaymentAttemptCount = 1;
       const mockCustomer = StripeResponseFactory(
@@ -831,6 +838,161 @@ describe('InvoiceManager', () => {
       expect(
         invoiceManager.safeFinalizeWithoutAutoAdvance
       ).toHaveBeenLastCalledWith(mockInvoice.id);
+    });
+
+    it('aborts the PayPal charge when invoice finalization fails', async () => {
+      const mockPaymentAttemptCount = 1;
+      const mockCustomer = StripeResponseFactory(
+        StripeCustomerFactory({
+          metadata: {
+            [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: '1',
+          },
+        })
+      );
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({
+          status: 'draft',
+          currency: 'usd',
+          metadata: {
+            [STRIPE_INVOICE_METADATA.RetryAttempts]: String(
+              mockPaymentAttemptCount
+            ),
+          },
+          customer_shipping: { address: StripeAddressFactory() },
+        })
+      );
+
+      jest
+        .spyOn(stripeClient, 'invoicesFinalizeInvoice')
+        .mockRejectedValue(
+          new MockStripeError('An unexpected error occurred.')
+        );
+      jest.spyOn(paypalClient, 'chargeCustomer').mockResolvedValue(
+        ChargeResponseFactory({
+          paymentStatus: 'Completed',
+        })
+      );
+      jest.spyOn(stripeClient, 'invoicesUpdate').mockResolvedValue(mockInvoice);
+      jest.spyOn(stripeClient, 'invoicesPay').mockResolvedValue();
+
+      await expect(
+        invoiceManager.processPayPalNonZeroInvoice(mockCustomer, mockInvoice)
+      ).rejects.toThrow('An unexpected error occurred.');
+
+      expect(paypalClient.chargeCustomer).not.toHaveBeenCalled();
+      expect(stripeClient.invoicesUpdate).not.toHaveBeenCalled();
+      expect(stripeClient.invoicesPay).not.toHaveBeenCalled();
+    });
+
+    it('charges the customer when the invoice was already finalized', async () => {
+      const mockPaymentAttemptCount = 1;
+      const mockCustomer = StripeResponseFactory(
+        StripeCustomerFactory({
+          metadata: {
+            [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: '1',
+          },
+        })
+      );
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({
+          status: 'open',
+          currency: 'usd',
+          metadata: {
+            [STRIPE_INVOICE_METADATA.RetryAttempts]: String(
+              mockPaymentAttemptCount
+            ),
+          },
+          customer_shipping: { address: StripeAddressFactory() },
+        })
+      );
+      const mockPayPalCharge = ChargeResponseFactory({
+        paymentStatus: 'Completed',
+      });
+
+      jest
+        .spyOn(stripeClient, 'invoicesFinalizeInvoice')
+        .mockRejectedValue(
+          new MockStripeError(
+            "This invoice is already finalized, you can't re-finalize a non-draft invoice."
+          )
+        );
+      jest
+        .spyOn(stripeClient, 'invoicesRetrieve')
+        .mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(paypalClient, 'chargeCustomer')
+        .mockResolvedValue(mockPayPalCharge);
+      jest.spyOn(stripeClient, 'invoicesUpdate').mockResolvedValue(mockInvoice);
+      jest.spyOn(stripeClient, 'invoicesPay').mockResolvedValue();
+
+      await invoiceManager.processPayPalNonZeroInvoice(
+        mockCustomer,
+        mockInvoice
+      );
+
+      expect(paypalClient.chargeCustomer).toHaveBeenCalledWith({
+        amountInCents: mockInvoice.amount_due,
+        billingAgreementId:
+          mockCustomer.metadata[STRIPE_CUSTOMER_METADATA.PaypalAgreement],
+        invoiceNumber: mockInvoice.id,
+        currencyCode: mockInvoice.currency,
+        countryCode: mockInvoice.customer_shipping?.address?.country,
+        idempotencyKey: `${mockInvoice.id}-${mockPaymentAttemptCount}`,
+      });
+      expect(stripeClient.invoicesPay).toHaveBeenCalledWith(mockInvoice.id);
+    });
+
+    it('finalizes the invoice before dispatching the PayPal charge', async () => {
+      const mockPaymentAttemptCount = 1;
+      const mockCustomer = StripeResponseFactory(
+        StripeCustomerFactory({
+          metadata: {
+            [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: '1',
+          },
+        })
+      );
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({
+          status: 'draft',
+          currency: 'usd',
+          metadata: {
+            [STRIPE_INVOICE_METADATA.RetryAttempts]: String(
+              mockPaymentAttemptCount
+            ),
+          },
+          customer_shipping: { address: StripeAddressFactory() },
+        })
+      );
+      const mockPayPalCharge = ChargeResponseFactory({
+        paymentStatus: 'Completed',
+      });
+      const callOrder: string[] = [];
+
+      jest
+        .spyOn(stripeClient, 'invoicesFinalizeInvoice')
+        .mockImplementation(async () => {
+          await Promise.resolve();
+          callOrder.push('invoicesFinalizeInvoice');
+          return mockInvoice;
+        });
+      jest
+        .spyOn(paypalClient, 'chargeCustomer')
+        .mockImplementation(async () => {
+          callOrder.push('chargeCustomer');
+          return mockPayPalCharge;
+        });
+      jest.spyOn(stripeClient, 'invoicesUpdate').mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(stripeClient, 'invoicesRetrieve')
+        .mockResolvedValue(mockInvoice);
+      jest.spyOn(stripeClient, 'invoicesPay').mockResolvedValue();
+
+      await invoiceManager.processPayPalNonZeroInvoice(
+        mockCustomer,
+        mockInvoice
+      );
+
+      expect(callOrder).toEqual(['invoicesFinalizeInvoice', 'chargeCustomer']);
     });
   });
 });

--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -284,7 +284,7 @@ export class InvoiceManager {
     let paypalCharge: ChargeResponse;
     try {
       // Charge the PayPal customer after the invoice is finalized to prevent charges with a failed invoice
-      this.safeFinalizeWithoutAutoAdvance(invoice.id);
+      await this.safeFinalizeWithoutAutoAdvance(invoice.id);
       paypalCharge = await this.paypalClient.chargeCustomer(chargeOptions);
     } catch (error) {
       if (PayPalClientError.hasPayPalNVPError(error)) {


### PR DESCRIPTION
## Because

* safeFinalizeWithoutAutoAdvance was being called without await,  so the PayPal charge ran concurrently with finalization instead of after it. Customers could be debited while finalization failed , and the rejection escaped the catch as an unhandled rejection.

## This pull request

* Awaits safeFinalizeWithoutAutoAdvance so a finalization failure propagates to the existing catch and aborts before chargeCustomer.

## Issue that this pull request solves

Closes #[PAY-3833](https://mozilla-hub.atlassian.net/browse/PAY-3833)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3833]: https://mozilla-hub.atlassian.net/browse/PAY-3833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ