### PR TITLE
feat(tests): skip func test approval for bot branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1100,15 +1100,40 @@ workflows:
       # but still allow them to be run on demand.
       # No `requires` on this job so it can be approved as soon as a PR
       # is opened.
+      # Skipped on filtered branches; those auto-run the functional tests.
+      # This allows auto-merge for bot dependency PRs,
+      # and allows devs to auto-run when branches definitely need func tests.
       - approve-functional-tests:
           name: Approve Functional Tests (PR)
           type: approval
+          filters:
+            branches:
+              ignore:
+                - /^dependabot\/.*/
+                - /^func\/.*/
       - playwright-functional-tests:
           name: Firefox Functional Tests - Playwright (PR)
           workflow: test_pull_request
           requires:
             - Build (PR)
             - Approve Functional Tests (PR)
+          filters:
+            branches:
+              ignore:
+                - /^dependabot\/.*/
+                - /^func\/.*/
+      # Auto-run functional tests (no manual approval) on filtered branches,
+      # so the check reaches a real conclusion instead of hanging pending.
+      - playwright-functional-tests:
+          name: Firefox Functional Tests - Playwright (auto)
+          workflow: test_pull_request
+          requires:
+            - Build (PR)
+          filters:
+            branches:
+              only:
+                - /^dependabot\/.*/
+                - /^func\/.*/
       - on-complete:
           name: Tests Complete (PR)
           stage: Tests
@@ -1121,6 +1146,8 @@ workflows:
             - Integration Test - Servers - Auth (PR)
             - Integration Test - Servers - Auth Scripts (PR)
             - Integration Test - Libraries (PR)
+            # Surface auto-run functional-test failures on bot branches.
+            - Firefox Functional Tests - Playwright (auto)
 
   # Triggered remotely. See .circleci/README.md
   production_smoke_tests:


### PR DESCRIPTION
## Because

- BLEnder skips fxa Dependabot PRs as "checks pending" because the manual `Approve Functional Tests (PR)` gate sits pending indefinitely on bot branches, which blocks auto-merge.

## This pull request

- Skips the manual functional-test approval on `dependabot/*` and `func/*` branches and auto-runs the functional tests there instead, so the check reaches a real pass/fail conclusion and bot dependency PRs can auto-merge. All other branches keep the existing manual-approval path unchanged. (`func/*` is an opt-in convention for devs who want functional tests to always run.)

## Issue that this pull request solves

Closes: FXA-14222

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.