### PR TITLE
fix(payments): Update payments-api version to reflect correct commit and source

### DIFF
--- a/apps/payments/api/src/app/app.service.ts
+++ b/apps/payments/api/src/app/app.service.ts
@@ -17,7 +17,7 @@ let commitHash = UNKNOWN;
 let sourceRepo = UNKNOWN;
 
 try {
-  const versionJsonPath = path.join(process.cwd(), 'config', 'version.json');
+  const versionJsonPath = path.join(__dirname, 'config', 'version.json');
   const info = JSON.parse(fs.readFileSync(versionJsonPath, 'utf-8'));
   commitHash = info.version.hash;
   sourceRepo = info.version.source;

--- a/apps/payments/api/webpack.config.js
+++ b/apps/payments/api/webpack.config.js
@@ -14,7 +14,10 @@ module.exports = {
       compiler: 'tsc',
       main: './src/main.ts',
       tsConfig: './tsconfig.app.json',
-      assets: ['./src/assets'],
+      assets: [
+        './src/assets',
+        { input: './config', glob: 'version.json', output: './config' },
+      ],
       optimization: false,
       outputHashing: 'none',
       generatePackageJson: true,


### PR DESCRIPTION
## Because

- app.service.ts used process.cwd() to locate config/version.json, which worked for payments-next because Next.js pins process.cwd() to app root. However, NestJS does not and depends on where node is invoked from.


## This pull request

- Adds config/version.json as webpack asset so it is copied to dist output directory alongside main.js
- Changes process.cwd() to __dirname (real runtime directory)

## Issue that this pull request solves

Closes: PAY-3843

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Currently on stage
<img width="603" height="253" alt="Screenshot 2026-07-30 at 9 57 22 AM" src="https://github.com/user-attachments/assets/26f91b0e-5128-4c57-ad5c-12577793c173" />

Local
<img width="511" height="238" alt="Screenshot 2026-07-30 at 9 57 37 AM" src="https://github.com/user-attachments/assets/f083b704-c2d1-4188-ae4f-26c39c2dea37" />