### PR TITLE
chore(blender): pin node_version to .nvmrc + enable dismiss_unaffected

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -1,3 +1,10 @@
 repo_name: "Firefox Accounts (mozilla/fxa)"
-node_version: "24"
+# Must match .nvmrc exactly — fxa's preinstall check (_scripts/check-node-version.sh)
+# requires the exact version, so "24" (-> latest 24.x) fails the install.
+node_version: "24.15.0"
 install_command: "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable --inline-builds"
+
+investigate:
+  # Let BLEnder close alerts it judges as not affecting our code.
+  # Only low/medium are auto-dismissed; critical/high always require a real fix.
+  dismiss_unaffected: true


### PR DESCRIPTION
Two `.blender/blender.yml` changes for BLEnder on fxa (batched).

## 1. Pin `node_version` to `.nvmrc` (bugfix — safe to merge)

`node_version` was `"24"`, which resolves to the latest 24.x (24.18.0). fxa's `preinstall` hook `_scripts/check-node-version.sh` requires the **exact** `.nvmrc` version (24.15.0), so **every** BLEnder fix/auto-engineer run aborted `yarn install` with `INCOMPATIBLE NODE VERSION` — meaning Claude never had a working build to fix against. Confirmed across recent fix runs (all `Current: v24.18.0`). Pinning to `24.15.0` fixes it.

## 2. Enable `investigate.dismiss_unaffected` (needs security review)

Lets BLEnder dismiss alerts it judges as not affecting our code. Only **low/medium** are auto-dismissed; **critical/high are never auto-dismissed**. This lets an automated agent close security alerts on its own judgment — **please review with whoever owns fxa security before merging.** Draft for that reason.

## Issue

Relates to: FXA-14222

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
