### PR TITLE
fix(metrics): correct login.complete for passkey sign-ins

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/context.js
+++ b/packages/fxa-auth-server/lib/metrics/context.js
@@ -83,7 +83,11 @@ module.exports = function (log, config) {
       return;
     }
 
-    metadata.service = this.payload.service || this.query.service;
+    // Keep a client-supplied metricsContext.service when the request carries no
+    // service of its own; /session/reauth sends none, and overwriting would drop
+    // the relying party from every event emitted after the stash.
+    metadata.service =
+      this.payload.service || this.query.service || metadata.service;
 
     let cacheKey;
     try {
@@ -164,6 +168,7 @@ module.exports = function (log, config) {
       data.flowBeginTime = metadata.flowBeginTime;
       data.flowCompleteSignal = metadata.flowCompleteSignal;
       data.flowType = metadata.flowType;
+      data.authMethod = metadata.authMethod;
       data.clientId = metadata.clientId;
 
       if (metadata.service) {
@@ -345,11 +350,17 @@ module.exports = function (log, config) {
    * @name setMetricsFlowCompleteSignal
    * @this request
    * @param {String} flowCompleteSignal
+   * @param {String} [flowType]
+   * @param {String} [authMethod] How the user authenticated, for the
+   *   `login.complete` reason. Set by whichever route authenticated, since the
+   *   flow may complete several requests later. Server-owned: it is absent from
+   *   SCHEMA so a client cannot supply one.
    */
-  function setFlowCompleteSignal(flowCompleteSignal, flowType) {
+  function setFlowCompleteSignal(flowCompleteSignal, flowType, authMethod) {
     if (this.payload && this.payload.metricsContext) {
       this.payload.metricsContext.flowCompleteSignal = flowCompleteSignal;
       this.payload.metricsContext.flowType = flowType;
+      this.payload.metricsContext.authMethod = authMethod;
     }
   }
 };

--- a/packages/fxa-auth-server/lib/metrics/context.spec.ts
+++ b/packages/fxa-auth-server/lib/metrics/context.spec.ts
@@ -89,7 +89,7 @@ describe('metricsContext', () => {
     expect(metricsContext.validate).toHaveLength(0);
 
     expect(typeof metricsContext.setFlowCompleteSignal).toBe('function');
-    expect(metricsContext.setFlowCompleteSignal).toHaveLength(2);
+    expect(metricsContext.setFlowCompleteSignal).toHaveLength(3);
   });
 
   it('instantiated cache correctly', () => {
@@ -170,6 +170,46 @@ describe('metricsContext', () => {
     );
 
     expect(cache.add).toHaveBeenCalledTimes(1);
+    expect(cache.add.mock.calls[0][1].service).toBe('qux');
+  });
+
+  it('metricsContext.stash keeps a metricsContext service when the request has none', async () => {
+    results.add = Promise.resolve('wibble');
+    const request = {
+      payload: {
+        metricsContext: {
+          service: 'sync',
+        } as any,
+      },
+      query: {},
+    };
+    await metricsContext.stash.call(request, {
+      uid: Array(64).fill('c').join(''),
+      id: 'foo',
+    });
+
+    expect(cache.add.mock.calls[0][1].service).toBe('sync');
+    expect(request.payload.metricsContext.service).toBe('sync');
+  });
+
+  it('metricsContext.stash prefers the request service over the metricsContext one', async () => {
+    results.add = Promise.resolve('wibble');
+    await metricsContext.stash.call(
+      {
+        payload: {
+          metricsContext: {
+            service: 'sync',
+          },
+          service: 'qux',
+        },
+        query: {},
+      },
+      {
+        uid: Array(64).fill('c').join(''),
+        id: 'foo',
+      }
+    );
+
     expect(cache.add.mock.calls[0][1].service).toBe('qux');
   });
 
@@ -410,7 +450,7 @@ describe('metricsContext', () => {
     );
 
     expect(typeof result).toBe('object');
-    expect(Object.keys(result)).toHaveLength(19);
+    expect(Object.keys(result)).toHaveLength(20);
     expect(result.time).toBeGreaterThan(time);
     expect(result.device_id).toBe('mock device id');
     expect(result.entrypoint).toBe('mock entry point');
@@ -471,7 +511,7 @@ describe('metricsContext', () => {
     );
 
     expect(typeof result).toBe('object');
-    expect(Object.keys(result)).toHaveLength(18);
+    expect(Object.keys(result)).toHaveLength(19);
     expect(result.time).toBeGreaterThan(time);
     expect(result.device_id).toBe('mock device id');
     expect(result.entrypoint).toBe('mock entry point');
@@ -526,7 +566,7 @@ describe('metricsContext', () => {
       {}
     );
 
-    expect(Object.keys(result)).toHaveLength(9);
+    expect(Object.keys(result)).toHaveLength(10);
     expect(result.entrypoint).toBeUndefined();
     expect(result.entrypoint_experiment).toBeUndefined();
     expect(result.entrypoint_variation).toBeUndefined();
@@ -936,6 +976,25 @@ describe('metricsContext', () => {
     expect(request.payload.metricsContext).toEqual({
       flowCompleteSignal: 'wibble',
       flowType: 'blee',
+    });
+  });
+
+  it('setFlowCompleteSignal with authMethod', () => {
+    const request = {
+      payload: {
+        metricsContext: {} as any,
+      },
+    };
+    metricsContext.setFlowCompleteSignal.call(
+      request,
+      'wibble',
+      'blee',
+      'passkey'
+    );
+    expect(request.payload.metricsContext).toEqual({
+      flowCompleteSignal: 'wibble',
+      flowType: 'blee',
+      authMethod: 'passkey',
     });
   });
 

--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -140,7 +140,10 @@ module.exports = (log, config, glean) => {
         await amplitude('flow.complete', request, data, metricsContext);
 
         if (metricsContext.flowType === 'login') {
-          glean.login.complete(request, { uid: data?.uid ?? '', reason: 'email' });
+          glean.login.complete(request, {
+            uid: data?.uid ?? '',
+            reason: metricsContext.authMethod || 'email',
+          });
         }
 
         return request.clearMetricsContext();

--- a/packages/fxa-auth-server/lib/metrics/events.spec.ts
+++ b/packages/fxa-auth-server/lib/metrics/events.spec.ts
@@ -810,6 +810,34 @@ describe('metrics/events', () => {
     });
   });
 
+  it('.emit on login flow complete uses authMethod as the reason', async () => {
+    const time = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(time);
+    const metricsContext = mocks.mockMetricsContext();
+    const request = mocks.mockRequest({
+      credentials: {
+        uid: 'deadbeef',
+      },
+      metricsContext,
+      payload: {
+        metricsContext: {
+          flowId: 'bar',
+          flowBeginTime: time - 1000,
+          flowCompleteSignal: 'account.login',
+          flowType: 'login',
+          authMethod: 'passkey',
+        },
+      },
+    });
+    await events.emit.call(request, 'account.login', { uid: 'quux' });
+
+    expect(glean.login.complete).toHaveBeenCalledTimes(1);
+    expect(glean.login.complete).toHaveBeenCalledWith(request, {
+      uid: 'quux',
+      reason: 'passkey',
+    });
+  });
+
   it('.emitRouteFlowEvent with matching route and response.statusCode', async () => {
     const time = Date.now();
     jest.spyOn(Date, 'now').mockReturnValue(time);

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -2665,7 +2665,8 @@ describe('/account/login', () => {
       expect(mockMetricsContext.setFlowCompleteSignal).toHaveBeenNthCalledWith(
         1,
         'account.signed',
-        'login'
+        'login',
+        'email'
       );
 
       expect(mockFxaMailer.sendVerifyLoginEmail).toHaveBeenCalledTimes(1);
@@ -2828,7 +2829,7 @@ describe('/account/login', () => {
         );
         expect(
           mockMetricsContext.setFlowCompleteSignal
-        ).toHaveBeenNthCalledWith(1, 'account.confirmed', expect.anything());
+        ).toHaveBeenNthCalledWith(1, 'account.confirmed', 'login', 'email');
 
         expect(response.verified).toBeFalsy();
         expect(response.verificationMethod).toBe('email');
@@ -2888,7 +2889,7 @@ describe('/account/login', () => {
         );
         expect(
           mockMetricsContext.setFlowCompleteSignal
-        ).toHaveBeenNthCalledWith(1, 'account.login', expect.anything());
+        ).toHaveBeenNthCalledWith(1, 'account.login', 'login', 'email');
 
         expect(response.emailVerified).toBeTruthy();
         expect(response.sessionVerified).toBeTruthy();
@@ -2989,7 +2990,7 @@ describe('/account/login', () => {
         );
         expect(
           mockMetricsContext.setFlowCompleteSignal
-        ).toHaveBeenNthCalledWith(1, 'account.confirmed', expect.anything());
+        ).toHaveBeenNthCalledWith(1, 'account.confirmed', 'login', 'email');
 
         expect(response.verified).toBeFalsy();
         expect(response.verificationMethod).toBe('email-otp');
@@ -5088,7 +5089,9 @@ describe('/account/email_bounce_status', () => {
     });
     const route = buildRoute();
     return runTest(route, request, () => {
-      expect(mockDB.emailBounces).toHaveBeenCalledWith('bob\\_smith@example.com');
+      expect(mockDB.emailBounces).toHaveBeenCalledWith(
+        'bob\\_smith@example.com'
+      );
     });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -118,6 +118,7 @@ describe('passkeys routes', () => {
     };
     request.emitMetricsEvent = jest.fn(() => Promise.resolve({}));
     request.setMetricsFlowCompleteSignal = jest.fn();
+    request.stashMetricsContext = jest.fn(() => Promise.resolve());
     return await route.handler(request);
   }
 
@@ -1237,21 +1238,34 @@ describe('passkeys routes', () => {
       );
     });
 
-    it('emits glean.login.complete with reason "passkey"', async () => {
+    it('stashes the metrics context against the new session token', async () => {
       await runTest('/passkey/authentication/finish', {
         auth: { credentials: {} },
         app: { ua: {} },
         payload,
       });
 
-      expect(glean.login.complete).toHaveBeenCalledTimes(1);
-      expect(glean.login.complete).toHaveBeenCalledWith(expect.anything(), {
-        uid: UID,
-        reason: 'passkey',
-      });
+      // The password-creation and key-fetch steps of a keys-required sign-in
+      // send no metrics context, so they resolve it from this stash.
+      expect(request.stashMetricsContext).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'new-session-token-id' })
+      );
     });
 
-    it('does not emit glean.login.complete when verification fails', async () => {
+    it('does not emit glean.login.complete directly at the ceremony', async () => {
+      await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload,
+      });
+
+      // login.complete is emitted by the flow-complete machinery, driven by the
+      // signal set below. Emitting here too would double-count every
+      // keys-required sign-in, which also completes at /session/reauth.
+      expect(glean.login.complete).not.toHaveBeenCalled();
+    });
+
+    it('does not set the login flow-complete signal when verification fails', async () => {
       mockPasskeyService.verifyAuthenticationResponse = jest
         .fn()
         .mockRejectedValue(AppError.passkeyAuthenticationFailed());
@@ -1264,6 +1278,7 @@ describe('passkeys routes', () => {
         })
       ).rejects.toThrow();
 
+      expect(request.setMetricsFlowCompleteSignal).not.toHaveBeenCalled();
       expect(glean.login.complete).not.toHaveBeenCalled();
     });
 
@@ -1580,8 +1595,24 @@ describe('passkeys routes', () => {
         });
         expect(request.setMetricsFlowCompleteSignal).toHaveBeenCalledWith(
           'account.login',
-          'login'
+          'login',
+          'passkey'
         );
+      });
+
+      it('sets the flow signal before emitting account.login when keysRequired is false', async () => {
+        await runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        });
+
+        // emitMetricsEvent only recognises the flow as complete — and so records
+        // login.complete — if the signal is already set. Reversing these two
+        // silently drops the event for keys-optional sign-ins.
+        expect(
+          request.setMetricsFlowCompleteSignal.mock.invocationCallOrder[0]
+        ).toBeLessThan(request.emitMetricsEvent.mock.invocationCallOrder[0]);
       });
 
       it('records the account.login security event when keysRequired is false', async () => {
@@ -1782,14 +1813,32 @@ describe('passkeys routes', () => {
       method: string,
       kind: 'payload' | 'params'
     ): Schema {
-      const all = passkeyRoutes(customs, db, config, statsd, glean, log);
+      const all = passkeyRoutes(
+        customs,
+        db,
+        config,
+        statsd,
+        glean,
+        log,
+        mailer
+      );
       const route = all.find(
         (r: any) => r.path === path && r.method === method
       );
       if (!route) {
         throw new Error(`Route not found: ${method} ${path}`);
       }
-      return route.options.validate[kind];
+      // Not every passkey route declares validation, so the union of route
+      // option types doesn't carry `validate`.
+      const schema = (
+        route.options as {
+          validate?: { payload?: Schema; params?: Schema };
+        }
+      ).validate?.[kind];
+      if (!schema) {
+        throw new Error(`No ${kind} schema on route: ${method} ${path}`);
+      }
+      return schema;
     }
 
     const authPayload = (

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -456,15 +456,16 @@ export class PasskeyHandler {
       request
     );
 
+    // Later steps of a keys-required sign-in (password creation, key fetch) send
+    // no metrics context of their own, so stash it against the new session token
+    // to keep them on the same flow.
+    await request.stashMetricsContext(sessionToken);
+
     await recordSecurityEvent('account.passkey.authentication_success', {
       db: this.db,
       request,
       account: { uid },
     });
-
-    // Shared completion signal across sign-in surfaces; mirrors passwordless
-    // (reason: 'otp') and linked-accounts (reason: 'google'|'apple').
-    this.glean.login.complete(request, { uid, reason: 'passkey' });
 
     // A keys-requiring login (Sync, or a non-Sync Firefox service like VPN when
     // the browser hasn't decoupled Sync) completes its key step later, at a
@@ -563,8 +564,14 @@ export class PasskeyHandler {
       // When keys are required the login completes at the later /session/reauth
       // step, which emits these; skip them here to avoid double-counting.
       if (!keysRequired) {
+        // Signal before emitting: emitMetricsEvent only recognises the flow as
+        // complete (and so records login.complete) if the signal is already set.
+        request.setMetricsFlowCompleteSignal(
+          'account.login',
+          'login',
+          'passkey'
+        );
         await request.emitMetricsEvent('account.login', { uid: account.uid });
-        request.setMetricsFlowCompleteSignal('account.login', 'login');
         await recordSecurityEvent('account.login', {
           db: this.db,
           request,

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -330,7 +330,13 @@ module.exports = (
         // Otherwise, the login itself is the end of the flow.
         flowCompleteSignal = 'account.login';
       }
-      request.setMetricsFlowCompleteSignal(flowCompleteSignal, 'login');
+      request.setMetricsFlowCompleteSignal(
+        flowCompleteSignal,
+        'login',
+        // A passkey-verified session reaching here is the password step of a
+        // passkey sign-in, not an email login.
+        sessionToken.verificationMethodValue === 'passkey' ? 'passkey' : 'email'
+      );
 
       await stashMetricsContext();
       await checkNumberOfActiveSessions();

--- a/packages/fxa-auth-server/lib/routes/utils/signin.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.spec.ts
@@ -743,6 +743,23 @@ describe('sendSigninNotifications', () => {
     Container.reset();
   });
 
+  it('sets authMethod "passkey" when the session was verified by a passkey', () => {
+    sessionToken.verificationMethodValue = 'passkey';
+
+    return sendSigninNotifications(
+      request,
+      accountRecord,
+      sessionToken,
+      undefined
+    ).then(() => {
+      expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledWith(
+        'account.login',
+        'login',
+        'passkey'
+      );
+    });
+  });
+
   it('emits correct notifications when no verifications are required', () => {
     return sendSigninNotifications(
       request,
@@ -753,7 +770,8 @@ describe('sendSigninNotifications', () => {
       expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledTimes(1);
       expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledWith(
         'account.login',
-        'login'
+        'login',
+        'email'
       );
 
       expect(metricsContext.stash).toHaveBeenCalledTimes(1);
@@ -839,7 +857,8 @@ describe('sendSigninNotifications', () => {
         expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledTimes(1);
         expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledWith(
           'account.login',
-          'login'
+          'login',
+          'email'
         );
 
         expect(metricsContext.stash).toHaveBeenCalledTimes(1);
@@ -905,7 +924,8 @@ describe('sendSigninNotifications', () => {
         expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledTimes(1);
         expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledWith(
           'account.confirmed',
-          'login'
+          'login',
+          'email'
         );
 
         expect(metricsContext.stash).toHaveBeenCalledTimes(2);
@@ -998,7 +1018,8 @@ describe('sendSigninNotifications', () => {
         expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledTimes(1);
         expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledWith(
           'account.login',
-          'login'
+          'login',
+          'email'
         );
 
         expect(metricsContext.stash).toHaveBeenCalledTimes(1);
@@ -1195,7 +1216,8 @@ describe('sendSigninNotifications', () => {
       expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledTimes(1);
       expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledWith(
         'account.confirmed',
-        'login'
+        'login',
+        'email'
       );
 
       expect(metricsContext.stash).toHaveBeenCalledTimes(2);
@@ -1487,7 +1509,8 @@ describe('sendSigninNotifications', () => {
       expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledTimes(1);
       expect(metricsContext.setFlowCompleteSignal).toHaveBeenCalledWith(
         'account.signed',
-        'login'
+        'login',
+        'email'
       );
 
       expect(metricsContext.stash).toHaveBeenCalledTimes(1);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -855,6 +855,7 @@ function mockMetricsContext(methods) {
                 flowCompleteSignal:
                   this.payload.metricsContext.flowCompleteSignal,
                 flowType: this.payload.metricsContext.flowType,
+                authMethod: this.payload.metricsContext.authMethod,
               },
               this.headers && this.headers.dnt === '1'
                 ? {}


### PR DESCRIPTION
## Because

- Every Sync passkey sign-in emitted two `login.complete` events, so passkey
  adoption and overall login volume have both been over-counted by roughly
  1,700 flows a week since Phase 1 GA.
- The surviving event was labelled `reason=email`, so Sync passkey logins were
  attributed to email sign-in and passkey conversion could not be measured from
  the backend funnel.
- The password step that completes a keys-required passkey sign-in carried no
  metrics context of its own, so it fell outside the flow and the completion
  event lost its relying party.

## This pull request

- Adds an `authMethod` argument to `setFlowCompleteSignal` in
  `packages/fxa-auth-server/lib/metrics/context.js`, carried on the metrics
  context and copied through `gather()` so the flow-complete emitter can read it.
- Reads that value in `packages/fxa-auth-server/lib/metrics/events.js`, falling
  back to `email`, making it the single source of the `login.complete` reason.
- Removes the unconditional `login.complete` from the passkey ceremony in
  `packages/fxa-auth-server/lib/routes/passkeys.ts`, and sets the flow-complete
  signal before emitting `account.login` so the keys-optional path still records
  a completion.
- Derives the method from the session token in
  `packages/fxa-auth-server/lib/routes/utils/signin.js`, so the password step of
  a passkey sign-in reports `passkey` rather than `email`.
- Stashes the metrics context against the new passkey session token, so the
  password-creation and key-fetch steps resolve it from the stash and stay on the
  same flow. No client or public API change is needed for this.
- Stops `stash()` overwriting a client-supplied `metricsContext.service` when the
  request carries none, so `login.complete` keeps its relying party.
- Asserts the emission count, not just the reason, in the route specs.

## Issue that this pull request solves

Closes: FXA-14302

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/metrics/context.js`, `lib/metrics/events.js`,
  `lib/routes/passkeys.ts`, `lib/routes/utils/signin.js`
- Suggested review order: `context.js` → `events.js` → `passkeys.ts` →
  `signin.js` → specs
- Risky or complex parts: the statement reorder in `passkeys.ts` is load-bearing —
  the signal must be set before `emitMetricsEvent` or the keys-optional path
  emits nothing. The `stash()` service fallback applies to any route that
  stashes, not only passkey ones.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Verified against a local stack across all three passkey branches: keys-optional
  (one event at the ceremony), keys-required with an existing password, and
  keys-required with set-password (ceremony silent, one `reason=passkey` event
  after the password step, `service=sync` on both rows, shared flow_id).
- Pre-merge review waived: metrics-only change, no auth logic altered — the
  `signin.js` edit only derives a label.
- Merging drops `reason='email'` volume by the duplicate count and shifts
  `reason='passkey'` later in time. Needs a heads-up to data/PM and a dashboard
  breakpoint date.
