### PR TITLE
fix(payments): Flaky functional test

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
+++ b/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
@@ -64,5 +64,11 @@ export async function GET(
     logger.error('Failed to sign in', { error });
   }
 
-  redirect(redirectUrl ?? redirectToUrl.href);
+  // When signIn fails, redirect to the content server for a full login
+  // instead of back to the manage page — that would create a redirect loop
+  // (manage detects no session → landing → signIn fails → manage → …).
+  redirect(
+    redirectUrl ??
+      `${config.contentServerUrl}/subscriptions${request.nextUrl.search}`
+  );
 }

--- a/packages/functional-tests/tests-payments-next/smoke-tests.spec.ts
+++ b/packages/functional-tests/tests-payments-next/smoke-tests.spec.ts
@@ -34,6 +34,11 @@ test.describe('severity-1 #smoke', () => {
     page,
   }) => {
     await page.goto(`${target.paymentsNextUrl}/subscriptions/manage`);
-    await expect(page).toHaveURL(new RegExp(target.contentServerUrl));
+    // The redirect chain may involve an OAuth prompt=none roundtrip
+    // (manage → landing → auth server → callback → content server),
+    // so allow extra time for the final URL to settle.
+    await expect(page).toHaveURL(new RegExp(target.contentServerUrl), {
+      timeout: 30_000,
+    });
   });
 });


### PR DESCRIPTION
## Because

While Payments functional tests pass in nightly, the following test is deemed as flaky: `tests-payments-next/smoke-tests.spec.ts: unauthenticated /subscriptions/manage redirects to FXA sign-in`
[https://app.circleci.com/pipelines/github/mozilla/fxa/71836/workflows/82bb8bcb-0467-4746-8fb3-14dcf5e9787f/jobs/693098](https://app.circleci.com/pipelines/github/mozilla/fxa/71836/workflows/82bb8bcb-0467-4746-8fb3-14dcf5e9787f/jobs/693098)

## This pull request

- Fixes landing route, so the fallback redirect now goes to `${config.contentServerUrl}/subscriptions` instead of back to manage - breaking the redirect loop
- Fixes Smoke test by bumping toHaveURL timeout to 30s for the longer OAuth redirect chain

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
## Screenshots (Optional)
<img width="1057" height="380" alt="Screenshot 2026-07-29 at 11 57 01 AM" src="https://github.com/user-attachments/assets/bb76e297-cfe9-49c3-be45-f538d61665f8" />