### PR TITLE
fix(auth): throttle token-exchange retries with 429 + Retry-After

### DIFF
--- a/libs/accounts/errors/src/app-error.ts
+++ b/libs/accounts/errors/src/app-error.ts
@@ -12,6 +12,7 @@ import {
   DEBUGGABLE_PAYLOAD_KEYS,
 } from './constants';
 import { OauthError } from './oauth-error';
+import { normalizeRetryAfterMs, retryAfterHeaderValue } from './util';
 import type { Request as HapiRequest } from 'hapi';
 
 /**
@@ -518,14 +519,14 @@ export class AppError extends Error {
     });
   }
 
+  /** @param retryAfterMs Wait in milliseconds; the `retry-after` header is seconds. */
   static tooManyRequests(
-    retryAfter: number,
+    retryAfterMs: number,
     retryAfterLocalized?: string,
     canUnblock?: boolean
   ) {
-    if (!retryAfter) {
-      retryAfter = 30;
-    }
+    // Normalize once so the payload and the header can never disagree.
+    const retryAfter = normalizeRetryAfterMs(retryAfterMs);
 
     const extraData: any = {
       retryAfter: retryAfter,
@@ -549,7 +550,7 @@ export class AppError extends Error {
       },
       extraData,
       {
-        'retry-after': retryAfter.toString(),
+        'retry-after': retryAfterHeaderValue(retryAfter),
       }
     );
 

--- a/libs/accounts/errors/src/index.spec.ts
+++ b/libs/accounts/errors/src/index.spec.ts
@@ -185,19 +185,33 @@ describe('AppErrors', () => {
   });
 
   it('tooManyRequests', () => {
-    let result = AppError.tooManyRequests(900, 'in 15 minutes');
+    let result = AppError.tooManyRequests(900_000, 'in 15 minutes');
     expect(result).toBeInstanceOf(AppError);
     expect(result.errno).toEqual(114);
     expect(result.message).toEqual('Client has sent too many requests');
     expect(result.output.statusCode).toEqual(429);
     expect(result.output.payload.error).toEqual('Too Many Requests');
-    expect(result.output.payload.retryAfter).toEqual(900);
+    expect(result.output.payload.retryAfter).toEqual(900_000);
     expect(result.output.payload.retryAfterLocalized).toEqual('in 15 minutes');
 
-    result = AppError.tooManyRequests(900);
-    expect(result.output.payload.retryAfter).toEqual(900);
+    result = AppError.tooManyRequests(900_000);
+    expect(result.output.payload.retryAfter).toEqual(900_000);
     expect(!result.output.payload.retryAfterLocalized).toBeTruthy();
   });
+
+  it('tooManyRequests reports retry-after in whole seconds', () => {
+    const result = AppError.tooManyRequests(900_500);
+    expect(result.output.headers['retry-after']).toEqual('901');
+  });
+
+  it.each([0, -1, NaN, Infinity, undefined])(
+    'tooManyRequests falls back to the default wait given %p',
+    (retryAfter) => {
+      const result = AppError.tooManyRequests(retryAfter as number);
+      expect(result.output.payload.retryAfter).toEqual(30_000);
+      expect(result.output.headers['retry-after']).toEqual('30');
+    }
+  );
 
   it('iapInvalidToken', () => {
     const defaultErrorMessage = 'Invalid IAP token';

--- a/libs/accounts/errors/src/util.ts
+++ b/libs/accounts/errors/src/util.ts
@@ -16,3 +16,18 @@ export function commaSeparatedListToArray(s: string) {
     .map((c) => c.trim())
     .filter((c) => !!c);
 }
+
+/** Wait advertised on a 429 when no usable duration is available. */
+export const DEFAULT_RETRY_AFTER_MS = 30_000;
+
+/** Falls back to the default for a missing or non-positive wait. */
+export function normalizeRetryAfterMs(retryAfterMs?: number): number {
+  return Number.isFinite(retryAfterMs) && (retryAfterMs as number) > 0
+    ? (retryAfterMs as number)
+    : DEFAULT_RETRY_AFTER_MS;
+}
+
+/** Converts a millisecond wait to the whole seconds `Retry-After` requires. */
+export function retryAfterHeaderValue(retryAfterMs?: number): string {
+  return `${Math.ceil(normalizeRetryAfterMs(retryAfterMs) / 1000)}`;
+}

--- a/libs/accounts/rate-limit/README.md
+++ b/libs/accounts/rate-limit/README.md
@@ -20,7 +20,7 @@ Where a 'section' is separated by ':' and leading and trailing whitespace within
 Note that comments can be added by starting a line with '#'.
 
 - action - this is the user action being checked. e.g. loginAttempt.
-- blockOn - this is the property we are checking. Options are ip, email, ip_email, and uid.
+- blockOn - this is the property we are checking. Options are ip, email, ip_email, ip_uid, uid, and token.
 - maxAttempts - the number of tries until the rule is considered violated and block (or ban) occurs
 - windowDuration - this the time span over which actions are counted. Once the window ends, actions are allowed again.
 - blockDuration - this is how long the block (or ban) lasts. Note that while active, attempts are being not counted!
@@ -33,6 +33,7 @@ Note that comments can be added by starting a line with '#'.
 - email - The user's email. This is useful only when the account isn't known and for some reason, we don't want to use ip_email.
 - uid - The user's account id. This can be useful from stopping a user that has logged in from doing something malicious, like trying to mine data.
 - ip_uid - The user's IP with the user's uid appended. This is useful for ensuring that one user can be impacted by another user's experience.
+- token - The hash of a credential the caller presented. This is useful for actions that must be checked before the account behind the credential is known.
 
 ### The 'default' Rule
 

--- a/libs/accounts/rate-limit/src/lib/config.ts
+++ b/libs/accounts/rate-limit/src/lib/config.ts
@@ -85,9 +85,11 @@ export function parseConfigRules(
         line
       );
     }
-    if (!/^ip$|^uid$|^email$|^ip_email$|^ip_uid$/.test(rule.blockingOn)) {
+    if (
+      !/^ip$|^uid$|^email$|^ip_email$|^ip_uid$|^token$/.test(rule.blockingOn)
+    ) {
       throw new InvalidRule(
-        `Blocking on must be ip, email, uid, or ip_email.`,
+        `Blocking on must be ip, email, uid, ip_email, ip_uid, or token.`,
         line
       );
     }

--- a/libs/accounts/rate-limit/src/lib/models.ts
+++ b/libs/accounts/rate-limit/src/lib/models.ts
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/** The attributes we can count and block on. */
-export type BlockOn = 'ip' | 'email' | 'uid' | 'ip_email' | 'ip_uid';
+/**
+ * The attributes we can count and block on. 'token' is a credential hash, for
+ * actions checked before the account behind the credential is known.
+ */
+export type BlockOn = 'ip' | 'email' | 'uid' | 'ip_email' | 'ip_uid' | 'token';
 
 export function isBlockOn(value: unknown): value is BlockOn {
   return (
@@ -11,7 +14,8 @@ export function isBlockOn(value: unknown): value is BlockOn {
     value === 'email' ||
     value === 'uid' ||
     value === 'ip_email' ||
-    value === 'ip_uid'
+    value === 'ip_uid' ||
+    value === 'token'
   );
 }
 

--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -57,6 +57,36 @@ describe('rate-limit', () => {
     expect(rateLimit.supportsAction('foo')).toBeTruthy();
   });
 
+  it.each(['token', 'ip_uid'] as const)(
+    'short circuits on a ban held against %s',
+    async (blockingOn) => {
+      const blockedValue = 'a'.repeat(64);
+      const banKey = `rate-limit:ban:${blockingOn}=${blockedValue}`;
+      const ban: BlockRecord = {
+        action: 'tokenExchange',
+        usedDefaultRule: false,
+        blockingOn,
+        blockedValue,
+        startTime: MOCK_NOW,
+        duration: 900,
+        attempts: 6,
+        reason: TOO_MANY_ATTEMPTS,
+        policy: 'ban',
+      };
+      redis.get = jest.fn(async (key: string) =>
+        key === banKey ? JSON.stringify(ban) : null
+      ) as unknown as Redis['get'];
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+
+      const result = await rateLimit.check('tokenExchange', {
+        [blockingOn]: blockedValue,
+      });
+
+      expect(result?.blockingOn).toBe(blockingOn);
+      expect(result?.policy).toBe('ban');
+    }
+  );
+
   it('throws if no action can be found', async () => {
     rateLimit = new RateLimit({ rules: {} }, redis, statsd);
     expect(rateLimit.check('foo', {})).rejects.toThrow(
@@ -73,30 +103,35 @@ describe('rate-limit', () => {
           'testEmail:email:1:1s:1s:block',
           'testUid:uid:1:1s:1s:block',
           'testIpUid:ip_uid:1:1s:1s:block',
+          'testToken:token:1:1s:1s:block',
         ]),
       },
       redis,
       statsd
     );
 
-    expect(rateLimit.check('testIp', {})).rejects.toThrow(
+    await expect(rateLimit.check('testIp', {})).rejects.toThrow(
       `A rule for the 'testIp' action requires that 'ip' is provided as an option.`
     );
 
-    expect(rateLimit.check('testEmail', {})).rejects.toThrow(
+    await expect(rateLimit.check('testEmail', {})).rejects.toThrow(
       `A rule for the 'testEmail' action requires that 'email' is provided as an option.`
     );
 
-    expect(rateLimit.check('testUid', {})).rejects.toThrow(
+    await expect(rateLimit.check('testUid', {})).rejects.toThrow(
       `A rule for the 'testUid' action requires that 'uid' is provided as an option.`
     );
 
-    expect(rateLimit.check('testIpEmail', {})).rejects.toThrow(
+    await expect(rateLimit.check('testIpEmail', {})).rejects.toThrow(
       `A rule for the 'testIpEmail' action requires that 'ip_email' is provided as an option.`
     );
 
-    expect(rateLimit.check('testIpUid', {})).rejects.toThrow(
+    await expect(rateLimit.check('testIpUid', {})).rejects.toThrow(
       `A rule for the 'testIpUid' action requires that 'ip_uid' is provided as an option.`
+    );
+
+    await expect(rateLimit.check('testToken', {})).rejects.toThrow(
+      `A rule for the 'testToken' action requires that 'token' is provided as an option.`
     );
   });
 
@@ -536,13 +571,14 @@ describe('rate-limit', () => {
         test        : uid                :  1           : 30 seconds            : 1 day          : block
         test        : ip_email           :  100         : 10 seconds            : 1 Month        : block
         test        : ip_uid             :  100         : 10 seconds            : 1 Month        : block
+        test        : token              :  5           : 10 seconds            : 1 Month        : block
         testBan     : ip                 :  100         : 10 seconds            : 1 Month        : ban
         testReport  : ip                 :  10          : 10 seconds            : 1 Month        : report
       `);
       let rules = ruleSet['test'];
 
       expect(rules).toBeDefined();
-      expect(rules.length).toEqual(5);
+      expect(rules.length).toEqual(6);
 
       expect(rules[0]).toBeDefined();
       expect(rules[0].maxAttempts).toEqual(1);
@@ -578,6 +614,13 @@ describe('rate-limit', () => {
       expect(rules[4].blockDurationInSeconds).toEqual(2592000);
       expect(rules[4].blockPolicy).toEqual('block');
 
+      expect(rules[5]).toBeDefined();
+      expect(rules[5].maxAttempts).toEqual(5);
+      expect(rules[5].blockingOn).toEqual('token');
+      expect(rules[5].windowDurationInSeconds).toEqual(10);
+      expect(rules[5].blockDurationInSeconds).toEqual(2592000);
+      expect(rules[5].blockPolicy).toEqual('block');
+
       rules = ruleSet['testBan'];
       expect(rules[0].maxAttempts).toEqual(100);
       expect(rules[0].blockingOn).toEqual('ip');
@@ -602,6 +645,21 @@ describe('rate-limit', () => {
         test     : ip                 :  1           :   1 second            : 1s             : block
       `)
       ).toThrow(/Invalid configuration! Duplicates detected:/);
+    });
+
+    it.each(['ip', 'email', 'uid', 'ip_email', 'ip_uid', 'token'])(
+      'accepts %s as a blockOn',
+      (blockOn) => {
+        expect(() =>
+          parseConfigRules(`test:${blockOn}:1:1s:1s:block`)
+        ).not.toThrow();
+      }
+    );
+
+    it('rejects an unknown blockOn', () => {
+      expect(() => parseConfigRules('test:sessionId:1:1s:1s:block')).toThrow(
+        /Blocking on must be ip, email, uid, ip_email, ip_uid, or token/
+      );
     });
 
     it('throws on malformed rule', () => {

--- a/libs/accounts/rate-limit/src/lib/rate-limit.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.ts
@@ -280,9 +280,7 @@ export class RateLimit {
       })(),
       wasBlocked: result != null,
       blockPolicy: result?.policy,
-      blockDurationSeconds: result
-        ? result.duration
-        : undefined,
+      blockDurationSeconds: result ? result.duration : undefined,
       wasSkipped,
       usedDefaultRule: firstRule?.isDefault ?? false,
     });
@@ -416,6 +414,8 @@ export class RateLimit {
       check('ip', opts.ip),
       check('ip_email', opts.ip_email),
       check('uid', opts.uid),
+      check('ip_uid', opts.ip_uid),
+      check('token', opts.token),
     ]);
     return bans;
   }

--- a/packages/fxa-auth-server/config/index.spec.ts
+++ b/packages/fxa-auth-server/config/index.spec.ts
@@ -45,4 +45,37 @@ describe('Config', () => {
       }).not.toThrow();
     });
   });
