### PR TITLE
fix(payments-ui): Reduce Sentry noise by adding PayPalClientError to decorator

### DIFF
--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -32,6 +32,7 @@ import {
 import {
   CheckoutTokenManager,
   PaypalBillingAgreementManager,
+  PayPalClientError,
 } from '@fxa/payments/paypal';
 import {
   ProductConfigError,
@@ -555,7 +556,7 @@ export class NextJSActionsService {
     await this.cartService.finalizeProcessingCart(args.cartId);
   }
 
-  @SanitizeExceptions()
+  @SanitizeExceptions({ allowlist: [PayPalClientError] })
   @CaptureTimingWithStatsD()
   @NextIOValidator(GetPayPalCheckoutTokenArgs, GetPayPalCheckoutTokenResult)
   @WithTypeCachableAsyncLocalStorage()
@@ -790,10 +791,7 @@ export class NextJSActionsService {
   @NextIOValidator(SubmitNeedsInputActionArgs, undefined)
   @WithTypeCachableAsyncLocalStorage()
   @AssertCartOwnership()
-  async submitNeedsInput(args: {
-    cartId: string;
-    requestArgs: CommonMetrics;
-  }) {
+  async submitNeedsInput(args: { cartId: string; requestArgs: CommonMetrics }) {
     await this.cartService.submitNeedsInput(args.cartId, args.requestArgs);
   }
 


### PR DESCRIPTION
## Because

- PayPalClientError ("Receiving country does not support the transaction currency") is being reported as an unhandled error in Sentry.
- The client-side PayPal buttons onError callback already handles this gracefully, but @SanitizeExceptions() on getPayPalCheckoutToken treats it as unexpected, reports it to Sentry via captureException, and re-throws as a generic error. 
- This is a known PayPal rejection for unsupported currency/country combos, not a bug.

## This pull request

- Adds PayPalClientError to the @SanitizeExceptions() allowlist on getPayPalCheckoutToken, so the error passes through to the client (where it's already handled) without generating Sentry noise. 

## Issue that this pull request solves

Closes PAY-3840

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.