### PR TITLE
docs(settings): Correct JwtTokenCache storage comment

### DIFF
--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -254,9 +254,9 @@ export type JwtPayload = {
 /**
  * External Container for holding JWTs.
  *
- * For now tokens will be held in page memory. This works as long as we have
- * no hard navigates, which should be the case in fxa settings. If edge cases
- * arise consider swapping `static state` for session storage.
+ * Tokens are backed by local storage so they survive hard navigates and page
+ * refreshes. `static state` is an in-memory cache of that stored value; it is
+ * lazily hydrated on first read and written through on every mutation.
  */
 export class JwtTokenCache {
   /** The following works with React.useSyncExternalStore. */


### PR DESCRIPTION
## Because

- The doc comment on `JwtTokenCache` stated that MFA JWTs "will be held in page memory" and would not survive hard navigates. That is not how the class behaves: the tokens are backed by local storage and intentionally persist across page refreshes.
- The comment also advised swapping `static state` for session storage "if edge cases arise," which would undo deliberate behavior that test infrastructure already relies on.

## This pull request

- Rewrites the `JwtTokenCache` doc comment in `packages/fxa-settings/src/lib/cache.ts` to state that tokens are backed by local storage and survive hard navigates and refreshes.
- Describes `static state` as what it actually is: an in-memory cache of the stored value, lazily hydrated on first read and written through on every mutation.
- Drops the stale suggestion to move to session storage.

No behavior change — comment only.

## Issue that this pull request solves

Closes: N/A

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Other information (Optional)

No Jira ticket — comment-only correction with no behavior change.

Supporting evidence for the corrected wording:
- `cache.ts:15` builds the store via `Storage.factory('localStorage')`, which resolves to `new Storage(win.localStorage)` (`storage.ts:160-161`).
- The `state` setter (`cache.ts:287-290`) calls `storage.set(...)`, and `setToken`/`removeToken`/`clearTokens` all reassign `state`, so every mutation is written through.
- `packages/functional-tests/lib/testAccountTracker.ts:666-690` reads and writes `localStorage['__fxa_storage.mfa_token_cache']` directly, so cross-navigation persistence is already depended upon.
