### PR TITLE
chore(blender): disable investigate on fxa (npm-only remediation loops on yarn)

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -5,16 +5,17 @@ node_version: "24.15.0"
 install_command: "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable --inline-builds"
 
 investigate:
-  # Let BLEnder close alerts it judges as not affecting our code.
-  # Only low/medium are auto-dismissed; critical/high always require a real fix.
+  # Disabled: BLEnder's alert remediation is npm-only (npm audit fix +
+  # package-lock.json). fxa is a yarn repo, so remediate always fails, the
+  # alert is never tagged "investigated", and the ~30-min sweep re-investigates
+  # it forever — a runaway cost loop with zero result. Off until BLEnder
+  # supports yarn (see upstream bugs).
+  enabled: false
   dismiss_unaffected: true
-  # fxa is a large monorepo; defaults exhaust before Claude reaches a verdict.
-  # Turns set high so the $ budget is the effective governor.
   max_claude_turns: 100
   max_budget_usd: 6.00
 
 fix:
-  # Same monorepo-size reasoning for the auto-fix flow.
   max_claude_turns: 100
   max_budget_usd: 6.00
   max_fix_attempts: 5


### PR DESCRIPTION
## Because

BLEnder's alert **remediation is npm-only** (`npm audit fix` + `package-lock.json`). fxa is a **yarn** repo, so the remediate step fails every time (`ENOLOCK`, no `package-lock.json`). Because it fails, the alert is never tagged `investigated/…`, so the **~30-minute scheduled sweep re-investigates the same ~169 alerts endlessly** — a runaway cost loop (dozens of ~$6 Claude runs every half hour) with **zero** alerts resolved.

## This pull request

Sets `investigate.enabled: false` in `.blender/blender.yml`, so the sweep **skips fxa alert investigation** entirely. Auto-merge of safe Dependabot PRs is **unaffected** (BLEnder's one working feature on this repo).

Re-enable once BLEnder supports yarn remediation and reaches the dismiss path for npm alerts (upstream bugs to be filed).

## Issue

Relates to: FXA-14222

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.
