### PR TITLE
feat(fxa): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,11 @@
 * @mozilla/fxa-devs
 
 *.ftl @mozilla/fxa-l10n
+
+# Dependency files left without code owner so version bumps can auto-merge via bot (BLEnder/Dependabot)
+/package.json
+/yarn.lock
+/package-lock.json
+**/package.json
+**/yarn.lock
+**/package-lock.json


### PR DESCRIPTION
## Because

- The blanket `* @mozilla/fxa-devs` rule requires a code-owner review on every file, including dependency manifests/lockfiles — which blocks BLEnder/Dependabot from auto-merging vetted dependency bumps.

## This pull request

- Leaves dependency manifests/lockfiles without a code owner (last-match-wins) so dependency-only PRs no longer require a code-owner review. All other files still require `@mozilla/fxa-devs` review, and GitHub Actions workflow files are intentionally **not** exempted. BLEnder still gates these merges on CI + compatibility + security advisories + no major bumps.

## Checklist

Put an x in the boxes that apply

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.