### PR TITLE
fix(functional-tests): assert help link href instead of opening it

### DIFF
--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { BaseLayout } from '../layout';
 
 export abstract class SettingsLayout extends BaseLayout {
@@ -74,14 +74,6 @@ export abstract class SettingsLayout extends BaseLayout {
 
   clickChangePassword() {
     return this.page.locator('[data-testid=password-unit-row-route]').click();
-  }
-
-  async clickHelp(): Promise<Page> {
-    const pagePromise = this.page.context().waitForEvent('page');
-    await this.helpLink.click();
-    const newPage = await pagePromise;
-    await newPage.waitForLoadState();
-    return newPage;
   }
 
   async signOut() {

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -18,9 +18,14 @@ test.describe('severity-1 #smoke', () => {
     await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
-    const helpPage = await settings.clickHelp();
 
-    expect(helpPage.url()).toContain('https://support.mozilla.org');
+    // Assert the href rather than opening the link. support.mozilla.org is
+    // behind Fastly, which rate limits CI egress IPs with a 429 and a 600s
+    // retry-after, and the error response never fires a 'load' event.
+    await expect(settings.helpLink).toHaveAttribute(
+      'href',
+      /^https:\/\/support\.mozilla\.org/
+    );
   });
 });
 


### PR DESCRIPTION
## Because

- The `settings help link` smoke test opened `support.mozilla.org` for real. SUMO sits behind Fastly, which rate limits CI egress IPs with HTTP 429 and `retry-after: 600`.

## This pull request

- Asserts the anchor's `href` via `toHaveAttribute` in `misc.spec.ts`, so the test issues no external request at all.
- Removes the now-unused `clickHelp()` from `layout.ts` and the `Page` import it orphaned.
- Follows the pattern already used in `firefoxPromoBanner.spec.ts`, which asserts external link hrefs without navigating.

## Issue that this pull request solves

Closes: N/A — no Jira ticket filed

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information