### PR TITLE
feat(auth): add statsd to free access script

### DIFF
--- a/packages/fxa-auth-server/scripts/free-access-program-reconcile.ts
+++ b/packages/fxa-auth-server/scripts/free-access-program-reconcile.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { promisify } from 'util';
+
 import Container from 'typedi';
 import { Logger } from '@nestjs/common';
 import { StatsD } from 'hot-shots';
@@ -93,6 +95,7 @@ async function main() {
   );
   Container.set(FreeAccessProgramJournalManagerConfig, journalManagerConfig);
 
+  statsd.increment('free-access-program-reconcile.startup');
   const notifier = new FreeAccessInProcessNotifier(
     database,
     Container.get(ProfileClient),
@@ -104,7 +107,9 @@ async function main() {
     firestore
   );
   Container.set(FreeAccessProgramJournalManager, journalManager);
-  const accountDatabase = await setupAccountDatabase(config.database.mysql.auth);
+  const accountDatabase = await setupAccountDatabase(
+    config.database.mysql.auth
+  );
   const accountManager = new AccountManager(accountDatabase);
   Container.set(AccountManager, accountManager);
 
@@ -118,8 +123,14 @@ async function main() {
   );
   Container.set(FreeAccessProgramService, service);
 
-  const result = await service.reconcile();
-  log.info('free-access-program-reconcile.complete', result);
+  try {
+    const result = await service.reconcile();
+    log.info('free-access-program-reconcile.complete', result);
+    statsd.increment('free-access-program-reconcile.shutdown');
+  } finally {
+    await promisify(statsd.close).bind(statsd)();
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
## Because

* Need to be able to track free access program reconcilation script start and shutdown.

## This pull request

* Adds statsd increments for start and shutdown of free access reconcile script

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
