### PR TITLE
feat(oauth): Stop counting non-Sync Desktop sign-ins as Sync auth/Sync DAU

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/desktop-sync-dau-authorization-bandaid.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/desktop-sync-dau-authorization-bandaid.spec.ts
@@ -1,0 +1,202 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { OAuthNativeClients, OAuthNativeServices } from '@fxa/accounts/oauth';
+import {
+  OAUTH_SCOPE_OLD_SYNC,
+  OAUTH_SCOPE_RELAY,
+} from 'fxa-shared/oauth/constants';
+
+import {
+  dropUnconsentedSyncScope,
+  excludeDauCacheKey,
+} from './desktop-sync-dau-authorization-bandaid';
+
+const SMARTWINDOW_SCOPE = 'https://identity.mozilla.com/apps/smartwindow';
+const VPN_SCOPE = 'https://identity.mozilla.com/apps/vpn';
+const DESKTOP = OAuthNativeClients.FirefoxDesktop;
+const WEB_RP = '98e6508e88680e1b';
+
+describe('dropUnconsentedSyncScope', () => {
+  describe('Firefox Desktop signing into a non-Sync browser service', () => {
+    it.each([
+      OAuthNativeServices.SmartWindow,
+      OAuthNativeServices.Relay,
+      OAuthNativeServices.Vpn,
+    ])('drops the Sync scope for service=%s', (serviceValue) => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC, SMARTWINDOW_SCOPE],
+          serviceValue,
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({
+        scopes: ['profile', SMARTWINDOW_SCOPE],
+        droppedSyncScope: true,
+      });
+    });
+
+    it('returns the remaining scopes when Sync was the only scope', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: [OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: OAuthNativeServices.SmartWindow,
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({ scopes: [], droppedSyncScope: true });
+    });
+
+    it('drops the Sync scope the server added for a keys_jwe flow, since a password is not Sync consent', () => {
+      // service=vpn + keys_jwe resolves to [apps/vpn, profile, apps/oldsync]
+      // via keysConditionalScope. The user never saw anything about Sync.
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: [VPN_SCOPE, 'profile', OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: OAuthNativeServices.Vpn,
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({
+        scopes: [VPN_SCOPE, 'profile'],
+        droppedSyncScope: true,
+      });
+    });
+
+    it('matches the client id case-insensitively', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: OAuthNativeServices.SmartWindow,
+          clientIdHex: DESKTOP.toUpperCase(),
+        })
+      ).toEqual({ scopes: ['profile'], droppedSyncScope: true });
+    });
+
+    it('matches the service case-insensitively', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: 'SmartWindow',
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({ scopes: ['profile'], droppedSyncScope: true });
+    });
+
+    it('does not mutate the scopes it was given', () => {
+      const scopes = ['profile', OAUTH_SCOPE_OLD_SYNC];
+      dropUnconsentedSyncScope({
+        scopes,
+        serviceValue: OAuthNativeServices.Vpn,
+        clientIdHex: DESKTOP,
+      });
+      expect(scopes).toEqual(['profile', OAUTH_SCOPE_OLD_SYNC]);
+    });
+  });
+
+  describe('cases that must keep the Sync scope', () => {
+    it('keeps it when the service is Sync in any casing', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: 'SYNC',
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({
+        scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+        droppedSyncScope: false,
+      });
+    });
+
+    it('keeps it when Desktop signed into Sync itself', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: OAuthNativeServices.Sync,
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({
+        scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+        droppedSyncScope: false,
+      });
+    });
+
+    it('keeps it when no service was resolved, since that means Sync by convention', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: '',
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({
+        scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+        droppedSyncScope: false,
+      });
+    });
+
+    it('keeps it on Android, where a VPN signup is also a Sync signup', () => {
+      // Fenix sends profile + oldsync + vpn with service=vpn while Sync is not
+      // decoupled on Android, so the user really has consented to both.
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC, VPN_SCOPE],
+          serviceValue: OAuthNativeServices.Vpn,
+          clientIdHex: OAuthNativeClients.Fenix,
+        })
+      ).toEqual({
+        scopes: ['profile', OAUTH_SCOPE_OLD_SYNC, VPN_SCOPE],
+        droppedSyncScope: false,
+      });
+    });
+
+    it('keeps it for a web RP, which never resolves a service', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+          serviceValue: '',
+          clientIdHex: WEB_RP,
+        })
+      ).toEqual({
+        scopes: ['profile', OAUTH_SCOPE_OLD_SYNC],
+        droppedSyncScope: false,
+      });
+    });
+
+    it('reports no drop when the Sync scope was not requested', () => {
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', OAUTH_SCOPE_RELAY],
+          serviceValue: OAuthNativeServices.Relay,
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({
+        scopes: ['profile', OAUTH_SCOPE_RELAY],
+        droppedSyncScope: false,
+      });
+    });
+
+    it('leaves an oldsync sub-scope alone, since the match is on the exact scope URL', () => {
+      const subScope = `${OAUTH_SCOPE_OLD_SYNC}/bookmarks`;
+      expect(
+        dropUnconsentedSyncScope({
+          scopes: ['profile', subScope],
+          serviceValue: OAuthNativeServices.SmartWindow,
+          clientIdHex: DESKTOP,
+        })
+      ).toEqual({
+        scopes: ['profile', subScope],
+        droppedSyncScope: false,
+      });
+    });
+  });
+});
+
+describe('excludeDauCacheKey', () => {
+  // Pins the literal format. Both consumers build their expected key by calling
+  // this function, so a prefix change would keep every test green while
+  // orphaning in-flight Redis entries across a deploy.
+  it('namespaces the code hash under syncDauExclude', () => {
+    expect(excludeDauCacheKey('ab'.repeat(32))).toBe(
+      `syncDauExclude:${'ab'.repeat(32)}`
+    );
+  });
+});

