### PR TITLE
feat(cms): record statsd timings for free access program cache lookups

### DIFF
--- a/libs/free-access-program/src/lib/free-access-program-webhooks.service.spec.ts
+++ b/libs/free-access-program/src/lib/free-access-program-webhooks.service.spec.ts
@@ -77,6 +77,9 @@ describe('FreeAccessProgramWebhooksService', () => {
 
     expect(manager.invalidateProjectionCache).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ handled: true });
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.invalidate.success'
+    );
   });
 
   it('does not invalidate for a non-access model', async () => {
@@ -87,6 +90,10 @@ describe('FreeAccessProgramWebhooksService', () => {
 
     expect(result).toEqual({ handled: false, reason: 'model' });
     expect(manager.invalidateProjectionCache).not.toHaveBeenCalled();
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.skipped',
+      { reason: 'model' }
+    );
   });
 
   it('does not invalidate for an unknown event type', async () => {
@@ -97,6 +104,10 @@ describe('FreeAccessProgramWebhooksService', () => {
 
     expect(result).toEqual({ handled: false, reason: 'event' });
     expect(manager.invalidateProjectionCache).not.toHaveBeenCalled();
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.skipped',
+      { reason: 'event' }
+    );
   });
 
   it('dedupes a replayed webhook without invalidating twice', async () => {
@@ -106,6 +117,9 @@ describe('FreeAccessProgramWebhooksService', () => {
     expect(manager.invalidateProjectionCache).toHaveBeenCalledTimes(1);
     expect(first).toEqual({ handled: true });
     expect(second).toEqual({ handled: true, dedupe: true });
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.duplicate'
+    );
   });
 
   it('swallows an invalidateProjectionCache failure and still reports handled', async () => {
@@ -120,6 +134,9 @@ describe('FreeAccessProgramWebhooksService', () => {
     expect(logger.error).toHaveBeenCalledWith(
       'freeAccessProgramWebhook.invalidate.error',
       { err: expect.any(Error) }
+    );
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.invalidate.error'
     );
   });
 });

--- a/libs/free-access-program/src/lib/free-access-program-webhooks.service.ts
+++ b/libs/free-access-program/src/lib/free-access-program-webhooks.service.ts
@@ -47,17 +47,23 @@ export class FreeAccessProgramWebhooksService {
 
     const classification = classifyAccessWebhook(body);
     if ('skip' in classification) {
+      this.statsd.increment('free_access_program.webhook.skipped', {
+        reason: classification.skip,
+      });
       return { handled: false, reason: classification.skip };
     }
 
     if (isDuplicateAccessWebhook(this.seenEvents, classification.dedupeKey, Date.now())) {
+      this.statsd.increment('free_access_program.webhook.duplicate');
       return { handled: true, dedupe: true };
     }
 
     try {
       await this.freeAccessManager.invalidateProjectionCache();
+      this.statsd.increment('free_access_program.webhook.invalidate.success');
     } catch (err) {
       // Swallow: the periodic cron sweep is the backstop.
+      this.statsd.increment('free_access_program.webhook.invalidate.error');
       this.logger.error('freeAccessProgramWebhook.invalidate.error', { err });
     }
 

--- a/libs/free-access-program/src/lib/free-access-program.service.spec.ts
+++ b/libs/free-access-program/src/lib/free-access-program.service.spec.ts
@@ -130,6 +130,34 @@ describe('FreeAccessProgramService', () => {
         await service.findCapabilitiesForEmail('USER@example.com')
       ).toEqual({ 'client-a': ['vpn'] });
     });
+
+    it('records a non-member membership check for a missing email', async () => {
+      await service.findCapabilitiesForEmail(null);
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.membership.check',
+        { member: 'false', lookup: 'email_capabilities' }
+      );
+    });
+
+    it('records a member membership check when capabilities are found', async () => {
+      configurationManager.getCachedProjection.mockResolvedValue(
+        projection([['user@example.com', entry({ 'client-a': ['vpn'] })]])
+      );
+      await service.findCapabilitiesForEmail('user@example.com');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.membership.check',
+        { member: 'true', lookup: 'email_capabilities' }
+      );
+    });
+
+    it('records a non-member membership check when the email has no capabilities', async () => {
+      configurationManager.getCachedProjection.mockResolvedValue({});
+      await service.findCapabilitiesForEmail('nobody@example.com');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.membership.check',
+        { member: 'false', lookup: 'email_capabilities' }
+      );
+    });
   });
 
   describe('findOfferingIdsForEmail', () => {
@@ -158,6 +186,26 @@ describe('FreeAccessProgramService', () => {
       expect(
         await service.findOfferingIdsForEmail('nobody@example.com')
       ).toEqual([]);
+    });
+
+    it('records a member membership check when offerings are found', async () => {
+      configurationManager.getCachedProjection.mockResolvedValue(
+        projection([['user@example.com', entry({ 'client-a': ['vpn'] }, ['vpn'])]])
+      );
+      await service.findOfferingIdsForEmail('user@example.com');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.membership.check',
+        { member: 'true', lookup: 'email_offerings' }
+      );
+    });
+
+    it('records a non-member membership check when the email has no offerings', async () => {
+      configurationManager.getCachedProjection.mockResolvedValue({});
+      await service.findOfferingIdsForEmail('nobody@example.com');
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.membership.check',
+        { member: 'false', lookup: 'email_offerings' }
+      );
     });
   });
 
