### PR TITLE
test(ci): verify approval gate still appears on non-filtered branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1122,6 +1122,8 @@ workflows:
               ignore:
                 - /^dependabot\/.*/
                 - /^func\/.*/
+      # TEMPORARY: no-op comment to trigger CI on a non-filtered branch and
+      # verify the manual approval gate still appears. Do not merge.
       # Auto-run functional tests (no manual approval) on filtered branches,
       # so the check reaches a real conclusion instead of hanging pending.
       - playwright-functional-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1148,6 +1148,10 @@ workflows:
             - Integration Test - Servers - Auth (PR)
             - Integration Test - Servers - Auth Scripts (PR)
             - Integration Test - Libraries (PR)
+            # TEMPORARY EXPERIMENT: this job is filtered out on non-filtered
+            # branches. Does the workflow error at creation, or does this job
+            # sit blocked forever? Do not merge.
+            - Firefox Functional Tests - Playwright (auto)
 
   # Triggered remotely. See .circleci/README.md
   production_smoke_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1100,15 +1100,40 @@ workflows:
       # but still allow them to be run on demand.
       # No `requires` on this job so it can be approved as soon as a PR
       # is opened.
+      # Skipped on filtered branches; those auto-run the functional tests.
+      # This allows auto-merge for bot dependency PRs,
+      # and allows devs to auto-run when branches definitely need func tests.
       - approve-functional-tests:
           name: Approve Functional Tests (PR)
           type: approval
+          filters:
+            branches:
+              ignore:
+                - /^dependabot\/.*/
+                - /^func\/.*/
       - playwright-functional-tests:
           name: Firefox Functional Tests - Playwright (PR)
           workflow: test_pull_request
           requires:
             - Build (PR)
             - Approve Functional Tests (PR)
+          filters:
+            branches:
+              ignore:
+                - /^dependabot\/.*/
+                - /^func\/.*/
+      # Auto-run functional tests (no manual approval) on filtered branches,
+      # so the check reaches a real conclusion instead of hanging pending.
+      - playwright-functional-tests:
+          name: Firefox Functional Tests - Playwright (auto)
+          workflow: test_pull_request
+          requires:
+            - Build (PR)
+          filters:
+            branches:
+              only:
+                - /^dependabot\/.*/
+                - /^func\/.*/
       - on-complete:
           name: Tests Complete (PR)
           stage: Tests


### PR DESCRIPTION
## Because

- We want to confirm the theory behind #20941: branch-filtering the approval job removes it from the workflow, so a *separate* auto-run functional-tests job is required — and ordinary branches must still get the manual gate.

## This pull request

- Temporary throwaway PR. Branches off \`func/update-func-autoapprove\` with a single no-op comment in \`.circleci/config.yml\`, on a branch name (\`test/func-approval-control\`) that matches neither \`dependabot/*\` nor \`func/*\`.
- Expected: \`Approve Functional Tests (PR)\` shows as an on-hold job, \`Firefox Functional Tests - Playwright (PR)\` waits on it, and \`Firefox Functional Tests - Playwright (auto)\` does **not** appear.

**Do not merge — will be closed and the branch deleted once observed.**