--- a/packages/fxa-auth-server/lib/oauth/desktop-sync-dau-authorization-bandaid.ts
+++ b/packages/fxa-auth-server/lib/oauth/desktop-sync-dau-authorization-bandaid.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Bandaid (FXA-14263). Firefox Desktop requests the Sync scope on every
+// browser-initiated flow (`FxAccountsConfig.sys.mjs::_getAuthParams`), whatever
+// service the user is signing into. So a Smart Window, Relay or VPN sign-in
+// writes an apps/oldsync consent row and mints an apps/oldsync access token for
+// a user who never authorized Sync, inflating both Sync authorizations and
+// Sync DAU (FXA-13364).
+//
+// Entering a password is deliberately not Sync consent, per Product: a
+// keys_jwe flow on a non-Sync service gets Sync keys so the user can enable
+// Sync later, but they saw nothing about Sync. Only `service=sync`, or a
+// missing service (very old browsers, which default to Sync), counts.
+//
+// One decision, two consumers: it keeps the row out of accountAuthorizations,
+// and — carried to /oauth/token on the auth code, which never sees `service=` —
+// tags the access_token.created Glean event `exclude_dau`. The scope is still
+// granted and the token still carries it, so Sync keeps working.
+//
+// Delete this module once Desktop drops `scope=` in favour of ADR 0049
+// resolution. Recording real consent when the user enables Sync in the browser
+// is FXA-14295. See also `vpn-in-desktop-dau-bandaid.ts`, the token-endpoint
+// counterpart, which has its own separate deletion trigger.
+//
+// Desktop-only: Fenix sends `profile + oldsync + vpn` with `service=vpn`, but
+// while Sync is not decoupled on Android that genuinely is a Sync signup.
+
+import { OAuthNativeClients, OAuthNativeServices } from '@fxa/accounts/oauth';
+import { OAUTH_SCOPE_OLD_SYNC } from 'fxa-shared/oauth/constants';
+
+/**
+ * Redis key for the pending exclude-DAU decision, keyed on the code's hash
+ * (never the code itself, which is a credential). Written at
+ * /oauth/authorization, read when the code is redeemed, expires with the code.
+ */
+export function excludeDauCacheKey(codeIdHex: string): string {
+  return `syncDauExclude:${codeIdHex}`;
+}
+
+export interface DropUnconsentedSyncScopeParams {
+  /** Scopes about to be written to `accountAuthorizations`. */
+  scopes: string[];
+  /** Resolved browser service; '' when absent, unknown, or ambiguous. */
+  serviceValue: string;
+  /** Hex OAuth client id for this authorization. */
+  clientIdHex: string;
+}
+
+export interface DropUnconsentedSyncScopeResult {
+  /** The scopes to record consent for. */
+  scopes: string[];
+  /** True when the Sync scope was removed. */
+  droppedSyncScope: boolean;
+}
+
+/**
+ * Returns the scopes to record consent for, with the Sync scope removed when
+ * Firefox Desktop resolved a browser service other than Sync. Everything else
+ * passes through untouched.
+ *
+ * Both inputs are matched case-insensitively rather than trusting callers to
+ * normalize. They are lowercase today, but `serviceValue` can come from an
+ * env-overridable config key, and an uppercase one would silently drop a
+ * genuine Sync consent.
+ */
+export function dropUnconsentedSyncScope({
+  scopes,
+  serviceValue,
+  clientIdHex,
+}: DropUnconsentedSyncScopeParams): DropUnconsentedSyncScopeResult {
+  if ((clientIdHex || '').toLowerCase() !== OAuthNativeClients.FirefoxDesktop) {
+    return { scopes, droppedSyncScope: false };
+  }
+  // An absent service conventionally means Sync (see `isDefaultSyncService` in
+  // fxa-settings), so only drop when another service was positively resolved.
+  const service = (serviceValue || '').toLowerCase();
+  if (!service || service === OAuthNativeServices.Sync) {
+    return { scopes, droppedSyncScope: false };
+  }
+  // Exact match on the scope URL; sub-scopes like .../oldsync/bookmarks are left.
+  const kept = scopes.filter((scope) => scope !== OAUTH_SCOPE_OLD_SYNC);
+  return { scopes: kept, droppedSyncScope: kept.length !== scopes.length };
+}

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -7,15 +7,21 @@ const Joi = require('joi');
 
 const { OauthError } = require('@fxa/accounts/errors');
 const { AppError: AuthError } = require('@fxa/accounts/errors');
-const { OAUTH_NATIVE_CLIENT_IDS } = require('@fxa/accounts/oauth');
+const {
+  OAUTH_NATIVE_CLIENT_IDS,
+  OAuthNativeClients,
+} = require('@fxa/accounts/oauth');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const validators = require('../../oauth/validators');
 const { validateRequestedGrant, generateTokens } = require('../../oauth/grant');
 const { makeAssertionJWT } = require('../../oauth/util');
 const verifyAssertion = require('../../oauth/assertion');
+const { isFirstAuthorization } = require('../../oauth/first-authorization');
+const encrypt = require('fxa-shared/auth/encrypt');
 const {
-  isFirstAuthorization,
-} = require('../../oauth/first-authorization');
+  dropUnconsentedSyncScope,
+  excludeDauCacheKey,
+} = require('../../oauth/desktop-sync-dau-authorization-bandaid');
 const OAUTH_DOCS = require('../../../docs/swagger/oauth-api').default;
 const OAUTH_SERVER_DOCS =
   require('../../../docs/swagger/oauth-server-api').default;
@@ -42,11 +48,14 @@ function isLocalHost(url) {
   return LOOPBACK_HOSTS.has(host);
 }
 
