### PR TITLE
fix(release): derive subplat train number from latest subplat tag

### DIFF
--- a/.github/workflows/tag-release-subplat.yml
+++ b/.github/workflows/tag-release-subplat.yml
@@ -22,62 +22,30 @@ jobs:
       - name: Fetch all git tags
         run: git fetch --tags origin
 
-      - name: Resolve latest FxA train tag
+      - name: Compute new version number
         run: |
-          set -euo pipefail
-          latest_fxa_tag=$(git tag -l 'v1.*.0' --sort=version:refname | tail -1)
-          if [[ -z "${latest_fxa_tag}" ]]; then
-            echo "ERROR: no v1.*.0 FxA train tag found in this repo." >&2
-            exit 1
-          fi
-          if [[ ! "${latest_fxa_tag}" =~ ^v1\.([0-9]+)\.0$ ]]; then
-            echo "ERROR: latest FxA train tag '${latest_fxa_tag}' did not parse as v1.<TRAIN>.0." >&2
-            exit 1
-          fi
-          train="${BASH_REMATCH[1]}"
-          sha=$(git rev-list -n 1 "${latest_fxa_tag}")
-          {
-            echo "TRAIN=${train}"
-            echo "SUBPLAT_TAG=subplat-v1.${train}.0"
-            echo "SUBPLAT_BRANCH=subplat-train-${train}"
-            echo "SUBPLAT_SHA=${sha}"
-          } >> "$GITHUB_ENV"
-          echo "Resolved ${latest_fxa_tag} (sha ${sha}); preparing subplat-v1.${train}.0 / subplat-train-${train}"
-
-      - name: Pre-flight - SubPlat tag must not already exist
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --tags origin "refs/tags/${SUBPLAT_TAG}" >/dev/null 2>&1; then
-            echo "Refusing to create ${SUBPLAT_TAG} - tag already exists on origin." >&2
-            exit 1
-          fi
-
-      - name: Pre-flight - SubPlat branch must not already exist
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --heads origin "refs/heads/${SUBPLAT_BRANCH}" >/dev/null 2>&1; then
-            echo "Refusing to create ${SUBPLAT_BRANCH} - branch already exists on origin." >&2
-            exit 1
-          fi
+          echo versionNumber=$(git tag -l 'subplat-v1.*' --sort=version:refname | tail -1 | awk '{print $2 + 1}' FS='.') >> "$GITHUB_ENV"
 
       - name: Add git tag to output
         id: echo
         run: |
-          echo "tag=${SUBPLAT_TAG}" >> "$GITHUB_OUTPUT"
+          echo tag=subplat-v1.${versionNumber}.0 >> $GITHUB_OUTPUT
 
       - name: Create release branch
-        run: git checkout -b "${SUBPLAT_BRANCH}" "${SUBPLAT_SHA}"
+        run: git checkout -b subplat-train-${versionNumber}
 
       - name: Initialize mandatory git config
         run: |
           git config user.name "${GITHUB_TRIGGERING_ACTOR}"
           git config user.email "noreply@github.com"
 
-      - name: Push branch
+      - name: Commit update to branch
+        if: env.versionNumber != ''
         run: |
-          git push origin "${SUBPLAT_BRANCH}"
+          git push origin subplat-train-${versionNumber}
 
       - name: Make a new tag
+        if: env.versionNumber != ''
         run: |
-          git tag -a "${SUBPLAT_TAG}" -m "SubPlat train release ${SUBPLAT_TAG}"
-          git push origin "${SUBPLAT_TAG}"
+          git tag -a "subplat-v1.${versionNumber}.0" -m "SubPlat train release ${versionNumber}"
+          git push origin subplat-v1.${versionNumber}.0


### PR DESCRIPTION
## Because

- Tag Release SubPlat Github Action was failing if FxA hasn't tagged yet

## This pull request

- Reworks the Tag Release SubPlat workflow so that it tags a new subplat version from main and more closely resembles the FxA tag release

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
