### PR TITLE
chore(blender): raise investigate/fix turn+budget caps for the fxa monorepo

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -8,3 +8,13 @@ investigate:
   # Let BLEnder close alerts it judges as not affecting our code.
   # Only low/medium are auto-dismissed; critical/high always require a real fix.
   dismiss_unaffected: true
+  # fxa is a large monorepo; defaults exhaust before Claude reaches a verdict.
+  # Turns set high so the $ budget is the effective governor.
+  max_claude_turns: 100
+  max_budget_usd: 6.00
+
+fix:
+  # Same monorepo-size reasoning for the auto-fix flow.
+  max_claude_turns: 100
+  max_budget_usd: 6.00
+  max_fix_attempts: 5


### PR DESCRIPTION
## Because

BLEnder's Investigate + Fix flows produced nothing on fxa: every investigate run hit the default **20-turn / $1.50** cap and exited with *no verdict* (`exit=1, likely hit max-turns or budget`), so no alert was dismissed, fixed, or commented on. fxa's monorepo is too large for Claude to reach a verdict/fix within the defaults.

## This pull request

Raises the per-repo caps in `.blender/blender.yml` (deep-merged over BLEnder defaults):
- `investigate`: `max_claude_turns` 20 → **100**, `max_budget_usd` $1.50 → **$6**
- `fix`: `max_claude_turns` 30 → **100**, `max_budget_usd` $2 → **$6**, `max_fix_attempts` 3 → **5**

Turns are set high deliberately so the **$6 budget is the effective governor** (per-turn cost on this repo means budget binds first); the turn cap just backstops runaway loops / the CI job timeout.

This lets investigations complete → produce verdicts → run remediation (dismiss unaffected low/medium; lock-bump / fix-PR / advisory for the rest, incl. critical/high).

## Issue

Relates to: FXA-14222

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