+
+  describe('rate limit rules', () => {
+    // The shipped rules file is otherwise only parsed at server boot, so a typo
+    // here surfaces as a deploy-time crash rather than a failing test.
+    function shippedRules() {
+      const { parseConfigRules } = require('@fxa/accounts/rate-limit');
+      const { config } = require('./index');
+      return parseConfigRules(config.get('rateLimit.rules'));
+    }
+
+    it('parses without error', () => {
+      expect(shippedRules).not.toThrow();
+    });
+
+    it('limits tokenExchange on both the token hash and the ip', () => {
+      expect(shippedRules()['tokenExchange']).toEqual([
+        {
+          blockingOn: 'token',
+          maxAttempts: 5,
+          windowDurationInSeconds: 900,
+          blockDurationInSeconds: 900,
+          blockPolicy: 'block',
+        },
+        {
+          blockingOn: 'ip',
+          maxAttempts: 100,
+          windowDurationInSeconds: 900,
+          blockDurationInSeconds: 900,
+          blockPolicy: 'block',
+        },
+      ]);
+    });
+  });
 });

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -202,3 +202,11 @@ passwordlessVerifyOtp                  : ip               : 100         : 24 hou
 passwordlessVerifyOtpPerDay            : ip_email         : 10          : 24 hours        : 24 hours     : block
 passwordlessVerifyOtpPerDay            : email            : 20          : 24 hours        : 24 hours     : block
 passwordlessVerifyOtpPerDay            : ip               : 100         : 24 hours        : 15 minutes   : ban
