### PR TITLE
fix(functional-tests): Stop concurrent tests stealing each other's SMS codes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,10 @@ executors:
       FEATURE_FLAGS_USING_2FA_BACKUP_PHONE: true
       GEODB_LOCATION_OVERRIDE: '{"location": {"countryCode": "US", "postalCode": "85001"}}'
       RECOVERY_PHONE__ENABLED: true
+      # Every local test registers the same magic number, so the production anti-abuse
+      # cap of 5 would reject them once they run in parallel. 8 nodes x 3 workers puts
+      # a ceiling of 24 on concurrent holders; 50 leaves room for slow teardowns.
+      RECOVERY_PHONE__MAX_UID_PER_NUMBER: 50
       # use test mode except for smoke tests
       RECOVERY_PHONE__TWILIO__CREDENTIAL_MODE: 'test'
       CUSTOMS_SERVER_URL: none
@@ -419,8 +423,17 @@ commands:
               echo "Phone-tagged tests run only on node 0; this is node ${CIRCLE_NODE_INDEX:-0}. Skipping.";
               exit 0;
             fi
+            # Apply the same severity filter as run-playwright-tests, so a #phone test
+            # cannot reach an environment (stage, production) its severity label excludes.
+            if [[ "<< parameters.project >>" == "production" ]]; then
+              GREP='(?=.*#phone)(?=.*severity-1)'
+            elif [[ "<< parameters.project >>" == "stage" ]]; then
+              GREP='(?=.*#phone)(?=.*severity-(1|2))'
+            else
+              GREP='#phone'
+            fi
             cd packages/functional-tests
-            yarn playwright test --project=<< parameters.project >> --grep "#phone" --workers=1
+            yarn playwright test --project=<< parameters.project >> --grep "$GREP" --workers=1 --pass-with-no-tests
 
   store-artifacts:
     steps:
@@ -820,8 +833,11 @@ jobs:
       - provision
       - check-playwright-test-count:
           project: production
+      - run-phone-tests-serialized:
+          project: production
       - run-playwright-tests:
           project: production
+          grep_invert: '#phone'
       - store-artifacts
 
   smoke-tests:
@@ -894,11 +910,10 @@ jobs:
           environment:
             NODE_ENV: test
           no_output_timeout: 20m
-      - run-phone-tests-serialized:
-          project: local
       - run-playwright-tests:
           project: local
-          grep_invert: '#phone'
+          # No phone reservation here: the local executor runs Twilio in test mode, so
+          # codes are read from redis by uid and cannot collide across workers.
           fail_fast: << parameters.fail_fast >>
       - store-artifacts
       - upload_to_gcs:

--- a/packages/functional-tests/README.md
+++ b/packages/functional-tests/README.md
@@ -462,3 +462,12 @@ FUNCTIONAL_TESTS__TWILIO__API_KEY__PRODUCTION=XXX
 FUNCTIONAL_TESTS__TWILIO__API_SECRET__PRODUCTION=XXX
 FUNCTIONAL_TESTS__TWILIO__TEST_NUMBER__PRODUCTION=XXX
 ```
+
+### Routing SMS tests in CI
+
+On stage and production every SMS test reads the same Twilio number, and the lookup returns the most recent message sent to that number regardless of which test triggered it. Two tests mid-flow at once will consume each other's codes, so CI keeps them apart:
+
+- **Tag the test `#phone`** if it needs real SMS coverage on a remote target. CI reserves node 0 and runs every `#phone` test there with `--workers=1`.
+- **Leave the severity label off** otherwise, which is the existing convention for local-only tests. Locally Twilio runs in test mode and codes are read from redis by uid, so those tests cannot collide and run in the normal parallel split.
+
+`SmsClient.getCode()` throws when a test carrying a severity label reads a code without `#phone`, so a new SMS test has to land on one side or the other rather than quietly racing.

--- a/packages/functional-tests/lib/sms.ts
+++ b/packages/functional-tests/lib/sms.ts
@@ -2,10 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { test } from '@playwright/test';
 import { Twilio } from 'twilio';
 import Redis from 'ioredis';
 import type { Redis as RedisType } from 'ioredis';
 import { TargetName, getFromEnv, getFromEnvWithFallback } from './targets';
+
+/** Remote targets select tests by severity label; #phone routes them to the serialized runner. */
+const SEVERITY_LABEL = /severity-\d/;
+const PHONE_TAG = /#phone\b/;
 
 // Default test number, see Twilio test credentials phone numbers:
 // https://www.twilio.com/docs/iam/test-credentials
@@ -99,10 +104,33 @@ export class SmsClient {
     phoneNumber?: string;
     timeout?: number;
   }) {
+    this.assertSmsTestIsIsolated();
+
     if (this.isTwilioEnabled()) {
       return this._getCodeTwilio(phoneNumber);
     } else {
       return this._getCodeLocal(uid, timeout);
+    }
+  }
+
+  /**
+   * Against a real Twilio number the code lookup returns the newest message sent to that
+   * number, whoever triggered it, so two concurrent SMS flows steal each other's codes.
+   * Stage and production select tests by severity label, so a labelled test must also be
+   * #phone to reach the serialized runner. Checked on every target so local catches it first.
+   *
+   * Only covers reads. A labelled test that sends to the shared number without ever calling
+   * this would still overwrite the message a #phone test is waiting on; none exist today.
+   */
+  private assertSmsTestIsIsolated() {
+    const title = test.info().titlePath.join(' ');
+    if (SEVERITY_LABEL.test(title) && !PHONE_TAG.test(title)) {
+      throw new Error(
+        `Test reads an SMS code and carries a severity label, so it will run on stage and
+production alongside other SMS tests and can consume their codes. Tag it #phone to put it on
+the serialized runner, or drop the severity label to keep it local.
+  Test: ${title}`
+      );
     }
   }
 

