### PR TITLE
test(fxa-shared): Make experiments/base hash tests deterministic

### DIFF
--- a/packages/fxa-shared/test/experiments/base.js
+++ b/packages/fxa-shared/test/experiments/base.js
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import crypto from 'node:crypto';
-const _ = require('underscore');
+const crypto = require('node:crypto');
 const { assert } = require('chai');
 import BaseExperiment from '../../experiments/base';
 
@@ -23,59 +22,99 @@ describe('experiments/base', () => {
   const min = fiftyPercent - leeway;
   const max = fiftyPercent + leeway;
 
-  before(() => {
+  beforeEach(() => {
     experiment = new BaseExperiment();
   });
 
+  // Fixed keys, not Math.random(): the assertions below are statistical, so
+  // random input means a run can fail with nothing having changed (FXA-14281).
+  // Derived with sha256 rather than written out, so the sample has the entropy
+  // of a real uid and no structure in common with the md5 under test.
+  const keys = Array.from({ length: ITERATIONS }, (_unused, i) =>
+    crypto.createHash('sha256').update(`${i}`).digest('hex').slice(0, 32)
+  );
+
+  const decileCounts = (values, upperBound) => {
+    const counts = new Array(10).fill(0);
+    values.forEach((value) => {
+      counts[Math.min(9, Math.floor((value / upperBound) * 10))]++;
+    });
+    return counts;
+  };
+
   describe('hash', () => {
     it('returns a 32 bit hash', () => {
-      const hashes = new Array(ITERATIONS);
-      for (let i = 0; i < ITERATIONS; ++i) {
-        const hash = experiment.hash(Math.random());
-        assert.ok(hash);
-        assert.ok(0 <= hash && hash < MAX_HASH_VALUE);
-        hashes[i] = hash;
-      }
+      const hashes = keys.map((key) => experiment.hash(key));
 
-      // assure each hash value is unique.
-      assert.lengthOf(_.uniq(hashes), ITERATIONS);
+      hashes.forEach((hash) => {
+        assert.isTrue(Number.isInteger(hash), `${hash} is not an integer`);
+        assert.ok(0 <= hash && hash < MAX_HASH_VALUE);
+      });
+    });
+
+    it('returns the same hash for the same key', () => {
+      keys.forEach((key) => {
+        assert.equal(experiment.hash(key), experiment.hash(key));
+      });
+    });
+
+    it('returns the same hash across runs for a known key', () => {
+      // Users are bucketed by this hash; a change here reassigns everyone.
+      assert.equal(experiment.hash('key-0'), 891502928);
+      assert.equal(experiment.hash('key-999'), 1945857247);
+    });
+
+    it('spreads hashes across the 32 bit range', () => {
+      const hashes = keys.map((key) => experiment.hash(key));
+
+      decileCounts(hashes, MAX_HASH_VALUE).forEach((count, i) => {
+        assert.ok(count > 0, `no hashes fell into decile ${i}`);
+      });
     });
   });
 
   describe('luckyNumber', () => {
     it('returns a number between 0 and 1', () => {
-      const luckyNumbers = new Array(ITERATIONS);
-      for (let i = 0; i < ITERATIONS; ++i) {
-        const luckyNumber = experiment.luckyNumber(Math.random());
+      keys.forEach((key) => {
+        const luckyNumber = experiment.luckyNumber(key);
+        assert.isNumber(luckyNumber);
+        assert.isFalse(Number.isNaN(luckyNumber), 'luckyNumber is NaN');
         assert.ok(0 <= luckyNumber && luckyNumber <= 1);
-        luckyNumbers[i] = luckyNumber;
-      }
+      });
+    });
 
-      // assure each hash value is unique.
-      assert.lengthOf(_.uniq(luckyNumbers), ITERATIONS);
+    it('returns the same number for the same key', () => {
+      keys.forEach((key) => {
+        assert.equal(experiment.luckyNumber(key), experiment.luckyNumber(key));
+      });
+    });
+
+    it('spreads numbers across [0,1]', () => {
+      const luckyNumbers = keys.map((key) => experiment.luckyNumber(key));
+
+      decileCounts(luckyNumbers, 1).forEach((count, i) => {
+        assert.ok(count > 0, `no lucky numbers fell into decile ${i}`);
+      });
     });
   });
 
   describe('bernoulliTrial', () => {
     it('returns false if percent is 0', () => {
-      for (let i = 0; i < ITERATIONS; ++i) {
-        assert.isFalse(experiment.bernoulliTrial(0, Math.random()));
-      }
+      keys.forEach((key) => {
+        assert.isFalse(experiment.bernoulliTrial(0, key));
+      });
     });
 
     it('returns true if percent is 1', () => {
-      for (let i = 0; i < ITERATIONS; ++i) {
-        assert.isTrue(experiment.bernoulliTrial(1, Math.random()));
-      }
+      keys.forEach((key) => {
+        assert.isTrue(experiment.bernoulliTrial(1, key));
+      });
     });
 
     it('returns roughly 50% true if percent is 0.5', () => {
-      let trueCount = 0;
-      for (let i = 0; i < ITERATIONS; ++i) {
-        if (experiment.bernoulliTrial(0.5, Math.random())) {
-          trueCount++;
-        }
-      }
+      const trueCount = keys.filter((key) =>
+        experiment.bernoulliTrial(0.5, key)
+      ).length;
 
       assert.ok(
         min <= trueCount && trueCount <= max,
@@ -91,13 +130,9 @@ describe('experiments/base', () => {
         treatment: 0,
       };
 
-      for (let i = 0; i < ITERATIONS; ++i) {
-        const choice = experiment.uniformChoice(
-          ['control', 'treatment'],
-          Math.random()
-        );
-        counts[choice]++;
-      }
+      keys.forEach((key) => {
+        counts[experiment.uniformChoice(['control', 'treatment'], key)]++;
+      });
 
       assert.ok(
         min <= counts.control && counts.control <= max,
@@ -210,14 +245,9 @@ describe('experiments/base', () => {
 
         const experimentChooser = new ExperimentChooser();
 
-        for (let i = 0; i < ITERATIONS; ++i) {
-          const choice = experiment.choose({
-            experimentChooser,
-            uuid: crypto.randomUUID(),
-          });
-
-          counts[choice]++;
-        }
+        keys.forEach((key) => {
+          counts[experiment.choose({ experimentChooser, uuid: key })]++;
+        });
 
         const fiftyPercentMin = fiftyPercent - leeway;
         const fiftyPercentMax = fiftyPercent + leeway;

--- a/packages/fxa-shared/test/experiments/base.js
+++ b/packages/fxa-shared/test/experiments/base.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const _ = require('underscore');
 const uuid = require('uuid');
 const { assert } = require('chai');
 import BaseExperiment from '../../experiments/base';
@@ -27,32 +26,64 @@ describe('experiments/base', () => {
     experiment = new BaseExperiment();
   });
 
+  // Fixed keys keep these tests deterministic. Random keys made the
+  // distribution assertions flaky, see FXA-14281.
+  const keys = Array.from({ length: ITERATIONS }, (_unused, i) => `key-${i}`);
+
+  // Count how many of `values` fall into each of ten equally sized buckets
+  // spanning [0, upperBound].
+  const decileCounts = (values, upperBound) => {
+    const counts = new Array(10).fill(0);
+    values.forEach((value) => {
+      counts[Math.min(9, Math.floor((value / upperBound) * 10))]++;
+    });
+    return counts;
+  };
+
   describe('hash', () => {
     it('returns a 32 bit hash', () => {
-      const hashes = new Array(ITERATIONS);
-      for (let i = 0; i < ITERATIONS; ++i) {
-        const hash = experiment.hash(Math.random());
-        assert.ok(hash);
-        assert.ok(0 <= hash && hash < MAX_HASH_VALUE);
-        hashes[i] = hash;
-      }
+      const hashes = keys.map((key) => experiment.hash(key));
 
-      // assure each hash value is unique.
-      assert.lengthOf(_.uniq(hashes), ITERATIONS);
+      hashes.forEach((hash) => {
+        assert.ok(0 <= hash && hash < MAX_HASH_VALUE);
+      });
+    });
+
+    it('returns the same hash for the same key', () => {
+      keys.forEach((key) => {
+        assert.equal(experiment.hash(key), experiment.hash(key));
+      });
+    });
+
+    it('spreads hashes across the 32 bit range', () => {
+      const hashes = keys.map((key) => experiment.hash(key));
+
+      decileCounts(hashes, MAX_HASH_VALUE).forEach((count, i) => {
+        assert.ok(count > 0, `no hashes fell into decile ${i}`);
+      });
     });
   });
 
   describe('luckyNumber', () => {
     it('returns a number between 0 and 1', () => {
-      const luckyNumbers = new Array(ITERATIONS);
-      for (let i = 0; i < ITERATIONS; ++i) {
-        const luckyNumber = experiment.luckyNumber(Math.random());
+      keys.forEach((key) => {
+        const luckyNumber = experiment.luckyNumber(key);
         assert.ok(0 <= luckyNumber && luckyNumber <= 1);
-        luckyNumbers[i] = luckyNumber;
-      }
+      });
+    });
 
-      // assure each hash value is unique.
-      assert.lengthOf(_.uniq(luckyNumbers), ITERATIONS);
+    it('returns the same number for the same key', () => {
+      keys.forEach((key) => {
+        assert.equal(experiment.luckyNumber(key), experiment.luckyNumber(key));
+      });
+    });
+
+    it('spreads numbers across [0,1]', () => {
+      const luckyNumbers = keys.map((key) => experiment.luckyNumber(key));
+
+      decileCounts(luckyNumbers, 1).forEach((count, i) => {
+        assert.ok(count > 0, `no lucky numbers fell into decile ${i}`);
+      });
     });
   });
 


### PR DESCRIPTION
## Because

The `hash` and `luckyNumber` tests in `packages/fxa-shared/test/experiments/base.js` hashed 1000 `Math.random()` values and asserted every result was unique. The hash is 32 bits, so by the birthday paradox a collision is expected roughly 1% of the time (~1 - e^(-1000²/2^33)) — this flaked the Unit Test job on the v1.342.0 stage deploy pipeline.

The same pattern runs through the rest of the file: every statistical assertion was fed `Math.random()` or `uuid.v4()`. Those margins are wider (~5σ), so they fail far more rarely, but they fail unreproducibly when they do.

## This pull request

- Uses a fixed key set instead of `Math.random()`/`crypto.randomUUID()` throughout the file, so the tests are deterministic. The keys are derived once with sha256 rather than written out, so the sample keeps the entropy of a real uid and shares no structure with the md5 under test. Verified the counts land well inside the existing ±8% tolerance: 492/1000 for the bernoulli split, 495 control for `uniformChoice`, 248–251 control/treatment for the chooser splits.
- Confirmed the fixed keys still catch what the `#5378` test was written for: re-running that scenario against crc32 gives control 502 / treatment 0 against a 170–330 tolerance, so the regression guard fails as loudly as it did with random uuids. That bug is a structural correlation between two experiment names over the same key, which is not key-dependent.
- Replaces the uniqueness assertions with the behaviour actually under test: output range, stability for a given key, and spread across the output range (every decile non-empty).
- Asserts `hash` returns an integer and `luckyNumber` a non-NaN number. `hash` is `parseInt(md5(...), 16)`, so a non-hex input yields `NaN` — which the range checks alone did not catch. (Copilot's review comment.)
- Pins golden values for `hash('key-0')`/`hash('key-999')`. The existing same-key test only proves purity within one run; the contract that matters is stability across versions, since a change silently re-buckets every user.
- `before` → `beforeEach` for the shared `experiment`. The `throws if deprecated` test mutates `name`/`deprecated` on it and `hash` mixes `this.name` into the digest, so the hashing tests were one reorder away from breaking. Nothing is broken today.

## Issue that this pull request solves

Fixes: FXA-14281

## Checklist

Put an `x` in the boxes that apply

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A

## Other information (Optional)

Verified locally: all 21 tests in the file pass.


