### PR TITLE
fix(apple-iap): fall back to cached IAP records on App Store failures

### DIFF
--- a/libs/payments/api-server/src/lib/billing-and-subscriptions.service.spec.ts
+++ b/libs/payments/api-server/src/lib/billing-and-subscriptions.service.spec.ts
@@ -88,13 +88,13 @@ describe('BillingAndSubscriptionsService', () => {
   let freeAccessProgramService: FreeAccessProgramService;
   let appleIapPurchaseManager: AppleIapPurchaseManager;
   let googleIapPurchaseManager: GoogleIapPurchaseManager;
-  let logger: { log: jest.Mock; error: jest.Mock };
+  let logger: { log: jest.Mock; warn: jest.Mock; error: jest.Mock };
 
   // Mutable so individual tests can toggle the feature flag; reset in beforeEach.
   const mockFreeAccessProgramConfig = { enabled: true };
 
   beforeEach(async () => {
-    logger = { log: jest.fn(), error: jest.fn() };
+    logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
     mockFreeAccessProgramConfig.enabled = true;
 
     const moduleRef = await Test.createTestingModule({
@@ -268,6 +268,25 @@ describe('BillingAndSubscriptionsService', () => {
       await expect(
         service.get({ uid: UID, clientId: CLIENT_ID })
       ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('reads the Apple IAP purchases with getForUserOrStaleCached', async () => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockRejectedValue(
+          new AccountCustomerNotFoundError(UID, new Error('not found'))
+        );
+      jest
+        .spyOn(freeAccessProgramService, 'findFreeAccessForUid')
+        .mockResolvedValue({ isMember: true, grantsByClient: {} });
+      const getForUserOrStaleCached = jest.spyOn(
+        appleIapPurchaseManager,
+        'getForUserOrStaleCached'
+      );
+
+      await service.get({ uid: UID, clientId: CLIENT_ID });
+
+      expect(getForUserOrStaleCached).toHaveBeenCalledWith(UID);
     });
 
     it('falls back to IAP-only flow when AccountCustomer is missing', async () => {

--- a/libs/payments/api-server/src/lib/billing-and-subscriptions.service.ts
+++ b/libs/payments/api-server/src/lib/billing-and-subscriptions.service.ts
@@ -112,7 +112,7 @@ export class BillingAndSubscriptionsService {
         ? this.subscriptionManager.listActiveForCustomer(stripeCustomer.id)
         : Promise.resolve<StripeSubscription[]>([]),
       this.googleIapPurchaseManager.getForUser(uid),
-      this.appleIapPurchaseManager.getForUser(uid),
+      this.appleIapPurchaseManager.getForUserOrStaleCached(uid),
       // Only resolve Free Access Program data when the feature is enabled.
       this.freeAccessProgramConfig.enabled
         ? this.freeAccessProgramService.findFreeAccessForUid(uid)

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -48,14 +48,28 @@ import {
 import { LocationConfig, MockLocationConfigProvider } from './location.config';
 import {
   AppleIapClient,
+  AppleIapClientBundleError,
   AppleIapPurchaseManager,
+  AppleIapServiceUnavailableError,
   GoogleIapClient,
   GoogleIapPurchaseManager,
   MockAppleIapClientConfigProvider,
   MockGoogleIapClientConfigProvider,
 } from '@fxa/payments/iap';
+import { AppStoreError } from 'app-store-server-api';
 import { faker } from '@faker-js/faker';
 import { Logger } from '@nestjs/common';
+
+// Apple reports a transient internal failure as errorCode 5000001, which
+// app-store-server-api flags as retryable.
+const APPLE_RETRYABLE_ERROR = new AppleIapServiceUnavailableError(
+  new AppStoreError(5000001, 'An unknown error occurred. Please try again.')
+);
+// A 401 from the App Store Server API surfaces as a plain Error, meaning our
+// JWT is invalid — never that the customer has no Apple subscriptions.
+const APPLE_INVALID_JWT_ERROR = new AppleIapClientBundleError(
+  new Error('The request is unauthorized; the JSON Web Token (JWT) is invalid.')
+);
 
 describe('EligibilityService', () => {
   let productConfigurationManager: ProductConfigurationManager;
@@ -309,6 +323,57 @@ describe('EligibilityService', () => {
         subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
       });
     });
+
+    it.each([
+      {
+        errorName: 'AppleIapServiceUnavailableError',
+        error: APPLE_RETRYABLE_ERROR,
+      },
+      {
+        errorName: 'AppleIapClientBundleError',
+        error: APPLE_INVALID_JWT_ERROR,
+      },
+    ])(
+      'rethrows $errorName instead of falling back to the cached Apple purchases',
+      async ({ error }) => {
+        const mockCustomer = StripeCustomerFactory();
+        const interval = SubplatInterval.Monthly;
+        const offeringApiIdentifier = faker.string.uuid();
+
+        jest
+          .spyOn(appleIapPurchaseManager, 'getForUser')
+          .mockRejectedValue(error);
+        jest.spyOn(appleIapPurchaseManager, 'getStaleCachedForUser');
+        jest
+          .spyOn(googleIapPurchaseManager, 'getForUser')
+          .mockResolvedValue([]);
+        jest
+          .spyOn(productConfigurationManager, 'getEligibilityContentByOffering')
+          .mockResolvedValue(
+            new EligibilityContentByOfferingResultUtil(
+              EligibilityContentByOfferingResultFactory({
+                offerings: [
+                  EligibilityContentOfferingResultFactory({
+                    apiIdentifier: offeringApiIdentifier,
+                  }),
+                ],
+              })
+            )
+          );
+
+        await expect(
+          eligibilityService.checkEligibility(
+            interval,
+            offeringApiIdentifier,
+            faker.string.uuid(),
+            mockCustomer.id
+          )
+        ).rejects.toThrow(error);
+        expect(
+          appleIapPurchaseManager.getStaleCachedForUser
+        ).not.toHaveBeenCalled();
+      }
+    );
 
     it('returns CREATE when Google IAP subscription is for a different product', async () => {
       const interval = SubplatInterval.Monthly;

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -48,14 +48,28 @@ import {
 import { LocationConfig, MockLocationConfigProvider } from './location.config';
 import {
   AppleIapClient,
+  AppleIapClientBundleError,
   AppleIapPurchaseManager,
+  AppleIapServiceUnavailableError,
   GoogleIapClient,
   GoogleIapPurchaseManager,
   MockAppleIapClientConfigProvider,
   MockGoogleIapClientConfigProvider,
 } from '@fxa/payments/iap';
+import { AppStoreError } from 'app-store-server-api';
 import { faker } from '@faker-js/faker';
 import { Logger } from '@nestjs/common';
+
+// Apple reports a transient internal failure as errorCode 5000001, which
+// app-store-server-api flags as retryable.
+const APPLE_RETRYABLE_ERROR = new AppleIapServiceUnavailableError(
+  new AppStoreError(5000001, 'An unknown error occurred. Please try again.')
+);
+// A 401 from the App Store Server API surfaces as a plain Error, meaning our
+// JWT is invalid — never that the customer has no Apple subscriptions.
+const APPLE_INVALID_JWT_ERROR = new AppleIapClientBundleError(
+  new Error('The request is unauthorized; the JSON Web Token (JWT) is invalid.')
+);
 
 describe('EligibilityService', () => {
   let productConfigurationManager: ProductConfigurationManager;
@@ -64,6 +78,7 @@ describe('EligibilityService', () => {
   let subscriptionManager: SubscriptionManager;
   let appleIapPurchaseManager: AppleIapPurchaseManager;
   let googleIapPurchaseManager: GoogleIapPurchaseManager;
+  let logger: Logger;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -97,6 +112,7 @@ describe('EligibilityService', () => {
     subscriptionManager = module.get(SubscriptionManager);
     appleIapPurchaseManager = module.get(AppleIapPurchaseManager);
     googleIapPurchaseManager = module.get(GoogleIapPurchaseManager);
+    logger = module.get(Logger);
   });
 
   describe('checkEligibility', () => {
@@ -308,6 +324,109 @@ describe('EligibilityService', () => {
       expect(result).toEqual({
         subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
       });
+    });
+
+    it('returns BLOCKED_IAP from the cached Apple purchases when the App Store Server API is unavailable', async () => {
+      const mockCustomer = StripeCustomerFactory();
+      const interval = SubplatInterval.Monthly;
+      const offeringApiIdentifier = faker.string.uuid();
+
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUser')
+        .mockRejectedValue(APPLE_RETRYABLE_ERROR);
+      jest
+        .spyOn(appleIapPurchaseManager, 'getStaleCachedForUser')
+        .mockResolvedValue([{ productId: 'apple_product_1' } as any]);
+      jest.spyOn(googleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      const warn = jest.spyOn(logger, 'warn').mockImplementation();
+      jest
+        .spyOn(productConfigurationManager, 'getEligibilityContentByOffering')
+        .mockResolvedValue(
+          new EligibilityContentByOfferingResultUtil(
+            EligibilityContentByOfferingResultFactory({
+              offerings: [
+                EligibilityContentOfferingResultFactory({
+                  apiIdentifier: offeringApiIdentifier,
+                }),
+              ],
+            })
+          )
+        );
+      jest
+        .spyOn(productConfigurationManager, 'getIapOfferings')
+        .mockResolvedValue(
+          new IapOfferingsByStoreIDsResultUtil(
+            IapOfferingByStoreIDResultFactory({
+              iaps: [
+                IapWithOfferingResultFactory({
+                  offering: IapOfferingResultFactory({
+                    apiIdentifier: offeringApiIdentifier,
+                    subGroups: [
+                      IapOfferingSubGroupResultFactory({
+                        offerings: [
+                          IapOfferingSubGroupOfferingResultFactory({
+                            apiIdentifier: offeringApiIdentifier,
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                }),
+              ],
+            })
+          )
+        );
+      const uid = faker.string.uuid();
+
+      const result = await eligibilityService.checkEligibility(
+        interval,
+        offeringApiIdentifier,
+        uid,
+        mockCustomer.id
+      );
+
+      expect(result).toEqual({
+        subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
+      });
+      expect(appleIapPurchaseManager.getStaleCachedForUser).toHaveBeenCalledWith(uid);
+      expect(warn).toHaveBeenCalledWith('checkEligibility.appleIapUnavailable', {
+        uid,
+      });
+    });
+
+    it('rethrows Apple IAP errors Apple did not ask us to retry', async () => {
+      const mockCustomer = StripeCustomerFactory();
+      const interval = SubplatInterval.Monthly;
+      const offeringApiIdentifier = faker.string.uuid();
+
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUser')
+        .mockRejectedValue(APPLE_INVALID_JWT_ERROR);
+      jest.spyOn(appleIapPurchaseManager, 'getStaleCachedForUser');
+      jest.spyOn(googleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      jest
+        .spyOn(productConfigurationManager, 'getEligibilityContentByOffering')
+        .mockResolvedValue(
+          new EligibilityContentByOfferingResultUtil(
+            EligibilityContentByOfferingResultFactory({
+              offerings: [
+                EligibilityContentOfferingResultFactory({
+                  apiIdentifier: offeringApiIdentifier,
+                }),
+              ],
+            })
+          )
+        );
+
+      await expect(
+        eligibilityService.checkEligibility(
+          interval,
+          offeringApiIdentifier,
+          faker.string.uuid(),
+          mockCustomer.id
+        )
+      ).rejects.toBe(APPLE_INVALID_JWT_ERROR);
+      expect(appleIapPurchaseManager.getStaleCachedForUser).not.toHaveBeenCalled();
     });
 
     it('returns CREATE when Google IAP subscription is for a different product', async () => {

--- a/libs/payments/eligibility/src/lib/eligibility.service.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.ts
@@ -2,12 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  type LoggerService,
+} from '@nestjs/common';
 import { SubscriptionManager, SubplatInterval } from '@fxa/payments/customer';
 import { ProductConfigurationManager } from '@fxa/shared/cms';
 import {
   GoogleIapPurchaseManager,
   AppleIapPurchaseManager,
+  AppleIapServiceUnavailableError,
 } from '@fxa/payments/iap';
 import { EligibilityManager } from './eligibility.manager';
 import {
@@ -26,7 +32,8 @@ export class EligibilityService {
     private eligibilityManager: EligibilityManager,
     private subscriptionManager: SubscriptionManager,
     private googleIapPurchaseManager: GoogleIapPurchaseManager,
-    private appleIapPurchaseManager: AppleIapPurchaseManager
+    private appleIapPurchaseManager: AppleIapPurchaseManager,
+    @Inject(Logger) private log: LoggerService
   ) {}
 
   /**
@@ -56,7 +63,15 @@ export class EligibilityService {
     const targetOffering = targetOfferingResult.getOffering();
 
     const [appleIapPurchases, googleIapPurchases] = await Promise.all([
-      this.appleIapPurchaseManager.getForUser(uid),
+      this.appleIapPurchaseManager.getForUser(uid).catch((error) => {
+        if (error instanceof AppleIapServiceUnavailableError) {
+          // Unconfirmed must not read as absent, or an overlapping purchase
+          // slips through — including a stale cache that reads inactive.
+          this.log.warn('checkEligibility.appleIapUnavailable', { uid });
+          return this.appleIapPurchaseManager.getStaleCachedForUser(uid);
+        }
+        throw error;
+      }),
       this.googleIapPurchaseManager.getForUser(uid),
     ]);
     if (appleIapPurchases.length || googleIapPurchases.length) {

--- a/libs/payments/iap/src/index.ts
+++ b/libs/payments/iap/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/google/subscription-purchase';
 export * from './lib/apple/apple-iap.client';
 export * from './lib/google/google-iap.client.config';
 export * from './lib/apple/apple-iap-purchase.manager';
+export * from './lib/apple/apple-iap.error';
 export * from './lib/apple/subscription-purchase';
 export * from './lib/google/google-iap.client';
 export * from './lib/apple/apple-iap.client.config';

--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.spec.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.spec.ts
@@ -8,17 +8,23 @@ import { AppleIapPurchaseManager } from './apple-iap-purchase.manager';
 import { AppleIapClient } from './apple-iap.client';
 import { Logger } from '@nestjs/common';
 import { FirestoreService } from '@fxa/shared/db/firestore';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MockAppleIapClientConfigProvider } from './apple-iap.client.config';
 import * as repository from './apple-iap-purchase.repository';
 import { AppStoreSubscriptionPurchase } from './subscription-purchase';
 import {
+  AppStoreError,
   decodeRenewalInfo,
   decodeTransaction,
   SubscriptionStatus,
   type StatusResponse,
 } from 'app-store-server-api';
 import { FirestoreAppleIapPurchaseRecordFactory } from '../factories';
-import { AppleIapNotFoundError } from './apple-iap.error';
+import {
+  AppleIapClientBundleError,
+  AppleIapNotFoundError,
+  AppleIapServiceUnavailableError,
+} from './apple-iap.error';
 
 jest.mock('./apple-iap-purchase.repository', () => ({
   getActivePurchasesForUserId: jest.fn(),
@@ -33,6 +39,7 @@ jest.mock('app-store-server-api', () => {
   return {
     Environment: actual.Environment,
     SubscriptionStatus: actual.SubscriptionStatus,
+    AppStoreError: actual.AppStoreError,
     decodeTransaction: jest.fn(),
     decodeRenewalInfo: jest.fn(),
     AppStoreServerAPI: jest.fn().mockImplementation(() => ({})),
@@ -42,6 +49,7 @@ jest.mock('app-store-server-api', () => {
 describe('AppleIapPurchaseManager', () => {
   let manager: AppleIapPurchaseManager;
   let appleIapClient: AppleIapClient;
+  let logger: Logger;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -63,11 +71,13 @@ describe('AppleIapPurchaseManager', () => {
             error: jest.fn(),
           },
         },
+        MockStatsDProvider,
       ],
     }).compile();
 
     manager = module.get(AppleIapPurchaseManager);
     appleIapClient = module.get(AppleIapClient);
+    logger = module.get(Logger);
   });
 
   afterEach(() => {
@@ -214,6 +224,32 @@ describe('AppleIapPurchaseManager', () => {
       await expect(manager.getForUser(userId)).resolves.not.toThrow();
     });
 
+    // Callers decide how to degrade — the change surfaces rely on this
+    // propagating rather than being swallowed here.
+    it('propagates AppleIapServiceUnavailableError', async () => {
+      const userId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+        }),
+      ]);
+      jest
+        .spyOn(appleIapClient, 'getSubscriptionStatuses')
+        .mockRejectedValue(
+          new AppleIapServiceUnavailableError(
+            new AppStoreError(
+              5000001,
+              'An unknown error occurred. Please try again.'
+            )
+          )
+        );
+
+      await expect(manager.getForUser(userId)).rejects.toThrow(
+        AppleIapServiceUnavailableError
+      );
+    });
+
     it('throws for unknown errors', async () => {
       const userId = faker.string.uuid();
 
@@ -235,6 +271,187 @@ describe('AppleIapPurchaseManager', () => {
 
       await expect(() => manager.getForUser(userId)).rejects.toThrow();
     });
+
+    it('does not query Apple when the user has no cached purchases', async () => {
+      const userId = faker.string.uuid();
+
+      jest
+        .spyOn(repository, 'getActivePurchasesForUserId')
+        .mockResolvedValue([]);
+      jest.spyOn(appleIapClient, 'getSubscriptionStatuses');
+
+      await manager.getForUser(userId);
+
+      expect(appleIapClient.getSubscriptionStatuses).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getForUserOrStaleCached', () => {
+    beforeEach(() => {
+      (decodeTransaction as jest.Mock).mockResolvedValue({
+        transactionId: 'abc',
+      });
+      (decodeRenewalInfo as jest.Mock).mockResolvedValue({
+        renewalInfo: 'xyz',
+      });
+    });
+
+    it('returns the purchase as verified by Apple when the App Store Server API is reachable', async () => {
+      const userId = faker.string.uuid();
+      const originalTransactionId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+          originalTransactionId,
+        }),
+      ]);
+      jest.spyOn(appleIapClient, 'getSubscriptionStatuses').mockResolvedValue({
+        data: [
+          {
+            lastTransactions: [
+              {
+                originalTransactionId,
+                status: SubscriptionStatus.Active,
+                signedTransactionInfo: faker.string.sample(),
+                signedRenewalInfo: faker.string.sample(),
+              },
+            ],
+          },
+        ],
+      } as StatusResponse);
+
+      const result = await manager.getForUserOrStaleCached(userId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].originalTransactionId).toBe(originalTransactionId);
+      expect(result[0].status).toBe(SubscriptionStatus.Active);
+    });
+
+    it('does not warn when the App Store Server API is reachable', async () => {
+      const userId = faker.string.uuid();
+      const originalTransactionId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+          originalTransactionId,
+        }),
+      ]);
+      jest.spyOn(appleIapClient, 'getSubscriptionStatuses').mockResolvedValue({
+        data: [
+          {
+            lastTransactions: [
+              {
+                originalTransactionId,
+                status: SubscriptionStatus.Active,
+                signedTransactionInfo: faker.string.sample(),
+                signedRenewalInfo: faker.string.sample(),
+              },
+            ],
+          },
+        ],
+      } as StatusResponse);
+
+      await manager.getForUserOrStaleCached(userId);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns only the cache-active purchases when the App Store Server API is unavailable', async () => {
+      const userId = faker.string.uuid();
+      const activeOriginalTransactionId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Active,
+          originalTransactionId: activeOriginalTransactionId,
+        }),
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+          originalTransactionId: faker.string.uuid(),
+        }),
+      ]);
+      jest
+        .spyOn(appleIapClient, 'getSubscriptionStatuses')
+        .mockRejectedValue(
+          new AppleIapServiceUnavailableError(
+            new AppStoreError(
+              5000001,
+              'An unknown error occurred. Please try again.'
+            )
+          )
+        );
+
+      const result = await manager.getForUserOrStaleCached(userId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].originalTransactionId).toBe(activeOriginalTransactionId);
+    });
+
+    it('warns with the App Store error message when the App Store Server API is unavailable', async () => {
+      const userId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+        }),
+      ]);
+      jest
+        .spyOn(appleIapClient, 'getSubscriptionStatuses')
+        .mockRejectedValue(
+          new AppleIapServiceUnavailableError(
+            new AppStoreError(
+              5000001,
+              'An unknown error occurred. Please try again.'
+            )
+          )
+        );
+
+      await manager.getForUserOrStaleCached(userId);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'getForUserOrStaleCached.appStoreUnavailable',
+        {
+          userId,
+          errorMessage:
+            'Apple IAP service unavailable: An unknown error occurred. Please try again.',
+        }
+      );
+    });
+
+    it('rethrows AppleIapClientBundleError without consulting the cache', async () => {
+      const userId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+        }),
+      ]);
+      jest
+        .spyOn(appleIapClient, 'getSubscriptionStatuses')
+        .mockRejectedValue(
+          new AppleIapClientBundleError(new Error('invalid JWT'))
+        );
+      jest.spyOn(manager, 'getStaleCachedForUser');
+
+      await expect(manager.getForUserOrStaleCached(userId)).rejects.toThrow(
+        AppleIapClientBundleError
+      );
+      expect(manager.getStaleCachedForUser).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty list when the user has no cached purchases', async () => {
+      const userId = faker.string.uuid();
+
+      jest
+        .spyOn(repository, 'getActivePurchasesForUserId')
+        .mockResolvedValue([]);
+
+      const result = await manager.getForUserOrStaleCached(userId);
+
+      expect(result).toEqual([]);
+    });
   });
 
   describe('forceRegisterToUser', () => {
@@ -249,6 +466,44 @@ describe('AppleIapPurchaseManager', () => {
         originalTransactionId,
         { userId }
       );
+    });
+  });
+
+  describe('getStaleCachedForUser', () => {
+    it('returns the cached purchases without querying Apple', async () => {
+      const userId = faker.string.uuid();
+      const originalTransactionId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+          originalTransactionId,
+        }),
+      ]);
+      jest.spyOn(appleIapClient, 'getSubscriptionStatuses');
+
+      const result = await manager.getStaleCachedForUser(userId);
+
+      expect(repository.getActivePurchasesForUserId).toHaveBeenCalledWith(
+        expect.anything(),
+        userId
+      );
+      expect(appleIapClient.getSubscriptionStatuses).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(AppStoreSubscriptionPurchase);
+      expect(result[0].originalTransactionId).toBe(originalTransactionId);
+    });
+
+    it('returns an empty list when the user has no cached purchases', async () => {
+      const userId = faker.string.uuid();
+
+      jest
+        .spyOn(repository, 'getActivePurchasesForUserId')
+        .mockResolvedValue([]);
+
+      const result = await manager.getStaleCachedForUser(userId);
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.spec.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.spec.ts
@@ -12,13 +12,17 @@ import { MockAppleIapClientConfigProvider } from './apple-iap.client.config';
 import * as repository from './apple-iap-purchase.repository';
 import { AppStoreSubscriptionPurchase } from './subscription-purchase';
 import {
+  AppStoreError,
   decodeRenewalInfo,
   decodeTransaction,
   SubscriptionStatus,
   type StatusResponse,
 } from 'app-store-server-api';
 import { FirestoreAppleIapPurchaseRecordFactory } from '../factories';
-import { AppleIapNotFoundError } from './apple-iap.error';
+import {
+  AppleIapNotFoundError,
+  AppleIapServiceUnavailableError,
+} from './apple-iap.error';
 
 jest.mock('./apple-iap-purchase.repository', () => ({
   getActivePurchasesForUserId: jest.fn(),
@@ -33,6 +37,7 @@ jest.mock('app-store-server-api', () => {
   return {
     Environment: actual.Environment,
     SubscriptionStatus: actual.SubscriptionStatus,
+    AppStoreError: actual.AppStoreError,
     decodeTransaction: jest.fn(),
     decodeRenewalInfo: jest.fn(),
     AppStoreServerAPI: jest.fn().mockImplementation(() => ({})),
@@ -214,6 +219,33 @@ describe('AppleIapPurchaseManager', () => {
       await expect(manager.getForUser(userId)).resolves.not.toThrow();
     });
 
+    // Callers decide how to degrade — the read paths skip the purchases, while
+    // EligibilityService falls back to the cached records — so this has to keep
+    // propagating rather than being swallowed here.
+    it('propagates AppleIapServiceUnavailableError', async () => {
+      const userId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+        }),
+      ]);
+      jest
+        .spyOn(appleIapClient, 'getSubscriptionStatuses')
+        .mockRejectedValue(
+          new AppleIapServiceUnavailableError(
+            new AppStoreError(
+              5000001,
+              'An unknown error occurred. Please try again.'
+            )
+          )
+        );
+
+      await expect(manager.getForUser(userId)).rejects.toThrow(
+        AppleIapServiceUnavailableError
+      );
+    });
+
     it('throws for unknown errors', async () => {
       const userId = faker.string.uuid();
 
@@ -249,6 +281,44 @@ describe('AppleIapPurchaseManager', () => {
         originalTransactionId,
         { userId }
       );
+    });
+  });
+
+  describe('getStaleCachedForUser', () => {
+    it('returns the cached purchases without querying Apple', async () => {
+      const userId = faker.string.uuid();
+      const originalTransactionId = faker.string.uuid();
+
+      jest.spyOn(repository, 'getActivePurchasesForUserId').mockResolvedValue([
+        FirestoreAppleIapPurchaseRecordFactory({
+          status: SubscriptionStatus.Expired,
+          originalTransactionId,
+        }),
+      ]);
+      jest.spyOn(appleIapClient, 'getSubscriptionStatuses');
+
+      const result = await manager.getStaleCachedForUser(userId);
+
+      expect(repository.getActivePurchasesForUserId).toHaveBeenCalledWith(
+        expect.anything(),
+        userId
+      );
+      expect(appleIapClient.getSubscriptionStatuses).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(AppStoreSubscriptionPurchase);
+      expect(result[0].originalTransactionId).toBe(originalTransactionId);
+    });
+
+    it('returns an empty list when the user has no cached purchases', async () => {
+      const userId = faker.string.uuid();
+
+      jest
+        .spyOn(repository, 'getActivePurchasesForUserId')
+        .mockResolvedValue([]);
+
+      const result = await manager.getStaleCachedForUser(userId);
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
@@ -5,6 +5,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { CollectionReference, Firestore } from '@google-cloud/firestore';
 import { FirestoreService } from '@fxa/shared/db/firestore';
+import { StatsDService, type StatsD } from '@fxa/shared/metrics/statsd';
 import {
   createPurchase,
   deletePurchasesByUserId,
@@ -27,6 +28,7 @@ import { AppleIapClient } from './apple-iap.client';
 import {
   AppleIapNotFoundError,
   AppleIapNoTransactionsFoundError,
+  AppleIapServiceUnavailableError,
   GetFromAppStoreIapUnknownError,
 } from './apple-iap.error';
 
@@ -36,7 +38,8 @@ export class AppleIapPurchaseManager {
     private config: AppleIapClientConfig,
     @Inject(FirestoreService) private firestore: Firestore,
     private appleIapClient: AppleIapClient,
-    private log: Logger
+    private log: Logger,
+    @Inject(StatsDService) private statsd: StatsD
   ) {}
 
   get collectionRef(): CollectionReference {
@@ -111,6 +114,29 @@ export class AppleIapPurchaseManager {
     }
 
     return purchaseList;
+  }
+
+  async getForUserOrStaleCached(
+    userId: string
+  ): Promise<AppStoreSubscriptionPurchase[]> {
+    try {
+      return await this.getForUser(userId);
+    } catch (error) {
+      if (!(error instanceof AppleIapServiceUnavailableError)) {
+        throw error;
+      }
+
+      this.log.warn('getForUserOrStaleCached.appStoreUnavailable', {
+        userId,
+        errorMessage: error.message,
+      });
+      this.statsd.increment('apple_iap_stale_cache_fallback');
+
+      const cachedPurchases = await this.getStaleCachedForUser(userId);
+      return cachedPurchases.filter((purchase) =>
+        purchase.isEntitlementActive()
+      );
+    }
   }
 
   /*
@@ -238,6 +264,27 @@ export class AppleIapPurchaseManager {
     await updatePurchase(this.collectionRef, originalTransactionId, {
       userId,
     });
+  }
+
+  /**
+   * Return the user's purchases as they are cached in Firestore, without
+   * refreshing them against the App Store Server API.
+   *
+   * Intended for callers that still have to make a decision when Apple is
+   * unreachable. Since the records can be stale, an inactive entitlement here
+   * is not proof that the subscription has lapsed.
+   */
+  async getStaleCachedForUser(
+    userId: string
+  ): Promise<AppStoreSubscriptionPurchase[]> {
+    const firestorePurchaseRecords = await getActivePurchasesForUserId(
+      this.collectionRef,
+      userId
+    );
+
+    return firestorePurchaseRecords.map((firestorePurchaseRecord) =>
+      AppStoreSubscriptionPurchase.fromFirestoreObject(firestorePurchaseRecord)
+    );
   }
 
   async getStaleCached(

--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
@@ -240,6 +240,27 @@ export class AppleIapPurchaseManager {
     });
   }
 
+  /**
+   * Return the user's purchases as they are cached in Firestore, without
+   * refreshing them against the App Store Server API.
+   *
+   * Intended for callers that still have to make a decision when Apple is
+   * unreachable. Since the records can be stale, an inactive entitlement here
+   * is not proof that the subscription has lapsed.
+   */
+  async getStaleCachedForUser(
+    userId: string
+  ): Promise<AppStoreSubscriptionPurchase[]> {
+    const firestorePurchaseRecords = await getActivePurchasesForUserId(
+      this.collectionRef,
+      userId
+    );
+
+    return firestorePurchaseRecords.map((firestorePurchaseRecord) =>
+      AppStoreSubscriptionPurchase.fromFirestoreObject(firestorePurchaseRecord)
+    );
+  }
+
   async getStaleCached(
     originalTransactionId: string
   ): Promise<AppStoreSubscriptionPurchase | undefined> {

--- a/libs/payments/iap/src/lib/apple/apple-iap.client.spec.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.client.spec.ts
@@ -4,8 +4,16 @@
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppleIapClient } from './apple-iap.client';
-import { AppleIapMissingCredentialsError } from './apple-iap.error';
-import { Environment, StatusResponse } from 'app-store-server-api';
+import {
+  AppleIapClientBundleError,
+  AppleIapMissingCredentialsError,
+  AppleIapServiceUnavailableError,
+} from './apple-iap.error';
+import {
+  AppStoreError,
+  Environment,
+  StatusResponse,
+} from 'app-store-server-api';
 import {
   AppleIapClientConfig,
   MockAppleIapClientConfig,
@@ -17,6 +25,7 @@ jest.mock('app-store-server-api', () => {
   const actual = jest.requireActual('app-store-server-api');
   return {
     Environment: actual.Environment,
+    AppStoreError: actual.AppStoreError,
     AppStoreServerAPI: jest.fn().mockImplementation(() => ({
       getSubscriptionStatuses: jest.fn(),
     })),
@@ -80,6 +89,64 @@ describe('AppleIapClient', () => {
       expect(mockApiInstance.getSubscriptionStatuses).toHaveBeenCalledWith(
         mockTransactionId
       );
+    });
+
+    // Apple reports internal errors in the 5xxxxxx range — 5000001 is the one
+    // it marks retryable, 5000000 is not — and rate limiting as 4290000.
+    it.each([
+      {
+        description: 'a retryable internal error',
+        errorCode: 5000001,
+        errorMessage: 'An unknown error occurred. Please try again.',
+      },
+      {
+        description: 'an internal error Apple does not mark retryable',
+        errorCode: 5000000,
+        errorMessage: 'An unknown error occurred.',
+      },
+      {
+        description: 'rate limiting',
+        errorCode: 4290000,
+        errorMessage: 'Rate limit exceeded.',
+      },
+    ])(
+      'throws AppleIapServiceUnavailableError for $description',
+      async ({ errorCode, errorMessage }) => {
+        const mockApiInstance = appleIapClient.appStoreServerApiClients
+          .values()
+          .next().value;
+        assert(mockApiInstance);
+
+        jest
+          .spyOn(mockApiInstance, 'getSubscriptionStatuses')
+          .mockRejectedValue(new AppStoreError(errorCode, errorMessage));
+
+        await expect(
+          appleIapClient.getSubscriptionStatuses(
+            appleIapClientConfig.credentials[0].bundleId,
+            faker.string.uuid()
+          )
+        ).rejects.toThrow(AppleIapServiceUnavailableError);
+      }
+    );
+
+    it('throws AppleIapClientBundleError for an App Store error Apple does not want retried', async () => {
+      const mockApiInstance = appleIapClient.appStoreServerApiClients
+        .values()
+        .next().value;
+      assert(mockApiInstance);
+
+      jest.spyOn(mockApiInstance, 'getSubscriptionStatuses').mockRejectedValue(
+        // 4000006 InvalidTransactionIdError — a caller bug, not a retry.
+        new AppStoreError(4000006, 'Invalid transaction id.')
+      );
+
+      await expect(
+        appleIapClient.getSubscriptionStatuses(
+          appleIapClientConfig.credentials[0].bundleId,
+          faker.string.uuid()
+        )
+      ).rejects.toThrow(AppleIapClientBundleError);
     });
 
     it('should throw AppleIapMissingCredentialsError if no credentials exist for bundleId', () => {

--- a/libs/payments/iap/src/lib/apple/apple-iap.client.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.client.ts
@@ -9,6 +9,7 @@ import {
   AppleIapError,
   AppleIapMissingCredentialsError,
   AppleIapNotFoundError,
+  AppleIapServiceUnavailableError,
 } from './apple-iap.error';
 import {
   AppStoreError,
@@ -19,6 +20,14 @@ import {
   AppleIapClientConfig,
   AppleIapClientConfigCredential,
 } from './apple-iap.client.config';
+
+/**
+ * Apple's error codes are range-structured, so 5xxxxxx identifies a failure on
+ * Apple's side rather than a problem with our request.
+ * See https://developer.apple.com/documentation/appstoreserverapi/error-codes
+ */
+const isAppStoreServerErrorCode = (errorCode: number) =>
+  Math.floor(errorCode / 1_000_000) === 5;
 
 @Injectable()
 export class AppleIapClient {
@@ -82,6 +91,15 @@ export class AppleIapClient {
 
     if (e instanceof AppStoreError && e.errorCode === 4040010) {
       return new AppleIapNotFoundError(e);
+    }
+
+    if (
+      e instanceof AppStoreError &&
+      (isAppStoreServerErrorCode(e.errorCode) ||
+        e.isRetryable ||
+        e.isRateLimitExceeded)
+    ) {
+      return new AppleIapServiceUnavailableError(e);
     }
 
     if (e instanceof Error) {

--- a/libs/payments/iap/src/lib/apple/apple-iap.error.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.error.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { AppStoreError } from 'app-store-server-api';
+
 import { BaseError } from '@fxa/shared/error';
 
 /**
@@ -57,6 +59,17 @@ export class GetFromAppStoreIapUnknownError extends AppleIapUnknownError {
   constructor(cause: Error) {
     super('Unknown Apple IAP error occured when retrieving purchase', cause);
     this.name = 'GetFromAppStoreIapUnknownError';
+  }
+}
+
+export class AppleIapServiceUnavailableError extends AppleIapError {
+  constructor(cause: AppStoreError) {
+    super(
+      'Apple IAP service unavailable',
+      { errorCode: cause.errorCode, retryAfter: cause.retryAfter },
+      cause
+    );
+    this.name = 'AppleIapServiceUnavailableError';
   }
 }
 

--- a/libs/payments/iap/src/lib/apple/apple-iap.service.spec.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.service.spec.ts
@@ -12,6 +12,7 @@ import {
 } from 'app-store-server-api';
 
 import { FirestoreService } from '@fxa/shared/db/firestore';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { AppleIapClient } from './apple-iap.client';
 import { MockAppleIapClientConfigProvider } from './apple-iap.client.config';
 import {
@@ -58,6 +59,7 @@ describe('AppleIapService', () => {
           provide: Logger,
           useValue: mockLogger,
         },
+        MockStatsDProvider,
       ],
     }).compile();
 

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -43,6 +43,7 @@ import {
 import {
   AppleIapClient,
   AppleIapPurchaseManager,
+  AppStoreSubscriptionPurchase,
   GoogleIapClient,
   GoogleIapPurchaseManager,
   MockAppleIapClientConfigProvider,
@@ -139,6 +140,7 @@ jest.mock('@fxa/shared/error', () => ({
 
 describe('SubscriptionManagementService', () => {
   let accountCustomerManager: AccountCustomerManager;
+  let appleIapPurchaseManager: AppleIapPurchaseManager;
   let customerManager: CustomerManager;
   let churnInterventionService: ChurnInterventionService;
   let paymentMethodManager: PaymentMethodManager;
@@ -219,6 +221,7 @@ describe('SubscriptionManagementService', () => {
     }).compile();
 
     accountCustomerManager = moduleRef.get(AccountCustomerManager);
+    appleIapPurchaseManager = moduleRef.get(AppleIapPurchaseManager);
     churnInterventionService = moduleRef.get(ChurnInterventionService);
     customerManager = moduleRef.get(CustomerManager);
     invoiceManager = moduleRef.get(InvoiceManager);
@@ -1340,6 +1343,50 @@ describe('SubscriptionManagementService', () => {
 
       expect(result.subscriptions).toEqual([mockSubscriptionContent]);
       expect(result.trialSubscriptions).toEqual([]);
+    });
+  });
+
+  describe('getAppleIapPurchases', () => {
+    const mockStoreId = faker.string.sample();
+    const mockExpiresDate = Date.UTC(2099, 0, 2);
+
+    const mockApplePurchase = () => {
+      const purchase = new AppStoreSubscriptionPurchase();
+      purchase.productId = mockStoreId;
+      purchase.expiresDate = mockExpiresDate;
+      return purchase;
+    };
+
+    it('maps the purchases to storeIds and purchaseDetails', async () => {
+      const mockUid = faker.string.uuid();
+
+      jest
+        .spyOn(appleIapPurchaseManager, 'getForUserOrStaleCached')
+        .mockResolvedValue([mockApplePurchase()]);
+
+      const result = await (
+        subscriptionManagementService as any
+      ).getAppleIapPurchases(mockUid);
+
+      expect(result).toEqual({
+        storeIds: [mockStoreId],
+        purchaseDetails: [
+          { storeId: mockStoreId, expiresDate: mockExpiresDate },
+        ],
+      });
+    });
+
+    it('reads the purchases with getForUserOrStaleCached', async () => {
+      const mockUid = faker.string.uuid();
+      const getForUserOrStaleCached = jest
+        .spyOn(appleIapPurchaseManager, 'getForUserOrStaleCached')
+        .mockResolvedValue([mockApplePurchase()]);
+
+      await (subscriptionManagementService as any).getAppleIapPurchases(
+        mockUid
+      );
+
+      expect(getForUserOrStaleCached).toHaveBeenCalledWith(mockUid);
     });
   });
 

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -438,7 +438,7 @@ export class SubscriptionManagementService {
     };
 
     const appleIapSubscriptions =
-      await this.appleIapPurchaseManager.getForUser(uid);
+      await this.appleIapPurchaseManager.getForUserOrStaleCached(uid);
 
     for (const purchase of appleIapSubscriptions) {
       purchases.storeIds.push(purchase.productId);

--- a/packages/fxa-auth-server/lib/payments/initSubplat.ts
+++ b/packages/fxa-auth-server/lib/payments/initSubplat.ts
@@ -120,7 +120,8 @@ export async function initSubplat({
     appleClientConfig,
     firestore,
     appleIapClient,
-    legacyLog
+    legacyLog,
+    statsd
   );
   const priceManager = new PriceManager(stripeClient);
   const productConfigurationManager = new ProductConfigurationManager(

--- a/packages/fxa-auth-server/lib/payments/initSubplat.ts
+++ b/packages/fxa-auth-server/lib/payments/initSubplat.ts
@@ -160,7 +160,8 @@ export async function initSubplat({
     eligibilityManager,
     subscriptionManager,
     googleIapPurchaseManager,
-    appleIapPurchaseManager
+    appleIapPurchaseManager,
+    logger
   );
   const churnInterventionService = new ChurnInterventionService(
     accountCustomerManager,


### PR DESCRIPTION
Because:

* The App Store Server API intermittently fails, and app-store-server-api surfaces those as an AppStoreError carrying one of Apple's 5xxxxxx codes.
* AppleIapPurchaseManager.getForUser rethrew everything but its not-found cases, so an Apple outage failed EligibilityService.checkEligibility and took cart setup and checkout down with it.
* Treating a purchase we cannot verify as absent is worse than erroring: a customer with an active Apple subscription could buy an overlapping web subscription.

This commit:

* Adds AppleIapServiceUnavailableError, and maps Apple's server-range error codes plus the library's isRetryable and isRateLimitExceeded flags to it in AppleIapClient.convertError.
* Adds AppleIapPurchaseManager.getStaleCachedForUser, which reads a customer's purchase records from Firestore without refreshing them against Apple.
* Falls back to those records in EligibilityService.checkEligibility, so a purchase we cannot verify still blocks an overlapping web purchase.
* Exports the Apple IAP error module from the payments-iap barrel, and passes the logger to EligibilityService in initSubplat.
* Leaves the billing endpoint and the subscription management page erroring, so a customer sees a failure rather than an empty subscription list.

Closes PAY-3841

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.