-module.exports = ({ log, oauthDB, config, statsd }) => {
+module.exports = ({ log, oauthDB, config, statsd, authServerCacheRedis }) => {
   if (!config) {
     config = require('../../../config').default.getProperties();
   }
   const MAX_TTL_S = config.oauthServer.expiration.accessToken / 1000;
+  const CODE_EXPIRATION_S = Math.ceil(
+    config.oauthServer.expiration.code / 1000
+  );
 
   const DISABLED_CLIENTS = new Set(config.oauthServer.disabledClients);
 
@@ -68,6 +77,30 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
       throw AuthError.disabledClientId(clientId);
     }
   }
+  // Hand the exclude-DAU decision to /oauth/token, which never receives
+  // `service=`. The auth code is the only link between the two requests.
+  // Written only when the answer is yes, so absence means "count it" — which
+  // is also what a Redis failure degrades to.
+  async function rememberExcludeDau(code, grant) {
+    if (!grant.excludeDau || !authServerCacheRedis) {
+      return;
+    }
+    try {
+      const codeId = encrypt.hash(code).toString('hex');
+      await authServerCacheRedis.set(
+        excludeDauCacheKey(codeId),
+        '1',
+        'EX',
+        CODE_EXPIRATION_S
+      );
+    } catch (err) {
+      statsd?.increment('accountAuthorization.exclude_dau_write_failed');
+      log.warn('accountAuthorization.exclude_dau_write_failed', {
+        err: err?.message,
+      });
+    }
+  }
+
   async function generateAuthorizationCode(client, payload, grant) {
     // Clients must use PKCE if and only if they are a public client.
     if (client.publicClient) {
@@ -93,6 +126,9 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
       })
     );
     code = hex(code);
+    // Awaited: the client can redeem the code when we return it, so the write
+    // must land first or /oauth/token can count the token towards DAU.
+    await rememberExcludeDau(code, grant);
 
     const redirect = new URL(payload.redirect_uri);
     redirect.searchParams.set('code', code);
@@ -185,6 +221,42 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
   // are skipped; the latter guards privileged services like VPN from
   // a non-Mozilla RP forging consent on the user behalf. Errors are
   // swallowed; bookkeeping cannot break sign-in.
