### PR TITLE
feat(settings): show a loading state and lock other options during passkey sign-in

### DIFF
--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.test.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.test.tsx
@@ -155,6 +155,50 @@ describe('AlternativeAuthOptions', () => {
     });
   });
 
+  describe('disabled prop (form-lock)', () => {
+    it('disables the passkey button without showing its loading spinner', () => {
+      renderWithLocalizationProvider(
+        <Subject
+          showPasskeySignin
+          passkeySignIn={{ onClick: jest.fn() }}
+          disabled
+        />
+      );
+      // Still shows the default label (not the loading label), but disabled.
+      expect(
+        screen.getByRole('button', { name: /sign in with passkey/i })
+      ).toBeDisabled();
+    });
+
+    it('disables the Google and Apple buttons', async () => {
+      renderWithLocalizationProvider(
+        <Subject
+          showPasskeySignin
+          passkeySignIn={{ onClick: jest.fn() }}
+          disabled
+        />
+      );
+      expect(
+        await screen.findByRole('button', { name: 'Continue with Google' })
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: 'Continue with Apple' })
+      ).toBeDisabled();
+    });
+
+    it('leaves all options enabled when disabled is false', async () => {
+      renderWithLocalizationProvider(
+        <Subject showPasskeySignin passkeySignIn={{ onClick: jest.fn() }} />
+      );
+      expect(
+        screen.getByRole('button', { name: /sign in with passkey/i })
+      ).toBeEnabled();
+      expect(
+        await screen.findByRole('button', { name: 'Continue with Google' })
+      ).toBeEnabled();
+    });
+  });
+
   describe('showThirdPartyAuth prop', () => {
     it('hides Google/Apple buttons when false', () => {
       renderWithLocalizationProvider(<Subject showThirdPartyAuth={false} />);

--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.test.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.test.tsx
@@ -155,6 +155,49 @@ describe('AlternativeAuthOptions', () => {
     });
   });
 
+  describe('disabled prop (form-lock)', () => {
+    it('disables the passkey button without showing its loading spinner', () => {
+      renderWithLocalizationProvider(
+        <Subject
+          showPasskeySignin
+          passkeySignIn={{ onClick: jest.fn() }}
+          disabled
+        />
+      );
+      expect(
+        screen.getByRole('button', { name: /sign in with passkey/i })
+      ).toBeDisabled();
+    });
+
+    it('disables the Google and Apple buttons', async () => {
+      renderWithLocalizationProvider(
+        <Subject
+          showPasskeySignin
+          passkeySignIn={{ onClick: jest.fn() }}
+          disabled
+        />
+      );
+      expect(
+        await screen.findByRole('button', { name: 'Continue with Google' })
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: 'Continue with Apple' })
+      ).toBeDisabled();
+    });
+
+    it('leaves all options enabled when disabled is false', async () => {
+      renderWithLocalizationProvider(
+        <Subject showPasskeySignin passkeySignIn={{ onClick: jest.fn() }} />
+      );
+      expect(
+        screen.getByRole('button', { name: /sign in with passkey/i })
+      ).toBeEnabled();
+      expect(
+        await screen.findByRole('button', { name: 'Continue with Google' })
+      ).toBeEnabled();
+    });
+  });
+
   describe('showThirdPartyAuth prop', () => {
     it('hides Google/Apple buttons when false', () => {
       renderWithLocalizationProvider(<Subject showThirdPartyAuth={false} />);

--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.tsx
@@ -22,6 +22,8 @@ export interface AlternativeAuthOptionsProps {
   /** Required for the passkey button to render, even when `showPasskeySignin` is true. */
   passkeySignIn?: PasskeySignInBinding;
   errorBanner?: React.ReactNode;
+  /** Locks every option; the passkey button keeps its own spinner via `isLoading`. */
+  disabled?: boolean;
   onContinueWithGoogle?: () => void;
   onContinueWithApple?: () => void;
 }
@@ -34,6 +36,7 @@ const AlternativeAuthOptions = ({
   showPasskeySignin = false,
   passkeySignIn,
   errorBanner,
+  disabled = false,
   onContinueWithGoogle,
   onContinueWithApple,
 }: AlternativeAuthOptionsProps) => {
@@ -81,6 +84,7 @@ const AlternativeAuthOptions = ({
         {renderPasskey && (
           <ButtonPasskeySignin
             isLoading={passkeySignIn.isLoading}
+            disabled={disabled}
             onClick={passkeySignIn.onClick}
           />
         )}
@@ -90,6 +94,7 @@ const AlternativeAuthOptions = ({
               variant,
               viewName,
               flowQueryParams,
+              disabled,
               onContinueWithGoogle,
               onContinueWithApple,
             }}

--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.tsx
@@ -22,6 +22,9 @@ export interface AlternativeAuthOptionsProps {
   /** Required for the passkey button to render, even when `showPasskeySignin` is true. */
   passkeySignIn?: PasskeySignInBinding;
   errorBanner?: React.ReactNode;
+  /** Disable every option here while another sign-in method on the surface is
+   * in flight (the passkey button still shows its own spinner via `isLoading`). */
+  disabled?: boolean;
   onContinueWithGoogle?: () => void;
   onContinueWithApple?: () => void;
 }
@@ -34,6 +37,7 @@ const AlternativeAuthOptions = ({
   showPasskeySignin = false,
   passkeySignIn,
   errorBanner,
+  disabled = false,
   onContinueWithGoogle,
   onContinueWithApple,
 }: AlternativeAuthOptionsProps) => {
@@ -81,6 +85,7 @@ const AlternativeAuthOptions = ({
         {renderPasskey && (
           <ButtonPasskeySignin
             isLoading={passkeySignIn.isLoading}
+            disabled={disabled}
             onClick={passkeySignIn.onClick}
           />
         )}
@@ -90,6 +95,7 @@ const AlternativeAuthOptions = ({
               variant,
               viewName,
               flowQueryParams,
+              disabled,
               onContinueWithGoogle,
               onContinueWithApple,
             }}

--- a/packages/fxa-settings/src/components/ButtonPasskeySignin/index.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonPasskeySignin/index.test.tsx
@@ -61,4 +61,27 @@ describe('ButtonPasskeySignin', () => {
 
     expect(handleClick).not.toHaveBeenCalled();
   });
+
+  it('is disabled without the loading spinner when disabled but not loading', () => {
+    renderWithLocalizationProvider(<ButtonPasskeySignin disabled={true} />);
+
+    screen.getByText('Sign in with passkey');
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(
+      screen.queryByText('icon_loading_arrow.min.svg')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not call onClick handler when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+
+    renderWithLocalizationProvider(
+      <ButtonPasskeySignin onClick={handleClick} disabled={true} />
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
 });

--- a/packages/fxa-settings/src/components/ButtonPasskeySignin/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonPasskeySignin/index.tsx
@@ -8,17 +8,22 @@ import BoxButton from '../BoxButton';
 
 export type ButtonPasskeySigninProps = {
   isLoading?: boolean;
+  /** Disable the button without showing the loading spinner — used to lock it
+   * while another sign-in method on the surface is in flight. */
+  disabled?: boolean;
   onClick?: () => void;
 };
 
 const ButtonPasskeySignin = ({
   isLoading = false,
+  disabled = false,
   onClick = () => {},
 }: ButtonPasskeySigninProps) => (
   <BoxButton
     type="button"
     leadingIcon={<PasskeyIcon className="w-5 h-5" ariaHidden />}
     isLoading={isLoading}
+    disabled={disabled}
     onClick={onClick}
   >
     {isLoading ? (

--- a/packages/fxa-settings/src/components/ButtonPasskeySignin/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonPasskeySignin/index.tsx
@@ -8,17 +8,21 @@ import BoxButton from '../BoxButton';
 
 export type ButtonPasskeySigninProps = {
   isLoading?: boolean;
+  /** Locks the button without showing its spinner, unlike `isLoading`. */
+  disabled?: boolean;
   onClick?: () => void;
 };
 
 const ButtonPasskeySignin = ({
   isLoading = false,
+  disabled = false,
   onClick = () => {},
 }: ButtonPasskeySigninProps) => (
   <BoxButton
     type="button"
     leadingIcon={<PasskeyIcon className="w-5 h-5" ariaHidden />}
     isLoading={isLoading}
+    disabled={disabled}
     onClick={onClick}
   >
     {isLoading ? (

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.test.tsx
@@ -101,6 +101,21 @@ describe('FormVerifyCode component', () => {
       expect(submitButton).toBeEnabled();
     });
 
+    it('keeps the submit button disabled when the disabled prop is set, even for a valid code', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject disabled />);
+      const input = screen.getByRole('textbox', {
+        name: 'Enter your 4-digit code',
+      });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
+
+      await user.type(input, '1234');
+
+      expect(submitButton).toBeDisabled();
+    });
+
     it('should disable submit button when invalid code is entered', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -53,6 +53,10 @@ export type FormVerifyCodeProps = {
   className?: string;
   /** Disables the submit button during a server-side throttle window. */
   isThrottled?: boolean;
+  /** Externally disable the submit button, e.g. while another sign-in method
+   * on the surface is in flight. Independent of the internal empty/invalid-code
+   * disabling. */
+  disabled?: boolean;
 };
 
 type FormData = {
@@ -74,6 +78,7 @@ const FormVerifyCode = ({
   onChangeCb,
   className = 'flex flex-col gap-4 my-6',
   isThrottled = false,
+  disabled = false,
 }: FormVerifyCodeProps) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -124,6 +129,11 @@ const FormVerifyCode = ({
   ]);
 
   const onSubmit = async ({ code }: FormData) => {
+    // Guard every submission entry point (button and the onPaste auto-submit)
+    // against the external locks, not just the button's disabled attribute.
+    if (disabled || isThrottled) {
+      return;
+    }
     setIsSubmitting(true);
     await verifyCode(code.trim());
     setIsSubmitting(false);
@@ -187,7 +197,7 @@ const FormVerifyCode = ({
         <CmsButtonWithFallback
           type="submit"
           className="cta-primary cta-xl"
-          disabled={isSubmitting || isDisabled || isThrottled}
+          disabled={isSubmitting || isDisabled || isThrottled || disabled}
           data-glean-id={gleanDataAttrs?.id}
           data-glean-label={gleanDataAttrs?.label}
           data-glean-type={gleanDataAttrs?.type}

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -53,6 +53,8 @@ export type FormVerifyCodeProps = {
   className?: string;
   /** Disables the submit button during a server-side throttle window. */
   isThrottled?: boolean;
+  /** Locks submit independently of the internal empty/invalid-code state. */
+  disabled?: boolean;
 };
 
 type FormData = {
@@ -74,6 +76,7 @@ const FormVerifyCode = ({
   onChangeCb,
   className = 'flex flex-col gap-4 my-6',
   isThrottled = false,
+  disabled = false,
 }: FormVerifyCodeProps) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -124,6 +127,10 @@ const FormVerifyCode = ({
   ]);
 
   const onSubmit = async ({ code }: FormData) => {
+    // The onPaste auto-submit bypasses the button's disabled attribute.
+    if (disabled || isThrottled) {
+      return;
+    }
     setIsSubmitting(true);
     await verifyCode(code.trim());
     setIsSubmitting(false);
@@ -187,7 +194,7 @@ const FormVerifyCode = ({
         <CmsButtonWithFallback
           type="submit"
           className="cta-primary cta-xl"
-          disabled={isSubmitting || isDisabled || isThrottled}
+          disabled={isSubmitting || isDisabled || isThrottled || disabled}
           data-glean-id={gleanDataAttrs?.id}
           data-glean-label={gleanDataAttrs?.label}
           data-glean-type={gleanDataAttrs?.type}

--- a/packages/fxa-settings/src/components/FormVerifyCode/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/mocks.tsx
@@ -14,6 +14,8 @@ export const Subject = ({
   verifyCode = onFormSubmit,
   submitFormOnPaste = true,
   formAttributes: customFormAttributes,
+  isThrottled,
+  disabled,
 }: Partial<FormVerifyCodeProps> & { formAttributes?: FormAttributes }) => {
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
 
@@ -36,6 +38,8 @@ export const Subject = ({
         submitFormOnPaste,
         codeErrorMessage,
         setCodeErrorMessage,
+        isThrottled,
+        disabled,
       }}
     />
   );

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/__snapshots__/index.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`ThirdPartyAuthComponent buttons match snapshot: apple 1`] = `
 <button
   aria-label="Continue with Apple"
   class="w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
+      disabled:opacity-50 disabled:cursor-not-allowed
       bg-black border-transparent dark:border-grey-300
       "
   type="button"
@@ -20,6 +21,7 @@ exports[`ThirdPartyAuthComponent buttons match snapshot: google 1`] = `
 <button
   aria-label="Continue with Google"
   class="w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
+      disabled:opacity-50 disabled:cursor-not-allowed
       bg-[#F9F4F4] border-[#747775] border-[1px]
       "
   type="button"

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -145,6 +145,33 @@ describe('ThirdPartyAuthComponent', () => {
     });
   });
 
+  it('disables both provider buttons when disabled is true', async () => {
+    renderWith({
+      onContinueWithApple,
+      onContinueWithGoogle,
+      flowQueryParams: { flowId: '123' },
+      disabled: true,
+    });
+
+    expect(await screen.findByLabelText('Continue with Google')).toBeDisabled();
+    expect(screen.getByLabelText('Continue with Apple')).toBeDisabled();
+  });
+
+  it('does not start a provider flow when a disabled button is clicked', async () => {
+    const user = userEvent.setup();
+    renderWith({
+      onContinueWithApple,
+      onContinueWithGoogle,
+      flowQueryParams: { flowId: '123' },
+      disabled: true,
+    });
+
+    await user.click(await screen.findByLabelText('Continue with Google'));
+
+    expect(onContinueWithGoogle).not.toHaveBeenCalled();
+    expect(hardNavigateSpy).not.toHaveBeenCalled();
+  });
+
   it('buttons match snapshot', async () => {
     renderWith({
       enabled: true,

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -26,6 +26,9 @@ export type ThirdPartyAuthProps = {
   viewName?: string;
   flowQueryParams?: QueryParams;
   variant?: ThirdPartyAuthVariant;
+  /** Disable both provider buttons while another sign-in method on the surface
+   * is in flight, so a user can't start a competing attempt. */
+  disabled?: boolean;
 };
 
 /**
@@ -39,6 +42,7 @@ const ThirdPartyAuth = ({
   viewName = 'unknown',
   flowQueryParams,
   variant = 'icon',
+  disabled = false,
 }: ThirdPartyAuthProps) => {
   const config = useConfig();
 
@@ -58,6 +62,7 @@ const ThirdPartyAuth = ({
           viewName,
           flowQueryParams,
           variant,
+          disabled,
           onSubmit: onContinueWithGoogle,
           buttonText: (
             <>
@@ -78,6 +83,7 @@ const ThirdPartyAuth = ({
           responseMode: 'form_post',
           flowQueryParams,
           variant,
+          disabled,
           onSubmit: onContinueWithApple,
           buttonText: (
             <>
@@ -105,6 +111,7 @@ const ThirdPartySignInButton = ({
   viewName,
   flowQueryParams,
   variant = 'icon',
+  disabled = false,
 }: {
   party: 'google' | 'apple';
   authorizationEndpoint: string;
@@ -120,6 +127,7 @@ const ThirdPartySignInButton = ({
   viewName?: string;
   flowQueryParams?: QueryParams;
   variant?: ThirdPartyAuthVariant;
+  disabled?: boolean;
 }) => {
   const { logViewEventOnce } = useMetrics();
   const { l10n } = useLocalization();
@@ -234,6 +242,7 @@ const ThirdPartySignInButton = ({
         onClick={handleClick}
         aria-label={getLoginAriaLabel()}
         leadingIcon={leadingIcon}
+        disabled={disabled}
       >
         <FtlMsg id={labelFtlId}>{labelDefault}</FtlMsg>
       </BoxButton>
@@ -243,7 +252,9 @@ const ThirdPartySignInButton = ({
   return (
     <button
       type="button"
+      disabled={disabled}
       className={`w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
+      disabled:opacity-50 disabled:cursor-not-allowed
       ${
         party === 'google'
           ? 'bg-[#F9F4F4] border-[#747775] border-[1px]'

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -26,6 +26,7 @@ export type ThirdPartyAuthProps = {
   viewName?: string;
   flowQueryParams?: QueryParams;
   variant?: ThirdPartyAuthVariant;
+  disabled?: boolean;
 };
 
 /**
@@ -39,6 +40,7 @@ const ThirdPartyAuth = ({
   viewName = 'unknown',
   flowQueryParams,
   variant = 'icon',
+  disabled = false,
 }: ThirdPartyAuthProps) => {
   const config = useConfig();
 
@@ -58,6 +60,7 @@ const ThirdPartyAuth = ({
           viewName,
           flowQueryParams,
           variant,
+          disabled,
           onSubmit: onContinueWithGoogle,
           buttonText: (
             <>
@@ -78,6 +81,7 @@ const ThirdPartyAuth = ({
           responseMode: 'form_post',
           flowQueryParams,
           variant,
+          disabled,
           onSubmit: onContinueWithApple,
           buttonText: (
             <>
@@ -105,6 +109,7 @@ const ThirdPartySignInButton = ({
   viewName,
   flowQueryParams,
   variant = 'icon',
+  disabled = false,
 }: {
   party: 'google' | 'apple';
   authorizationEndpoint: string;
@@ -120,6 +125,7 @@ const ThirdPartySignInButton = ({
   viewName?: string;
   flowQueryParams?: QueryParams;
   variant?: ThirdPartyAuthVariant;
+  disabled?: boolean;
 }) => {
   const { logViewEventOnce } = useMetrics();
   const { l10n } = useLocalization();
@@ -234,6 +240,7 @@ const ThirdPartySignInButton = ({
         onClick={handleClick}
         aria-label={getLoginAriaLabel()}
         leadingIcon={leadingIcon}
+        disabled={disabled}
       >
         <FtlMsg id={labelFtlId}>{labelDefault}</FtlMsg>
       </BoxButton>
@@ -243,7 +250,9 @@ const ThirdPartySignInButton = ({
   return (
     <button
       type="button"
+      disabled={disabled}
       className={`w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
+      disabled:opacity-50 disabled:cursor-not-allowed
       ${
         party === 'google'
           ? 'bg-[#F9F4F4] border-[#747775] border-[1px]'

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.test.tsx
@@ -888,6 +888,90 @@ describe('usePasskeySignIn', () => {
     expect(Sentry.captureException as jest.Mock).toHaveBeenCalledWith(navError);
   });
 
+  describe('isNavigating (page-level loading state)', () => {
+    it('starts false before any sign-in attempt', () => {
+      const { args } = buildArgs();
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      expect(result.current.isNavigating).toBe(false);
+    });
+
+    it('is raised and left set on the no-password committed-success path', async () => {
+      const { args } = buildArgs();
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+      expect(result.current.isNavigating).toBe(true);
+    });
+
+    it('is not raised when handleNavigation returns an error, so the form stays rendered', async () => {
+      (handleNavigation as jest.Mock).mockResolvedValue({
+        error: new Error('OAuth completion failed'),
+      });
+      const { args } = buildArgs();
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+      expect(result.current.isNavigating).toBe(false);
+      expect(result.current.errorBanner).toBeDefined();
+    });
+
+    it('is raised before routing to the password step when keys are required', async () => {
+      const { args, spies } = buildArgs({
+        integration: {
+          isSync: () => true,
+          isFirefoxNonSync: () => false,
+          requiresPasswordForLogin: () => true,
+          getService: () => 'sync',
+          type: IntegrationType.OAuthNative,
+          data: {},
+        } as unknown as PasskeySignInIntegration,
+      });
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+      expect(spies.navigateWithQuery).toHaveBeenCalledWith(
+        '/signin_passkey_fallback',
+        { state: { passkeySurface: 'emailfirst' } }
+      );
+      expect(result.current.isNavigating).toBe(true);
+    });
+
+    it('stays raised on the Firefox mobile WebChannel handoff, where no navigation is performed', async () => {
+      const { args } = buildArgs({
+        integration: {
+          isSync: () => false,
+          isFirefoxNonSync: () => true,
+          requiresPasswordForLogin: () => false,
+          getService: () => 'vpn',
+          getClientId: () => 'service-id',
+          isFirefoxMobileClient: () => true,
+          type: IntegrationType.OAuthNative,
+          data: {},
+        } as unknown as PasskeySignInIntegration,
+      });
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+      expect(result.current.isNavigating).toBe(true);
+    });
+
+    it('is not raised when the ceremony is cancelled', async () => {
+      (getCredential as jest.Mock).mockRejectedValue(
+        new DOMException('cancelled', 'NotAllowedError')
+      );
+      const { args } = buildArgs();
+      const { result } = renderHook(() => usePasskeySignIn(args), { wrapper });
+      await act(async () => {
+        await result.current.onClick();
+      });
+      expect(result.current.isNavigating).toBe(false);
+    });
+  });
+
   it('shows the "passkey not recognized" banner on errno PASSKEY_NOT_FOUND', async () => {
     const { args, spies } = buildArgs();
     spies.completePasskeyAuthentication.mockRejectedValue(

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -230,6 +230,8 @@ export interface UsePasskeySignInArgs {
 
 export interface UsePasskeySignInResult {
   isLoading: boolean;
+  /** Verification succeeded and navigation is pending. Never raised on an error. */
+  isNavigating: boolean;
   errorBanner: React.ReactNode | undefined;
   onClick: () => Promise<void>;
 }
@@ -258,6 +260,7 @@ export function usePasskeySignIn({
   supportsKeysOptionalLogin,
 }: UsePasskeySignInArgs): UsePasskeySignInResult {
   const [isLoading, setIsLoading] = useState(false);
+  const [isNavigating, setIsNavigating] = useState(false);
   const [banner, setBanner] = useState<PasskeyBannerState | undefined>();
   const inFlight = useRef(false);
   const navigate = useNavigate();
@@ -367,6 +370,7 @@ export function usePasskeySignIn({
     const finish = () => {
       inFlight.current = false;
       setIsLoading(false);
+      setIsNavigating(false);
     };
     const setUnexpectedError = () =>
       setLocalizedError(
@@ -511,6 +515,7 @@ export function usePasskeySignIn({
         const fallbackPath = completion.hasPassword
           ? '/signin_passkey_fallback'
           : '/post_verify/set_password';
+        setIsNavigating(true);
         // Thread the passkey context so the destination page can tag its Glean
         // events with the originating surface.
         navigateWithQuery(fallbackPath, {
@@ -555,11 +560,11 @@ export function usePasskeySignIn({
       if (navError) {
         Sentry.captureException(navError);
         setUnexpectedError();
+        finish();
       } else {
-        // Terminal success for the no-password-needed branch: WebAuthn
-        // ceremony verified, no Sync password step required, navigation
-        // completed cleanly. Fire the consolidated success event with the
-        // appropriate `<surface>_nopassword` reason for Looker funnels.
+        // Deliberately not finish()'d — the loading state must survive the hard
+        // redirect or WebChannel handoff as this component unmounts.
+        setIsNavigating(true);
         GleanMetrics.passkey.authSuccess({
           event: {
             reason: buildPasskeyAuthSuccessReason(
@@ -569,7 +574,6 @@ export function usePasskeySignIn({
           },
         });
       }
-      finish();
     } catch (err) {
       const errno = (err as { errno?: number })?.errno;
       if (errno === AuthUiErrors.PASSKEY_NOT_FOUND.errno) {
@@ -608,5 +612,5 @@ export function usePasskeySignIn({
     supportsKeysOptionalLogin,
   ]);
 
-  return { isLoading, errorBanner, onClick };
+  return { isLoading, isNavigating, errorBanner, onClick };
 }

--- a/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
+++ b/packages/fxa-settings/src/lib/passkeys/signin-flow.ts
@@ -230,6 +230,12 @@ export interface UsePasskeySignInArgs {
 
 export interface UsePasskeySignInResult {
   isLoading: boolean;
+  /**
+   * True once verification has succeeded and navigation/handoff is pending —
+   * raised only on the committed-success path (never on an error), so surfaces
+   * can show a page-level loading state without wiping the form on a failure.
+   */
+  isNavigating: boolean;
   errorBanner: React.ReactNode | undefined;
   onClick: () => Promise<void>;
 }
@@ -258,6 +264,7 @@ export function usePasskeySignIn({
   supportsKeysOptionalLogin,
 }: UsePasskeySignInArgs): UsePasskeySignInResult {
   const [isLoading, setIsLoading] = useState(false);
+  const [isNavigating, setIsNavigating] = useState(false);
   const [banner, setBanner] = useState<PasskeyBannerState | undefined>();
   const inFlight = useRef(false);
   const navigate = useNavigate();
@@ -367,6 +374,7 @@ export function usePasskeySignIn({
     const finish = () => {
       inFlight.current = false;
       setIsLoading(false);
+      setIsNavigating(false);
     };
     const setUnexpectedError = () =>
       setLocalizedError(
@@ -511,6 +519,10 @@ export function usePasskeySignIn({
         const fallbackPath = completion.hasPassword
           ? '/signin_passkey_fallback'
           : '/post_verify/set_password';
+        // Committed navigation to the password step — raise the page-level
+        // loading state so the surface shows a spinner through the soft nav
+        // rather than a reverted button.
+        setIsNavigating(true);
         // Thread the passkey context so the destination page can tag its Glean
         // events with the originating surface.
         navigateWithQuery(fallbackPath, {
@@ -553,13 +565,19 @@ export function usePasskeySignIn({
       });
 
       if (navError) {
+        // No page-level loading state was raised — the button held the
+        // loading state during the await. Re-enable the form and surface the
+        // banner in place; no page swap.
         Sentry.captureException(navError);
         setUnexpectedError();
+        finish();
       } else {
-        // Terminal success for the no-password-needed branch: WebAuthn
-        // ceremony verified, no Sync password step required, navigation
-        // completed cleanly. Fire the consolidated success event with the
-        // appropriate `<surface>_nopassword` reason for Looker funnels.
+        // Navigation completed cleanly. Keep the page-level loading state
+        // raised — deliberately not finish()'d — to cover the possibly-hard
+        // redirect or WebChannel handoff while this component is torn down,
+        // mirroring Signin/index.tsx's success path. Then fire the consolidated
+        // `<surface>_nopassword` success event for Looker.
+        setIsNavigating(true);
         GleanMetrics.passkey.authSuccess({
           event: {
             reason: buildPasskeyAuthSuccessReason(
@@ -569,7 +587,6 @@ export function usePasskeySignIn({
           },
         });
       }
-      finish();
     } catch (err) {
       const errno = (err as { errno?: number })?.errno;
       if (errno === AuthUiErrors.PASSKEY_NOT_FOUND.errno) {
@@ -608,5 +625,5 @@ export function usePasskeySignIn({
     supportsKeysOptionalLogin,
   ]);
 
-  return { isLoading, errorBanner, onClick };
+  return { isLoading, isNavigating, errorBanner, onClick };
 }

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -76,6 +76,10 @@ export const Index = ({
     passkey.onClick();
   };
 
+  // While a submit or passkey ceremony is in flight, disable the other sign-in
+  // options so a competing attempt can't race the one already running.
+  const authInProgress = isSubmitting || passkey.isLoading;
+
   const legalTerms = integration.getLegalTerms();
 
   const emailEngageEventEmitted = useRef(false);
@@ -133,7 +137,10 @@ export const Index = ({
   const splitLayout = cmsInfo?.EmailFirstPage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       {cmsInfo ? (
         <>
           <CmsLogo
@@ -223,7 +230,7 @@ export const Index = ({
               className="cta-primary cta-xl"
               type="submit"
               data-glean-id="email_first_submit"
-              disabled={isSubmitting}
+              disabled={authInProgress}
               buttonColor={cmsInfo?.shared.buttonColor}
               buttonText={cmsInfo?.EmailFirstPage.primaryButtonText}
             >
@@ -253,6 +260,7 @@ export const Index = ({
             : undefined
         }
         errorBanner={showPasskeySignin ? passkey.errorBanner : undefined}
+        disabled={authInProgress}
         viewName="index"
         flowQueryParams={flowQueryParams}
       />

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -76,6 +76,8 @@ export const Index = ({
     passkey.onClick();
   };
 
+  const authInProgress = isSubmitting || passkey.isLoading;
+
   const legalTerms = integration.getLegalTerms();
 
   const emailEngageEventEmitted = useRef(false);
@@ -133,7 +135,10 @@ export const Index = ({
   const splitLayout = cmsInfo?.EmailFirstPage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       {cmsInfo ? (
         <>
           <CmsLogo
@@ -223,7 +228,7 @@ export const Index = ({
               className="cta-primary cta-xl"
               type="submit"
               data-glean-id="email_first_submit"
-              disabled={isSubmitting}
+              disabled={authInProgress}
               buttonColor={cmsInfo?.shared.buttonColor}
               buttonText={cmsInfo?.EmailFirstPage.primaryButtonText}
             >
@@ -253,6 +258,7 @@ export const Index = ({
             : undefined
         }
         errorBanner={showPasskeySignin ? passkey.errorBanner : undefined}
+        disabled={authInProgress}
         viewName="index"
         flowQueryParams={flowQueryParams}
       />

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as ReactUtils from 'fxa-react/lib/utils';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { usePageViewEvent } from '../../../lib/metrics';
@@ -238,6 +238,83 @@ describe('SigninPasswordlessCode page', () => {
       (isWebAuthnSupported as jest.Mock).mockReturnValue(false);
       renderWithPasskeyFlags({ isSignup: false, hasPasskey: true });
       expect(passkeyButton()).not.toBeInTheDocument();
+    });
+  });
+
+  describe('passkey / OTP form-lock', () => {
+    const renderWithPasskey = (
+      props: Partial<SigninPasswordlessCodeProps> & { isSignup?: boolean } = {}
+    ) => {
+      (isWebAuthnSupported as jest.Mock).mockReturnValue(true);
+      const context = mockAppContext({ authClient: mockAuthClient });
+      if (context.config) {
+        context.config.featureFlags = {
+          ...context.config.featureFlags,
+          passkeysEnabled: true,
+          passkeyAuthenticationEnabled: true,
+        };
+      }
+      renderWithLocalizationProvider(
+        <AppContext.Provider value={context}>
+          <Subject
+            integration={createMockSigninWebIntegration()}
+            hasPasskey={true}
+            isSignup={false}
+            {...props}
+          />
+        </AppContext.Provider>
+      );
+    };
+    const passkeyButton = () =>
+      screen.getByRole('button', { name: 'Sign in with passkey' });
+
+    it('disables the passkey button and resend while an OTP code is being verified', async () => {
+      let resolveConfirm: (value: unknown) => void = () => {};
+      mockAuthClient.passwordlessConfirmCode = jest.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveConfirm = resolve;
+        })
+      );
+      const user = userEvent.setup();
+      renderWithPasskey();
+
+      await user.type(
+        screen.getByLabelText('Enter 6-digit code'),
+        MOCK_PASSWORDLESS_CODE
+      );
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      expect(passkeyButton()).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: 'Email new code.' })
+      ).toBeDisabled();
+
+      // Settle the pending submission so the test leaves no dangling act.
+      await act(async () => {
+        resolveConfirm({
+          uid: MOCK_UID,
+          sessionToken: MOCK_SESSION_TOKEN,
+          verified: true,
+          authAt: 1,
+        });
+      });
+    });
+
+    it('re-enables the passkey button after a failed OTP submission (finally releases the lock)', async () => {
+      mockAuthClient.passwordlessConfirmCode = jest
+        .fn()
+        .mockRejectedValue(AuthUiErrors.INVALID_VERIFICATION_CODE);
+      const user = userEvent.setup();
+      renderWithPasskey();
+
+      await user.type(
+        screen.getByLabelText('Enter 6-digit code'),
+        MOCK_PASSWORDLESS_CODE
+      );
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      await screen.findByTestId('tooltip');
+      expect(passkeyButton()).toBeEnabled();
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -113,6 +113,8 @@ const SigninPasswordlessCode = ({
   const [resendCountdown, setResendCountdown] = useState<number>(
     resendCountdownSeconds
   );
+  // Mirrors FormVerifyCode's internal submit state, which it doesn't expose.
+  const [otpSubmitting, setOtpSubmitting] = useState<boolean>(false);
   const throttle = useThrottle();
 
   const gleanOtp = isSignup
@@ -480,6 +482,17 @@ const SigninPasswordlessCode = ({
     }
   };
 
+  const handleVerifyCode = async (code: string) => {
+    setOtpSubmitting(true);
+    try {
+      await onSubmit(code);
+    } finally {
+      setOtpSubmitting(false);
+    }
+  };
+
+  const authInProgress = otpSubmitting || passkey.isLoading;
+
   const cmsInfo = integration?.getCmsInfo();
   //TODO: Signup/SigninPasswordlessCodePage to be added as part of FXA-13020
   const {
@@ -519,7 +532,10 @@ const SigninPasswordlessCode = ({
   };
 
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       <CardHeader
         headingText="Enter confirmation code"
         headingAndSubheadingFtlId="signin-passwordless-code-heading"
@@ -593,7 +609,7 @@ const SigninPasswordlessCode = ({
         {...{
           formAttributes,
           viewName,
-          verifyCode: onSubmit,
+          verifyCode: handleVerifyCode,
           localizedCustomCodeRequiredMessage,
           codeErrorMessage,
           setCodeErrorMessage,
@@ -609,6 +625,7 @@ const SigninPasswordlessCode = ({
           },
           className: `flex flex-col gap-4 mt-6 ${showPasskeySignin ? 'mb-2' : 'mb-6'}`,
           isThrottled: throttle.isThrottled,
+          disabled: authInProgress,
         }}
       />
 
@@ -637,7 +654,9 @@ const SigninPasswordlessCode = ({
             <button
               className="link-blue"
               onClick={handleResendCode}
-              disabled={resendCodeLoading || throttle.isThrottled}
+              disabled={
+                resendCodeLoading || throttle.isThrottled || authInProgress
+              }
             >
               Email new code.
             </button>
@@ -654,6 +673,7 @@ const SigninPasswordlessCode = ({
             onClick: passkey.onClick,
           }}
           errorBanner={passkey.errorBanner}
+          disabled={authInProgress}
           {...{ viewName, flowQueryParams }}
         />
       )}

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -113,6 +113,10 @@ const SigninPasswordlessCode = ({
   const [resendCountdown, setResendCountdown] = useState<number>(
     resendCountdownSeconds
   );
+  // Tracks the OTP submission so the passkey option can be locked while a code
+  // is being verified (FormVerifyCode owns its own submit state, so mirror it
+  // here via the verifyCode wrapper below).
+  const [otpSubmitting, setOtpSubmitting] = useState<boolean>(false);
   const throttle = useThrottle();
 
   const gleanOtp = isSignup
@@ -480,6 +484,21 @@ const SigninPasswordlessCode = ({
     }
   };
 
+  // Wraps onSubmit so the surface can observe OTP submission without reaching
+  // into FormVerifyCode's internal submit state.
+  const handleVerifyCode = async (code: string) => {
+    setOtpSubmitting(true);
+    try {
+      await onSubmit(code);
+    } finally {
+      setOtpSubmitting(false);
+    }
+  };
+
+  // While a submit or passkey ceremony is in flight, disable the other sign-in
+  // options so a competing attempt can't race the one already running.
+  const authInProgress = otpSubmitting || passkey.isLoading;
+
   const cmsInfo = integration?.getCmsInfo();
   //TODO: Signup/SigninPasswordlessCodePage to be added as part of FXA-13020
   const {
@@ -519,7 +538,10 @@ const SigninPasswordlessCode = ({
   };
 
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       <CardHeader
         headingText="Enter confirmation code"
         headingAndSubheadingFtlId="signin-passwordless-code-heading"
@@ -593,7 +615,7 @@ const SigninPasswordlessCode = ({
         {...{
           formAttributes,
           viewName,
-          verifyCode: onSubmit,
+          verifyCode: handleVerifyCode,
           localizedCustomCodeRequiredMessage,
           codeErrorMessage,
           setCodeErrorMessage,
@@ -609,6 +631,7 @@ const SigninPasswordlessCode = ({
           },
           className: `flex flex-col gap-4 mt-6 ${showPasskeySignin ? 'mb-2' : 'mb-6'}`,
           isThrottled: throttle.isThrottled,
+          disabled: authInProgress,
         }}
       />
 
@@ -637,7 +660,9 @@ const SigninPasswordlessCode = ({
             <button
               className="link-blue"
               onClick={handleResendCode}
-              disabled={resendCodeLoading || throttle.isThrottled}
+              disabled={
+                resendCodeLoading || throttle.isThrottled || authInProgress
+              }
             >
               Email new code.
             </button>
@@ -654,6 +679,7 @@ const SigninPasswordlessCode = ({
             onClick: passkey.onClick,
           }}
           errorBanner={passkey.errorBanner}
+          disabled={authInProgress}
           {...{ viewName, flowQueryParams }}
         />
       )}

--- a/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
@@ -97,8 +97,13 @@ const SigninAlternativeAuthOptions = ({
     GleanMetrics.login.alternativeAuthView();
   }, []);
 
+  const authInProgress = passkey.isLoading;
+
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       {(localizedSuccessBannerHeading || localizedSuccessBannerDescription) && (
         <Banner
           type="success"
@@ -149,6 +154,7 @@ const SigninAlternativeAuthOptions = ({
             : undefined
         }
         errorBanner={showPasskeySignin ? passkey.errorBanner : undefined}
+        disabled={authInProgress}
         {...{ viewName, flowQueryParams }}
       />
 

--- a/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.tsx
@@ -97,8 +97,15 @@ const SigninAlternativeAuthOptions = ({
     GleanMetrics.login.alternativeAuthView();
   }, []);
 
+  // The passkey ceremony is the only in-flight sign-in method here (third-party
+  // auth just redirects); lock the options while it runs.
+  const authInProgress = passkey.isLoading;
+
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       {(localizedSuccessBannerHeading || localizedSuccessBannerDescription) && (
         <Banner
           type="success"
@@ -149,6 +156,7 @@ const SigninAlternativeAuthOptions = ({
             : undefined
         }
         errorBanner={showPasskeySignin ? passkey.errorBanner : undefined}
+        disabled={authInProgress}
         {...{ viewName, flowQueryParams }}
       />
 

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -265,6 +265,38 @@ describe('Signin component', () => {
       render({ hasPasskey: true });
       expect(passkeyButton()).not.toBeInTheDocument();
     });
+
+    it('keeps the passkey button enabled after a failed password attempt (only the submit button stays disabled)', async () => {
+      const beginSigninHandler = jest.fn().mockReturnValueOnce(
+        createBeginSigninResponseError({
+          errno: AuthUiErrors.INCORRECT_PASSWORD.errno,
+        })
+      );
+      render({ hasPasskey: true, beginSigninHandler });
+
+      await enterPasswordAndSubmit();
+
+      await waitFor(() => {
+        expect(passkeyButton()).toBeEnabled();
+      });
+      expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+    });
+
+    it('releases the passkey lock and surfaces an error when the sign-in handler throws', async () => {
+      const beginSigninHandler = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('network'));
+      render({ hasPasskey: true, beginSigninHandler });
+
+      await enterPasswordAndSubmit();
+
+      await waitFor(() => {
+        expect(passkeyButton()).toBeEnabled();
+      });
+      expect(GleanMetrics.login.error).toHaveBeenCalledWith({
+        event: { reason: 'network' },
+      });
+    });
   });
 
   describe('without sessionToken', () => {

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -265,6 +265,25 @@ describe('Signin component', () => {
       render({ hasPasskey: true });
       expect(passkeyButton()).not.toBeInTheDocument();
     });
+
+    it('keeps the passkey button enabled after a failed password attempt (only the submit button stays disabled)', async () => {
+      const beginSigninHandler = jest.fn().mockReturnValueOnce(
+        createBeginSigninResponseError({
+          errno: AuthUiErrors.INCORRECT_PASSWORD.errno,
+        })
+      );
+      render({ hasPasskey: true, beginSigninHandler });
+
+      await enterPasswordAndSubmit();
+
+      // The failed password must not strand the alternative option: the passkey
+      // button stays clickable, while the submit button keeps its own disabled
+      // state until the field is edited.
+      await waitFor(() => {
+        expect(passkeyButton()).toBeEnabled();
+      });
+      expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+    });
   });
 
   describe('without sessionToken', () => {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -98,6 +98,9 @@ const Signin = ({
   const [passwordTooltipErrorText, setPasswordTooltipErrorText] =
     useState<string>('');
   const [signinLoading, setSigninLoading] = useState<boolean>(false);
+  // Unlike signinLoading, which lingers after an error until the field is edited.
+  const [signinAttemptInFlight, setSigninAttemptInFlight] =
+    useState<boolean>(false);
   const [hasEngaged, setHasEngaged] = useState<boolean>(false);
 
   const isOAuthNative = isOAuthNativeIntegration(integration);
@@ -153,120 +156,134 @@ const Signin = ({
       GleanMetrics.login.submit();
 
       setSigninLoading(true);
-      const { data, error } = await beginSigninHandler(email, password);
+      setSigninAttemptInFlight(true);
+      try {
+        const { data, error } = await beginSigninHandler(email, password);
 
-      if (data) {
-        GleanMetrics.login.success();
+        if (data) {
+          GleanMetrics.login.success();
 
-        const isFullyVerified =
-          data.signIn.emailVerified && data.signIn.sessionVerified;
-        const navigationOptions = {
-          navigate,
-          email,
-          signinData: data.signIn,
-          unwrapBKey: data.unwrapBKey,
-          integration,
-          finishOAuthFlowHandler,
-          redirectTo:
-            isWebIntegration(integration) && webRedirectCheck?.isValid
-              ? integration.data.redirectTo
-              : '',
-          queryParams: location.search,
-          showInlineRecoveryKeySetup: data.showInlineRecoveryKeySetup,
-          handleFxaLogin: true,
-          handleFxaOAuthLogin: true,
-          performNavigation: !(
-            integration.isFirefoxMobileClient() && isFullyVerified
-          ),
-          isServiceWithEmailVerification,
-          authClient,
-        };
+          const isFullyVerified =
+            data.signIn.emailVerified && data.signIn.sessionVerified;
+          const navigationOptions = {
+            navigate,
+            email,
+            signinData: data.signIn,
+            unwrapBKey: data.unwrapBKey,
+            integration,
+            finishOAuthFlowHandler,
+            redirectTo:
+              isWebIntegration(integration) && webRedirectCheck?.isValid
+                ? integration.data.redirectTo
+                : '',
+            queryParams: location.search,
+            showInlineRecoveryKeySetup: data.showInlineRecoveryKeySetup,
+            handleFxaLogin: true,
+            handleFxaOAuthLogin: true,
+            performNavigation: !(
+              integration.isFirefoxMobileClient() && isFullyVerified
+            ),
+            isServiceWithEmailVerification,
+            authClient,
+          };
 
-        const { error: navError } = await handleNavigation(navigationOptions);
-        if (navError) {
-          setLocalizedBannerError(
-            getLocalizedErrorMessage(ftlMsgResolver, navError)
-          );
-        }
-      }
-      if (error) {
-        GleanMetrics.login.error({ event: { reason: error.message } });
-        const { errno } = error;
-
-        if (
-          errno === AuthUiErrors.PASSWORD_REQUIRED.errno ||
-          errno === AuthUiErrors.INCORRECT_PASSWORD.errno
-        ) {
-          setLocalizedBannerError('');
-          setLocalizedBannerErrorDescription('');
-          setLocalizedBannerErrorLink(undefined);
-          setPasswordTooltipErrorText(
-            getLocalizedErrorMessage(ftlMsgResolver, error)
-          );
-        } else {
-          switch (errno) {
-            case AuthUiErrors.THROTTLED.errno:
-            case AuthUiErrors.REQUEST_BLOCKED.errno:
-              const { localizedErrorMessage } =
-                await sendUnblockEmailHandler(email);
-              if (localizedErrorMessage) {
-                // Sending the unblock email could itself be rate limited.
-                // If it is, the error should be displayed on this screen
-                // and the user shouldn't even have the chance to continue.
-                setLocalizedBannerError(localizedErrorMessage);
-                setSigninLoading(false);
-                break;
-              }
-
-              // Store password to be used in another component
-              sensitiveDataClient.setDataType(SensitiveData.Key.Password, {
-                plainTextPassword: password,
-              });
-              // navigate only if sending the unblock code email is successful
-              navigateWithQuery('/signin_unblock', {
-                state: {
-                  email,
-                  // TODO: in FXA-9177, consider persisting hasLinkedAccount and hasPassword to localStorage
-                  hasPassword,
-                  hasLinkedAccount,
-                },
-              });
-              break;
-            case AuthUiErrors.EMAIL_HARD_BOUNCE.errno:
-            case AuthUiErrors.EMAIL_SENT_COMPLAINT.errno:
-              navigateWithQuery('/signin_bounced');
-              break;
-            case AuthUiErrors.ACCOUNT_RESET.errno:
-              setLocalizedBannerError(
-                ftlMsgResolver.getMsg(
-                  'signin-account-locked-banner-heading',
-                  'Reset your password'
-                )
-              );
-              setLocalizedBannerErrorDescription(
-                ftlMsgResolver.getMsg(
-                  'signin-account-locked-banner-description',
-                  'We locked your account to keep it safe from suspicious activity.'
-                )
-              );
-              setLocalizedBannerErrorLink({
-                path: `/reset_password?email=${email}`,
-                localizedText: ftlMsgResolver.getMsg(
-                  'signin-account-locked-banner-link',
-                  'Reset your password to sign in'
-                ),
-                gleanId: 'login_locked_account_banner_link',
-              });
-              GleanMetrics.login.lockedAccountBannerView();
-              break;
-            default:
-              setLocalizedBannerError(
-                getLocalizedErrorMessage(ftlMsgResolver, error)
-              );
-              setSigninLoading(false);
-              break;
+          const { error: navError } = await handleNavigation(navigationOptions);
+          if (navError) {
+            setLocalizedBannerError(
+              getLocalizedErrorMessage(ftlMsgResolver, navError)
+            );
+            setSigninAttemptInFlight(false);
           }
         }
+        if (error) {
+          setSigninAttemptInFlight(false);
+          GleanMetrics.login.error({ event: { reason: error.message } });
+          const { errno } = error;
+
+          if (
+            errno === AuthUiErrors.PASSWORD_REQUIRED.errno ||
+            errno === AuthUiErrors.INCORRECT_PASSWORD.errno
+          ) {
+            setLocalizedBannerError('');
+            setLocalizedBannerErrorDescription('');
+            setLocalizedBannerErrorLink(undefined);
+            setPasswordTooltipErrorText(
+              getLocalizedErrorMessage(ftlMsgResolver, error)
+            );
+          } else {
+            switch (errno) {
+              case AuthUiErrors.THROTTLED.errno:
+              case AuthUiErrors.REQUEST_BLOCKED.errno:
+                const { localizedErrorMessage } =
+                  await sendUnblockEmailHandler(email);
+                if (localizedErrorMessage) {
+                  // Sending the unblock email could itself be rate limited.
+                  // If it is, the error should be displayed on this screen
+                  // and the user shouldn't even have the chance to continue.
+                  setLocalizedBannerError(localizedErrorMessage);
+                  setSigninLoading(false);
+                  break;
+                }
+
+                // Store password to be used in another component
+                sensitiveDataClient.setDataType(SensitiveData.Key.Password, {
+                  plainTextPassword: password,
+                });
+                // navigate only if sending the unblock code email is successful
+                navigateWithQuery('/signin_unblock', {
+                  state: {
+                    email,
+                    // TODO: in FXA-9177, consider persisting hasLinkedAccount and hasPassword to localStorage
+                    hasPassword,
+                    hasLinkedAccount,
+                  },
+                });
+                break;
+              case AuthUiErrors.EMAIL_HARD_BOUNCE.errno:
+              case AuthUiErrors.EMAIL_SENT_COMPLAINT.errno:
+                navigateWithQuery('/signin_bounced');
+                break;
+              case AuthUiErrors.ACCOUNT_RESET.errno:
+                setLocalizedBannerError(
+                  ftlMsgResolver.getMsg(
+                    'signin-account-locked-banner-heading',
+                    'Reset your password'
+                  )
+                );
+                setLocalizedBannerErrorDescription(
+                  ftlMsgResolver.getMsg(
+                    'signin-account-locked-banner-description',
+                    'We locked your account to keep it safe from suspicious activity.'
+                  )
+                );
+                setLocalizedBannerErrorLink({
+                  path: `/reset_password?email=${email}`,
+                  localizedText: ftlMsgResolver.getMsg(
+                    'signin-account-locked-banner-link',
+                    'Reset your password to sign in'
+                  ),
+                  gleanId: 'login_locked_account_banner_link',
+                });
+                GleanMetrics.login.lockedAccountBannerView();
+                break;
+              default:
+                setLocalizedBannerError(
+                  getLocalizedErrorMessage(ftlMsgResolver, error)
+                );
+                setSigninLoading(false);
+                break;
+            }
+          }
+        }
+      } catch (err) {
+        // Either handler can reject rather than return `{ error }`; without this
+        // the lock would strand the other options until a reload.
+        GleanMetrics.login.error({
+          event: { reason: (err as Error)?.message ?? 'unexpected' },
+        });
+        setSigninAttemptInFlight(false);
+        setSigninLoading(false);
+        setLocalizedBannerError(getLocalizedErrorMessage(ftlMsgResolver, err));
       }
     },
     [
@@ -307,8 +324,14 @@ const Signin = ({
   const additionalAccessibilityInfo =
     cmsInfo?.shared.additionalAccessibilityInfo;
 
+  const signinButtonLocked = signinLoading || passkey.isLoading;
+  const alternativesLocked = signinAttemptInFlight || passkey.isLoading;
+
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       {(localizedSuccessBannerHeading || localizedSuccessBannerDescription) && (
         <Banner
           type="success"
@@ -382,7 +405,7 @@ const Signin = ({
           <FtlMsg id="signin-button">
             <CmsButtonWithFallback
               type="submit"
-              disabled={signinLoading}
+              disabled={signinButtonLocked}
               buttonColor={cmsInfo?.shared.buttonColor}
               buttonText={signinPageCms?.primaryButtonText}
             >
@@ -401,6 +424,7 @@ const Signin = ({
             : undefined
         }
         errorBanner={showPasskeySignin ? passkey.errorBanner : undefined}
+        disabled={alternativesLocked}
         {...{ viewName, flowQueryParams }}
       />
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -98,6 +98,12 @@ const Signin = ({
   const [passwordTooltipErrorText, setPasswordTooltipErrorText] =
     useState<string>('');
   const [signinLoading, setSigninLoading] = useState<boolean>(false);
+  // Separate from signinLoading (which lingers after an error to keep the
+  // submit button disabled until the field is edited): this tracks only whether
+  // a password attempt is actively in flight, so the alternative-auth options
+  // are released as soon as the attempt fails.
+  const [signinAttemptInFlight, setSigninAttemptInFlight] =
+    useState<boolean>(false);
   const [hasEngaged, setHasEngaged] = useState<boolean>(false);
 
   const isOAuthNative = isOAuthNativeIntegration(integration);
@@ -153,6 +159,7 @@ const Signin = ({
       GleanMetrics.login.submit();
 
       setSigninLoading(true);
+      setSigninAttemptInFlight(true);
       const { data, error } = await beginSigninHandler(email, password);
 
       if (data) {
@@ -187,9 +194,17 @@ const Signin = ({
           setLocalizedBannerError(
             getLocalizedErrorMessage(ftlMsgResolver, navError)
           );
+          // Stay on this page → release the alternative-auth lock so the user
+          // can try another method.
+          setSigninAttemptInFlight(false);
         }
       }
       if (error) {
+        // Release the alternative-auth lock as soon as the attempt fails, so a
+        // wrong password doesn't leave the passkey / third-party options
+        // disabled until the field is edited (signinLoading keeps the submit
+        // button itself disabled by design).
+        setSigninAttemptInFlight(false);
         GleanMetrics.login.error({ event: { reason: error.message } });
         const { errno } = error;
 
@@ -307,8 +322,20 @@ const Signin = ({
   const additionalAccessibilityInfo =
     cmsInfo?.shared.additionalAccessibilityInfo;
 
+  // The password submit stays disabled while its own attempt is settling
+  // (signinLoading lingers after an error until the field is edited) or a
+  // passkey ceremony is running.
+  const signinButtonLocked = signinLoading || passkey.isLoading;
+  // The alternative options lock only while an attempt is actively in flight —
+  // released on error (see signInWithPassword) so a failed password doesn't
+  // strand them — or while a passkey ceremony is running.
+  const alternativesLocked = signinAttemptInFlight || passkey.isLoading;
+
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
+    <AppLayout
+      {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}
+      loading={passkey.isNavigating}
+    >
       {(localizedSuccessBannerHeading || localizedSuccessBannerDescription) && (
         <Banner
           type="success"
@@ -382,7 +409,7 @@ const Signin = ({
           <FtlMsg id="signin-button">
             <CmsButtonWithFallback
               type="submit"
-              disabled={signinLoading}
+              disabled={signinButtonLocked}
               buttonColor={cmsInfo?.shared.buttonColor}
               buttonText={signinPageCms?.primaryButtonText}
             >
@@ -401,6 +428,7 @@ const Signin = ({
             : undefined
         }
         errorBanner={showPasskeySignin ? passkey.errorBanner : undefined}
+        disabled={alternativesLocked}
         {...{ viewName, flowQueryParams }}
       />
 


### PR DESCRIPTION
## Because

- After a passkey verification succeeded, the sign-in surface stayed on screen with no success indication while navigation was pending, and the passkey button reverted to a clickable state — which was confusing and invited unintended retries (first noticed on the email-first flow).
- While one sign-in method was in flight, the other options on the same surface stayed interactive, so a user could start a competing attempt and race the one already running.

## This pull request

- Adds an `isNavigating` state to `usePasskeySignIn` in `packages/fxa-settings/src/lib/passkeys/signin-flow.ts`, raised only on committed-success paths (never on an error), and passes `loading={passkey.isNavigating}` to `AppLayout` on all four passkey sign-in surfaces (`Index`, `Signin`, `SigninAlternativeAuthOptions`, `SigninPasswordlessCode`) so the page shows a spinner through navigation / the WebChannel handoff instead of a reverted button.
- Adds a bidirectional form-lock so each surface disables its other sign-in methods (password/OTP submit, third-party auth, passkey) while any one attempt is in flight, via new optional `disabled` props on `ButtonPasskeySignin`, `ThirdPartyAuth`, `AlternativeAuthOptions`, and `FormVerifyCode`.
- On the `Signin` page, tracks the password attempt separately (`signinAttemptInFlight`) so a failed password releases the passkey/third-party lock immediately, while the submit button keeps its existing disabled-until-edited behaviour.
- Releases the lock if `beginSigninHandler` or `handleNavigation` rejects instead of returning `{ error }`, so an unexpected network or key-stretching failure can't strand the passkey / third-party options until a reload.
- Adds unit tests for the new hook state, the `disabled` props on the shared components, and the Signin/OTP form-lock behaviour.

## Issue that this pull request solves

Closes: FXA-14267

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-settings/src/lib/passkeys/signin-flow.ts` — the `isNavigating` state machine and its error-path resets.
- Suggested review order: hook (`signin-flow.ts`) → shared components (`ButtonPasskeySignin`, `ThirdPartyAuth`, `AlternativeAuthOptions`, `FormVerifyCode`) → surfaces (`Index`, `Signin`, `SigninPasswordlessCode`, `SigninAlternativeAuthOptions`).
- Risky or complex parts: the hook's success-vs-error branching — `isNavigating` is set only after navigation is committed, and every cancel/error path routes through `finish()` to reset the loading/disabled state. Also `Signin`'s `try/catch` around the submit path — it's the one place the lock is released without a per-branch reset.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
