### PR TITLE
fix(auth): resolve invoice subscriptions outside the list expand

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/processor.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/processor.spec.ts
@@ -119,7 +119,7 @@ describe('PaypalProcessor', () => {
     it('marks invoice and cancels subscription', async () => {
       const invoice = deepCopy(paidInvoice);
       invoice.parent = {
-        subscription_details: { subscription: { id: 'sub_basil' } },
+        subscription_details: { subscription: 'sub_basil' },
       };
       mockStripeHelper.markUncollectible = jest.fn().mockResolvedValue({});
       mockStripeHelper.cancelSubscription = jest.fn().mockResolvedValue({});

--- a/packages/fxa-auth-server/lib/payments/paypal/processor.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/processor.ts
@@ -12,7 +12,7 @@ import { AppError as error } from '@fxa/accounts/errors';
 import { StripeWebhookHandler } from '../../routes/subscriptions/stripe-webhook';
 import { reportSentryError } from '../../sentry';
 import { AuthLogger } from '../../types';
-import { StripeHelper } from '../stripe';
+import { getInvoiceSubscription, StripeHelper } from '../stripe';
 import {
   PAYPAL_BILLING_AGREEMENT_INVALID,
   PAYPAL_SOURCE_ERRORS,
@@ -91,13 +91,13 @@ export class PaypalProcessor {
   }
 
   private async cancelInvoiceSubscription(invoice: Stripe.Invoice) {
+    const subscription = getInvoiceSubscription(invoice);
     return Promise.all([
       this.stripeHelper.markUncollectible(invoice),
       this.stripeHelper.cancelSubscription(
-        (
-          invoice.parent?.subscription_details
-            ?.subscription as Stripe.Subscription
-        ).id
+        typeof subscription === 'string'
+          ? subscription
+          : (subscription as Stripe.Subscription).id
       ),
     ]);
   }

--- a/packages/fxa-auth-server/lib/payments/stripe.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.spec.ts
@@ -1771,27 +1771,37 @@ describe('StripeHelper', () => {
   });
 
   describe('fetchOpenInvoices', () => {
-    it('returns customer paypal agreement id', async () => {
+    const openInvoice = (subscriptionId: string) => {
       const invoice = deepCopy(invoicePaidSubscriptionCreate);
       invoice.parent = {
-        subscription_details: { subscription: { status: 'active' } },
+        type: 'subscription_details',
+        subscription_details: { subscription: subscriptionId },
       };
-      const invoice2 = deepCopy(invoicePaidSubscriptionCreate);
-      invoice2.parent = {
-        subscription_details: { subscription: { status: 'cancelled' } },
-      };
-      async function* genInvoice() {
-        yield invoice;
-        yield invoice2;
+      return invoice;
+    };
+
+    const mockInvoiceList = (invoices: any[]) => {
+      async function* genInvoices() {
+        for (const invoice of invoices) {
+          yield invoice;
+        }
       }
       jest
         .spyOn(stripeHelper.stripe.invoices, 'list')
-        .mockReturnValue(genInvoice());
-      const actual: any[] = [];
-      for await (const item of stripeHelper.fetchOpenInvoices(0)) {
-        actual.push(item);
+        .mockReturnValue(genInvoices());
+    };
+
+    const collectInvoices = async () => {
+      const invoices: any[] = [];
+      for await (const invoice of stripeHelper.fetchOpenInvoices(0)) {
+        invoices.push(invoice);
       }
-      expect(actual).toEqual([invoice]);
+      return invoices;
+    };
+
+    it('lists open send_invoice invoices without expanding the subscription', async () => {
+      mockInvoiceList([]);
+      await collectInvoices();
       expect(
         stripeHelper.stripe.invoices.list as jest.Mock
       ).toHaveBeenCalledTimes(1);
@@ -1803,11 +1813,50 @@ describe('StripeHelper', () => {
         collection_method: 'send_invoice',
         status: 'open',
         created: 0,
-        expand: [
-          'data.customer',
-          'data.parent.subscription_details.subscription',
-        ],
+        expand: ['data.customer'],
       });
+    });
+
+    it('yields invoices whose subscription is active', async () => {
+      const invoice = openInvoice('sub_active');
+      mockInvoiceList([invoice]);
+      jest
+        .spyOn(stripeHelper, 'expandResource')
+        .mockResolvedValue({ id: 'sub_active', status: 'active' });
+      const actual = await collectInvoices();
+      expect(actual).toEqual([invoice]);
+      expect(stripeHelper.expandResource).toHaveBeenCalledWith(
+        'sub_active',
+        SUBSCRIPTIONS_RESOURCE
+      );
+    });
+
+    it('skips invoices whose subscription is not active', async () => {
+      mockInvoiceList([openInvoice('sub_canceled')]);
+      jest
+        .spyOn(stripeHelper, 'expandResource')
+        .mockResolvedValue({ id: 'sub_canceled', status: 'canceled' });
+      const actual = await collectInvoices();
+      expect(actual).toEqual([]);
+    });
+
+    it('skips invoices whose subscription cannot be resolved', async () => {
+      mockInvoiceList([openInvoice('sub_missing')]);
+      jest.spyOn(stripeHelper, 'expandResource').mockResolvedValue(undefined);
+      const actual = await collectInvoices();
+      expect(actual).toEqual([]);
+    });
+
+    it('yields only the invoices with an active subscription', async () => {
+      const activeInvoice = openInvoice('sub_active');
+      mockInvoiceList([openInvoice('sub_canceled'), activeInvoice]);
+      jest
+        .spyOn(stripeHelper, 'expandResource')
+        .mockResolvedValueOnce({ id: 'sub_canceled', status: 'canceled' })
+        .mockResolvedValueOnce({ id: 'sub_active', status: 'active' });
+      const actual = await collectInvoices();
+      expect(actual).toEqual([activeInvoice]);
+      expect(stripeHelper.expandResource).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -988,6 +988,11 @@ export class StripeHelper extends StripeHelperBase {
    * Note that created times for Stripe are in seconds since epoch and that
    * invoices can be open for subscriptions that are cancelled, thus the extra
    * subscription check before returning an invoice.
+   *
+   * The subscription is resolved per invoice rather than expanded on the list
+   * call: Stripe rejects `data.parent.subscription_details.subscription` as an
+   * expansion on the invoice list endpoint. Invoices are therefore yielded with
+   * an unexpanded subscription reference.
    */
   async *fetchOpenInvoices(
     created: Stripe.InvoiceListParams['created'],
@@ -999,10 +1004,12 @@ export class StripeHelper extends StripeHelperBase {
       collection_method: 'send_invoice',
       status: 'open',
       created,
-      expand: ['data.customer', 'data.parent.subscription_details.subscription'],
+      expand: ['data.customer'],
     })) {
-      const subscription = invoice.parent?.subscription_details
-        ?.subscription as Stripe.Subscription;
+      const subscription = await this.expandResource(
+        getInvoiceSubscription(invoice),
+        SUBSCRIPTIONS_RESOURCE
+      );
       if (
         subscription &&
         ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)


### PR DESCRIPTION
Because:
* The Stripe SDK upgrade (35929f23a8, API 2026-06-24.dahlia) rewrote fetchOpenInvoices' expand to `data.parent.subscription_details.subscription`. Stripe rejects that path on the invoice list endpoint, so the PayPal processor 400s on its first page and no open invoices are retried or cancelled. It surfaces as `Cannot acquire lock to run` because the Stripe error is the `[cause]` thrown inside the Redlock block.

This commit:
* Drops the rejected expand and resolves each invoice's subscription via getInvoiceSubscription + expandResource(SUBSCRIPTIONS_RESOURCE), the pair invoicePayableWithPaypal already uses. The active-status filter is unchanged; invoices are now yielded with an unexpanded subscription.
* Reads the subscription through getInvoiceSubscription in PaypalProcessor.cancelInvoiceSubscription, which had cast it to an expanded object to take `.id`.
* Covers the new resolution path in the fetchOpenInvoices tests, including an unresolvable subscription.

Closes #PAY-3890

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.