+  // Resolve the browser service this authorization is for. Falls back
+  // to inferring from a canonical scope when the URL omits service=,
+  // but only when exactly one is present — ambiguous requests resolve to ''.
+  function resolveServiceValue(req, requestedScopes) {
+    const serviceParam = (req.payload.service || '').toLowerCase();
+    if (oauthDB.isKnownService(serviceParam)) {
+      return serviceParam;
+    }
+    const inferred = requestedScopes
+      .map((s) => oauthDB.getServiceForCanonicalScope(s))
+      .filter(Boolean);
+    return inferred.length === 1 ? inferred[0] : '';
+  }
+
+  // Whether this sign-in should be kept out of the Sync DAU signal. Computed
+  // separately from the consent write because it has to hold for requests that
+  // never reach the ledger: prompt=none silent re-auths, and clients not on a
+  // service's allowlist. Both still mint an apps/oldsync access token.
+  function shouldExcludeSyncDau(req, grant) {
+    const clientIdHex = hex(grant.clientId);
+    // Cheapest gate first. dropUnconsentedSyncScope checks this too, but
+    // short-circuit here if we can.
+    if (clientIdHex !== OAuthNativeClients.FirefoxDesktop) {
+      return false;
+    }
+    const requestedScopes = grant.scope.getScopeValues();
+    if (requestedScopes.length === 0) {
+      return false;
+    }
+    return dropUnconsentedSyncScope({
+      scopes: requestedScopes,
+      serviceValue: resolveServiceValue(req, requestedScopes),
+      clientIdHex,
+    }).droppedSyncScope;
+  }
+
   async function recordAuthorizationRows(req, grant) {
     if (req.payload.prompt === 'none') {
       statsd?.increment('accountAuthorization.skipped', {
@@ -197,23 +269,7 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
       return;
     }
     const clientIdHex = hex(grant.clientId);
-    // Lowercase the service so a casing variant (service=VPN) does not
-    // silently land as service='' and bypass the allowlist gate.
-    const serviceParam = (req.payload.service || '').toLowerCase();
-    let serviceValue = oauthDB.isKnownService(serviceParam) ? serviceParam : '';
-    // When the URL omits service= (e.g. VPN cached sign-in only sends
-    // client_id + scope=apps/vpn), recover the service from a canonical
-    // scope in the request so the row lands at service=<vpn> rather
-    // than service=''. Only fires when exactly one canonical scope is
-    // present; ambiguous multi-canonical requests fall back to ''.
-    if (!serviceValue) {
-      const inferred = requestedScopes
-        .map((s) => oauthDB.getServiceForCanonicalScope(s))
-        .filter(Boolean);
-      if (inferred.length === 1) {
-        serviceValue = inferred[0];
-      }
-    }
+    const serviceValue = resolveServiceValue(req, requestedScopes);
     // Expose the resolved service for native clients so the `login` event can
     // report the browser service (matching the grain of `firstAuthorization`,
     // incl. scope-only flows like VPN cached sign-in) instead of the shared
@@ -236,6 +292,15 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
         scopesToConsent.add(canonical);
       }
     }
+    // Desktop requests the Sync scope on every browser flow, so drop it from
+    // the ledger when another service was signed into. Grant and tokens are
+    // untouched — see ../../oauth/desktop-sync-dau-authorization-bandaid.
+    const { scopes: consentScopes, droppedSyncScope } =
+      dropUnconsentedSyncScope({
+        scopes: Array.from(scopesToConsent),
+        serviceValue,
+        clientIdHex,
+      });
     const now = Date.now();
     const uidHex = hex(grant.userId);
     // Detect the user's first use of this service / RP, to drive
@@ -262,7 +327,7 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
     // accountAuthorization.write_failed and keeps sign-in working.
     await oauthDB.recordSignInConsents({
       uid: uidHex,
-      scopes: Array.from(scopesToConsent),
+      scopes: consentScopes,
       service: serviceValue,
       clientId: clientIdHex,
       now,
@@ -270,6 +335,14 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
     // Only flag once the write succeeded, so the signal matches what landed.
     if (firstAuthorization) {
       req.app.firstAuthorization = true;
+    }
+    // Emitted after the write, like firstAuthorization above, so the counter
+    // tracks rows actually kept out of the ledger rather than decisions made.
+    // A failed write emits accountAuthorization.write_failed instead.
+    if (droppedSyncScope) {
+      statsd?.increment('accountAuthorization.sync_scope_dropped', {
+        service: serviceValue || 'unset',
+      });
     }
     statsd?.increment('accountAuthorization.recorded', {
       service: serviceValue || 'unset',
@@ -292,6 +365,9 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
     }
     validateClientDetails(client, payload);
     const grant = await validateRequestedGrant(claims, client, payload);
+    // Set before recordAuthorizationRows so the decision survives its early
+    // returns and its swallow-all catch — the token is minted either way.
+    grant.excludeDau = shouldExcludeSyncDau(req, grant);
     try {
       await recordAuthorizationRows(req, grant);
     } catch (err) {

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { createMock } from '@golevelup/ts-jest';
+import { OAuthNativeClients } from '@fxa/accounts/oauth';
 import { AuthLogger } from '../../types';
 
 const Joi = require('joi');
@@ -21,7 +22,7 @@ const mockLog = createMock<AuthLogger>();
 
 const baseConfig = {
   oauthServer: {
-    expiration: { accessToken: 3600000 },
+    expiration: { accessToken: 3600000, code: 900000 },
     disabledClients: [DISABLED_CLIENT_ID],
     allowHttpRedirects: false,
     contentUrl: 'http://localhost',
@@ -341,6 +342,20 @@ describe('/authorization POST consent write', () => {
   const UID_HEX = 'a'.repeat(32);
   const SYNC_SCOPE = 'https://identity.mozilla.com/apps/oldsync';
   const VPN_SCOPE = 'https://identity.mozilla.com/apps/vpn';
+  const SMARTWINDOW_SCOPE = 'https://identity.mozilla.com/apps/smartwindow';
+  const DESKTOP_CLIENT_ID = OAuthNativeClients.FirefoxDesktop;
+
+  /**
+   * The metric names emitted, for negative assertions. `toHaveBeenCalledWith`
+   * requires an exact argument-list match, so a regression that emitted a
+   * counter with no tag object — or a different arity — would slip past
+   * `not.toHaveBeenCalledWith(name, expect.anything())`.
+   */
+  function emittedMetrics(statsd: { increment: jest.Mock }): string[] {
+    return statsd.increment.mock.calls.map(
+      (call: unknown[]) => call[0] as string
+    );
+  }
 
   function buildOauthDB(overrides: Record<string, any> = {}) {
     return {
@@ -382,10 +397,14 @@ describe('/authorization POST consent write', () => {
     log?: any;
     payload?: Record<string, any>;
     app?: Record<string, any>;
+    /** Client id on both the payload and the resolved grant. */
+    clientId?: string;
+    authServerCacheRedis?: any;
   }) {
     // Real hapi requests always have `app`; recordAuthorizationRows stashes
     // service/firstAuthorization there. Returned so tests can assert on it.
     const app = opts.app ?? {};
+    const clientId = opts.clientId ?? CLIENT_ID;
     let routes: any;
     await jest.isolateModulesAsync(async () => {
       jest.doMock('../../oauth/assertion', () =>
@@ -393,12 +412,9 @@ describe('/authorization POST consent write', () => {
       );
       jest.doMock('../../oauth/grant', () => ({
         validateRequestedGrant: jest.fn(async (_claims, _client, payload) => ({
-          clientId: Buffer.from(CLIENT_ID, 'hex'),
+          clientId: Buffer.from(clientId, 'hex'),
           userId: Buffer.from(UID_HEX, 'hex'),
-          scope: {
-            getScopeValues: () =>
-              (payload.scope as string).split(/\s+/).filter(Boolean),
-          },
+          scope: ScopeSet.fromString(payload.scope as string),
           offline: payload.access_type !== 'online',
         })),
         generateTokens: jest.fn(async () => ({})),
@@ -408,11 +424,12 @@ describe('/authorization POST consent write', () => {
         oauthDB: opts.oauthDB,
         config: baseConfig,
         statsd: opts.statsd,
+        authServerCacheRedis: opts.authServerCacheRedis,
       });
       await routes[1].config.handler({
         headers: {},
         app,
-        payload: buildPayload(opts.payload),
+        payload: buildPayload({ client_id: clientId, ...opts.payload }),
       });
     });
     return { app };
@@ -667,8 +684,199 @@ describe('/authorization POST consent write', () => {
     expect([...scopes].sort()).toEqual([SYNC_SCOPE, VPN_SCOPE, 'profile']);
     // apps/oldsync's canonical owner is 'sync', but every row in this grant
     // is currently keyed to the URL service='vpn'. FXA-13874 tracks changing
-    // this so the apps/oldsync row is keyed to 'sync' instead.
+    // this so the apps/oldsync row is keyed to 'sync' instead. Note this
+    // client is a web RP; on Firefox Desktop the apps/oldsync row is dropped
+    // entirely by the FXA-14263 bandaid, covered below.
     expect(service).toBe('vpn');
+  });
+
+  // FXA-14263: Desktop asks for the Sync scope on every browser flow, so a
+  // non-Sync sign-in would otherwise file an apps/oldsync consent row for a
+  // user who never authorized Sync.
+  it('drops the Sync scope from the consent write when Desktop signs into a non-Sync service', async () => {
+    const oauthDB = buildOauthDB({
+      isKnownService: jest.fn(
+        (s: string) => s === 'sync' || s === 'smartwindow'
+      ),
+      getCanonicalScopeForService: jest.fn((s: string) => {
+        if (s === 'sync') return SYNC_SCOPE;
+        if (s === 'smartwindow') return SMARTWINDOW_SCOPE;
+        return undefined;
+      }),
+    });
+    const statsd = { increment: jest.fn() };
+
+    await runHandler({
+      oauthDB,
+      statsd,
+      clientId: DESKTOP_CLIENT_ID,
+      payload: { service: 'smartwindow', scope: `profile ${SYNC_SCOPE}` },
+    });
+
+    expect(oauthDB.recordSignInConsents).toHaveBeenCalledTimes(1);
+    const { scopes } = (oauthDB.recordSignInConsents as jest.Mock).mock
+      .calls[0][0];
+    expect([...scopes].sort()).toEqual([SMARTWINDOW_SCOPE, 'profile']);
+    expect(statsd.increment).toHaveBeenCalledWith(
+      'accountAuthorization.sync_scope_dropped',
+      { service: 'smartwindow' }
+    );
+  });
+
+  // The bandaid must touch the consent ledger and nothing else.
+  // Granted refresh and access token scopes should be untouched.
+  it('leaves the Sync scope on the grant when it drops it from the consent write', async () => {
+    const oauthDB = buildOauthDB({
+      isKnownService: jest.fn(
+        (s: string) => s === 'sync' || s === 'smartwindow'
+      ),
+      getCanonicalScopeForService: jest.fn((s: string) => {
+        if (s === 'sync') return SYNC_SCOPE;
+        if (s === 'smartwindow') return SMARTWINDOW_SCOPE;
+        return undefined;
+      }),
+    });
+
+    await runHandler({
+      oauthDB,
+      clientId: DESKTOP_CLIENT_ID,
+      payload: { service: 'smartwindow', scope: `profile ${SYNC_SCOPE}` },
+    });
+
+    // The ledger loses the Sync scope while the grant that becomes the code —
+    // and from there the access and refresh tokens — keeps it.
+    const { scopes } = (oauthDB.recordSignInConsents as jest.Mock).mock
+      .calls[0][0];
+    expect([...scopes].sort()).toEqual([SMARTWINDOW_SCOPE, 'profile']);
+
+    const grant = (oauthDB.generateCode as jest.Mock).mock.calls[0][0];
+    expect([...grant.scope.getScopeValues()].sort()).toEqual(
+      [SYNC_SCOPE, 'profile'].sort()
+    );
+  });
+
+  // The consent drop and the DAU tag are one decision. /oauth/token never sees
+  // `service=`, so it's stashed against the code's hash here. Read side:
+  // ./token.spec.ts.
+  describe('carrying the decision to /oauth/token', () => {
+    const CODE_HEX = 'a1'.repeat(32);
+    const encrypt = require('fxa-shared/auth/encrypt');
+    const {
+      excludeDauCacheKey,
+    } = require('../../oauth/desktop-sync-dau-authorization-bandaid');
+
+    function buildDesktopOauthDB() {
+      return buildOauthDB({
+        generateCode: jest.fn(async () => CODE_HEX),
+        isKnownService: jest.fn(
+          (s: string) => s === 'sync' || s === 'smartwindow'
+        ),
+        getCanonicalScopeForService: jest.fn((s: string) => {
+          if (s === 'sync') return SYNC_SCOPE;
+          if (s === 'smartwindow') return SMARTWINDOW_SCOPE;
+          return undefined;
+        }),
+      });
+    }
+
+    it('stashes the flag against the code hash, expiring with the code', async () => {
+      const authServerCacheRedis = { set: jest.fn().mockResolvedValue('OK') };
+
+      await runHandler({
+        oauthDB: buildDesktopOauthDB(),
+        authServerCacheRedis,
+        clientId: DESKTOP_CLIENT_ID,
+        payload: { service: 'smartwindow', scope: `profile ${SYNC_SCOPE}` },
+      });
+
+      expect(authServerCacheRedis.set).toHaveBeenCalledWith(
+        excludeDauCacheKey(encrypt.hash(CODE_HEX).toString('hex')),
+        '1',
+        'EX',
+        900
+      );
+    });
+
+    it('writes nothing to Redis when the sign-in is Sync', async () => {
+      const authServerCacheRedis = { set: jest.fn().mockResolvedValue('OK') };
+
+      await runHandler({
+        oauthDB: buildDesktopOauthDB(),
+        authServerCacheRedis,
+        clientId: DESKTOP_CLIENT_ID,
+        payload: { service: 'sync', scope: `profile ${SYNC_SCOPE}` },
+      });
+
+      expect(authServerCacheRedis.set).not.toHaveBeenCalled();
+    });
+
+    it('still issues the code when the Redis write fails', async () => {
+      const authServerCacheRedis = {
+        set: jest.fn().mockRejectedValue(new Error('no redis')),
+      };
+      const oauthDB = buildDesktopOauthDB();
+      const statsd = { increment: jest.fn() };
+
+      await runHandler({
+        oauthDB,
+        statsd,
+        authServerCacheRedis,
+        clientId: DESKTOP_CLIENT_ID,
+        payload: { service: 'smartwindow', scope: `profile ${SYNC_SCOPE}` },
+      });
+
+      expect(oauthDB.generateCode).toHaveBeenCalledTimes(1);
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'accountAuthorization.exclude_dau_write_failed'
+      );
+    });
+  });
+
+  // The scope-keeping branch itself is covered by the pure spec; what is
+  // route-unique here is that the counter stays silent.
+  it('does not emit sync_scope_dropped when Desktop signs into Sync', async () => {
+    const statsd = { increment: jest.fn() };
+
+    await runHandler({
+      oauthDB: buildOauthDB(),
+      statsd,
+      clientId: DESKTOP_CLIENT_ID,
+      payload: { service: 'sync', scope: `profile ${SYNC_SCOPE}` },
+    });
+
+    expect(emittedMetrics(statsd)).not.toContain(
+      'accountAuthorization.sync_scope_dropped'
+    );
+  });
+
+  // The counter tracks rows actually kept out of the ledger, not decisions
+  // made, so a failed write must not increment it.
+  it('does not emit sync_scope_dropped when the consent write fails', async () => {
+    const statsd = { increment: jest.fn() };
+
+    await runHandler({
+      oauthDB: buildOauthDB({
+        isKnownService: jest.fn(
+          (s: string) => s === 'sync' || s === 'smartwindow'
+        ),
+        getCanonicalScopeForService: jest.fn((s: string) => {
+          if (s === 'sync') return SYNC_SCOPE;
+          if (s === 'smartwindow') return SMARTWINDOW_SCOPE;
+          return undefined;
+        }),
+        recordSignInConsents: jest.fn().mockRejectedValue(new Error('db down')),
+      }),
+      statsd,
+      clientId: DESKTOP_CLIENT_ID,
+      payload: { service: 'smartwindow', scope: `profile ${SYNC_SCOPE}` },
+    });
+
+    expect(emittedMetrics(statsd)).toContain(
+      'accountAuthorization.write_failed'
+    );
+    expect(emittedMetrics(statsd)).not.toContain(
+      'accountAuthorization.sync_scope_dropped'
+    );
   });
 });
 

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -12,7 +12,13 @@ module.exports = (
   customs
 ) => {
   const routes = [
-    require('./authorization')({ log, oauthDB, config, statsd }),
+    require('./authorization')({
+      log,
+      oauthDB,
+      config,
+      statsd,
+      authServerCacheRedis,
+    }),
     require('./authorized-clients/destroy')({ oauthDB }),
     require('./authorized-clients/list')({ oauthDB }),
     require('./client/get')({ log, oauthDB }),

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -99,6 +99,9 @@ const ACCOUNT_ACTIVITY_UPDATE_AFTER_MS = config.get(
 
 // VPN-in-Desktop DAU bandaid (FXA-14159).
 const vpnInDesktopDauBandaid = require('../../oauth/vpn-in-desktop-dau-bandaid');
+const {
+  excludeDauCacheKey,
+} = require('../../oauth/desktop-sync-dau-authorization-bandaid');
 // The client and scope the bandaid targets are fixed product facts, not
 // operational knobs, so they're constants rather than config: Firefox Desktop
 // is the only client that mints a VPN token for every signed-in user, and the
@@ -295,9 +298,10 @@ module.exports = ({
     requestedGrant.ttl = Math.min(params.ttl, MAX_TTL_S);
     // When true, the `access_token.created` Glean event is tagged with
     // `exclude_dau` so this token creation is excluded from the DAU signal (the
-    // event still fires). Exposed on the authorization_code / fxa-credentials
-    // grants only; absent elsewhere, so it coerces to false.
-    requestedGrant.excludeDau = params.exclude_dau === true;
+    // event still fires). Set either by the client, or by the
+    // authorization_code grant carrying the server-side decision (FXA-14263).
+    requestedGrant.excludeDau =
+      params.exclude_dau === true || requestedGrant.excludeDau === true;
     return requestedGrant;
   }
 
@@ -364,6 +368,28 @@ module.exports = ({
     }
     // Looks legit! Codes are one-time-use, so remove it from the db.
     await oauthDB.removeCode(buf(code));
+    // Pick up the exclude-DAU decision left by /oauth/authorization (FXA-14263).
+    // Absent key means "count it", so a Redis failure degrades to today's
+    // behaviour. No delete needed: the key expires with the code, which is
+    // itself one-time-use. Constant checks first — only a Desktop code carrying
+    // the Sync scope can have a flag, so everything else skips Redis.
+    if (
+      authServerCacheRedis &&
+      hex(codeObj.clientId) === FIREFOX_DESKTOP_CLIENT_ID &&
+      codeObj.scope?.contains(OAUTH_SCOPE_OLD_SYNC)
+    ) {
+      try {
+        const cached = await authServerCacheRedis.get(
+          excludeDauCacheKey(encrypt.hash(code).toString('hex'))
+        );
+        if (cached === '1') {
+          codeObj.excludeDau = true;
+        }
+      } catch (err) {
+        statsd?.increment('oauth.excludeDau.readFailed');
+        log.warn('oauth.excludeDau.readFailed', { err: err?.message });
+      }
+    }
     return codeObj;
   }
 

--- a/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
@@ -13,6 +13,11 @@ const {
   OAUTH_SCOPE_RELAY,
   OAUTH_SCOPE_SESSION_TOKEN,
 } = require('fxa-shared/oauth/constants');
+const encrypt = require('fxa-shared/auth/encrypt');
+const { OAuthNativeClients } = require('@fxa/accounts/oauth');
+const {
+  excludeDauCacheKey,
+} = require('../../oauth/desktop-sync-dau-authorization-bandaid');
 
 function buf(v: any) {
   return Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex');
@@ -35,6 +40,7 @@ const GRANT_TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange';
 const SUBJECT_TOKEN_TYPE_REFRESH =
   'urn:ietf:params:oauth:token-type:refresh_token';
 const FIREFOX_IOS_CLIENT_ID = '1b1a3e44c54fbb58';
+const FIREFOX_DESKTOP_CLIENT_ID = OAuthNativeClients.FirefoxDesktop;
 // Mirrors encrypt.hash(), used by the route to key the rate limit.
 const SUBJECT_TOKEN_HASH = crypto
   .createHash('sha256')
@@ -1575,6 +1581,182 @@ describe('/oauth/token POST', () => {
           clientId: CLIENT_ID,
         }
       );
+    });
+  });
+});
+
+// FXA-14263: /oauth/authorization is the only request that sees `service=`, so
+// it decides whether a Desktop sign-in counts toward Sync DAU and leaves the
+// answer in Redis against the code's hash. Here we assert the read side.
+// Read side of the FXA-14263 carry: /oauth/authorization decides, leaves the
+// answer in Redis against the code's hash, and the redemption picks it up.
+describe('exclude_dau carried on the authorization code', () => {
+  const EXPECTED_KEY = excludeDauCacheKey(
+    encrypt.hash(CODE_WITH_KEYS).toString('hex')
+  );
+
+  function codeRequest(payloadOverrides: Record<string, unknown> = {}) {
+    return {
+      app: {},
+      // Code redemption is client-authenticated; no session token rides along.
+      auth: { credentials: undefined },
+      headers: {},
+      payload: {
+        client_id: FIREFOX_DESKTOP_CLIENT_ID,
+        grant_type: 'authorization_code',
+        code: CODE_WITH_KEYS,
+        ...payloadOverrides,
+      },
+      emitMetricsEvent: () => {},
+    };
+  }
+
+  // The route short-circuits before Redis unless the code is a Firefox Desktop
+  // one carrying the Sync scope, so the default code fixture has to be that.
+  function buildOauthDB(codeOverrides: Record<string, unknown> = {}) {
+    return {
+      ...tokenRoutesArgMocks.oauthDB,
+      async getCode() {
+        return {
+          userId: buf(UID),
+          clientId: buf(FIREFOX_DESKTOP_CLIENT_ID),
+          createdAt: Date.now(),
+          scope: ScopeSet.fromArray([OAUTH_SCOPE_OLD_SYNC, 'profile']),
+          ...codeOverrides,
+        };
+      },
+      getCanonicalScopeForService: (service: string) =>
+        service === 'sync' ? OAUTH_SCOPE_OLD_SYNC : undefined,
+    };
+  }
+
+  async function run({
+    redis,
+    oauthDB = buildOauthDB(),
+    payload,
+  }: {
+    redis?: { get: jest.Mock };
+    oauthDB?: Record<string, any>;
+    payload?: Record<string, unknown>;
+  }) {
+    resetAndMockDeps();
+    // The shared generateTokens stub passes `scope` through untouched, but the
+    // real one emits `access.scope.toString()`. These tests carry a real
+    // ScopeSet on the code, so match production or the route throws.
+    jest.doMock('../../oauth/grant', () => ({
+      ...tokenRoutesDepMocks['../../oauth/grant'],
+      generateTokens: (grant: any) => {
+        const t = { ...grant, scope: grant.scope.toString() } as any;
+        if (grant.offline) {
+          t.refresh_token = '00ff';
+        }
+        return t;
+      },
+    }));
+    const glean = { oauth: { tokenCreated: jest.fn() } };
+    const routes = require('./token')({
+      ...tokenRoutesArgMocks,
+      oauthDB,
+      glean,
+      authServerCacheRedis: redis,
+    });
+    const request = codeRequest(payload);
+    await routes[1].handler(request);
+    return { glean, request };
+  }
+
+  it('tags the token created event when the code was flagged', async () => {
+    const redis = { get: jest.fn().mockResolvedValue('1') };
+
+    const { glean, request } = await run({ redis });
+
+    expect(redis.get).toHaveBeenCalledWith(EXPECTED_KEY);
+    expect(glean.oauth.tokenCreated).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        reason: 'authorization_code',
+        scopes: ScopeSet.fromArray([
+          OAUTH_SCOPE_OLD_SYNC,
+          'profile',
+        ]).toString(),
+        excludeDau: true,
+      })
+    );
+  });
+
+  it('does not tag the event when no flag was recorded for the code', async () => {
+    const redis = { get: jest.fn().mockResolvedValue(null) };
+
+    const { glean, request } = await run({ redis });
+
+    expect(redis.get).toHaveBeenCalledWith(EXPECTED_KEY);
+    expect(glean.oauth.tokenCreated).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ excludeDau: false })
+    );
+  });
+
+  it('counts the token and reports the failure when Redis is unavailable', async () => {
+    const redis = { get: jest.fn().mockRejectedValue(new Error('no redis')) };
+
+    const { glean, request } = await run({ redis });
+
+    expect(glean.oauth.tokenCreated).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ excludeDau: false })
+    );
+    // The only signal that the bandaid has silently stopped working.
+    expect(mockStatsD.increment).toHaveBeenCalledWith(
+      'oauth.excludeDau.readFailed'
+    );
+  });
+
+  it('counts the token when no cache is wired up', async () => {
+    const { glean, request } = await run({ redis: undefined });
+
+    expect(glean.oauth.tokenCreated).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ excludeDau: false })
+    );
+  });
+
+  it('keeps a client-supplied exclude_dau even when nothing was cached', async () => {
+    const redis = { get: jest.fn().mockResolvedValue(null) };
+
+    const { glean, request } = await run({
+      redis,
+      payload: { exclude_dau: true },
+    });
+
+    expect(redis.get).toHaveBeenCalled();
+    expect(glean.oauth.tokenCreated).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ excludeDau: true })
+    );
+  });
+
+  describe('skips Redis when the code cannot carry a flag', () => {
+    it('does not read for a code without the Sync scope', async () => {
+      const redis = { get: jest.fn() };
+
+      await run({
+        redis,
+        oauthDB: buildOauthDB({ scope: ScopeSet.fromArray(['profile']) }),
+      });
+
+      expect(redis.get).not.toHaveBeenCalled();
+    });
+
+    it('does not read for a non-Desktop client', async () => {
+      const redis = { get: jest.fn() };
+
+      await run({
+        redis,
+        oauthDB: buildOauthDB({ clientId: buf(FIREFOX_IOS_CLIENT_ID) }),
+        payload: { client_id: FIREFOX_IOS_CLIENT_ID },
+      });
+
+      expect(redis.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_consents.in.spec.ts
@@ -758,3 +758,90 @@ describe('accountAuthorizations v2 dual-write and read (FXA-14169)', () => {
     expect(await db.hasConsentForSignIn(id, UNKNOWN_SCOPE, '')).toBe(true);
   });
 });
+
+// FXA-14263: Firefox Desktop requests the Sync scope on every browser flow,
+// so signing into another browser service used to file an apps/oldsync consent
+// row for a user who never authorized Sync. The bandaid drops that row and
+// must leave everything else alone. Branch coverage lives in
+// lib/oauth/desktop-sync-dau-authorization-bandaid.spec.ts; this pins the behaviour
+// against a real ScopeSet, a real code redemption, and real DB rows.
+describe('#integration - Sync consent for non-Sync Desktop sign-ins', () => {
+  let testClient: any;
+
+  // The shared PKCE_CODE_CHALLENGE above has no published verifier, and these
+  // tests redeem the code, so derive a matching pair (RFC 7636 S256).
+  const CODE_VERIFIER = 'WLjNEANMbRNUSG0uQsUZMQGgIL5FUknGz2jRipY79ZC';
+  const CODE_CHALLENGE = crypto
+    .createHash('sha256')
+    .update(CODE_VERIFIER)
+    .digest('base64url');
+
+  beforeEach(async () => {
+    testClient = await Client.createAndVerify(
+      server.publicUrl,
+      server.uniqueEmail(),
+      'test password',
+      server.mailbox,
+      { version: '' }
+    );
+    track(testClient.uid);
+  });
+
+  // Mirrors Desktop signing into Smart Window: scope= is the Sync scope
+  // regardless of which service the user actually chose.
+  function desktopAuthParams(overrides: Record<string, unknown> = {}) {
+    return {
+      client_id: DESKTOP,
+      scope: OLDSYNC_SCOPE,
+      state: 'xyz',
+      access_type: 'offline',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+      ...overrides,
+    };
+  }
+
+  it('omits the Sync consent row when the resolved service is not Sync', async () => {
+    await testClient.createAuthorizationCode(
+      desktopAuthParams({ service: 'smartwindow' })
+    );
+
+    const rows = await db.listAccountConsentsByUid(testClient.uid);
+    expect(rows.map((r: any) => r.scope)).not.toContain(OLDSYNC_SCOPE);
+    expect(rows).toEqual([
+      expect.objectContaining({
+        scope: SMARTWINDOW_SCOPE,
+        service: 'smartwindow',
+      }),
+    ]);
+  });
+
+  it('still grants the Sync scope on the code and the access token', async () => {
+    const authResult = await testClient.createAuthorizationCode(
+      desktopAuthParams({ service: 'smartwindow' })
+    );
+
+    // The authorization response reports the granted scope...
+    expect(authResult.scope).toContain(OLDSYNC_SCOPE);
+
+    // ...and the access token minted from that code carries it too, so the
+    // bandaid really is ledger-only and does not impact functionality.
+    const tokens = await testClient.grantOAuthTokens({
+      client_id: DESKTOP,
+      code: authResult.code,
+      code_verifier: CODE_VERIFIER,
+    });
+    expect(tokens.scope).toContain(OLDSYNC_SCOPE);
+  });
+
+  it('records the Sync consent row when the service is Sync', async () => {
+    await testClient.createAuthorizationCode(
+      desktopAuthParams({ service: 'sync' })
+    );
+
+    const rows = await db.listAccountConsentsByUid(testClient.uid);
+    expect(rows).toEqual([
+      expect.objectContaining({ scope: OLDSYNC_SCOPE, service: 'sync' }),
+    ]);
+  });
+});


### PR DESCRIPTION
Because:
- Firefox Desktop requests the Sync scope on every browser-initiated OAuth flow, whatever service the user is signing into. So a Smart Window, Relay or VPN sign-in mints an apps/oldsync access token and writes an apps/oldsync consent row — inflating both Sync DAU and Sync authorizations, even for passwordless accounts that could never have used Sync.
- Product confirmed entering a password is not Sync consent either: the user gets Sync keys so they can enable Sync later, but saw nothing about Sync.

This commit:
- Adds dropUnconsentedSyncScope: on Firefox Desktop, the Sync scope counts as consented only when the resolved service is sync, or absent (very old browsers, which default to Sync).
- Applies that one decision to both consumers. It keeps the row out of accountAuthorizations, and rides the auth code to /oauth/token — which never sees service= — so the access_token.created Glean event is tagged exclude_dau. The flag is stashed in Redis against the code's hash and expires with the code.
- Leaves the grant and the issued tokens untouched, so Sync keeps working for these users.

Recording real consent when the user turns Sync on in the browser needs a signal Firefox does not send; FXA-14295 covers that endpoint. An underlying fix is Desktop dropping scope= for ADR 0049 resolution. When that has been in Release long enough, lib/oauth/desktop-sync-consent-bandaid.ts can be deleted.

Closes FXA-14263

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out [this doc](https://docs.google.com/document/d/19e4ZOGcSyFHxm5odqkBvO25Jwu3nZmn-3HieEpGtwRQ/), which has some test cases + screenshots of the account auth table, and an output from a temp tool I had Claude make to make grepping through auth-server DAU logs here less painful. (Please ping me if you'd like the script, otherwise you can search auth server logs for `exclude_dau` and see the events)