+
+#
+# Token Exchange (RFC 8693)
+# A successful exchange revokes the subject token, so a repeat with the same token is a retry of
+# a rejection. Counting on the token hash throttles the looping client without affecting others.
+#
+tokenExchange                          : token            : 5           : 15 minutes      : 15 minutes   : block
+tokenExchange                          : ip               : 100         : 15 minutes      : 15 minutes   : block

--- a/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
@@ -323,5 +323,9 @@ export const AUTH_SERVER_API_DESCRIPTION = {
             "retryAfterLocalized": "in a few seconds"
         }
   \`\`\`
+
+    Rate limiting uses the same shape with \`429 Too Many Requests\` and
+    \`errno: 114\`. On those responses \`retryAfter\` is in **milliseconds**;
+    the \`Retry-After\` header is in seconds, as always.
   `,
 };

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -182,6 +182,16 @@ class CustomsClient {
     return this.handleCustomsResult(request, result);
   }
 
+  /**
+   * Rate limits on a credential hash, for actions checked before the account
+   * behind it is known. v2 only; no-ops when v2 is off.
+   */
+  async checkToken(request, action, tokenHash) {
+    const opts = toOpts(request?.app?.clientAddress);
+    opts.token = tokenHash;
+    await this.checkV2(request, 'checkToken', action, opts);
+  }
+
   async flag(ip, info) {
     // noop since this is being deprecated
     return Promise.resolve();
@@ -247,15 +257,18 @@ class CustomsClient {
       const unblock = !!result.unblock;
 
       if (result.retryAfter) {
+        // Legacy reports seconds; everything downstream expects ms.
+        const retryAfter = result.retryAfter * 1000;
+
         // Create a localized retryAfterLocalized value from retryAfter.
         // For example '713' becomes '12 minutes' in English.
         const retryAfterLocalized = localizeTimestamp.format(
-          Date.now() + result.retryAfter * 1000,
+          Date.now() + retryAfter,
           request.headers['accept-language']
         );
 
         throw this.error.tooManyRequests(
-          result.retryAfter,
+          retryAfter,
           retryAfterLocalized,
           unblock
         );
@@ -320,6 +333,7 @@ class CustomsClient {
         uid: opts.uid,
         ip_email: opts.ip_email,
         ip_uid: opts.ip_uid,
+        token: opts.token,
       });
     } catch (err) {
       Sentry.captureException(err, {

--- a/packages/fxa-auth-server/lib/customs.spec.ts
+++ b/packages/fxa-auth-server/lib/customs.spec.ts
@@ -118,7 +118,8 @@ describe('Customs', () => {
     expect(err.message).toBe('Client has sent too many requests');
     expect(err.isBoom).toBeTruthy();
     expect(err.output.statusCode).toBe(429);
-    expect(err.output.payload.retryAfter).toBe(10001);
+    // Legacy reports seconds; payload is normalized to ms, header back to seconds.
+    expect(err.output.payload.retryAfter).toBe(10001000);
     expect(err.output.headers['retry-after']).toBe('10001');
   });
 
@@ -218,7 +219,7 @@ describe('Customs', () => {
       err = e;
     }
     expect(err.output.statusCode).toBe(429);
-    expect(err.output.payload.retryAfter).toBe(10001);
+    expect(err.output.payload.retryAfter).toBe(10001000);
     expect(err.output.payload.retryAfterLocalized).toBe('in 3 hours');
 
     const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
@@ -437,6 +438,43 @@ describe('Customs', () => {
           ip_email: normalizedIpEmail,
         })
       );
+    });
+
+    it('checks a token hash alongside the ip on checkToken', async () => {
+      const tokenHash = 'a'.repeat(64);
+      mockRateLimit.check = jest.fn(async () => Promise.resolve(null));
+
+      await customs.checkToken(request, 'tokenExchange', tokenHash);
+
+      expect(mockRateLimit.check).toHaveBeenCalledWith('tokenExchange', {
+        ip,
+        token: tokenHash,
+      });
+    });
+
+    it('throws a 429 in milliseconds when checkToken is blocked', async () => {
+      const tokenHash = 'a'.repeat(64);
+      mockRateLimit.check = jest.fn(async () =>
+        Promise.resolve({ retryAfter: 900000, reason: 'too-many-attempts' })
+      );
+
+      const err: any = await customs
+        .checkToken(request, 'tokenExchange', tokenHash)
+        .catch((e: any) => e);
+
+      expect(err.errno).toBe(114);
+      expect(err.output.statusCode).toBe(429);
+      expect(err.output.payload.retryAfter).toBe(900000);
+      expect(err.output.headers['retry-after']).toBe('900');
+    });
+
+    it('does not call the legacy customs server on checkToken when v2 is off', async () => {
+      const customsV1Only = new Customs(CUSTOMS_URL_REAL, log, error, statsd);
+      global.fetch = jest.fn();
+
+      await customsV1Only.checkToken(request, 'tokenExchange', 'a'.repeat(64));
+
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('unblocks the ip and normalized email on reset', async () => {

--- a/packages/fxa-auth-server/lib/error.spec.ts
+++ b/packages/fxa-auth-server/lib/error.spec.ts
@@ -136,17 +136,17 @@ describe('AppErrors', () => {
   });
 
   it('tooManyRequests', () => {
-    let result = AppError.tooManyRequests(900, 'in 15 minutes');
+    let result = AppError.tooManyRequests(900_000, 'in 15 minutes');
     expect(result instanceof AppError).toBe(true);
     expect(result.errno).toBe(114);
     expect(result.message).toBe('Client has sent too many requests');
     expect(result.output.statusCode).toBe(429);
     expect(result.output.payload.error).toBe('Too Many Requests');
-    expect(result.output.payload.retryAfter).toBe(900);
+    expect(result.output.payload.retryAfter).toBe(900_000);
     expect(result.output.payload.retryAfterLocalized).toBe('in 15 minutes');
 
-    result = AppError.tooManyRequests(900);
-    expect(result.output.payload.retryAfter).toBe(900);
+    result = AppError.tooManyRequests(900_000);
+    expect(result.output.payload.retryAfter).toBe(900_000);
     expect(result.output.payload.retryAfterLocalized).toBeUndefined();
   });
 

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -88,7 +88,8 @@ module.exports = function (
     devicesImpl,
     statsd,
     glean,
-    authServerCacheRedis
+    authServerCacheRedis,
+    customs
   );
   const oauthRoutes = oauth.map((route) => ({
     path: route.path,

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -8,7 +8,8 @@ module.exports = (
   devices,
   statsd,
   glean,
-  authServerCacheRedis
+  authServerCacheRedis,
+  customs
 ) => {
   const routes = [
     require('./authorization')({ log, oauthDB, config, statsd }),
@@ -29,6 +30,7 @@ module.exports = (
       statsd,
       glean,
       authServerCacheRedis,
+      customs,
     }),
     require('./verify')({ log, glean }),
   ].flat();

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -262,6 +262,7 @@ module.exports = ({
   statsd,
   glean,
   authServerCacheRedis,
+  customs,
 }) => {
   async function validateGrantParameters(client, params) {
     let requestedGrant;
@@ -605,7 +606,15 @@ module.exports = ({
     // Token exchange doesn't require client authentication since the
     // subject_token is already bound to an allowed client.
     let client = null;
-    if (params.grant_type !== GRANT_TOKEN_EXCHANGE) {
+    if (params.grant_type === GRANT_TOKEN_EXCHANGE) {
+      // A successful exchange revokes the subject token, so a repeat with the
+      // same token is a retry of a rejection. Must stay ahead of the db reads.
+      await customs.checkToken(
+        req,
+        'tokenExchange',
+        hex(encrypt.hash(params.subject_token))
+      );
+    } else {
       client = await authenticateClient(req.headers, params);
       // Refuse to generate new access tokens for disabled clients that are already
       // connected to the account. We allow disabled clients to claim existing authorization

--- a/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const crypto = require('crypto');
 const Joi = require('joi');
 const { Container } = require('typedi');
+const { AppError: AuthError } = require('@fxa/accounts/errors');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
 const {
@@ -33,6 +35,11 @@ const GRANT_TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange';
 const SUBJECT_TOKEN_TYPE_REFRESH =
   'urn:ietf:params:oauth:token-type:refresh_token';
 const FIREFOX_IOS_CLIENT_ID = '1b1a3e44c54fbb58';
+// Mirrors encrypt.hash(), used by the route to key the rate limit.
+const SUBJECT_TOKEN_HASH = crypto
+  .createHash('sha256')
+  .update(Buffer.from(REFRESH_TOKEN, 'hex'))
+  .digest('hex');
 
 const noop = () => {};
 const mockLog = { debug: noop, warn: noop, info: noop, error: noop };
@@ -41,6 +48,7 @@ const mockStatsD = { increment: jest.fn() };
 const mockGlean = {
   oauth: { tokenCreated: jest.fn() },
 };
+const mockCustoms = { checkToken: jest.fn().mockResolvedValue(undefined) };
 
 const tokenRoutesDepMocks = {
   '../../oauth/assertion': async () => true,
@@ -131,6 +139,7 @@ const tokenRoutesArgMocks = {
   devices: {},
   statsd: mockStatsD,
   glean: mockGlean,
+  customs: mockCustoms,
 };
 
 let tokenRoutes: any;
@@ -702,6 +711,60 @@ describe('token exchange grant_type', () => {
       expect(result.scope).toContain(OAUTH_SCOPE_OLD_SYNC);
       expect(result.scope).toContain(OAUTH_SCOPE_RELAY);
       expect(hex(removedTokenId)).toBe('1234567890abcdef');
+    });
+  });
+
+  describe('rate limiting', () => {
+    function exchangeRequest() {
+      return {
+        app: {},
+        headers: {},
+        payload: {
+          grant_type: GRANT_TOKEN_EXCHANGE,
+          subject_token: REFRESH_TOKEN,
+          subject_token_type: SUBJECT_TOKEN_TYPE_REFRESH,
+          scope: OAUTH_SCOPE_RELAY,
+        },
+        emitMetricsEvent: () => {},
+      };
+    }
+
+    it('throttles on the hash of the subject_token', async () => {
+      resetAndMockDeps();
+      const routes = require('./token')(tokenRoutesArgMocks);
+      const request = exchangeRequest();
+
+      await expect(routes[0].config.handler(request)).rejects.toMatchObject({
+        errno: 108, // the stub subject_token does not resolve
+      });
+
+      expect(mockCustoms.checkToken).toHaveBeenCalledWith(
+        request,
+        'tokenExchange',
+        SUBJECT_TOKEN_HASH
+      );
+    });
+
+    it('rejects a throttled exchange without reading the oauth db', async () => {
+      resetAndMockDeps();
+      const getRefreshToken = jest.fn();
+      const routes = require('./token')({
+        ...tokenRoutesArgMocks,
+        customs: {
+          checkToken: jest
+            .fn()
+            .mockRejectedValue(
+              AuthError.tooManyRequests(900_000, 'in 15 minutes')
+            ),
+        },
+        oauthDB: { ...tokenRoutesArgMocks.oauthDB, getRefreshToken },
+      });
+
+      await expect(
+        routes[0].config.handler(exchangeRequest())
+      ).rejects.toMatchObject({ errno: 114 });
+
+      expect(getRefreshToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-auth-server/lib/server.in.spec.ts
+++ b/packages/fxa-auth-server/lib/server.in.spec.ts
@@ -715,10 +715,11 @@ describe('lib/server', () => {
 
           it('handles customs block', async () => {
             customs.checkIpOnly = jest.fn(async () => {
-              throw error.tooManyRequests(100, 'foo');
+              throw error.tooManyRequests(100000, 'foo');
             });
 
-            const { statusCode, result } = await query('/account/status');
+            const { statusCode, result, headers } =
+              await query('/account/status');
 
             expect(customs.checkIpOnly).toHaveBeenCalledTimes(1);
             expect(statusCode).toBe(429);
@@ -728,9 +729,33 @@ describe('lib/server', () => {
               error: 'Too Many Requests',
               info: 'https://mozilla.github.io/ecosystem-platform/api#section/Response-format',
               message: 'Client has sent too many requests',
-              retryAfter: 100,
+              retryAfter: 100000,
               retryAfterLocalized: 'foo',
             });
+            expect(headers['retry-after']).toBe('100');
+          });
+
+          it('sends a default retry-after on a 429 that carries no wait', async () => {
+            customs.checkIpOnly = jest.fn(async () => {
+              throw error.smsSendRateLimitExceeded();
+            });
+
+            const { statusCode, headers } = await query('/account/status');
+
+            expect(statusCode).toBe(429);
+            expect(headers['retry-after']).toBe('30');
+          });
+
+          it('keeps a retry-after the 429 already set', async () => {
+            customs.checkIpOnly = jest.fn(async () => {
+              const err = error.tooManyRequests(100000, 'foo');
+              err.header('retry-after', '5');
+              throw err;
+            });
+
+            const { headers } = await query('/account/status');
+
+            expect(headers['retry-after']).toBe('5');
           });
 
           for (const endpoint of [

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -26,6 +26,7 @@ const {
   reportValidationError,
 } = require('fxa-shared/sentry/report-validation-error');
 const { logErrorWithGlean } = require('./metrics/glean');
+const { retryAfterHeaderValue } = require('@fxa/accounts/errors');
 const mfa = require('./routes/auth-schemes/mfa');
 const verifiedSessionToken = require('./routes/auth-schemes/verified-session-token');
 
@@ -409,6 +410,17 @@ async function create(
       response = error.translate(request, response, oauthRoutes);
       if (config.env !== 'prod') {
         response.backtrace(request.app.traced);
+      }
+
+      // Clients need Retry-After to back off; payload is ms, header is seconds.
+      if (
+        response.output?.statusCode === 429 &&
+        !response.output.headers?.['retry-after']
+      ) {
+        response.header(
+          'retry-after',
+          retryAfterHeaderValue(response.output.payload?.retryAfter)
+        );
       }
     }
     response.header('Timestamp', `${Math.floor(Date.now() / 1000)}`);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -42,6 +42,7 @@ const CUSTOMS_METHOD_NAMES = [
   'check',
   'checkAuthenticated',
   'checkIpOnly',
+  'checkToken',
   'flag',
   'reset',
   'v2Enabled',

--- a/packages/fxa-auth-server/test/remote/oauth_token_route.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_token_route.in.spec.ts
@@ -88,6 +88,7 @@ const tokenRoutesArgMocks = {
   statsd: mockStatsD,
   glean: mockGlean,
   authServerCacheRedis: mockAuthServerCacheRedis,
+  customs: { checkToken: jest.fn().mockResolvedValue(undefined) },
 };
 
 // Captured at module scope so beforeAll's set and afterAll's remove use the


### PR DESCRIPTION
## Because

- Repeated rejected token-exchange requests on `/v1/oauth/token` were answered identically every time, giving the client no signal to back off.
- 429s carried `retryAfter` in the body only, so clients that back off on the `Retry-After` header saw nothing.
- Customs v2 reports that wait in milliseconds, where the header requires seconds.

## This pull request

- Rate limits the token-exchange grant on the `subject_token` hash, ahead of the grant's db reads.
- Adds a `token` block key to `@fxa/accounts/rate-limit`, for actions checked before the account behind a credential is known.
- Sends `Retry-After` in whole seconds, with an `onPreResponse` backstop so every 429 carries the header.
- Normalizes the legacy customs `retryAfter` to milliseconds so the payload matches customs v2 and fxa-settings.
- Folds in FXA-14217, which was cancelled in favour of landing it here.

## Issue that this pull request solves

Closes: FXA-14081

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files: `lib/routes/oauth/token.js`, `lib/customs.js`, `lib/server.js`, `config/rate-limit-rules.txt`.
- Suggested order: rules file → `token.js` → `customs.js` → errors lib → `server.js` → tests.
- A successful exchange revokes the subject token, so a repeat with the same token is a retry of a rejection — which is why counting every attempt is equivalent to counting rejections.
- Riskiest part: the `retryAfter` **body** value on the legacy customs path changes from seconds to ms.
- Customs v2 already reported ms and is the path that actually serves 429s, so there is no client-visible change; `Retry-After` is now correct on both.

## Other information (Optional)

Follow-ups, not addressed here:

- Token blocks self-expire after 15 minutes and are not searchable or clearable through admin tooling.
- The throttle counts every exchange attempt, so repeated backend failures on the same token consume its budget.
- Pre-existing: `ip_uid` is missing from `findBans` in the rate-limit lib, so an `ip_uid : ban` rule would never fire.