@@ -245,6 +293,27 @@ describe('FreeAccessProgramService', () => {
         isMember: true,
         grantsByClient: {},
       });
+    });
+
+    it('records a non-member membership check when the uid has no email', async () => {
+      accountManager.getPrimaryEmailByUid.mockResolvedValue(undefined);
+      await service.findFreeAccessForUid(UID);
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.membership.check',
+        { member: 'false', lookup: 'uid' }
+      );
+    });
+
+    it('records a member membership check when the uid resolves to a member', async () => {
+      accountManager.getPrimaryEmailByUid.mockResolvedValue('user@example.com');
+      configurationManager.getCachedProjection.mockResolvedValue(
+        projection([['user@example.com', entry({ 'client-a': ['vpn'] })]])
+      );
+      await service.findFreeAccessForUid(UID);
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.membership.check',
+        { member: 'true', lookup: 'uid' }
+      );
     });
   });
 
@@ -375,7 +444,7 @@ describe('FreeAccessProgramService', () => {
       );
     });
 
-    it('logs and continues when an individual notification rejects', async () => {
+    it('continues and records both notify.error and notify.success when one notification rejects', async () => {
       journalManager.get.mockResolvedValue({});
       configurationManager.getFreshProjection.mockResolvedValue(
         projection([
@@ -392,6 +461,23 @@ describe('FreeAccessProgramService', () => {
       expect(statsd.increment).toHaveBeenCalledWith(
         'free_access_program.reconcile.notify.error'
       );
+      // The second email still delivered, so success is counted alongside.
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.reconcile.notify.success'
+      );
+    });
+
+    it('increments notify.success for each delivered notification', async () => {
+      journalManager.get.mockResolvedValue({});
+      configurationManager.getFreshProjection.mockResolvedValue(
+        projection([['alice@example.com', entry({ 'client-a': ['vpn'] })]])
+      );
+
+      await service.reconcile();
+
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'free_access_program.reconcile.notify.success'
+      );
     });
 
     it('emits success metric and duration timing on a normal run', async () => {
@@ -405,6 +491,24 @@ describe('FreeAccessProgramService', () => {
       );
       expect(statsd.timing).toHaveBeenCalledWith(
         'free_access_program.reconcile.duration_ms',
+        expect.any(Number)
+      );
+    });
+
+    it('times the journal load, delegating projection timing to the manager', async () => {
+      journalManager.get.mockResolvedValue({});
+      configurationManager.getFreshProjection.mockResolvedValue({});
+
+      await service.reconcile();
+
+      expect(statsd.timing).toHaveBeenCalledWith(
+        'free_access_program.reconcile.load.journal_ms',
+        expect.any(Number)
+      );
+      // Projection timing is emitted inside getFreshProjection (the CMS
+      // manager), not by the service.
+      expect(statsd.timing).not.toHaveBeenCalledWith(
+        'free_access_program.reconcile.load.projection_ms',
         expect.any(Number)
       );
     });

--- a/libs/free-access-program/src/lib/free-access-program.service.ts
+++ b/libs/free-access-program/src/lib/free-access-program.service.ts
@@ -41,15 +41,33 @@ export class FreeAccessProgramService {
   async findCapabilitiesForEmail(
     email?: string | null
   ): Promise<FreeAccessCapabilityMap> {
-    if (!email) return {};
+    if (!email) {
+      this.recordMembershipCheck('email_capabilities', false);
+      return {};
+    }
     const projection = await this.configurationManager.getCachedProjection();
-    return projection[email.toLowerCase()]?.capabilities ?? {};
+    const capabilities = projection[email.toLowerCase()]?.capabilities ?? {};
+    this.recordMembershipCheck(
+      'email_capabilities',
+      Object.keys(capabilities).length > 0
+    );
+    return capabilities;
   }
 
   async findOfferingIdsForEmail(email?: string | null): Promise<string[]> {
-    if (!email) return [];
+    if (!email) {
+      this.recordMembershipCheck('email_offerings', false);
+      return [];
+    }
     const projection = await this.configurationManager.getCachedProjection();
-    return [...(projection[email.toLowerCase()]?.offeringApiIdentifiers ?? [])];
+    const offeringApiIdentifiers = [
+      ...(projection[email.toLowerCase()]?.offeringApiIdentifiers ?? []),
+    ];
+    this.recordMembershipCheck(
+      'email_offerings',
+      offeringApiIdentifiers.length > 0
+    );
+    return offeringApiIdentifiers;
   }
 
   async findFreeAccessForUid(uid: string): Promise<FreeAccessForUid> {
@@ -58,14 +76,31 @@ export class FreeAccessProgramService {
     const email = (
       await this.accountManager.getPrimaryEmailByUid(uid)
     )?.toLowerCase();
-    if (!email) return empty;
+    if (!email) {
+      this.recordMembershipCheck('uid', false);
+      return empty;
+    }
 
     const projection = await this.configurationManager.getCachedProjection();
-    if (!(email in projection)) return empty;
+    if (!(email in projection)) {
+      this.recordMembershipCheck('uid', false);
+      return empty;
+    }
 
     const grantsByClient =
       await this.configurationManager.getCachedAccessGrantsByClient();
+    this.recordMembershipCheck('uid', true);
     return { isMember: true, grantsByClient: grantsByClient[email] ?? {} };
+  }
+
+  private recordMembershipCheck(
+    lookup: 'uid' | 'email_capabilities' | 'email_offerings',
+    member: boolean
+  ): void {
+    this.statsd.increment('free_access_program.membership.check', {
+      member: `${member}`,
+      lookup,
+    });
   }
 
   async reconcile(): Promise<ReconcileResult> {
@@ -79,8 +114,19 @@ export class FreeAccessProgramService {
 
     const startedAt = Date.now();
     try {
+      // Time the journal (Firestore) load here; the CMS fetch is timed inside
+      // getFreshProjection (reconcile.load.projection_ms). Kept in flight
+      // together so reconcile latency stays attributable to each source.
+      const journalStartedAt = Date.now();
+      const beforePromise = journalManager.get().then((result) => {
+        this.statsd.timing(
+          'free_access_program.reconcile.load.journal_ms',
+          Date.now() - journalStartedAt
+        );
+        return result;
+      });
       const [before, after] = await Promise.all([
-        journalManager.get(),
+        beforePromise,
         this.configurationManager.getFreshProjection(),
       ]);
 
@@ -133,6 +179,7 @@ export class FreeAccessProgramService {
     for (const email of emails) {
       try {
         await notifier.notifyEmailChanged(email);
+        this.statsd.increment('free_access_program.reconcile.notify.success');
       } catch (err) {
         this.statsd.increment('free_access_program.reconcile.notify.error');
         this.logger.error(err);

--- a/libs/shared/cms/src/lib/free-access-program-configuration.manager.spec.ts
+++ b/libs/shared/cms/src/lib/free-access-program-configuration.manager.spec.ts
@@ -4,10 +4,15 @@
 
 import { Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { StatsD } from 'hot-shots';
 
 import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
+import { MockStatsDProvider, StatsDService } from '@fxa/shared/metrics/statsd';
 
-import { FreeAccessProgramConfigurationManager } from './free-access-program-configuration.manager';
+import {
+  deriveCacheTimingTags,
+  FreeAccessProgramConfigurationManager,
+} from './free-access-program-configuration.manager';
 import { StrapiClient } from './strapi.client';
 import { MockStrapiClientConfigProvider } from './strapi.client.config';
 
@@ -38,6 +43,7 @@ jest.mock('@fxa/shared/db/type-cacheable', () => ({
 describe('FreeAccessProgramConfigurationManager', () => {
   let manager: FreeAccessProgramConfigurationManager;
   let strapiClient: { queryUncached: jest.Mock };
+  let mockStatsd: StatsD;
 
   beforeEach(async () => {
     strapiClient = { queryUncached: jest.fn() };
@@ -45,6 +51,7 @@ describe('FreeAccessProgramConfigurationManager', () => {
       providers: [
         MockStrapiClientConfigProvider,
         MockFirestoreProvider,
+        MockStatsDProvider,
         { provide: StrapiClient, useValue: strapiClient },
         {
           provide: Logger,
@@ -54,6 +61,7 @@ describe('FreeAccessProgramConfigurationManager', () => {
       ],
     }).compile();
     manager = moduleRef.get(FreeAccessProgramConfigurationManager);
+    mockStatsd = moduleRef.get(StatsDService);
   });
 
   afterEach(() => {
@@ -145,6 +153,34 @@ describe('FreeAccessProgramConfigurationManager', () => {
       });
     });
 
+    it('emits a fresh cms_free_access_request timing', async () => {
+      jest.spyOn(mockStatsd, 'timing');
+      strapiClient.queryUncached.mockResolvedValue({ accesses: [] });
+
+      await manager.getFreshProjection();
+
+      expect(mockStatsd.timing).toHaveBeenCalledWith(
+        'cms_free_access_request',
+        expect.any(Number),
+        undefined,
+        {
+          method: 'query',
+          operationName: 'freeAccessProgramProjection',
+          error: 'false',
+          cache: 'false',
+          cacheType: 'fresh',
+        }
+      );
+    });
+
+    it('does not emit the timing when the fetch fails', async () => {
+      jest.spyOn(mockStatsd, 'timing');
+      strapiClient.queryUncached.mockRejectedValue(new Error('strapi-down'));
+
+      await expect(manager.getFreshProjection()).rejects.toThrow('strapi-down');
+      expect(mockStatsd.timing).not.toHaveBeenCalled();
+    });
+
     it('propagates errors from the Strapi client', async () => {
       strapiClient.queryUncached.mockRejectedValue(new Error('strapi-down'));
       await expect(manager.getFreshProjection()).rejects.toThrow(
@@ -215,4 +251,87 @@ describe('FreeAccessProgramConfigurationManager', () => {
       ).resolves.toBeUndefined();
     });
   });
+
+  describe('recordCacheTiming', () => {
+    it('emits a cms_free_access_request timing for a memory hit', () => {
+      jest.spyOn(mockStatsd, 'timing');
+
+      manager.recordCacheTiming('freeAccessProgramProjection', 'memory', 12, 'cache');
+
+      expect(mockStatsd.timing).toHaveBeenCalledWith(
+        'cms_free_access_request',
+        12,
+        undefined,
+        {
+          method: 'query',
+          operationName: 'freeAccessProgramProjection',
+          error: 'false',
+          cache: 'true',
+          cacheType: 'memory',
+        }
+      );
+    });
+
+    it('emits a stringified error/cache tag for a Firestore fallback', () => {
+      jest.spyOn(mockStatsd, 'timing');
+
+      manager.recordCacheTiming(
+        'freeAccessProgramAccessGrantsByClient',
+        'firestore',
+        34,
+        'fallback'
+      );
+
+      expect(mockStatsd.timing).toHaveBeenCalledWith(
+        'cms_free_access_request',
+        34,
+        undefined,
+        {
+          method: 'query',
+          operationName: 'freeAccessProgramAccessGrantsByClient',
+          error: 'true',
+          cache: 'true',
+          cacheType: 'fallback',
+        }
+      );
+    });
+
+    it('does not emit for a memory miss (recorded by the Firestore tier instead)', () => {
+      jest.spyOn(mockStatsd, 'timing');
+
+      manager.recordCacheTiming('freeAccessProgramProjection', 'memory', 5, 'method');
+
+      expect(mockStatsd.timing).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('deriveCacheTimingTags', () => {
+  it('tags a memory hit as a non-error cache hit', () => {
+    expect(deriveCacheTimingTags('memory', 'cache')).toEqual({
+      error: false,
+      cache: true,
+      cacheType: 'memory',
+    });
+  });
+
+  it('returns null for a memory miss so it is not double-counted', () => {
+    expect(deriveCacheTimingTags('memory', 'method')).toBeNull();
+  });
+
+  it.each([
+    { result: 'method', error: false, cache: false },
+    { result: 'stale', error: false, cache: true },
+    { result: 'fallback', error: true, cache: true },
+    { result: 'fallbackFailed', error: true, cache: false },
+  ])(
+    'maps Firestore result "$result" to error=$error cache=$cache',
+    ({ result, error, cache }) => {
+      expect(deriveCacheTimingTags('firestore', result)).toEqual({
+        error,
+        cache,
+        cacheType: result,
+      });
+    }
+  );
 });

--- a/libs/shared/cms/src/lib/free-access-program-configuration.manager.ts
+++ b/libs/shared/cms/src/lib/free-access-program-configuration.manager.ts
@@ -6,8 +6,10 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { LoggerService } from '@nestjs/common';
 import { Cacheable, CacheClear } from '@type-cacheable/core';
 import { Firestore } from '@google-cloud/firestore';
+import { StatsD } from 'hot-shots';
 import * as Sentry from '@sentry/node';
 
+import { StatsDService } from '@fxa/shared/metrics/statsd';
 import { FirestoreService } from '@fxa/shared/db/firestore';
 import {
   CacheFirstStrategy,
@@ -33,6 +35,24 @@ const DEFAULT_FIRESTORE_OFFLINE_CACHE_TTL_SECONDS = 604800; // 7 days
 const DEFAULT_FIRESTORE_CACHE_TTL_SECONDS = 1800; // 30 minutes
 const DEFAULT_MEM_CACHE_TTL_SECONDS = 300; // 5 minutes
 
+type CacheTimingTags = { error: boolean; cache: boolean; cacheType: string };
+
+export function deriveCacheTimingTags(
+  cacheTier: 'memory' | 'firestore',
+  result: string
+): CacheTimingTags | null {
+  if (cacheTier === 'memory') {
+    return result === 'cache'
+      ? { error: false, cache: true, cacheType: 'memory' }
+      : null;
+  }
+  return {
+    error: result === 'fallback' || result === 'fallbackFailed',
+    cache: result === 'stale' || result === 'fallback',
+    cacheType: result,
+  };
+}
+
 @Injectable()
 export class FreeAccessProgramConfigurationManager {
   private memoryCacheAdapter: MemoryAdapter;
@@ -42,7 +62,8 @@ export class FreeAccessProgramConfigurationManager {
     private config: StrapiClientConfig,
     private strapiClient: StrapiClient,
     @Inject(FirestoreService) firestore: Firestore,
-    @Inject(Logger) private log: LoggerService
+    @Inject(Logger) private log: LoggerService,
+    @Inject(StatsDService) private statsd: StatsD
   ) {
     this.memoryCacheAdapter = new MemoryAdapter();
     this.firestoreCacheAdapter = new FirestoreAdapter(
@@ -51,16 +72,41 @@ export class FreeAccessProgramConfigurationManager {
     );
   }
 
+  recordCacheTiming(
+    operationName: string,
+    cacheTier: 'memory' | 'firestore',
+    elapsed: number,
+    result: string
+  ): void {
+    const tags = deriveCacheTimingTags(cacheTier, result);
+    if (!tags) {
+      return;
+    }
+    this.statsd.timing('cms_free_access_request', elapsed, undefined, {
+      method: 'query',
+      operationName,
+      error: `${tags.error}`,
+      cache: `${tags.cache}`,
+      cacheType: tags.cacheType,
+    });
+  }
+
   @Cacheable({
     cacheKey: () => PROJECTION_CACHE_KEY,
     strategy: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       new CacheFirstStrategy(
         (err) => Sentry.captureException(err),
-        () => {},
+        (startTime, endTime, result) =>
+          context.recordCacheTiming(
+            PROJECTION_CACHE_KEY,
+            'memory',
+            endTime - startTime,
+            result
+          ),
         context.log
       ),
     ttlSeconds: (_args: any, context: FreeAccessProgramConfigurationManager) =>
-      context.config.memCacheTTL ?? DEFAULT_MEM_CACHE_TTL_SECONDS,
+      context.config.memCacheTTL || DEFAULT_MEM_CACHE_TTL_SECONDS,
     client: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       context.memoryCacheAdapter,
   })
@@ -68,13 +114,19 @@ export class FreeAccessProgramConfigurationManager {
     cacheKey: () => PROJECTION_CACHE_KEY,
     strategy: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       new StaleWhileRevalidateWithFallbackStrategy(
-        context.config.firestoreCacheTTL ?? DEFAULT_FIRESTORE_CACHE_TTL_SECONDS,
+        context.config.firestoreCacheTTL || DEFAULT_FIRESTORE_CACHE_TTL_SECONDS,
         (err) => Sentry.captureException(err),
-        () => {},
+        (startTime, endTime, result) =>
+          context.recordCacheTiming(
+            PROJECTION_CACHE_KEY,
+            'firestore',
+            endTime - startTime,
+            result
+          ),
         context.log
       ),
     ttlSeconds: (_args: any, context: FreeAccessProgramConfigurationManager) =>
-      context.config.firestoreOfflineCacheTTL ??
+      context.config.firestoreOfflineCacheTTL ||
       DEFAULT_FIRESTORE_OFFLINE_CACHE_TTL_SECONDS,
     client: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       context.firestoreCacheAdapter,
@@ -90,13 +142,26 @@ export class FreeAccessProgramConfigurationManager {
   }
 
   async getFreshProjection(): Promise<FreeAccessProjection> {
+    const startedAt = Date.now();
     const queryResult = await this.strapiClient.queryUncached(
       accessesQuery,
       {}
     );
     const util = new AccessUtil(queryResult);
+    const projection = util.project();
 
-    return util.project();
+    // Uncached fetch (bypasses both cache tiers). Reported under the same
+    // metric as the cached lookups so fresh vs cached latency is comparable,
+    // tagged cacheType 'fresh' to set it apart.
+    this.statsd.timing('cms_free_access_request', Date.now() - startedAt, undefined, {
+      method: 'query',
+      operationName: PROJECTION_CACHE_KEY,
+      error: 'false',
+      cache: 'false',
+      cacheType: 'fresh',
+    });
+
+    return projection;
   }
 
   /**
@@ -110,11 +175,17 @@ export class FreeAccessProgramConfigurationManager {
     strategy: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       new CacheFirstStrategy(
         (err) => Sentry.captureException(err),
-        () => {},
+        (startTime, endTime, result) =>
+          context.recordCacheTiming(
+            ACCESS_GRANTS_CACHE_KEY,
+            'memory',
+            endTime - startTime,
+            result
+          ),
         context.log
       ),
     ttlSeconds: (_args: any, context: FreeAccessProgramConfigurationManager) =>
-      context.config.memCacheTTL ?? DEFAULT_MEM_CACHE_TTL_SECONDS,
+      context.config.memCacheTTL || DEFAULT_MEM_CACHE_TTL_SECONDS,
     client: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       context.memoryCacheAdapter,
   })
@@ -122,13 +193,19 @@ export class FreeAccessProgramConfigurationManager {
     cacheKey: () => ACCESS_GRANTS_CACHE_KEY,
     strategy: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       new StaleWhileRevalidateWithFallbackStrategy(
-        context.config.firestoreCacheTTL ?? DEFAULT_FIRESTORE_CACHE_TTL_SECONDS,
+        context.config.firestoreCacheTTL || DEFAULT_FIRESTORE_CACHE_TTL_SECONDS,
         (err) => Sentry.captureException(err),
-        () => {},
+        (startTime, endTime, result) =>
+          context.recordCacheTiming(
+            ACCESS_GRANTS_CACHE_KEY,
+            'firestore',
+            endTime - startTime,
+            result
+          ),
         context.log
       ),
     ttlSeconds: (_args: any, context: FreeAccessProgramConfigurationManager) =>
-      context.config.firestoreOfflineCacheTTL ??
+      context.config.firestoreOfflineCacheTTL ||
       DEFAULT_FIRESTORE_OFFLINE_CACHE_TTL_SECONDS,
     client: (_args: any, context: FreeAccessProgramConfigurationManager) =>
       context.firestoreCacheAdapter,

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -249,7 +249,8 @@ async function run(config) {
             strapiClientConfig,
             strapiClient,
             firestore,
-            log
+            log,
+            statsd
           );
         freeAccessJournalManagerConfig = Object.assign(
           new FreeAccessProgramJournalManagerConfig(),

--- a/packages/fxa-auth-server/lib/routes/subscriptions/free-access-program-webhook.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/free-access-program-webhook.spec.ts
@@ -4,6 +4,7 @@
 
 import { createMock } from '@golevelup/ts-jest';
 import Boom from '@hapi/boom';
+import type { StatsD } from 'hot-shots';
 
 import { freeAccessProgramWebhookRoutes } from './free-access-program-webhook';
 import { AuthLogger } from '../../types';
@@ -14,12 +15,14 @@ describe('freeAccessProgramWebhookRoutes', () => {
   let log: any;
   let strapiClient: { verifyWebhookSignature: jest.Mock };
   let reconciler: { reconcile: jest.Mock };
+  let statsd: jest.Mocked<Pick<StatsD, 'increment'>>;
 
   const route = () => {
     const routes = freeAccessProgramWebhookRoutes(
       log,
       strapiClient as any,
-      reconciler as any
+      reconciler as any,
+      statsd as unknown as StatsD
     );
     return routes[0];
   };
@@ -43,6 +46,7 @@ describe('freeAccessProgramWebhookRoutes', () => {
     log = createMock<AuthLogger>();
     strapiClient = { verifyWebhookSignature: jest.fn().mockReturnValue(true) };
     reconciler = { reconcile: jest.fn().mockResolvedValue({ changed: 0 }) };
+    statsd = { increment: jest.fn() } as jest.Mocked<Pick<StatsD, 'increment'>>;
   });
 
   it('registers the access webhook route', () => {
@@ -79,5 +83,54 @@ describe('freeAccessProgramWebhookRoutes', () => {
     const result = await invoke({ model: 'something-else' });
     expect(result).toEqual({ handled: false, reason: 'model' });
     expect(reconciler.reconcile).not.toHaveBeenCalled();
+  });
+
+  it('increments the auth.error counter on an invalid signature', async () => {
+    strapiClient.verifyWebhookSignature.mockReturnValue(false);
+
+    await expect(invoke()).rejects.toMatchObject({ isBoom: true });
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.auth.error'
+    );
+  });
+
+  it('increments the skipped counter with the reason tag', async () => {
+    await invoke({ model: 'something-else' });
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.skipped',
+      { reason: 'model' }
+    );
+  });
+
+  it('increments the duplicate counter on a replayed event', async () => {
+    // Reuse one handler so the dedupe map persists across both calls.
+    const handler = route().handler as any;
+    const request = {
+      headers: { authorization: 'Bearer secret' },
+      payload: {
+        event: 'entry.publish',
+        model: 'access',
+        entry: { documentId: 'ent-1' },
+      },
+    };
+
+    await handler(request);
+    await handler(request);
+
+    expect(reconciler.reconcile).toHaveBeenCalledTimes(1);
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.duplicate'
+    );
+  });
+
+  it('increments reconcile.error and still returns handled when reconcile throws', async () => {
+    reconciler.reconcile.mockRejectedValue(new Error('boom'));
+
+    const result = await invoke();
+
+    expect(result).toEqual({ handled: true });
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'free_access_program.webhook.reconcile.error'
+    );
   });
 });

--- a/packages/fxa-auth-server/lib/routes/subscriptions/free-access-program-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/free-access-program-webhook.ts
@@ -4,6 +4,7 @@
 
 import Boom from '@hapi/boom';
 import { ServerRoute } from '@hapi/hapi';
+import type { StatsD } from 'hot-shots';
 import isA from 'joi';
 
 import {
@@ -35,7 +36,8 @@ const payloadSchema = isA
 export const freeAccessProgramWebhookRoutes = (
   log: AuthLogger,
   strapiClient: StrapiClient,
-  reconciler: FreeAccessProgramService
+  reconciler: FreeAccessProgramService,
+  statsd: StatsD
 ): ServerRoute[] => {
   const seenEvents = new Map<string, number>();
 
@@ -69,6 +71,7 @@ export const freeAccessProgramWebhookRoutes = (
         const authorization =
           (request.headers.authorization as string | undefined) ?? '';
         if (!strapiClient.verifyWebhookSignature(authorization)) {
+          statsd.increment('free_access_program.webhook.auth.error');
           throw Boom.unauthorized('Invalid Strapi webhook signature');
         }
 
@@ -76,12 +79,16 @@ export const freeAccessProgramWebhookRoutes = (
           request.payload as StrapiAccessWebhookPayload
         );
         if ('skip' in classification) {
+          statsd.increment('free_access_program.webhook.skipped', {
+            reason: classification.skip,
+          });
           return { handled: false, reason: classification.skip };
         }
 
         if (
           isDuplicateAccessWebhook(seenEvents, classification.dedupeKey, Date.now())
         ) {
+          statsd.increment('free_access_program.webhook.duplicate');
           return { handled: true, dedupe: true };
         }
 
@@ -89,6 +96,7 @@ export const freeAccessProgramWebhookRoutes = (
           await reconciler.reconcile();
         } catch (err) {
           // Swallow: the periodic cron sweep is the backstop.
+          statsd.increment('free_access_program.webhook.reconcile.error');
           log.error('subscriptions.freeAccessProgramWebhook.reconcile.error', {
             err,
           });

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ServerRoute } from '@hapi/hapi';
+import { StatsD } from 'hot-shots';
 import zendesk from 'node-zendesk';
 import Container from 'typedi';
 
@@ -45,7 +46,8 @@ export const createRoutes = (
       ...freeAccessProgramWebhookRoutes(
         log,
         Container.get(StrapiClient),
-        Container.get(FreeAccessProgramService)
+        Container.get(FreeAccessProgramService),
+        Container.get(StatsD)
       )
     );
   }

--- a/packages/fxa-auth-server/scripts/free-access-program-reconcile.ts
+++ b/packages/fxa-auth-server/scripts/free-access-program-reconcile.ts
@@ -72,11 +72,15 @@ async function main() {
   Container.set(FirestoreService as unknown as string, firestore);
   Container.set(Logger, log as unknown as Logger);
 
+  const statsd = Container.get(StatsD);
+  Container.set(StatsDService as unknown as string, statsd);
+
   const configurationManager = new FreeAccessProgramConfigurationManager(
     strapiClientConfig as unknown as StrapiClientConfig,
     strapiClient,
     firestore,
-    log as unknown as Logger
+    log as unknown as Logger,
+    statsd
   );
   Container.set(FreeAccessProgramConfigurationManager, configurationManager);
 
@@ -89,8 +93,6 @@ async function main() {
   );
   Container.set(FreeAccessProgramJournalManagerConfig, journalManagerConfig);
 
-  const statsd = Container.get(StatsD);
-  Container.set(StatsDService as unknown as string, statsd);
   const notifier = new FreeAccessInProcessNotifier(
     database,
     Container.get(ProfileClient),


### PR DESCRIPTION
## Because

* Free access program cache lookups had no telemetry.

## This pull request

* Emits cms_free_access_request statsd timings from the memory and Firestore cache strategies.
* Injects StatsD into FreeAccessProgramConfigurationManager and updates its call sites.

## Issue that this pull request solves

Closes: #PAY-3875

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
