### PR TITLE
bug(settings): Continue with firefox in POC was always directing to app store

### DIFF
--- a/packages/fxa-settings/src/pages/PocPairInit/index.tsx
+++ b/packages/fxa-settings/src/pages/PocPairInit/index.tsx
@@ -2,6 +2,46 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*
+ * FXA-13863 — Deep-link proof of concept (THROWAWAY). See PocDeepLink for the
+ * QR harness that feeds this page.
+ *
+ * iOS findings, recorded here because they constrain the whole flow:
+ *
+ * 1. The app hand-off MUST be a top-level, user-initiated navigation. WebKit
+ *    ignores external-scheme navigations made from a subframe, so the hidden
+ *    iframe this page used previously never launched anything on iOS — and the
+ *    store-fallback timer then fired and sent users with Firefox *installed* to
+ *    the App Store. We now put the deep link in the CTA's `href` so the tap
+ *    itself is the navigation.
+ *
+ * 2. The "address is invalid" alert cannot be suppressed with a custom scheme.
+ *    When Firefox isn't installed, `firefox://` raises it, and no API reports it.
+ *    Universal Links are the only alert-free mechanism, and they don't work yet:
+ *    we serve accounts.firefox.com's apple-app-site-association claiming `/pair`,
+ *    `/pair/*` and `/poc_deep_link` (see
+ *    fxa-content-server/server/lib/routes/get-apple-app-site-association.js), but
+ *    Universal Links are a two-sided handshake and Firefox iOS ships
+ *    `com.apple.developer.associated-domains` as an EMPTY array — no
+ *    `applinks:accounts.firefox.com` on the app side, in any build flavor. Until
+ *    the app adds it (mobile-side work, FXA-13732), our AASA entries are inert.
+ *
+ * 3. The store fallback is therefore inferred, not detected: we treat "the page
+ *    never went hidden" as "the app never opened". The trap is that iOS hands
+ *    focus back to the page when the "Open in Firefox?" dialog is confirmed, a
+ *    beat BEFORE it backgrounds Safari — so regained focus can only *start* a
+ *    grace window, never trigger the redirect. See `armStoreFallback`.
+ *
+ *    Known limitation: a *cancelled* "Open in Firefox?" confirmation is
+ *    genuinely indistinguishable from the error alert — both are blur → focus
+ *    with nothing following — so cancelling sends a user who *has* Firefox to the
+ *    App Store. That's why the redirect uses assign() and not replace(): Back
+ *    returns here so they can retry.
+ *
+ * This mirrors the Android situation noted at `deepLink` below: the no-chooser /
+ * no-alert path on both platforms is verified app links, which is app-side work.
+ */
+
 import React, { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router';
 import AppLayout from '../../components/AppLayout';
@@ -13,7 +53,13 @@ import { useConfig } from '../../models';
 
 export const viewName = 'poc_pair_init';
 
-const DEFAULT_TIMEOUT_MS = 1500;
+// Backstop for a *silent* failure — no dialog, no launch. Override with `?timeout=`.
+const DEFAULT_TIMEOUT_MS = 2000;
+// How long we let the app switch win after focus comes back. Tapping "Open" on
+// iOS's "Open in Firefox?" dialog hands focus back to the page BEFORE Safari is
+// backgrounded, so focus alone must never redirect — see `armStoreFallback`.
+// Override with `?grace=` to tune on-device.
+const DEFAULT_GRACE_MS = 1000;
 const DEFAULT_CHANNEL_ID = 'pocChannelId00000000000000000000';
 const DEFAULT_CHANNEL_KEY = 'pocChannelKey0000000000000000000000000000000';
 
@@ -69,6 +115,7 @@ function readConfig(search: string) {
   const action = SAFE_ACTION.test(rawAction) ? rawAction : 'open-url';
 
   const timeout = Number(params.get('timeout')) || DEFAULT_TIMEOUT_MS;
+  const grace = Number(params.get('grace')) || DEFAULT_GRACE_MS;
 
   const sampleQuery = new URLSearchParams({
     channel_id: params.get('channel_id') || DEFAULT_CHANNEL_ID,
@@ -81,7 +128,7 @@ function readConfig(search: string) {
   const target =
     sameOriginHttpUrl(params.get('url') || defaultTarget, origin) || defaultTarget;
 
-  return { target, timeout, scheme, action, protocol };
+  return { target, timeout, grace, scheme, action, protocol };
 }
 
 type Status = 'redirecting' | 'prompt' | 'attempting' | 'desktop';
@@ -92,7 +139,7 @@ const PocPairInit = () => {
   const location = useLocation();
   const search =
     typeof window !== 'undefined' ? window.location.search : location.search;
-  const { target, timeout, scheme, action, protocol } = readConfig(search);
+  const { target, timeout, grace, scheme, action, protocol } = readConfig(search);
 
   const config = useConfig();
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
@@ -110,16 +157,18 @@ const PocPairInit = () => {
   // App Links (https + assetlinks.json + app autoVerify), which
   // cannot work in the local http setup, and must be done in a follow up. For
   // this POC, we will have to live the activity chooser when testing on local host.
-  const deepLink = isAndroid
-    ? `intent://${target.replace(/^https?:\/\//, '')}` +
-      `#Intent;scheme=${protocol};package=org.mozilla.firefox;` +
-      `S.browser_fallback_url=${encodeURIComponent(storeUrl)};end`
-    : `${scheme}://${action}?url=${encodeURIComponent(target)}`;
+  const deepLink = (() => {
+    if(isAndroid) {
+      return `intent://${target.replace(/^https?:\/\//, '')}#Intent;scheme=${protocol};package=org.mozilla.firefox;S.browser_fallback_url=${encodeURIComponent(storeUrl)};end`
+    }
+    return `${scheme}://${action}?url=${encodeURIComponent(target)}`
+  })()
 
   const [status, setStatus] = useState<Status>(
     isFirefox ? 'redirecting' : isMobile ? 'prompt' : 'desktop'
   );
-  // Ref so the visibility listener and the timer share one source of truth.
+  // Shared source of truth for "the app took the foreground", written by the
+  // visibility listeners and read by both store-fallback triggers.
   const appOpenedRef = useRef(false);
   // Holds the teardown for the in-flight attempt so we can clean up on unmount.
   const cleanupRef = useRef<(() => void) | null>(null);
@@ -135,77 +184,112 @@ const PocPairInit = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Triggered by a user gesture (button tap). Attaching the listeners and firing
-  // the deep link synchronously here preserves the user-activation that iOS needs
-  // to follow a custom scheme, and ensures the listeners are live before we fire.
-  const continueWithFirefox = () => {
+  /**
+   * Watch for the deep link failing and send the user to the store when it does.
+   *
+   * There is no API that reports "the custom scheme didn't resolve", so we infer
+   * it (finding 3 up top). The subtlety that makes this hard: iOS dismisses BOTH
+   * native dialogs the same way as far as the page can see.
+   *
+   *   not installed:  tap → blur ("address is invalid") → focus (tapped OK)
+   *                   → nothing else ever happens.
+   *   installed:      tap → blur ("Open in Firefox?") → focus (tapped Open!)
+   *                   → *then* Safari is backgrounded → blur + hidden.
+   *
+   * So the regained focus is NOT the decision point — it arrives on the happy
+   * path too, before iOS has backgrounded us. Redirecting there sent people who
+   * tapped "Open" to the App Store. Instead focus only opens a `grace` window,
+   * and any of hidden/pagehide/a second blur cancels it. Nothing left to cancel
+   * it by the time the window closes ⇒ the launch really did fail.
+   */
+  const armStoreFallback = () => {
     cleanupRef.current?.();
     appOpenedRef.current = false;
-    setStatus('attempting');
+    let sawBlur = false;
+    let sawFocus = false;
+    let graceTimer = 0;
 
-    // The store fallback differs by platform. On Android the intent:// URL's
-    // `S.browser_fallback_url` handles the not-installed case natively, so no JS
-    // fallback is needed. On iOS the custom scheme silently no-ops when Firefox
-    // isn't installed, so we watch for the app opening and, failing that within
-    // `timeout`, redirect to the App Store.
-    if (!isAndroid) {
-      // Primary signal: the page being hidden/backgrounded means Firefox took
-      // the foreground ⇒ cancel the store fallback.
-      //
-      // We deliberately do NOT listen for window `blur`. On Safari and Brave the
-      // custom-scheme confirmation ("Open in Firefox?") and the "Cannot Open
-      // Page" error dialog both steal focus and fire `blur` *before* anything
-      // actually launches — falsely marking the app as opened and suppressing
-      // the store fallback (so a not-installed user is stranded instead of sent
-      // to the store). visibilitychange/pagehide only fire on a real
-      // background/teardown, so they don't have that false positive.
-      const onHidden = () => {
-        if (document.hidden) {
-          appOpenedRef.current = true;
-        }
-      };
-      const onLeave = () => {
-        appOpenedRef.current = true;
-      };
-      document.addEventListener('visibilitychange', onHidden);
-      window.addEventListener('pagehide', onLeave);
-
-      // Timer callbacks are throttled/suspended while the page is backgrounded,
-      // so if Firefox actually opened this fires late (or only after we return).
-      // We check if the app never flagged as opened and the page is still visible.
-      // We removed the strict wall-clock elapsed check here because Safari's handling
-      // of custom schemes can throttle the timer loop unpredictably.
-      const timer = window.setTimeout(() => {
-        const neverLeft = !appOpenedRef.current && document.visibilityState === 'visible';
-
-        if (neverLeft) {
-          window.location.replace(storeUrl);
-        }
-      }, timeout);
-
-      cleanupRef.current = () => {
-        document.removeEventListener('visibilitychange', onHidden);
-        window.removeEventListener('pagehide', onLeave);
-        window.clearTimeout(timer);
-        cleanupRef.current = null;
-      };
-    }
-
-    // Fire the attempt within the gesture, after any listeners are attached.
-    // We route this through an invisible iframe instead of window.location.href.
-    // This allows Safari to test the protocol under the hood without triggering
-    // the destructive "Address is invalid" modal that blocks subsequent JS execution.
-    const iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
-    iframe.src = deepLink;
-    document.body.appendChild(iframe);
-
-    // Clean up the DOM element immediately after execution
-    window.setTimeout(() => {
-      if (document.body.contains(iframe)) {
-        document.body.removeChild(iframe);
+    const goToStore = () => {
+      if (appOpenedRef.current || document.visibilityState !== 'visible') {
+        return;
       }
-    }, 100);
+      cleanupRef.current?.();
+      // assign(), not replace(): Back returns to this interstitial, so a user who
+      // cancelled an "Open in Firefox?" confirmation can retry (finding 3).
+      window.location.assign(storeUrl);
+    };
+
+    // Definitive "the app opened" signals — a real background/teardown.
+    const onHidden = () => {
+      if (document.hidden) {
+        appOpenedRef.current = true;
+        window.clearTimeout(graceTimer);
+      }
+    };
+    const onLeave = () => {
+      appOpenedRef.current = true;
+      window.clearTimeout(graceTimer);
+    };
+
+    const onBlur = () => {
+      window.clearTimeout(graceTimer);
+      // A blur *after* we'd already regained focus is the app taking the
+      // foreground on its second act — i.e. the dialog was confirmed and the
+      // launch is under way. Treat it as opened, so this still holds together on
+      // any iOS version where visibilitychange doesn't fire for an app switch.
+      if (sawFocus) {
+        appOpenedRef.current = true;
+      }
+      sawBlur = true;
+    };
+
+    const onFocus = () => {
+      if (appOpenedRef.current) {
+        return;
+      }
+      sawFocus = true;
+      window.clearTimeout(graceTimer);
+      graceTimer = window.setTimeout(goToStore, grace);
+    };
+
+    document.addEventListener('visibilitychange', onHidden);
+    window.addEventListener('pagehide', onLeave);
+    window.addEventListener('blur', onBlur);
+    window.addEventListener('focus', onFocus);
+
+    // Backstop for a silent failure: the scheme no-ops with no dialog at all, so
+    // there's no blur/focus pair to key off. Deliberately gated on `!sawBlur` —
+    // if a dialog did appear, the blur/focus machinery owns the decision, and
+    // firing here could redirect while that dialog is still on screen (which is
+    // what a bare timer does to anyone slow to tap "Open").
+    const timer = window.setTimeout(() => {
+      if (!sawBlur) {
+        goToStore();
+      }
+    }, timeout);
+
+    cleanupRef.current = () => {
+      document.removeEventListener('visibilitychange', onHidden);
+      window.removeEventListener('pagehide', onLeave);
+      window.removeEventListener('blur', onBlur);
+      window.removeEventListener('focus', onFocus);
+      window.clearTimeout(timer);
+      window.clearTimeout(graceTimer);
+      cleanupRef.current = null;
+    };
+  };
+
+  // The tap on the <a href={deepLink}> below performs the hand-off itself —
+  // deliberately no preventDefault() and no JS navigation, since the native
+  // top-level navigation is what iOS requires (finding 1) and routing it through
+  // JS only risks losing the user activation. This just arms the fallback.
+  const onAttempt = () => {
+    setStatus('attempting');
+    // Android's intent:// carries its own store fallback via
+    // S.browser_fallback_url, so it needs no JS watchdog.
+    if (!isAndroid) {
+      armStoreFallback();
+    }
   };
 
   return (
@@ -233,16 +317,30 @@ const PocPairInit = () => {
             {'To continue, you’ll need to use Firefox. Tap below to open it — ' +
               `if Firefox isn’t installed, you’ll be taken to the ${storeName}.`}
           </p>
-          <button
-            className="cta-primary cta-xl"
-            onClick={continueWithFirefox}
-          >
+          {/* The deep link lives in `href` so the tap is a top-level,
+              user-initiated navigation — the only form iOS honours. */}
+          <a className="cta-primary cta-xl" href={deepLink} onClick={onAttempt}>
             Continue with Firefox
-          </button>
+          </a>
           {status === 'attempting' && (
             <p className="flex items-center justify-center gap-2 text-sm text-grey-400">
               <LoadingSpinner imageClassName="w-4 h-4 animate-spin" />
               Opening Firefox…
+            </p>
+          )}
+          {/* Escape hatch, not the primary path — armStoreFallback() redirects on
+              its own. This covers the residual case where the alert happens to
+              fire visibilitychange on some iOS version, which correctly suppresses
+              both triggers and would otherwise leave the user sitting here.
+              Android has its own native fallback and doesn't need it. */}
+          {!isAndroid && (
+            <p className="text-sm text-grey-400">
+              {status === 'attempting'
+                ? 'Firefox didn’t open? '
+                : 'Don’t have Firefox? '}
+              <a className="link-blue" href={storeUrl}>
+                Get Firefox on the {storeName}
+              </a>
             </p>
           )}
         </div>
@@ -250,7 +348,7 @@ const PocPairInit = () => {
 
       {/* Debug block — POC visibility into what this page resolved. */}
       <pre className="text-xs text-start break-all whitespace-pre-wrap mt-6 text-grey-400">
-        {`deepLink: ${deepLink}\ntarget:   ${target}\ntimeout:  ${timeout}ms`}
+        {`deepLink: ${deepLink}\ntarget:   ${target}\ntimeout:  ${timeout}ms\ngrace:    ${grace}ms`}
       </pre>
     </AppLayout>
   );


### PR DESCRIPTION
## Because

- We caused a regression with the last fix.
- iOS was always going to the app store and never opening FIrefox even if it was not installed.

## This pull request

- If Firefox is installed, we ensure that Firefox opens via a deep link.

## Issue that this pull request solves

Closes: [FXA-14230](https://mozilla-hub.atlassian.net/browse/FXA-14230) _(... yet another follow up fix)_

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-14230]: https://mozilla-hub.atlassian.net/browse/FXA-14230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