### PR TITLE
feat(passkeys): Add passwordless sync feature flags

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -469,6 +469,7 @@
     "enabled": true,
     "registrationEnabled": true,
     "authenticationEnabled": true,
+    "passwordlessSyncEnabled": true,
     "requestPrfAtRegistration": true,
     "requestPrfAtAuthentication": "all",
     "prfSalt": "dGVzdC1wcmYtc2FsdA",

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2729,6 +2729,12 @@ const convictConf = convict({
       env: 'PASSKEYS__AUTHENTICATION_ENABLED',
       format: Boolean,
     },
+    passwordlessSyncEnabled: {
+      default: false,
+      doc: 'Enable passwordless sync sign-in, where kB is recovered from a passkey-wrapped envelope instead of the password. Requires passkeys.enabled.',
+      env: 'PASSKEYS__PASSWORDLESS_SYNC_ENABLED',
+      format: Boolean,
+    },
     rpId: {
       default: '',
       doc: 'WebAuthn Relying Party ID. Must match the domain of the deployment (e.g. "accounts.firefox.com"). Required when passkeys are enabled.',

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2713,7 +2713,7 @@ const convictConf = convict({
   passkeys: {
     enabled: {
       default: false,
-      doc: 'Master switch for passkeys. Must be true for registrationEnabled or authenticationEnabled to take effect.',
+      doc: 'Primary switch for passkeys. Must be true for registrationEnabled or authenticationEnabled to take effect.',
       env: 'PASSKEYS__ENABLED',
       format: Boolean,
     },

--- a/packages/fxa-auth-server/lib/passkey-utils.spec.ts
+++ b/packages/fxa-auth-server/lib/passkey-utils.spec.ts
@@ -5,6 +5,7 @@
 import {
   isPasskeyAuthenticationEnabled,
   isPasskeyFeatureEnabled,
+  isPasskeyPasswordlessSyncEnabled,
   isPasskeyRegistrationEnabled,
   PasskeyFlagsConfig,
 } from './passkey-utils';
@@ -81,6 +82,43 @@ describe('passkey-utils', () => {
         passkeys: { enabled: false, authenticationEnabled: true },
       };
       expect(() => isPasskeyAuthenticationEnabled(config)).toThrow(
+        'Feature not enabled'
+      );
+    });
+  });
+
+  describe('isPasskeyPasswordlessSyncEnabled', () => {
+    it('should return true when master and passwordless sync flags are both enabled', () => {
+      const config = {
+        passkeys: { enabled: true, passwordlessSyncEnabled: true },
+      };
+      expect(isPasskeyPasswordlessSyncEnabled(config)).toBe(true);
+    });
+
+    it('should throw when master is enabled but passwordlessSyncEnabled is false', () => {
+      const config = {
+        passkeys: { enabled: true, passwordlessSyncEnabled: false },
+      };
+      expect(() => isPasskeyPasswordlessSyncEnabled(config)).toThrow(
+        'Feature not enabled'
+      );
+    });
+
+    it('should throw when master is disabled even if passwordlessSyncEnabled is true', () => {
+      const config = {
+        passkeys: { enabled: false, passwordlessSyncEnabled: true },
+      };
+      expect(() => isPasskeyPasswordlessSyncEnabled(config)).toThrow(
+        'Feature not enabled'
+      );
+    });
+
+    it('should throw when config.passkeys.passwordlessSyncEnabled is undefined', () => {
+      // Simulate a config predating this flag, e.g. a stale deployed config file.
+      const config = { passkeys: { enabled: true } } as PasskeyFlagsConfig<
+        'enabled' | 'passwordlessSyncEnabled'
+      >;
+      expect(() => isPasskeyPasswordlessSyncEnabled(config)).toThrow(
         'Feature not enabled'
       );
     });

--- a/packages/fxa-auth-server/lib/passkey-utils.spec.ts
+++ b/packages/fxa-auth-server/lib/passkey-utils.spec.ts
@@ -34,14 +34,14 @@ describe('passkey-utils', () => {
   });
 
   describe('isPasskeyRegistrationEnabled', () => {
-    it('should return true when master and registration flags are both enabled', () => {
+    it('should return true when primary and registration flags are both enabled', () => {
       const config = {
         passkeys: { enabled: true, registrationEnabled: true },
       };
       expect(isPasskeyRegistrationEnabled(config)).toBe(true);
     });
 
-    it('should throw when master is enabled but registrationEnabled is false', () => {
+    it('should throw when primary is enabled but registrationEnabled is false', () => {
       const config = {
         passkeys: { enabled: true, registrationEnabled: false },
       };
@@ -50,7 +50,7 @@ describe('passkey-utils', () => {
       );
     });
 
-    it('should throw when master is disabled even if registrationEnabled is true', () => {
+    it('should throw when primary is disabled even if registrationEnabled is true', () => {
       const config = {
         passkeys: { enabled: false, registrationEnabled: true },
       };
@@ -61,14 +61,14 @@ describe('passkey-utils', () => {
   });
 
   describe('isPasskeyAuthenticationEnabled', () => {
-    it('should return true when master and authentication flags are both enabled', () => {
+    it('should return true when primary and authentication flags are both enabled', () => {
       const config = {
         passkeys: { enabled: true, authenticationEnabled: true },
       };
       expect(isPasskeyAuthenticationEnabled(config)).toBe(true);
     });
 
-    it('should throw when master is enabled but authenticationEnabled is false', () => {
+    it('should throw when primary is enabled but authenticationEnabled is false', () => {
       const config = {
         passkeys: { enabled: true, authenticationEnabled: false },
       };
@@ -77,7 +77,7 @@ describe('passkey-utils', () => {
       );
     });
 
-    it('should throw when master is disabled even if authenticationEnabled is true', () => {
+    it('should throw when primary is disabled even if authenticationEnabled is true', () => {
       const config = {
         passkeys: { enabled: false, authenticationEnabled: true },
       };
@@ -88,14 +88,14 @@ describe('passkey-utils', () => {
   });
 
   describe('isPasskeyPasswordlessSyncEnabled', () => {
-    it('should return true when master and passwordless sync flags are both enabled', () => {
+    it('should return true when primary and passwordless sync flags are both enabled', () => {
       const config = {
         passkeys: { enabled: true, passwordlessSyncEnabled: true },
       };
       expect(isPasskeyPasswordlessSyncEnabled(config)).toBe(true);
     });
 
-    it('should throw when master is enabled but passwordlessSyncEnabled is false', () => {
+    it('should throw when primary is enabled but passwordlessSyncEnabled is false', () => {
       const config = {
         passkeys: { enabled: true, passwordlessSyncEnabled: false },
       };
@@ -104,7 +104,7 @@ describe('passkey-utils', () => {
       );
     });
 
-    it('should throw when master is disabled even if passwordlessSyncEnabled is true', () => {
+    it('should throw when primary is disabled even if passwordlessSyncEnabled is true', () => {
       const config = {
         passkeys: { enabled: false, passwordlessSyncEnabled: true },
       };

--- a/packages/fxa-auth-server/lib/passkey-utils.ts
+++ b/packages/fxa-auth-server/lib/passkey-utils.ts
@@ -31,7 +31,7 @@ export function isPasskeyFeatureEnabled(
 
 /**
  * Checks if passkey registration (adding new passkeys) is enabled.
- * Requires both the master `passkeys.enabled` flag and `passkeys.registrationEnabled`.
+ * Requires both the primary `passkeys.enabled` flag and `passkeys.registrationEnabled`.
  * Management routes (list/delete/rename) use isPasskeyFeatureEnabled instead.
  * @throws AppError.featureNotEnabled if either flag is disabled
  */
@@ -46,13 +46,28 @@ export function isPasskeyRegistrationEnabled(
 
 /**
  * Checks if passkey authentication (sign in with passkey) is enabled.
- * Requires both the master `passkeys.enabled` flag and `passkeys.authenticationEnabled`.
+ * Requires both the primary `passkeys.enabled` flag and `passkeys.authenticationEnabled`.
  * @throws AppError.featureNotEnabled if either flag is disabled
  */
 export function isPasskeyAuthenticationEnabled(
   config: PasskeyFlagsConfig<'enabled' | 'authenticationEnabled'>
 ): boolean {
   if (!config.passkeys.enabled || !config.passkeys.authenticationEnabled) {
+    throw AppError.featureNotEnabled();
+  }
+  return true;
+}
+
+/**
+ * Checks if passwordless sync sign-in is enabled, where `kB` is recovered from a
+ * passkey-wrapped envelope instead of the password.
+ * Requires both the primary `passkeys.enabled` flag and `passkeys.passwordlessSyncEnabled`.
+ * @throws AppError.featureNotEnabled if either flag is disabled
+ */
+export function isPasskeyPasswordlessSyncEnabled(
+  config: PasskeyFlagsConfig<'enabled' | 'passwordlessSyncEnabled'>
+): boolean {
+  if (!config.passkeys.enabled || !config.passkeys.passwordlessSyncEnabled) {
     throw AppError.featureNotEnabled();
   }
   return true;

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -79,6 +79,7 @@
     "passkeysEnabled": true,
     "passkeyRegistrationEnabled": true,
     "passkeyAuthenticationEnabled": true,
+    "passkeyPasswordlessSyncEnabled": true,
     "passwordlessEnabled": true
   },
   "darkMode": {

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -142,6 +142,9 @@ const settingsConfig = {
     passkeyAuthenticationEnabled: config.get(
       'featureFlags.passkeyAuthenticationEnabled'
     ),
+    passkeyPasswordlessSyncEnabled: config.get(
+      'featureFlags.passkeyPasswordlessSyncEnabled'
+    ),
     passwordlessEnabled: config.get('featureFlags.passwordlessEnabled'),
   },
   darkMode: {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -249,7 +249,7 @@ const conf = (module.exports = convict({
     },
     passkeysEnabled: {
       default: false,
-      doc: 'Master switch for passkeys UI. Must be true for registration or authentication UI to activate.',
+      doc: 'Primary switch for passkeys UI. Must be true for registration or authentication UI to activate.',
       format: Boolean,
       env: 'FEATURE_FLAGS_PASSKEYS_ENABLED',
     },

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -265,6 +265,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_PASSKEY_AUTHENTICATION_ENABLED',
     },
+    passkeyPasswordlessSyncEnabled: {
+      default: false,
+      doc: 'Enables passwordless sync sign-in UI, where sync keys are recovered from a passkey instead of the password',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_PASSKEY_PASSWORDLESS_SYNC_ENABLED',
+    },
     passwordlessEnabled: {
       default: false,
       doc: 'Enables auto-redirect to passwordless OTP signup for new accounts on allowed RPs',

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -64,6 +64,9 @@ function getIndexRouteDefinition(config) {
   const FEATURE_FLAGS_PASSKEY_AUTHENTICATION_ENABLED = config.get(
     'featureFlags.passkeyAuthenticationEnabled'
   );
+  const FEATURE_FLAGS_PASSKEY_PASSWORDLESS_SYNC_ENABLED = config.get(
+    'featureFlags.passkeyPasswordlessSyncEnabled'
+  );
   const PASSKEYS_MAX_PER_USER = config.get('passkeys.maxPerUser');
   const DARK_MODE_ENABLED = config.get('darkMode.enabled');
   const GLEAN_ENABLED = config.get('glean.enabled');
@@ -136,6 +139,8 @@ function getIndexRouteDefinition(config) {
       passkeyRegistrationEnabled: FEATURE_FLAGS_PASSKEY_REGISTRATION_ENABLED,
       passkeyAuthenticationEnabled:
         FEATURE_FLAGS_PASSKEY_AUTHENTICATION_ENABLED,
+      passkeyPasswordlessSyncEnabled:
+        FEATURE_FLAGS_PASSKEY_PASSWORDLESS_SYNC_ENABLED,
     },
     darkMode: {
       enabled: DARK_MODE_ENABLED,

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -57,8 +57,8 @@ export interface Config {
     isPromptNoneEnabled: boolean;
     isPromptNoneEnabledClientIds: string[];
     reactClientIdsEnabled: string[];
-    clientInfoTimeout: number,
-    clientInfoRetries: number,
+    clientInfoTimeout: number;
+    clientInfoRetries: number;
   };
   recoveryCodes: {
     count: number;
@@ -118,6 +118,7 @@ export interface Config {
     passkeysEnabled?: boolean;
     passkeyRegistrationEnabled?: boolean;
     passkeyAuthenticationEnabled?: boolean;
+    passkeyPasswordlessSyncEnabled?: boolean;
     passwordlessEnabled?: boolean;
   };
   darkMode?: {
@@ -184,7 +185,7 @@ export function getDefault() {
       isPromptNoneEnabledClientIds: new Array<string>(),
       reactClientIdsEnabled: new Array<string>(),
       clientInfoRetries: 4,
-      clientInfoTimeout: 10_000
+      clientInfoTimeout: 10_000,
     },
     recoveryCodes: {
       count: 8,
@@ -230,7 +231,8 @@ export function getDefault() {
     },
     mobileStoreLinks: {
       ios: 'https://apps.apple.com/app/firefox-private-safe-browser/id989804926',
-      android: 'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
+      android:
+        'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
     },
     featureFlags: {
       recoveryCodeSetupOnSyncSignIn: false,


### PR DESCRIPTION
## Because

- Passwordless sync sign-in needs a feature flag on both the backend and the
  frontend before the routes and UI paths that use it can be gated in later
  tickets in this epic.
- Both flags default off, so this lands dark and is safe to deploy ahead of any
  of the behaviour it will eventually gate.

## This pull request

- Adds `passkeys.passwordlessSyncEnabled` to the auth-server convict block in
  `packages/fxa-auth-server/config/index.ts` (default `false`, env
  `PASSKEYS__PASSWORDLESS_SYNC_ENABLED`).
- Adds `isPasskeyPasswordlessSyncEnabled` to
  `packages/fxa-auth-server/lib/passkey-utils.ts`, which throws
  `AppError.featureNotEnabled()` unless both the primary `passkeys.enabled` flag
  and the new flag are on — the same shape as the existing
  `isPasskeyRegistrationEnabled` and `isPasskeyAuthenticationEnabled` guards.
- Adds `passkeyPasswordlessSyncEnabled` to the content-server feature flags in
  `configuration.js`, and passes it through in both `beta-settings.js` and
  `routes/react-app/route-definition-index.js`, matching how `passkeysEnabled`
  is wired.
- Adds the flag to the `featureFlags` interface in
  `packages/fxa-settings/src/lib/config.ts`.
- Enables the flag in local config for both services
  (`fxa-auth-server/config/dev.json` and the content-server
  `local.json-dist` template).

## Issue that this pull request solves

Closes: FXA-13141

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/passkey-utils.ts` for the guard, and the
  three content-server files for flag plumbing.
- Suggested review order: auth-server config and guard, then the content-server
  pass-throughs, then the local config enablement.
- Risky or complex parts: none functionally — nothing reads either flag yet.
  The thing worth checking is that no plumbing site was missed, since a missed
  one fails silently rather than loudly (see below).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

**Verified on the running local services**, not just statically:

- auth-server reports `passkeys.passwordlessSyncEnabled: true` in its resolved
  config after restart, with `/__heartbeat__` returning 200.
- content-server exposes `passkeyPasswordlessSyncEnabled: true` in the
  `meta[name="fxa-config"]` tag on `localhost:3030` — which is the exact source
  the functional tests read via `ConfigPage.getConfig()`.
- `packages/fxa-auth-server/lib/passkey-utils.spec.ts` passes 13/13, and
  `fxa-settings` typechecks with 0 errors.

**Heads-up for anyone running this locally:** the content-server
`server/config/local.json` is gitignored, so only the `local.json-dist` template
change is in this diff. `local.json` overlays last, so until you add
`"passkeyPasswordlessSyncEnabled": true` to your own copy, the flag reads
`false` locally even though `-dist` has it on. Functional tests in this epic
`test.skip` on missing flags, so that shows up as a green run rather than a
failure. I hit this during verification.

**Ticket correction:** FXA-13141 says "note there is no `isPasskeyFeatureEnabled`".
It does exist, at `packages/fxa-auth-server/lib/passkey-utils.ts:23`, and three
passkey management routes use it. I followed the code rather than the ticket.
