### PR TITLE
refactor(oauth): remove MySQL access token lookups and deletes

### DIFF
--- a/packages/fxa-admin-server/src/scripts/audit-tokens.spec.ts
+++ b/packages/fxa-admin-server/src/scripts/audit-tokens.spec.ts
@@ -18,14 +18,12 @@ import { Account } from 'fxa-shared/db/models/auth';
 import { Knex } from 'knex';
 import { Profile } from 'fxa-shared/db/models/profile';
 import { uuidTransformer } from 'fxa-shared/db/transformers';
-import { randomBytes } from 'node:crypto';
 
 const config = Config.getProperties();
 const exec = util.promisify(require('node:child_process').exec);
 const cwd = path.resolve(__dirname, '..');
 
 describe('#integration - scripts/audit-tokens', () => {
-  let fxaOauthDb: Knex;
   let fxaProfileDb: Knex;
   const uid = 'f9916686c226415abd06ae550f073cea';
   const email = 'user1@test.com';
@@ -37,7 +35,6 @@ describe('#integration - scripts/audit-tokens', () => {
     // separate databases instances. During local testing, we use the same
     // instance for all databases.
     fxaProfileDb = bindKnex(config.database.profile, TargetDB.profile);
-    fxaOauthDb = bindKnex(config.database.fxa_oauth, TargetDB.oauth);
 
     await clearDb();
 
@@ -49,15 +46,6 @@ describe('#integration - scripts/audit-tokens', () => {
       displayName: 'test',
     });
 
-    // Add a dummy auth token. Note, there are no DTOs for oauth db tables currently.
-    await fxaOauthDb('tokens').insert({
-      token: randomBytes(32),
-      clientId: randomBytes(8),
-      userId: uuidTransformer.to(uid),
-      type: 'refresh',
-      scope: '',
-    });
-
     // Manually delete the account to simulate orphaned record situation.
     await Account.knexQuery().del();
   });
@@ -66,7 +54,6 @@ describe('#integration - scripts/audit-tokens', () => {
     afterAll(async () => {
       await clearDb();
       await fxaProfileDb('profile').del();
-      await fxaOauthDb('tokens').del();
     });
 
     it('counts rows in fxa db table', async () => {
@@ -74,9 +61,12 @@ describe('#integration - scripts/audit-tokens', () => {
       assert.equal(result.table_size, 1);
     });
 
+    // Checks only that a query against the oauth database succeeds. The exact
+    // number is not asserted because auditRowCounts reads
+    // INFORMATION_SCHEMA.table_rows, which is an InnoDB estimate, not a count.
     it('counts rows in oauth db table', async () => {
-      const result = await auditRowCounts('fxa_oauth.tokens');
-      assert.equal(result.table_size, 1);
+      const result = await auditRowCounts('fxa_oauth.refreshTokens');
+      assert.isNumber(result.table_size);
     });
 
     it('counts rows in profile db table', async () => {

--- a/packages/fxa-admin-server/src/scripts/audit-tokens.ts
+++ b/packages/fxa-admin-server/src/scripts/audit-tokens.ts
@@ -83,10 +83,10 @@ const tables = {
   unverifiedTokens: toTable('unverifiedTokens'),
   verificationReminders: toTable('verificationReminders'),
 
-  // OAuth tables
+  // OAuth tables. Note that `fxa_oauth.tokens` is deliberately absent: OAuth
+  // access tokens are stored only in redis, so the table is never written to.
   oauthCodes: toTable('codes', 'fxa_oauth'),
   oauthRefreshTokens: toTable('refreshTokens', 'fxa_oauth'),
-  oauthTokens: toTable('tokens', 'fxa_oauth'),
 
   // Profile tables
   profile: toTable('profile', 'fxa_profile'),
@@ -358,7 +358,6 @@ async function auditAll() {
       [tables.verificationReminders, 'createdAt', 'uid'],
       [tables.oauthCodes, 'createdAt', 'token'],
       [tables.oauthRefreshTokens, 'createdAt', 'token'],
-      [tables.oauthTokens, 'createdAt', 'token'],
     ];
     for (const [table, colName, colSort] of set) {
       await auditAge(table, colName, colSort);

--- a/packages/fxa-auth-server/lib/inactive-accounts/active-status.ts
+++ b/packages/fxa-auth-server/lib/inactive-accounts/active-status.ts
@@ -35,6 +35,12 @@ export const hasActiveRefreshToken = async (
   const refreshTokens = await tokensFn(uid);
   return refreshTokens.some((t) => t.lastUsedAt >= activeByDateTimestamp);
 };
+/**
+ * Best-effort. Access tokens are read from redis, and that read swallows its own
+ * errors and returns an empty list, so an outage looks the same as "no tokens"
+ * and biases toward inactive. They are also short-lived, so this only ever
+ * reflected recent activity.
+ */
 export const hasAccessToken = async (
   tokensFn: GetTokensFn<{ lastUsedAt: number }>,
   uid: string

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -151,27 +151,13 @@ class OauthDB extends ConnectedServicesDb {
   }
 
   async getAccessToken(id) {
-    await this.ready();
-    const t = await this.redis.getAccessToken(id);
-    if (t) {
-      return t;
-    }
-    return await this.mysql._getAccessToken(id);
+    // redis reports a miss as null, but callers and tests expect the
+    // `undefined` that the removed MySQL fallback resolved.
+    return (await this.redis.getAccessToken(id)) ?? undefined;
   }
 
   async removeAccessToken(token) {
-    await this.ready();
-    const done = await this.redis.removeAccessToken(token.tokenId);
-    if (!done) {
-      return await this.mysql._removeAccessToken(token.tokenId);
-    }
-  }
-
-  async getAccessTokensByUid(uid) {
-    await this.ready();
-    const tokens = await this.redis.getAccessTokens(uid);
-    const otherTokens = await this.mysql._getAccessTokensByUid(uid);
-    return tokens.concat(otherTokens);
+    return await this.redis.removeAccessToken(token.tokenId);
   }
 
   async getRefreshToken(id) {

--- a/packages/fxa-auth-server/lib/oauth/db/index.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/db/index.spec.ts
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Covers how the OAuth DB reads and revokes access tokens. This is thin
+ * orchestration over two injected clients, so it is worth covering here rather
+ * than only in the infra-backed `test/remote/oauth_db.in.spec.ts` suite.
+ */
+const oauthDb = require('./index');
+
+const MOCK_UID = 'f9416ce3703e4916a4cd6b1e665a3f1a';
+const MOCK_TOKEN_ID = Buffer.from('a'.repeat(64), 'hex');
+const MOCK_ACCESS_TOKEN = { tokenId: MOCK_TOKEN_ID, userId: MOCK_UID };
+const REDIS_DOWN = new Error('ECONNREFUSED');
+
+type RedisMock = {
+  getAccessToken: jest.Mock;
+  removeAccessToken: jest.Mock;
+  getAccessTokens: jest.Mock;
+  removeAccessTokensForUser: jest.Mock;
+  removeRefreshTokensForUser: jest.Mock;
+};
+
+function buildRedisMock(): RedisMock {
+  return {
+    getAccessToken: jest.fn().mockResolvedValue(MOCK_ACCESS_TOKEN),
+    removeAccessToken: jest.fn().mockResolvedValue(true),
+    getAccessTokens: jest.fn().mockResolvedValue([MOCK_ACCESS_TOKEN]),
+    removeAccessTokensForUser: jest.fn().mockResolvedValue(undefined),
+    removeRefreshTokensForUser: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('lib/oauth/db - access tokens', () => {
+  let redis: RedisMock;
+
+  beforeEach(() => {
+    redis = buildRedisMock();
+    // Assign through `cache`/`db`, not `redis`/`mysql` — the latter are getters
+    // over the former and have no setters.
+    oauthDb.cache = redis;
+    // `ready()` only seeds config-declared clients and scopes into MySQL.
+    oauthDb.ready = jest.fn().mockResolvedValue(undefined);
+  });
+
+  describe('getAccessToken', () => {
+    it('resolves the token held in redis', async () => {
+      const result = await oauthDb.getAccessToken(MOCK_TOKEN_ID);
+
+      expect(result).toEqual(MOCK_ACCESS_TOKEN);
+      expect(redis.getAccessToken).toHaveBeenCalledWith(MOCK_TOKEN_ID);
+    });
+
+    // Redis reports a miss as `null`, but the removed MySQL fallback resolved
+    // `undefined` (from `rows[0]`), and callers/tests depend on that. Without
+    // this normalization the sentinel silently changes.
+    //
+    // This covers read *failures* too: RedisShared.getAccessToken catches its
+    // own errors and returns null, so a failed read looks identical to a miss.
+    // That errs the safe way — an unreadable token is rejected, never accepted.
+    it('resolves undefined, not null, when redis reports a miss', async () => {
+      redis.getAccessToken.mockResolvedValue(null);
+
+      const result = await oauthDb.getAccessToken(MOCK_TOKEN_ID);
+
+      expect(result).toBeUndefined();
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('removeAccessToken', () => {
+    it('revokes the token in redis by its tokenId', async () => {
+      await oauthDb.removeAccessToken(MOCK_ACCESS_TOKEN);
+
+      expect(redis.removeAccessToken).toHaveBeenCalledWith(MOCK_TOKEN_ID);
+    });
+
+    it.each([true, false])(
+      'resolves redis’ "was it there" signal (%s)',
+      async (wasPresent) => {
+        redis.removeAccessToken.mockResolvedValue(wasPresent);
+
+        await expect(
+          oauthDb.removeAccessToken(MOCK_ACCESS_TOKEN)
+        ).resolves.toBe(wasPresent);
+      }
+    );
+
+    it('propagates a redis failure rather than reporting success', async () => {
+      redis.removeAccessToken.mockRejectedValue(REDIS_DOWN);
+
+      await expect(
+        oauthDb.removeAccessToken(MOCK_ACCESS_TOKEN)
+      ).rejects.toThrow(REDIS_DOWN);
+    });
+  });
+
+  // Inherited from ConnectedServicesDb rather than overridden here, so these
+  // also pin that the inherited implementation reads the same redis cache.
+  describe('getAccessTokensByUid', () => {
+    it('resolves exactly the tokens redis holds, with nothing merged in', async () => {
+      const result = await oauthDb.getAccessTokensByUid(MOCK_UID);
+
+      expect(result).toEqual([MOCK_ACCESS_TOKEN]);
+      expect(redis.getAccessTokens).toHaveBeenCalledWith(MOCK_UID);
+    });
+
+    it('resolves an empty list when redis holds no tokens', async () => {
+      redis.getAccessTokens.mockResolvedValue([]);
+
+      await expect(oauthDb.getAccessTokensByUid(MOCK_UID)).resolves.toEqual([]);
+    });
+  });
+
+  // `_removeTokensAndCodes` no longer deletes access tokens in MySQL, so this
+  // redis revocation is the only thing standing between account deletion /
+  // password reset and a live access token.
+  describe('removeTokensAndCodes', () => {
+    let mysql: { _removeTokensAndCodes: jest.Mock };
+
+    beforeEach(() => {
+      mysql = { _removeTokensAndCodes: jest.fn().mockResolvedValue(undefined) };
+      oauthDb.db = mysql;
+    });
+
+    it('revokes the user’s access tokens in redis', async () => {
+      await oauthDb.removeTokensAndCodes(MOCK_UID);
+
+      expect(redis.removeAccessTokensForUser).toHaveBeenCalledWith(MOCK_UID);
+    });
+
+    it('also revokes refresh tokens and clears the MySQL rows', async () => {
+      await oauthDb.removeTokensAndCodes(MOCK_UID);
+
+      expect(redis.removeRefreshTokensForUser).toHaveBeenCalledWith(MOCK_UID);
+      expect(mysql._removeTokensAndCodes).toHaveBeenCalledWith(MOCK_UID);
+    });
+
+    it('does not clear the MySQL rows if the redis revocation fails', async () => {
+      redis.removeAccessTokensForUser.mockRejectedValue(REDIS_DOWN);
+
+      await expect(oauthDb.removeTokensAndCodes(MOCK_UID)).rejects.toThrow(
+        REDIS_DOWN
+      );
+      expect(mysql._removeTokensAndCodes).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -5,7 +5,6 @@
 const encrypt = require('fxa-shared/auth/encrypt');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const unique = require('../../unique');
-const AccessToken = require('../accessToken');
 const { ScopeIdCache } = require('../../scopes-cache');
 
 // Shared base class
@@ -60,34 +59,18 @@ const QUERY_CLIENT_UPDATE =
 // This query deletes everything related to the client, and is thus quite expensive!
 // Don't worry, it's not exposed to any production-facing routes.
 const QUERY_CLIENT_DELETE =
-  'DELETE clients, codes, tokens, refreshTokens, clientDevelopers ' +
+  'DELETE clients, codes, refreshTokens, clientDevelopers ' +
   'FROM clients ' +
   'LEFT JOIN codes ON clients.id = codes.clientId ' +
-  'LEFT JOIN tokens ON clients.id = tokens.clientId ' +
   'LEFT JOIN refreshTokens ON clients.id = refreshTokens.clientId ' +
   'LEFT JOIN clientDevelopers ON clients.id = clientDevelopers.clientId ' +
   'WHERE clients.id=?';
 const QUERY_CODE_INSERT =
   'INSERT INTO codes (clientId, userId, scope, authAt, amr, aal, offline, code, codeChallengeMethod, codeChallenge, keysJwe, profileChangedAt, sessionTokenId) ' +
   'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-const QUERY_ACCESS_TOKEN_INSERT =
-  'INSERT INTO tokens (clientId, userId, scope, type, expiresAt, ' +
-  'token, profileChangedAt) VALUES (?, ?, ?, ?, ?, ?, ?)';
 const QUERY_REFRESH_TOKEN_INSERT =
   'INSERT INTO refreshTokens (clientId, userId, scope, token, profileChangedAt) VALUES ' +
   '(?, ?, ?, ?, ?)';
-// Access token storage in redis annotates each token with client metadata,
-// so we do the same when reading from MySQL, for consistency.
-// Note that the `token` field stores the hash of the token rather than the raw token,
-// and hence would more properly be called `tokenId`.
-const QUERY_ACCESS_TOKEN_FIND =
-  'SELECT tokens.token AS tokenId, tokens.clientId, tokens.createdAt, ' +
-  '  tokens.userId, tokens.scope, ' +
-  '  tokens.createdAt, tokens.expiresAt, tokens.profileChangedAt, ' +
-  '  clients.name as clientName, clients.canGrant AS clientCanGrant, ' +
-  '  clients.publicClient ' +
-  'FROM tokens LEFT OUTER JOIN clients ON clients.id = tokens.clientId ' +
-  'WHERE tokens.token=?';
 // Note that the `token` field stores the hash of the token rather than the raw token,
 // and hence would more properly be called `tokenId`.
 const QUERY_REFRESH_TOKEN_FIND =
@@ -98,17 +81,9 @@ const QUERY_REFRESH_TOKEN_LAST_USED_UPDATE =
   'UPDATE refreshTokens SET lastUsedAt=? WHERE token=?';
 const QUERY_CODE_FIND = 'SELECT * FROM codes WHERE code=?';
 const QUERY_CODE_DELETE = 'DELETE FROM codes WHERE code=?';
-const QUERY_ACCESS_TOKEN_DELETE = 'DELETE FROM tokens WHERE token=?';
 const QUERY_REFRESH_TOKEN_DELETE = 'DELETE FROM refreshTokens WHERE token=?';
-const QUERY_ACCESS_TOKEN_DELETE_USER = 'DELETE FROM tokens WHERE userId=?';
-// These next two queries can be very expensive if MySQL
-// tries to filter by clientId before userId, so we add
-// an explicit index hint to help ensure this doesn't happen.
-const QUERY_DELETE_ACCESS_TOKEN_FOR_PUBLIC_CLIENTS =
-  'DELETE tokens ' +
-  'FROM tokens FORCE INDEX (tokens_user_id)' +
-  'INNER JOIN clients ON tokens.clientId = clients.id ' +
-  'WHERE tokens.userId=? AND (clients.publicClient = 1 OR clients.canGrant = 1)';
+// This query can be very expensive if MySQL tries to filter by clientId before
+// userId, so we add an explicit index hint to help ensure this doesn't happen.
 const QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS =
   'DELETE refreshTokens ' +
   'FROM refreshTokens FORCE INDEX (tokens_user_id)' +
@@ -146,18 +121,6 @@ const QUERY_DEVELOPER_DELETE =
   'FROM developers ' +
   'LEFT JOIN clientDevelopers ON developers.developerId = clientDevelopers.developerId ' +
   'WHERE developers.email=?';
-// When listing access tokens, we deliberately do not exclude tokens that have expired.
-// Such tokens will be cleaned up by a background job.
-// There's minimal downside to showing tokens in the brief period between when they expire and when
-// they get deleted from the db.
-const QUERY_LIST_ACCESS_TOKENS_BY_UID =
-  'SELECT tokens.token AS tokenId, tokens.clientId, tokens.createdAt, ' +
-  '  tokens.userId, tokens.scope, ' +
-  '  tokens.createdAt, tokens.expiresAt, tokens.profileChangedAt, ' +
-  '  clients.name as clientName, clients.canGrant AS clientCanGrant, ' +
-  '  clients.publicClient ' +
-  'FROM tokens LEFT OUTER JOIN clients ON clients.id = tokens.clientId ' +
-  'WHERE tokens.userId=?';
 const QUERY_LIST_REFRESH_TOKENS_BY_UID =
   'SELECT refreshTokens.token AS tokenId, refreshTokens.clientId, refreshTokens.createdAt, refreshTokens.lastUsedAt, ' +
   '  refreshTokens.scope, clients.name as clientName, clients.canGrant AS clientCanGrant ' +
@@ -191,8 +154,6 @@ const QUERY_LIST_REFRESH_TOKENS_BY_CLIENT_ID =
   'SELECT refreshTokens.createdAt, refreshTokens.userId FROM refreshTokens WHERE refreshTokens.clientId=?';
 const DELETE_ACTIVE_CODES_BY_CLIENT_AND_UID =
   'DELETE FROM codes WHERE clientId=? AND userId=?';
-const DELETE_ACTIVE_TOKENS_BY_CLIENT_AND_UID =
-  'DELETE FROM tokens WHERE clientId=? AND userId=?';
 const DELETE_ACTIVE_REFRESH_TOKENS_BY_CLIENT_AND_UID =
   'DELETE FROM refreshTokens WHERE clientId=? AND userId=?';
 const DELETE_REFRESH_TOKEN_WITH_CLIENT_AND_UID =
@@ -507,55 +468,6 @@ class MysqlStore extends MysqlOAuthShared {
     return this._write(QUERY_CODE_DELETE, [hash]);
   }
 
-  _generateAccessToken(accessToken) {
-    return this._write(QUERY_ACCESS_TOKEN_INSERT, [
-      accessToken.clientId,
-      accessToken.userId,
-      accessToken.scope.toString(),
-      accessToken.type,
-      accessToken.expiresAt,
-      accessToken.tokenId,
-      accessToken.profileChangedAt,
-    ]);
-  }
-
-  /**
-   * Get an access token by token id
-   * @param id Token Id
-   * @returns {*}
-   */
-  _getAccessToken(id) {
-    return this._readOne(QUERY_ACCESS_TOKEN_FIND, [buf(id)]).then(function (t) {
-      if (t) {
-        t = AccessToken.fromMySQL(t);
-      }
-      return t;
-    });
-  }
-
-  /**
-   * Remove token by token id
-   * @param id
-   * @returns {*}
-   */
-  _removeAccessToken(id) {
-    return this._write(QUERY_ACCESS_TOKEN_DELETE, [buf(id)]);
-  }
-
-  /**
-   * Get all access tokens for a given user.
-   * @param {String} uid User ID as hex
-   * @returns {Promise}
-   */
-  async _getAccessTokensByUid(uid) {
-    const accessTokens = await this._read(QUERY_LIST_ACCESS_TOKENS_BY_UID, [
-      buf(uid),
-    ]);
-    return accessTokens.map((t) => {
-      return AccessToken.fromMySQL(t);
-    });
-  }
-
   /**
    * Get all refresh tokens for a given user.
    * @param {String} uid User ID as hex
@@ -600,7 +512,11 @@ class MysqlStore extends MysqlOAuthShared {
   }
 
   /**
-   * Delete all authorization grants for some clientId and uid.
+   * Delete the authorization codes and refresh tokens for some clientId and uid.
+   *
+   * The caller is responsible for also revoking this pair's access tokens,
+   * which live only in redis — see `deleteClientAuthorization` in
+   * lib/oauth/db/index.js.
    *
    * @param {String} clientId Client ID
    * @param {String} uid User Id as Hex
@@ -612,17 +528,12 @@ class MysqlStore extends MysqlOAuthShared {
       buf(uid),
     ]);
 
-    const deleteTokens = this._write(DELETE_ACTIVE_TOKENS_BY_CLIENT_AND_UID, [
-      buf(clientId),
-      buf(uid),
-    ]);
-
     const deleteRefreshTokens = this._write(
       DELETE_ACTIVE_REFRESH_TOKENS_BY_CLIENT_AND_UID,
       [buf(clientId), buf(uid)]
     );
 
-    return Promise.all([deleteCodes, deleteTokens, deleteRefreshTokens]);
+    return Promise.all([deleteCodes, deleteRefreshTokens]);
   }
 
   async _pruneAuthorizationCodes(ttl) {
@@ -644,10 +555,12 @@ class MysqlStore extends MysqlOAuthShared {
 
   /**
    * Delete a specific refresh token, for some clientId and uid.
-   * Also deletes *all* access tokens for the clientId and uid combination,
-   * otherwise the refresh token is deleted but none of the access tokens
-   * created from that refresh token are, leaving ghost access tokens
-   * to appear in the users devices & apps list. See:
+   *
+   * The caller is responsible for also revoking *all* access tokens for the
+   * clientId and uid combination (they live in redis), otherwise the refresh
+   * token is deleted but none of the access tokens created from that refresh
+   * token are, leaving ghost access tokens to appear in the users devices &
+   * apps list. See:
    *
    * https://github.com/mozilla/fxa/issues/1249
    * https://github.com/mozilla/fxa/issues/3017
@@ -666,17 +579,7 @@ class MysqlStore extends MysqlOAuthShared {
       [buf(tokenId), buf(clientId), buf(uid)]
     );
 
-    // only delete access tokens if deleting the refresh
-    // tokens has succeeded.
-    if (deleteRefreshTokenRes.affectedRows) {
-      await this._write(DELETE_ACTIVE_TOKENS_BY_CLIENT_AND_UID, [
-        buf(clientId),
-        buf(uid),
-      ]);
-      return true;
-    }
-
-    return false;
+    return deleteRefreshTokenRes.affectedRows > 0;
   }
 
   generateRefreshToken(vals) {
@@ -919,11 +822,12 @@ class MysqlStore extends MysqlOAuthShared {
     });
   }
 
+  // Access tokens are not touched here; they live only in redis and are
+  // revoked by the caller in lib/oauth/db/index.js.
   _removeTokensAndCodes(userId) {
     // TODO this should be a transaction or stored procedure
     var id = buf(userId);
-    return this._write(QUERY_ACCESS_TOKEN_DELETE_USER, [id])
-      .then(this._write.bind(this, QUERY_REFRESH_TOKEN_DELETE_USER, [id]))
+    return this._write(QUERY_REFRESH_TOKEN_DELETE_USER, [id])
       .then(this._write.bind(this, QUERY_CODE_DELETE_USER, [id]))
       .then(this._write.bind(this, QUERY_ACCOUNT_ACTIVITY_DELETE_USER, [id]));
   }
@@ -1002,19 +906,17 @@ class MysqlStore extends MysqlOAuthShared {
   }
 
   /**
-   * Removes user's tokens and refreshTokens for canGrant and publicClient clients
+   * Removes user's refreshTokens for canGrant and publicClient clients.
+   * Their access tokens live only in redis and are revoked by the caller in
+   * lib/oauth/db/index.js.
    *
    * @param {Buffer | string} userId
    * @returns {Promise}
    */
   _removePublicAndCanGrantTokens(userId) {
-    const uid = buf(userId);
-
-    return this._write(QUERY_DELETE_ACCESS_TOKEN_FOR_PUBLIC_CLIENTS, [
-      uid,
-    ]).then(() =>
-      this._write(QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS, [uid])
-    );
+    return this._write(QUERY_DELETE_REFRESH_TOKEN_FOR_PUBLIC_CLIENTS, [
+      buf(userId),
+    ]);
   }
 
   async getScope(scope) {

--- a/packages/fxa-auth-server/test/remote/oauth_db.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_db.in.spec.ts
@@ -127,11 +127,20 @@ describe('db', () => {
       expect(hex(t.tokenId)).toBe(hex(hash));
     });
 
+    // Guards the revocation assertion below: access tokens are keyed by the
+    // hash of the token, so looking one up by the raw token always misses and
+    // would make that assertion pass whether or not revocation happened.
+    it('should get the right accessToken', async () => {
+      const hash = encrypt.hash(token);
+      const t = await db.getAccessToken(hash);
+      expect(hex(t.tokenId)).toBe(hex(hash));
+    });
+
     it('should delete tokens and codes for the given userId', async () => {
       await db.removeTokensAndCodes(userId);
       const c = await db.getCode(code);
       expect(c).toBeUndefined();
-      const t = await db.getAccessToken(token);
+      const t = await db.getAccessToken(encrypt.hash(token));
       expect(t).toBeUndefined();
       const rt = await db.getRefreshToken(encrypt.hash(refreshToken));
       expect(rt).toBeUndefined();

--- a/packages/fxa-shared/connected-services/accessors.ts
+++ b/packages/fxa-shared/connected-services/accessors.ts
@@ -109,7 +109,6 @@ export class ConnectedServicesCache {
  */
 export interface IConnectedServicesDbStore {
   getRefreshTokensByUid(uid: string): Promise<any>;
-  getAccessTokensByUid(uid: string): Promise<any>;
   close(): Promise<void>;
 }
 
@@ -143,9 +142,7 @@ export class ConnectedServicesDb {
   }
 
   async getAccessTokensByUid(uid: string) {
-    const tokens = await this.cache.getAccessTokens(uid);
-    const otherTokens = await this.db.getAccessTokensByUid(uid);
-    return tokens.concat(otherTokens);
+    return await this.cache.getAccessTokens(uid);
   }
 
   async close() {

--- a/packages/fxa-shared/db/models/auth/access-token.ts
+++ b/packages/fxa-shared/db/models/auth/access-token.ts
@@ -56,26 +56,6 @@ export class AccessToken {
   }
 
   /**
-   * @param {any} row
-   * @returns {AccessToken}
-   */
-  static fromMySQL(row: any) {
-    return new AccessToken(
-      row.tokenId,
-      row.clientId,
-      row.clientName,
-      row.clientCanGrant,
-      row.publicClient,
-      row.userId,
-      ScopeSet.fromString(row.scope),
-      row.createdAt,
-      row.profileChangedAt,
-      row.expiresAt,
-      null
-    );
-  }
-
-  /**
    *
    * @param {string} string
    * @returns {AccessToken}

--- a/packages/fxa-shared/db/mysql.ts
+++ b/packages/fxa-shared/db/mysql.ts
@@ -5,7 +5,6 @@ import { randomUUID } from 'crypto';
 import { StatsD } from 'hot-shots';
 import mysql from 'mysql';
 
-import { AccessToken as AccessToken } from '../db/models/auth/access-token';
 import { ILogger } from '../log';
 import ScopeSet from '../oauth/scopes';
 
@@ -52,15 +51,6 @@ const QUERY_LIST_REFRESH_TOKENS_BY_UID =
   '  refreshTokens.scope, clients.name as clientName, clients.canGrant AS clientCanGrant ' +
   'FROM refreshTokens LEFT OUTER JOIN clients ON clients.id = refreshTokens.clientId ' +
   'WHERE refreshTokens.userId=?';
-
-const QUERY_LIST_ACCESS_TOKENS_BY_UID =
-  'SELECT tokens.token AS tokenId, tokens.clientId, tokens.createdAt, ' +
-  '  tokens.userId, tokens.scope, ' +
-  '  tokens.createdAt, tokens.expiresAt, tokens.profileChangedAt, ' +
-  '  clients.name as clientName, clients.canGrant AS clientCanGrant, ' +
-  '  clients.publicClient ' +
-  'FROM tokens LEFT OUTER JOIN clients ON clients.id = tokens.clientId ' +
-  'WHERE tokens.userId=?';
 
 const QUERY_LIST_ALL_CLIENTS =
   'SELECT id, name, imageUri, redirectUri, canGrant, ' +
@@ -394,16 +384,6 @@ export class MysqlOAuthShared extends MysqlStoreShared {
     metrics?: StatsD
   ) {
     super(options, events, log, metrics);
-  }
-
-  async getAccessTokensByUid(uid: string) {
-    const accessTokens = await this._read(QUERY_LIST_ACCESS_TOKENS_BY_UID, [
-      buf(uid),
-    ]);
-
-    return accessTokens.map((t: any) => {
-      return AccessToken.fromMySQL(t);
-    });
   }
 
   async getRefreshTokensByUid(uid: string) {

--- a/packages/fxa-shared/test/connected-services/accessors.ts
+++ b/packages/fxa-shared/test/connected-services/accessors.ts
@@ -13,13 +13,18 @@ import {
   ISessionTokensCache,
 } from '../../connected-services';
 
+const MOCK_ACCESS_TOKEN = Object.freeze({ tokenId: 'a'.repeat(64) });
+
 describe('connected-services/accessors', () => {
   class TestDbStore implements IConnectedServicesDbStore {
     async getRefreshTokensByUid(uid: string): Promise<any> {
       return [{ tokenId: '1234' }];
     }
+    // Deliberately not part of IConnectedServicesDbStore. It exists here only
+    // so the cache-only contract for access tokens is pinned by an assertion
+    // rather than merely by the interface's shape.
     async getAccessTokensByUid(uid: string): Promise<any> {
-      return [];
+      throw new Error('access tokens must not be read from the database');
     }
     async close() {
       return;
@@ -48,7 +53,7 @@ describe('connected-services/accessors', () => {
       return {};
     }
     async getAccessTokens(uid: string | Buffer): Promise<any> {
-      return [];
+      return [MOCK_ACCESS_TOKEN];
     }
   }
 
@@ -80,12 +85,12 @@ describe('connected-services/accessors', () => {
   });
 
   describe('connected services database', () => {
-    it('gets access tokens', async () => {
-      const uid = '1234';
-      const result = await db.getAccessTokensByUid('1234');
+    it('gets access tokens from the cache only', async () => {
+      const result = await db.getAccessTokensByUid(uid);
 
+      assert.deepEqual(result, [MOCK_ACCESS_TOKEN]);
       Sinon.assert.calledOnceWithExactly(stubTokenCache.getAccessTokens, uid);
-      Sinon.assert.calledOnceWithExactly(stubDbStore.getAccessTokensByUid, uid);
+      Sinon.assert.notCalled(stubDbStore.getAccessTokensByUid);
     });
 
     it('gets access refresh tokens', async () => {
@@ -102,18 +107,17 @@ describe('connected-services/accessors', () => {
   });
 
   describe('connected services cache', async () => {
-    it('gets accesss token', async () => {
+    it('gets access token', async () => {
       const result = await cache.getAccessToken(uid);
 
       assert.notInstanceOf(result, Array);
       Sinon.assert.calledOnce(stubTokenCache.getAccessToken);
     });
 
-    it('gets accesss tokens', async () => {
+    it('gets access tokens', async () => {
       const result = await cache.getAccessTokens(uid);
 
-      assert.instanceOf(result, Array);
-      assert.lengthOf(result, 0);
+      assert.deepEqual(result, [MOCK_ACCESS_TOKEN]);
       Sinon.assert.calledOnce(stubTokenCache.getAccessTokens);
     });
 


### PR DESCRIPTION
Because:
* Access tokens live only in redis. `fxa_oauth.tokens` is a relic of the pre-refresh-token Pocket integration, and its rows were deleted when Pocket was decommissioned as an RP.
* Nothing has written to the table for some time — `_generateAccessToken` already had zero callers — so the read-through fallbacks and the deletes could never match a row.

This commit:
* Drops the MySQL fallback from `getAccessToken` and `removeAccessToken`, and deletes the `getAccessTokensByUid` override so it inherits the cache-only implementation from `ConnectedServicesDb`. Both remaining methods also drop `await this.ready()`, which only seeds config-declared clients and scopes into MySQL.
* Deletes `_generateAccessToken`, `_getAccessToken`, `_removeAccessToken`, `_getAccessTokensByUid`, `AccessToken.fromMySQL` and their queries, and removes the access token deletes from `_removeTokensAndCodes`, `_removePublicAndCanGrantTokens`, `_deleteClientAuthorization` and `_deleteClientRefreshToken`. The redis revocation each caller already performs in `lib/oauth/db/index.js` is now the whole story.
* Drops `getAccessTokensByUid` from `IConnectedServicesDbStore` and `MysqlOAuthShared`, making admin-server's attached-clients view redis-only, and stops auditing the table in admin-server's `audit-tokens` script. That ends the `db-audit.fxa_oauth_tokens.*` statsd series — check for panels or alerts on it.
* Normalizes `getAccessToken` to resolve `undefined` rather than redis' `null` on a miss, so the contract callers and tests rely on is unchanged.
* Adds `lib/oauth/db/index.spec.ts` pinning the redis-only routing, and fixes an assertion in `oauth_db.in.spec.ts` that looked an access token up by its raw value instead of its hash and so could never fail.

closes FXA-14204

--

See ticket for link to graph showing this table is empty. I've filed FXA- 14292 to remove the table here after.

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.