--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test } from '../../lib/fixtures/standard';
+import { Page, expect, test } from '../../lib/fixtures/standard';
 import { enableTotpOnAccount } from '../../lib/pairing-helpers';
 import { gotoSyncSession } from '../../lib/sync-helpers';
 import { getTotpCode } from '../../lib/totp';
@@ -12,58 +12,58 @@ const CLIENTID_123Done = 'dcdb5ae7add825d2';
 const ENTRYPOINT_SYNC = 'firefox-cms';
 const CLIENTID_SYNC = '5882386c6d801776';
 
+async function assertCmsCustomization(
+  page: Page,
+  {
+    headline,
+    description,
+    logoUrl,
+    logoAlt = '123Done logo',
+    buttonColor,
+    buttonText,
+  }: {
+    headline: string;
+    description?: string;
+    logoUrl?: string;
+    logoAlt?: string;
+    buttonColor: string;
+    buttonText: string;
+  }
+) {
+  await expect(page.getByRole('heading', { name: headline })).toBeVisible();
+
+  if (description) {
+    await expect(page.getByText(description)).toBeVisible();
+  }
+
+  if (logoUrl) {
+    // A Firefox-branded mobile promo (PromoQrMobile) renders a second img
+    // with the same alt text, so scope to the CMS logo by its src.
+    const logo = page
+      .getByRole('img', { name: logoAlt, exact: true })
+      .and(page.locator(`[src="${logoUrl}"]`));
+    await expect(logo).toBeVisible();
+    await expect(logo).toHaveAttribute('src', logoUrl);
+  }
+
+  const button = page.getByRole('button', {
+    name: buttonText,
+    exact: true,
+  });
+  await expect(button).toBeVisible();
+  await expect(button).toHaveClass(/cta-primary-cms/);
+  await expect(button).toHaveClass(/cta-xl/);
+  await expect(button).toHaveClass(/cta-primary/);
+  await expect(button).toHaveCSS('--cta-bg', buttonColor);
+  await expect(button).toHaveCSS('--cta-border', buttonColor);
+  await expect(button).toHaveCSS('--cta-active', buttonColor);
+  await expect(button).toHaveCSS('--cta-disabled', buttonColor);
+}
+
 test.describe('severity-1 #smoke', () => {
   test.describe.configure({ mode: 'parallel' });
   test.describe('CMS customization with 2FA flows', () => {
     let config: any;
-
-    async function assertCmsCustomization(
-      page: any,
-      {
-        headline,
-        description,
-        logoUrl,
-        logoAlt = '123Done logo',
-        buttonColor,
-        buttonText,
-      }: {
-        headline: string;
-        description?: string;
-        logoUrl?: string;
-        logoAlt?: string;
-        buttonColor: string;
-        buttonText: string;
-      }
-    ) {
-      await expect(page.getByRole('heading', { name: headline })).toBeVisible();
-
-      if (description) {
-        await expect(page.getByText(description)).toBeVisible();
-      }
-
-      if (logoUrl) {
-        // A Firefox-branded mobile promo (PromoQrMobile) renders a second img
-        // with the same alt text, so scope to the CMS logo by its src.
-        const logo = page
-          .getByRole('img', { name: logoAlt, exact: true })
-          .and(page.locator(`[src="${logoUrl}"]`));
-        await expect(logo).toBeVisible();
-        await expect(logo).toHaveAttribute('src', logoUrl);
-      }
-
-      const button = page.getByRole('button', {
-        name: buttonText,
-        exact: true,
-      });
-      await expect(button).toBeVisible();
-      await expect(button).toHaveClass(/cta-primary-cms/);
-      await expect(button).toHaveClass(/cta-xl/);
-      await expect(button).toHaveClass(/cta-primary/);
-      await expect(button).toHaveCSS('--cta-bg', buttonColor);
-      await expect(button).toHaveCSS('--cta-border', buttonColor);
-      await expect(button).toHaveCSS('--cta-active', buttonColor);
-      await expect(button).toHaveCSS('--cta-disabled', buttonColor);
-    }
 
     test.beforeAll(async ({ target }) => {
       // These tests require customizations for 123Done and Sync. Please contact
@@ -90,11 +90,6 @@ test.describe('severity-1 #smoke', () => {
         isConfigEmpty(relierConfig) || isConfigEmpty(syncConfig),
         'CMS customization is not set up for 123Done or Sync'
       );
-
-      // SmsClient is lazy loaded, check these flags to ensure it is initialized
-      const isEnabled =
-        target.smsClient.isRedisEnabled() || target.smsClient.isTwilioEnabled();
-      test.skip(!isEnabled, 'SMS client needs redis or twilio to be enabled');
     });
 
     test.beforeEach(async ({ pages: { configPage } }) => {
@@ -220,159 +215,6 @@ test.describe('severity-1 #smoke', () => {
       // Enter TOTP code
       const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
-
-      // Verify successful login
-      expect(await relier.isLoggedIn()).toBe(true);
-    });
-
-    test('enable 2FA and signin with recovery phone - 123Done', async ({
-      target,
-      page,
-      pages: {
-        signin,
-        relier,
-        settings,
-        totp,
-        signinRecoveryPhone,
-        recoveryPhone,
-      },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-
-      // First, sign in and enable 2FA
-      await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
-      await relier.clickEmailFirst();
-
-      await assertCmsCustomization(page, {
-        headline: 'Make Space for What Matters',
-        description:
-          'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Create My List',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      let submitButton = page.getByRole('button', {
-        name: 'Create My List',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter your password',
-        description: 'for your Mozilla account',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Sign in',
-      });
-      await signin.passwordTextbox.fill(credentials.password);
-      submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
-      await submitButton.click();
-
-      // Verify successful login and go to settings
-      expect(await relier.isLoggedIn()).toBe(true);
-      await settings.goto();
-
-      // Enable 2FA
-      await expect(settings.totp.status).toHaveText('Disabled');
-      await settings.totp.addButton.click();
-      await settings.confirmMfaGuard(credentials.email);
-
-      // Set up 2FA with QR code and recovery phone
-      await totp.startTwoStepAuthWithQrCodeAndRecoveryPhoneChoice(credentials);
-
-      await expect(recoveryPhone.addHeader()).toBeVisible();
-
-      await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
-      await recoveryPhone.clickSendCode();
-
-      await expect(recoveryPhone.confirmHeader).toBeVisible();
-
-      const code = await target.smsClient.getCode({ ...credentials });
-
-      await recoveryPhone.enterCode(code);
-      await recoveryPhone.clickConfirm();
-
-      await page.waitForURL(/settings/);
-
-      await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toContainText(
-        'Two-step authentication has been enabled'
-      );
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      // Sign out
-      await settings.signOut();
-
-      await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
-      await relier.signOut();
-
-      // Sign in again with 2FA
-      await relier.clickEmailFirst();
-
-      await assertCmsCustomization(page, {
-        headline: 'Make Space for What Matters',
-        description:
-          'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Create My List',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      submitButton = page.getByRole('button', {
-        name: 'Create My List',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter your password',
-        description: 'for your Mozilla account',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Sign in',
-      });
-      await signin.passwordTextbox.fill(credentials.password);
-      submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
-      await submitButton.click();
-
-      // Should now be on TOTP code page
-      await expect(page).toHaveURL(/signin_totp_code/);
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter two-step authentication code',
-        buttonColor: '#4845D2',
-        buttonText: 'Confirm',
-      });
-
-      // Click trouble entering code to use recovery phone
-      await page.getByRole('link', { name: 'Trouble entering code?' }).click();
-
-      // Should be on recovery phone page
-      await expect(page).toHaveURL(/signin_recovery_phone/);
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter recovery code',
-        buttonColor: '#4845D2',
-        buttonText: 'Confirm',
-      });
-
-      // Get SMS code and enter it
-      const smsCode = await target.smsClient.getCode({ ...credentials });
-
-      await signinRecoveryPhone.enterCode(smsCode);
-      await signinRecoveryPhone.clickConfirm();
 
       // Verify successful login
       expect(await relier.isLoggedIn()).toBe(true);
@@ -579,5 +421,178 @@ test.describe('severity-1 #smoke', () => {
       // Verify successful login
       await page.waitForURL(/settings/);
     });
+  });
+});
+
+// Local only — see "Routing SMS tests in CI" in the README.
+test.describe('CMS customization with 2FA via recovery phone (local only)', () => {
+  test.beforeAll(async ({ target }) => {
+    // Only 123Done is needed here, unlike the Sync-and-123Done suite above.
+    const relierConfig = await target.authClient.getCmsConfig(
+      CLIENTID_123Done,
+      ENTRYPOINT_123Done
+    );
+    test.skip(
+      !relierConfig ||
+        typeof relierConfig !== 'object' ||
+        Object.keys(relierConfig).length === 0,
+      'CMS customization is not set up for 123Done'
+    );
+
+    target.smsClient.guardTestPhoneNumber();
+  });
+
+  test.beforeEach(async ({ pages: { configPage } }) => {
+    const config = await configPage.getConfig();
+    test.skip(config.cms.enabled !== true, 'CMS customization is not enabled');
+  });
+
+  test('enable 2FA and signin with recovery phone - 123Done', async ({
+    target,
+    page,
+    pages: {
+      signin,
+      relier,
+      settings,
+      totp,
+      signinRecoveryPhone,
+      recoveryPhone,
+    },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+
+    // First, sign in and enable 2FA
+    await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
+    await relier.clickEmailFirst();
+
+    await assertCmsCustomization(page, {
+      headline: 'Make Space for What Matters',
+      description:
+        'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
+      logoUrl:
+        'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+      buttonColor: '#4845D2',
+      buttonText: 'Create My List',
+    });
+
+    await page.getByRole('textbox', { name: 'Email' }).fill(credentials.email);
+    let submitButton = page.getByRole('button', {
+      name: 'Create My List',
+      exact: true,
+    });
+    await submitButton.click();
+
+    await assertCmsCustomization(page, {
+      headline: 'Enter your password',
+      description: 'for your Mozilla account',
+      logoUrl:
+        'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+      buttonColor: '#4845D2',
+      buttonText: 'Sign in',
+    });
+    await signin.passwordTextbox.fill(credentials.password);
+    submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
+    await submitButton.click();
+
+    // Verify successful login and go to settings
+    expect(await relier.isLoggedIn()).toBe(true);
+    await settings.goto();
+
+    // Enable 2FA
+    await expect(settings.totp.status).toHaveText('Disabled');
+    await settings.totp.addButton.click();
+    await settings.confirmMfaGuard(credentials.email);
+
+    // Set up 2FA with QR code and recovery phone
+    await totp.startTwoStepAuthWithQrCodeAndRecoveryPhoneChoice(credentials);
+
+    await expect(recoveryPhone.addHeader()).toBeVisible();
+
+    await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
+    await recoveryPhone.clickSendCode();
+
+    await expect(recoveryPhone.confirmHeader).toBeVisible();
+
+    const code = await target.smsClient.getCode({ ...credentials });
+
+    await recoveryPhone.enterCode(code);
+    await recoveryPhone.clickConfirm();
+
+    await page.waitForURL(/settings/);
+
+    await expect(settings.settingsHeading).toBeVisible();
+    await expect(settings.alertBar).toContainText(
+      'Two-step authentication has been enabled'
+    );
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    // Sign out
+    await settings.signOut();
+
+    await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
+    await relier.signOut();
+
+    // Sign in again with 2FA
+    await relier.clickEmailFirst();
+
+    await assertCmsCustomization(page, {
+      headline: 'Make Space for What Matters',
+      description:
+        'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
+      logoUrl:
+        'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+      buttonColor: '#4845D2',
+      buttonText: 'Create My List',
+    });
+
+    await page.getByRole('textbox', { name: 'Email' }).fill(credentials.email);
+    submitButton = page.getByRole('button', {
+      name: 'Create My List',
+      exact: true,
+    });
+    await submitButton.click();
+
+    await assertCmsCustomization(page, {
+      headline: 'Enter your password',
+      description: 'for your Mozilla account',
+      logoUrl:
+        'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+      buttonColor: '#4845D2',
+      buttonText: 'Sign in',
+    });
+    await signin.passwordTextbox.fill(credentials.password);
+    submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
+    await submitButton.click();
+
+    // Should now be on TOTP code page
+    await expect(page).toHaveURL(/signin_totp_code/);
+
+    await assertCmsCustomization(page, {
+      headline: 'Enter two-step authentication code',
+      buttonColor: '#4845D2',
+      buttonText: 'Confirm',
+    });
+
+    // Click trouble entering code to use recovery phone
+    await page.getByRole('link', { name: 'Trouble entering code?' }).click();
+
+    // Should be on recovery phone page
+    await expect(page).toHaveURL(/signin_recovery_phone/);
+
+    await assertCmsCustomization(page, {
+      headline: 'Enter recovery code',
+      buttonColor: '#4845D2',
+      buttonText: 'Confirm',
+    });
+
+    // Get SMS code and enter it
+    const smsCode = await target.smsClient.getCode({ ...credentials });
+
+    await signinRecoveryPhone.enterCode(smsCode);
+    await signinRecoveryPhone.clickConfirm();
+
+    // Verify successful login
+    expect(await relier.isLoggedIn()).toBe(true);
   });
 });

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -95,43 +95,50 @@ test.describe('severity-1 #smoke', () => {
 
       expect(await relier.isLoggedIn()).toBe(true);
     });
+  });
+});
 
-    test('can setup TOTP inline with recovery phone choice', async ({
-      target,
-      pages: { page, relier, signin, totp, recoveryPhone, inlineTotpSetup },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
+// Local only — see "Routing SMS tests in CI" in the README.
+test.describe('OAuth totp with recovery phone (local only)', () => {
+  test.beforeAll(({ target }) => {
+    target.smsClient.guardTestPhoneNumber();
+  });
 
-      await relier.goto();
-      await relier.clickRequire2FA();
-      await signin.fillOutEmailFirstForm(credentials.email);
-      await signin.fillOutPasswordForm(credentials.password);
+  test('can setup TOTP inline with recovery phone choice', async ({
+    target,
+    pages: { page, relier, signin, totp, recoveryPhone, inlineTotpSetup },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
 
-      await page.waitForURL(/inline_totp_setup/);
+    await relier.goto();
+    await relier.clickRequire2FA();
+    await signin.fillOutEmailFirstForm(credentials.email);
+    await signin.fillOutPasswordForm(credentials.password);
 
-      await expect(inlineTotpSetup.introHeading).toBeVisible();
-      await inlineTotpSetup.continueButton.click();
-      await expect(totp.setup2faAppHeading).toBeVisible();
-      await totp.setUp2faAppWithManualCode(credentials);
+    await page.waitForURL(/inline_totp_setup/);
 
-      await page.waitForURL(/inline_recovery_setup/);
+    await expect(inlineTotpSetup.introHeading).toBeVisible();
+    await inlineTotpSetup.continueButton.click();
+    await expect(totp.setup2faAppHeading).toBeVisible();
+    await totp.setUp2faAppWithManualCode(credentials);
 
-      await totp.chooseRecoveryPhoneOption();
-      await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
-      await recoveryPhone.clickSendCode();
+    await page.waitForURL(/inline_recovery_setup/);
 
-      await expect(recoveryPhone.confirmHeader).toBeVisible();
+    await totp.chooseRecoveryPhoneOption();
+    await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
+    await recoveryPhone.clickSendCode();
 
-      const smsCode = await target.smsClient.getCode({ ...credentials });
+    await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-      await recoveryPhone.enterCode(smsCode);
-      await recoveryPhone.clickConfirm();
+    const smsCode = await target.smsClient.getCode({ ...credentials });
 
-      await page.getByRole('button', { name: 'Continue' }).click();
+    await recoveryPhone.enterCode(smsCode);
+    await recoveryPhone.clickConfirm();
 
-      expect(await relier.isLoggedIn()).toBe(true);
-    });
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    expect(await relier.isLoggedIn()).toBe(true);
   });
 });
 

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -16,11 +16,7 @@ import { gotoSyncSession } from '../../lib/sync-helpers';
 import { getTotpCode } from '../../lib/totp';
 
 test.describe('severity-1 #smoke', () => {
-  test.describe('recovery phone #phone', () => {
-    // Run these tests sequentially. This must be done when using the Twilio API, because they rely on
-    // the same test phone number, and we cannot determine the order in which the messages were received.
-    test.describe.configure({ mode: 'serial' });
-
+  test.describe('recovery phone', () => {
     let testNumber: string;
 
     test.beforeAll(async ({ target }) => {
@@ -51,7 +47,7 @@ test.describe('severity-1 #smoke', () => {
       );
     });
 
-    test('can setup, confirm and remove recovery phone', async ({
+    test('can setup, confirm and remove recovery phone #phone', async ({
       target,
       pages: { page, settings, signin, recoveryPhone, totp },
       testAccountTracker,
@@ -101,7 +97,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.totp.addRecoveryPhoneButton).toBeVisible();
     });
 
-    test('can change recovery phone', async ({
+    test('can change recovery phone #phone', async ({
       target,
       pages: { page, settings, signin, recoveryPhone, totp },
       testAccountTracker,
@@ -141,7 +137,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.alertBar).toHaveText('Recovery phone changed');
     });
 
-    test('can sign-in to settings with recovery phone', async ({
+    test('can sign-in to settings with recovery phone #phone', async ({
       target,
       pages: {
         page,
@@ -185,358 +181,7 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/settings/);
     });
 
-    test('can sign-in Sync (fx_desktop_v3) with recovery phone', async ({
-      target,
-      syncBrowserPages: {
-        page,
-        settings,
-        signin,
-        recoveryPhone,
-        totp,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-        connectAnotherDevice,
-      },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signInAccount(target, page, settings, signin, credentials);
-
-      await setup2faWithBackupCodeChoice(credentials, settings, totp);
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      await addRecoveryPhone(
-        settings,
-        recoveryPhone,
-        page,
-        credentials,
-        target
-      );
-
-      await settings.signOut();
-      await page.waitForURL(/\//);
-      await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
-        { waitUntil: 'load' }
-      );
-
-      await fillOutRecoveryPhoneFromEmailFirst({
-        page,
-        signin,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-        credentials,
-        target,
-      });
-
-      await page.waitForURL(/pair/);
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      await signin.checkWebChannelMessage(FirefoxCommand.Login);
-
-      await connectAnotherDevice.clickNotNowPair();
-      await page.waitForURL(/settings/);
-    });
-
-    test('can sign-in Sync (oauth_webchannel_v1) with recovery phone', async ({
-      target,
-      syncOAuthBrowserPages: {
-        page,
-        settings,
-        signin,
-        recoveryPhone,
-        totp,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-        connectAnotherDevice,
-      },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signInAccount(target, page, settings, signin, credentials);
-
-      await setup2faWithBackupCodeChoice(credentials, settings, totp);
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      await addRecoveryPhone(
-        settings,
-        recoveryPhone,
-        page,
-        credentials,
-        target
-      );
-
-      await settings.signOut();
-      await page.waitForURL(/\//);
-
-      // Real /pair handshake so Firefox derives real Sync keys.
-      await gotoSyncSession(page, target);
-      await page.waitForURL(/action=email/, { timeout: 15000 });
-
-      await fillOutRecoveryPhoneFromEmailFirst({
-        page,
-        signin,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-        credentials,
-        target,
-      });
-
-      await page.waitForURL(/pair/);
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
-      await signin.checkWebChannelMessage(FirefoxCommand.Login);
-
-      await connectAnotherDevice.clickNotNowPair();
-      await page.waitForURL(/settings/);
-    });
-
-    test('can sign-in with recovery phone after resend code', async ({
-      target,
-      pages: {
-        page,
-        settings,
-        signin,
-        recoveryPhone,
-        totp,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-      },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signInAccount(target, page, settings, signin, credentials);
-
-      await setup2faWithBackupCodeChoice(credentials, settings, totp);
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      await addRecoveryPhone(
-        settings,
-        recoveryPhone,
-        page,
-        credentials,
-        target
-      );
-
-      await settings.signOut();
-      await page.waitForURL(/\//);
-
-      await signin.fillOutEmailFirstForm(credentials.email);
-      await signin.fillOutPasswordForm(credentials.password);
-
-      await page.waitForURL(/signin_totp_code/);
-
-      await signinTotpCode.clickTroubleEnteringCode();
-
-      await page.waitForURL(/signin_recovery_choice/);
-
-      await signinRecoveryChoice.clickChoosePhone();
-      await signinRecoveryChoice.clickContinue();
-
-      await page.waitForURL(/signin_recovery_phone/);
-
-      // Invalid code
-      await signinRecoveryPhone.enterCode('123456');
-      await signinRecoveryPhone.clickConfirm();
-
-      await expect(
-        page.getByText(/The code is invalid or expired./)
-      ).toBeVisible();
-
-      const originalCode = await target.smsClient.getCode({ ...credentials });
-
-      // Sends a new code
-      await signinRecoveryPhone.clickResendCode();
-      await expect(page.getByText('Code sent')).toBeVisible();
-
-      const nextCode = await target.smsClient.getCode({ ...credentials });
-
-      expect(originalCode).not.toEqual(nextCode);
-
-      // Enter the new code and login
-      await signinRecoveryPhone.enterCode(nextCode);
-
-      await signinRecoveryPhone.clickConfirm();
-
-      await page.waitForURL(/settings/);
-    });
-
-    test('can sign-in 123Done with recovery phone', async ({
-      target,
-      pages: {
-        page,
-        settings,
-        signin,
-        recoveryPhone,
-        totp,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-        relier,
-      },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signInAccount(target, page, settings, signin, credentials);
-
-      await setup2faWithBackupCodeChoice(credentials, settings, totp);
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      await addRecoveryPhone(
-        settings,
-        recoveryPhone,
-        page,
-        credentials,
-        target
-      );
-
-      await settings.signOut();
-
-      await relier.goto();
-      await relier.clickEmailFirst();
-
-      await fillOutRecoveryPhoneFromEmailFirst({
-        page,
-        signin,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-        credentials,
-        target,
-      });
-
-      expect(await relier.isLoggedIn()).toBe(true);
-    });
-
-    test('can use recovery code with recovery phone setup', async ({
-      target,
-      pages: {
-        page,
-        settings,
-        signin,
-        recoveryPhone,
-        totp,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryCode,
-      },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signInAccount(target, page, settings, signin, credentials);
-
-      const totpCredentials = await setup2faWithBackupCodeChoice(
-        credentials,
-        settings,
-        totp
-      );
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      await addRecoveryPhone(
-        settings,
-        recoveryPhone,
-        page,
-        credentials,
-        target
-      );
-
-      await settings.signOut();
-      await page.waitForURL(/\//);
-
-      await signin.fillOutEmailFirstForm(credentials.email);
-      await signin.fillOutPasswordForm(credentials.password);
-
-      await page.waitForURL(/signin_totp_code/);
-
-      await signinTotpCode.clickTroubleEnteringCode();
-
-      await page.waitForURL(/signin_recovery_choice/);
-
-      await signinRecoveryChoice.clickChooseCode();
-      await signinRecoveryChoice.clickContinue();
-
-      await page.waitForURL(/signin_recovery_code/);
-
-      await signinRecoveryCode.fillOutCodeForm(
-        totpCredentials.recoveryCodes[0]
-      );
-
-      await page.waitForURL(/settings/);
-
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      await expect(settings.settingsHeading).toBeVisible();
-    });
-
-    test('can still use totp code with recovery phone setup', async ({
-      target,
-      pages: {
-        page,
-        settings,
-        signin,
-        recoveryPhone,
-        totp,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-      },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signInAccount(target, page, settings, signin, credentials);
-
-      const totpCredentials = await setup2faWithBackupCodeChoice(
-        credentials,
-        settings,
-        totp
-      );
-      await expect(settings.totp.status).toHaveText('Enabled');
-
-      await addRecoveryPhone(
-        settings,
-        recoveryPhone,
-        page,
-        credentials,
-        target
-      );
-
-      await settings.signOut();
-      await page.waitForURL(/\//);
-
-      await signin.fillOutEmailFirstForm(credentials.email);
-      await signin.fillOutPasswordForm(credentials.password);
-
-      await page.waitForURL(/signin_totp_code/);
-
-      await signinTotpCode.clickTroubleEnteringCode();
-
-      await page.waitForURL(/signin_recovery_choice/);
-
-      await signinRecoveryChoice.clickChoosePhone();
-      await signinRecoveryChoice.clickContinue();
-
-      await page.waitForURL(/signin_recovery_phone/);
-
-      await signinRecoveryPhone.clickBack();
-      await page.waitForURL(/signin_recovery_choice/);
-
-      await signinRecoveryChoice.clickBack();
-      await page.waitForURL(/signin_totp_code/);
-
-      const totpCode = await getTotpCode(totpCredentials.secret);
-      await signinTotpCode.fillOutCodeForm(totpCode);
-
-      await page.waitForURL(/settings/);
-      await expect(await settings.totp.status).toHaveText('Enabled');
-    });
-
-    test('can set up recovery phone during initial 2FA setup', async ({
+    test('can set up recovery phone during initial 2FA setup #phone', async ({
       target,
       pages: { page, settings, signin, recoveryPhone, totp },
       testAccountTracker,
@@ -559,7 +204,7 @@ test.describe('severity-1 #smoke', () => {
       );
     });
 
-    test('sign in with only recovery phone available (no backup codes)', async ({
+    test('sign in with only recovery phone available (no backup codes) #phone', async ({
       target,
       pages: {
         page,
@@ -609,6 +254,326 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/settings/);
       await expect(settings.settingsHeading).toBeVisible();
     });
+  });
+});
+
+// Local only — see "Routing SMS tests in CI" in the README.
+test.describe('recovery phone (local only)', () => {
+  test.beforeAll(async ({ target }) => {
+    target.smsClient.guardTestPhoneNumber();
+  });
+
+  test('can sign-in Sync (fx_desktop_v3) with recovery phone', async ({
+    target,
+    syncBrowserPages: {
+      page,
+      settings,
+      signin,
+      recoveryPhone,
+      totp,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      connectAnotherDevice,
+    },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
+
+    await setup2faWithBackupCodeChoice(credentials, settings, totp);
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    await addRecoveryPhone(settings, recoveryPhone, page, credentials, target);
+
+    await settings.signOut();
+    await page.waitForURL(/\//);
+    await page.goto(
+      `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
+      { waitUntil: 'load' }
+    );
+
+    await fillOutRecoveryPhoneFromEmailFirst({
+      page,
+      signin,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      credentials,
+      target,
+    });
+
+    await page.waitForURL(/pair/);
+    await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+
+    await signin.checkWebChannelMessage(FirefoxCommand.Login);
+
+    await connectAnotherDevice.clickNotNowPair();
+    await page.waitForURL(/settings/);
+  });
+
+  test('can sign-in Sync (oauth_webchannel_v1) with recovery phone', async ({
+    target,
+    syncOAuthBrowserPages: {
+      page,
+      settings,
+      signin,
+      recoveryPhone,
+      totp,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      connectAnotherDevice,
+    },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
+
+    await setup2faWithBackupCodeChoice(credentials, settings, totp);
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    await addRecoveryPhone(settings, recoveryPhone, page, credentials, target);
+
+    await settings.signOut();
+    await page.waitForURL(/\//);
+
+    // Real /pair handshake so Firefox derives real Sync keys.
+    await gotoSyncSession(page, target);
+    await page.waitForURL(/action=email/, { timeout: 15000 });
+
+    await fillOutRecoveryPhoneFromEmailFirst({
+      page,
+      signin,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      credentials,
+      target,
+    });
+
+    await page.waitForURL(/pair/);
+    await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+
+    await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+    await signin.checkWebChannelMessage(FirefoxCommand.Login);
+
+    await connectAnotherDevice.clickNotNowPair();
+    await page.waitForURL(/settings/);
+  });
+
+  test('can sign-in with recovery phone after resend code', async ({
+    target,
+    pages: {
+      page,
+      settings,
+      signin,
+      recoveryPhone,
+      totp,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+    },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
+
+    await setup2faWithBackupCodeChoice(credentials, settings, totp);
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    await addRecoveryPhone(settings, recoveryPhone, page, credentials, target);
+
+    await settings.signOut();
+    await page.waitForURL(/\//);
+
+    await signin.fillOutEmailFirstForm(credentials.email);
+    await signin.fillOutPasswordForm(credentials.password);
+
+    await page.waitForURL(/signin_totp_code/);
+
+    await signinTotpCode.clickTroubleEnteringCode();
+
+    await page.waitForURL(/signin_recovery_choice/);
+
+    await signinRecoveryChoice.clickChoosePhone();
+    await signinRecoveryChoice.clickContinue();
+
+    await page.waitForURL(/signin_recovery_phone/);
+
+    // Invalid code
+    await signinRecoveryPhone.enterCode('123456');
+    await signinRecoveryPhone.clickConfirm();
+
+    await expect(
+      page.getByText(/The code is invalid or expired./)
+    ).toBeVisible();
+
+    const originalCode = await target.smsClient.getCode({ ...credentials });
+
+    // Sends a new code
+    await signinRecoveryPhone.clickResendCode();
+    await expect(page.getByText('Code sent')).toBeVisible();
+
+    const nextCode = await target.smsClient.getCode({ ...credentials });
+
+    expect(originalCode).not.toEqual(nextCode);
+
+    // Enter the new code and login
+    await signinRecoveryPhone.enterCode(nextCode);
+
+    await signinRecoveryPhone.clickConfirm();
+
+    await page.waitForURL(/settings/);
+  });
+
+  test('can sign-in 123Done with recovery phone', async ({
+    target,
+    pages: {
+      page,
+      settings,
+      signin,
+      recoveryPhone,
+      totp,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      relier,
+    },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
+
+    await setup2faWithBackupCodeChoice(credentials, settings, totp);
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    await addRecoveryPhone(settings, recoveryPhone, page, credentials, target);
+
+    await settings.signOut();
+
+    await relier.goto();
+    await relier.clickEmailFirst();
+
+    await fillOutRecoveryPhoneFromEmailFirst({
+      page,
+      signin,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      credentials,
+      target,
+    });
+
+    expect(await relier.isLoggedIn()).toBe(true);
+  });
+
+  test('can use recovery code with recovery phone setup', async ({
+    target,
+    pages: {
+      page,
+      settings,
+      signin,
+      recoveryPhone,
+      totp,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryCode,
+    },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
+
+    const totpCredentials = await setup2faWithBackupCodeChoice(
+      credentials,
+      settings,
+      totp
+    );
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    await addRecoveryPhone(settings, recoveryPhone, page, credentials, target);
+
+    await settings.signOut();
+    await page.waitForURL(/\//);
+
+    await signin.fillOutEmailFirstForm(credentials.email);
+    await signin.fillOutPasswordForm(credentials.password);
+
+    await page.waitForURL(/signin_totp_code/);
+
+    await signinTotpCode.clickTroubleEnteringCode();
+
+    await page.waitForURL(/signin_recovery_choice/);
+
+    await signinRecoveryChoice.clickChooseCode();
+    await signinRecoveryChoice.clickContinue();
+
+    await page.waitForURL(/signin_recovery_code/);
+
+    await signinRecoveryCode.fillOutCodeForm(totpCredentials.recoveryCodes[0]);
+
+    await page.waitForURL(/settings/);
+
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    await expect(settings.settingsHeading).toBeVisible();
+  });
+
+  test('can still use totp code with recovery phone setup', async ({
+    target,
+    pages: {
+      page,
+      settings,
+      signin,
+      recoveryPhone,
+      totp,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+    },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
+
+    const totpCredentials = await setup2faWithBackupCodeChoice(
+      credentials,
+      settings,
+      totp
+    );
+    await expect(settings.totp.status).toHaveText('Enabled');
+
+    await addRecoveryPhone(settings, recoveryPhone, page, credentials, target);
+
+    await settings.signOut();
+    await page.waitForURL(/\//);
+
+    await signin.fillOutEmailFirstForm(credentials.email);
+    await signin.fillOutPasswordForm(credentials.password);
+
+    await page.waitForURL(/signin_totp_code/);
+
+    await signinTotpCode.clickTroubleEnteringCode();
+
+    await page.waitForURL(/signin_recovery_choice/);
+
+    await signinRecoveryChoice.clickChoosePhone();
+    await signinRecoveryChoice.clickContinue();
+
+    await page.waitForURL(/signin_recovery_phone/);
+
+    await signinRecoveryPhone.clickBack();
+    await page.waitForURL(/signin_recovery_choice/);
+
+    await signinRecoveryChoice.clickBack();
+    await page.waitForURL(/signin_totp_code/);
+
+    const totpCode = await getTotpCode(totpCredentials.secret);
+    await signinTotpCode.fillOutCodeForm(totpCode);
+
+    await page.waitForURL(/settings/);
+    await expect(await settings.totp.status).toHaveText('Enabled');
   });
 });
 

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -17,10 +17,6 @@ import { BaseTarget } from '../../lib/targets/base';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('change 2FA', () => {
-    test.beforeAll(({ target }) => {
-      target.smsClient.guardTestPhoneNumber();
-    });
-
     // happy path
     test('can change 2FA and signin with new 2FA', async ({
       page,
@@ -105,53 +101,60 @@ test.describe('severity-2 #smoke', () => {
 
       await expect(settings.settingsHeading).toBeVisible();
     });
+  });
+});
 
-    test('can change 2fa and use existing recovery phone to sign in', async ({
-      page,
+// Local only — see "Routing SMS tests in CI" in the README.
+test.describe('change 2FA with recovery phone (local only)', () => {
+  test.beforeAll(({ target }) => {
+    target.smsClient.guardTestPhoneNumber();
+  });
+
+  test('can change 2fa and use existing recovery phone to sign in', async ({
+    page,
+    target,
+    testAccountTracker,
+    pages: {
+      recoveryPhone,
+      settings,
+      signin,
+      signinRecoveryCode,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      signinTotpCode,
+      totp,
+    },
+  }) => {
+    const credentials = await testAccountTracker.signUp();
+    await signin.emailFirstSignin(credentials);
+
+    await addThenChange2FA({ settings, totp, target, credentials });
+
+    // connect phone
+    await addPhoneRecovery({
+      credentials,
+      recoveryPhone,
+      settings,
       target,
-      testAccountTracker,
-      pages: {
-        recoveryPhone,
-        settings,
-        signin,
-        signinRecoveryCode,
-        signinRecoveryChoice,
-        signinRecoveryPhone,
-        signinTotpCode,
-        totp,
-      },
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signin.emailFirstSignin(credentials);
-
-      await addThenChange2FA({ settings, totp, target, credentials });
-
-      // connect phone
-      await addPhoneRecovery({
-        credentials,
-        recoveryPhone,
-        settings,
-        target,
-      });
-
-      // sign out
-      await settings.signOut();
-
-      // Sign in with recovery phone
-      await completeSigninWithDualRecovery({
-        method: 'Phone',
-        page,
-        signin,
-        signinTotpCode,
-        signinRecoveryChoice,
-        signinRecoveryCode,
-        signinRecoveryPhone,
-        credentials,
-        target,
-      });
-
-      await expect(settings.settingsHeading).toBeVisible();
     });
+
+    // sign out
+    await settings.signOut();
+
+    // Sign in with recovery phone
+    await completeSigninWithDualRecovery({
+      method: 'Phone',
+      page,
+      signin,
+      signinTotpCode,
+      signinRecoveryChoice,
+      signinRecoveryCode,
+      signinRecoveryPhone,
+      credentials,
+      target,
+    });
+
+    await expect(settings.settingsHeading).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Because

- Every SMS test reads its code from one shared Twilio number, and the lookup returns the most recent message sent to that number regardless of which test triggered it. Two tests mid-flow at once consume each other's codes.
- CI reserves a single-worker node for `#phone` tests, but `recoveryPhone.spec.ts` was the only spec carrying the tag. Four other specs read SMS codes untagged and raced it from the parallel split.

## This pull request

Splits SMS coverage in two. A small `#phone` set keeps running against stage and production on the reserved serial node; the rest move to describes with no severity label, the existing convention for local-only tests.

### Kept on stage and production — 5 tests, tagged `#phone`

All in `tests/settings/recoveryPhone.spec.ts`. Between them they cover both SMS endpoints (setup and sign-in), both entry points (settings and inline), the change path, and the lockout branch.

| Test | Why it stays |
| --- | --- |
| `can setup, confirm and remove recovery phone` | Real delivery on setup, plus invalid-code, resend and removal |
| `can set up recovery phone during initial 2FA setup` | Inline entry point |
| `can sign-in to settings with recovery phone` | Sign-in send path — a different endpoint from setup |
| `sign in with only recovery phone available (no backup codes)` | No-backup-codes branch; failure here means lockout |
| `can change recovery phone` | Replaces an existing number |

`setup fails with invalid number` also stays on stage. It reads no SMS, so it needs no tag.

### Moved to local only — 9 tests

| Spec | Tests |
| --- | --- |
| `settings/recoveryPhone.spec.ts` | Sync `fx_desktop_v3` sign-in, Sync `oauth_webchannel_v1` sign-in, sign-in after resend code, 123Done sign-in, recovery code with phone set up, TOTP code with phone set up |
| `oauth/totp.spec.ts` | inline TOTP with recovery phone choice |
| `cms/cms-2fa.spec.ts` | 2FA sign-in with recovery phone (123Done) |
| `settings/replace2fa.spec.ts` | change 2FA, sign in with existing recovery phone |

These exercise integrations (Sync, 123Done, CMS, OAuth) or fallback branches that non-phone tests already cover on the same surfaces — not SMS delivery itself. The three phone tests in `resetPassword2FA.spec.ts` were already in an unlabelled describe and are untouched.

### Supporting changes

- Raises `RECOVERY_PHONE__MAX_UID_PER_NUMBER` for the local test executor. The reserved node was also working around `maxRegistrationsPerNumber`, which defaults to 5 (see `dde89599e9`); every local test registers the same magic number, so that cap would reject them once they run in parallel.
- Drops the phone reservation from the local job, so these run in the parallel split. Locally Twilio is in test mode and codes are read from redis by uid, so they cannot collide.
- Filters `run-phone-tests-serialized` by severity, matching `run-playwright-tests`, and adds the reservation to the deprecated `production-smoke-tests` job.
- `SmsClient.getCode()` throws when a severity-labelled test reads an SMS code without `#phone`.
- Documents the rule in `functional-tests/README.md`.

## Issue that this pull request solves

Closes: FXA-14284

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the kept/moved split above is a coverage judgement, not a mechanical result — that is the part worth disagreeing with. Then `lib/sms.ts` for the guard and `.circleci/config.yml` for the wiring.
- Suggested review order: `.circleci/config.yml`, `lib/sms.ts`, then the specs.
- Risky or complex parts: review the specs with whitespace ignored. Most of the line count is moved blocks reindented by prettier.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Verified with `playwright --list`: 5 tests match `#phone` on local, stage and production; the stage split is 328 tests with no SMS test among them; local runs all 409. `circleci config validate`, `tsc` and prettier all pass.
