### PR TITLE
test(functional-tests): decouple smoke locators from CMS-overridable copy

### DIFF
--- a/.claude/rules/testing/functional-pages.md
+++ b/.claude/rules/testing/functional-pages.md
@@ -1,0 +1,87 @@
+---
+paths:
+  - 'packages/functional-tests/pages/**'
+  - 'packages/functional-tests/tests/**'
+  - 'packages/functional-tests/lib/**'
+---
+
+# FXA Functional-Test Locator Rules
+
+Applies to Playwright page objects and specs under `packages/functional-tests`.
+Stacks on top of `.claude/rules/testing/base.md`.
+
+---
+
+## Never match CMS-overridable copy
+
+Relying parties override page copy through the CMS, keyed by client id and
+entrypoint. A locator that matches default English copy fails precisely when the
+CMS is working as intended — and it fails in the smoke suites, against stage and
+production, where CMS content exists.
+
+`libs/shared/cms/src/lib/queries/relying-party/query.ts` is the authoritative
+list of overridable pages;
+`fxa-settings/src/models/integrations/relier-interfaces.ts` mirrors it for the
+client. Every page listed can have its `headline`, `description`,
+`primaryButtonText` and `pageTitle` replaced.
+
+```ts
+// Violation — the CTA label is CMS-overridable
+get submitButton() {
+  return this.page.getByRole('button', { name: /^(Confirm|Start syncing)$/i });
+}
+
+// Correct — structural, survives any copy change
+get submitButton() {
+  this.checkPath();
+  return this.formSubmitButton;
+}
+```
+
+## Where identity comes from
+
+Removing copy also removes the page identity it incidentally provided. Replace
+it deliberately, in this order:
+
+1. **`checkPath()`** — the CMS overrides content, never routes, so the URL is
+   the only CMS-immune identity signal. Use it when the page object maps to
+   exactly one route.
+2. **Form fields** — input labels come from FTL, not the CMS, so field
+   visibility proves which step you are on. Use this in flow helpers for page
+   objects that span several routes and so cannot use `checkPath()`.
+3. **A `data-testid`** when two steps share a route and no field distinguishes
+   them. Add it to the component and guard it in that component's unit test, so
+   the contract is asserted where it is cheap.
+4. **`BaseLayout.formSubmitButton`** and **`BaseTokenCodePage.pageHeading`** —
+   structural, but see the hazard below.
+
+A heading proves the page rendered, not which page it is; never let one be the
+only guard before an action. The same applies to any getter that is an alias of
+the generic form submit — pair it with a field or URL guard.
+
+## Level matching is not a safe swap for copy matching
+
+`getByRole('heading', { level: 1 })` looks like a drop-in replacement, but a
+strict-mode violation **throws immediately — `expect` never retries it**. A copy
+match that resolves to nothing retries for the full timeout, which is what lets
+an assertion double as a wait for a pending navigation.
+
+Two ways that bites:
+
+- On a page with a second `h1` (Settings renders one for the header logo), level
+  matching turns a working wait into an instant failure.
+- Where a page renders a generic `h1` and puts its headline in an `h2`, it
+  resolves to one element and matches the wrong heading **silently** — no
+  strict-mode error to warn you.
+
+Use `pageHeading` only where the page object is route-guarded and its single
+`h1` is the headline. Everywhere else, move the call site to a field locator or
+a testid; changing the getter alone makes things worse.
+
+## Copy belongs in unit tests
+
+Assert copy — default and CMS branches — in the `fxa-settings` component tests,
+where it is cheap and deterministic. When you remove a copy assertion from a
+page object, confirm the component test covers it; add the test if it does not.
+
+Specs under `tests/cms/` deliberately assert CMS copy and are exempt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Suggest these proactively when the task matches — do not wait to be asked.
 
 ## 8) Testing Guidelines
 
-> Detailed test rules auto-load from `.claude/rules/testing/` when editing test files: `base.md` for all tests, `react.md` layers on for `*.test.tsx`.
+> Detailed test rules auto-load from `.claude/rules/testing/` by path: `base.md` for all tests, `react.md` layers on for `*.test.tsx`, `functional-pages.md` for anything under `packages/functional-tests`.
 
 **Shift-left is a golden goal.** Prefer testing business logic at the lowest layer that exercises it. FXA has three layers, cheapest to costliest: unit (`nx test-unit`), integration (`nx test-integration`), functional/E2E (Playwright in `packages/functional-tests`). Route handlers and React components should be thin shells; their tests cover wiring (auth, request/response shape, error propagation, rendering), not business branches. When a route or component has more than ~3 tests differing only in input shape, that's the signal to extract the rule into a pure function or hook and unit-test it directly. Shifting left is not required for every change — but always strive for it, and flag the opportunities to improve.
 

--- a/packages/functional-tests/pages/README.md
+++ b/packages/functional-tests/pages/README.md
@@ -4,8 +4,12 @@ Page Object Models (POMs) do the heavy lifting of performing actions and getting
 data on a page. If React Components are on one side of the browser coin POMs are
 on the other.
 
-## Organization
+## Locator strategy
 
-TBD
+**Never match a CMS-overridable string.** Relying parties can override page copy
+through the CMS, so a locator matching default English copy fails precisely when
+the CMS is working as intended.
 
-## Tips
+The full rule — what to use for identity instead, and the strict-mode hazard
+that makes level matching unsafe — is in
+[`.claude/rules/testing/functional-pages.md`](../../../.claude/rules/testing/functional-pages.md).

--- a/packages/functional-tests/pages/baseTokenCode.ts
+++ b/packages/functional-tests/pages/baseTokenCode.ts
@@ -6,6 +6,15 @@ import { expect } from '@playwright/test';
 import { BaseLayout } from './layout';
 
 export abstract class BaseTokenCodePage extends BaseLayout {
+  // Only valid for confirmSignupCode, signinTokenCode, signinUnblock and
+  // signinPasswordlessCode, whose single h1 is the page headline. The totp,
+  // recovery-code and recovery-phone pages render a generic "Sign in" h1
+  // (HeadingPrimary) with their headline in an h2, so this would match that
+  // instead — silently, since it still resolves to one element.
+  protected get pageHeading() {
+    return this.page.getByRole('heading', { level: 1 });
+  }
+
   get codeInput() {
     this.checkPath();
     return this.page.getByRole('textbox');
@@ -23,9 +32,7 @@ export abstract class BaseTokenCodePage extends BaseLayout {
 
   get submitButton() {
     this.checkPath();
-    return this.page.getByRole('button', {
-      name: /^(Confirm|Start syncing)$/i,
-    });
+    return this.formSubmitButton;
   }
 
   get successMessage() {

--- a/packages/functional-tests/pages/confirmSignupCode.ts
+++ b/packages/functional-tests/pages/confirmSignupCode.ts
@@ -9,6 +9,6 @@ export class ConfirmSignupCodePage extends BaseTokenCodePage {
 
   get heading() {
     this.checkPath();
-    return this.page.getByRole('heading', { name: /^Enter confirmation code/ });
+    return this.pageHeading;
   }
 }

--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 import { BaseTarget } from '../lib/targets/base';
 
 import {
@@ -26,6 +26,13 @@ export abstract class BaseLayout {
 
   protected get baseUrl() {
     return this.target.baseUrl;
+  }
+
+  // CTA text is CMS-overridable; `form` scope keeps this single-match on pages
+  // that render a second submit button. Protected so page objects expose it
+  // under a name that says which button it is.
+  protected get formSubmitButton(): Locator {
+    return this.page.locator('form button[type="submit"]');
   }
 
   get url() {

--- a/packages/functional-tests/pages/signin.ts
+++ b/packages/functional-tests/pages/signin.ts
@@ -10,34 +10,19 @@ import { PasskeyPage } from './passkey';
 export class SigninPage extends PasskeyPage {
   readonly path = 'signin';
 
-  get authenticationFormHeading() {
-    return this.page.getByRole('heading', {
-      name: /^Enter (?:authentication|security) code/,
-    });
-  }
-
-  get authenticationCodeTextbox() {
-    return this.page
-      .getByRole('textbox', { name: 'code' })
-      .or(this.page.getByPlaceholder('Enter 6-digit code'));
-  }
-
   get authenticationCodeTextboxTooltip() {
     return this.page.getByText('Invalid two-step authentication code', {
       exact: true,
     });
   }
 
-  get cachedSigninHeading() {
-    return this.page.getByRole('heading', { name: /^Sign in/ });
+  // Shares /signin with the password step, so identify it by test id.
+  get cachedSigninSubmitButton() {
+    return this.page.getByTestId('cached-signin-submit');
   }
 
   get codeTextbox() {
     return this.page.getByRole('textbox', { name: 'Enter 6-digit code' });
-  }
-
-  get confirmButton() {
-    return this.page.getByRole('button', { name: 'Confirm' });
   }
 
   // Use /Continue with.*Apple/ because of hidden bidi Unicode characters around "Apple" in its accessible name.
@@ -50,12 +35,8 @@ export class SigninPage extends PasskeyPage {
     return this.page.getByRole('button', { name: /Continue with .*Google/ });
   }
 
-  get emailFirstHeading() {
-    return this.page.getByRole('heading', { name: /^Enter your email/ });
-  }
-
   get emailFirstSubmitButton() {
-    return this.page.getByRole('button', { name: 'Sign up or sign in' });
+    return this.formSubmitButton;
   }
 
   get emailTextbox() {
@@ -69,16 +50,13 @@ export class SigninPage extends PasskeyPage {
   get useDifferentAccountLink() {
     return this.page.getByRole('link', { name: /^Use a different account/ });
   }
-  get passwordFormHeading() {
-    return this.page.getByRole('heading', { name: /^Enter your password/ });
-  }
 
   get passwordTextbox() {
     return this.page.getByRole('textbox', { name: 'password' });
   }
 
   get signInButton() {
-    return this.page.getByRole('button', { name: 'Sign in', exact: true });
+    return this.formSubmitButton;
   }
 
   get passkeySigninButton() {
@@ -116,14 +94,6 @@ export class SigninPage extends PasskeyPage {
       .or(this.page.getByRole('link', { name })); // Backbone
   }
 
-  get syncSignInHeading() {
-    return this.page.getByRole('heading', {
-      // Fluent inserts directional markers around "Mozilla account" so
-      // just look for partial match
-      name: /^Continue to your/,
-    });
-  }
-
   get badRequestHeading() {
     return this.page.getByRole('heading', {
       name: /Bad Request: Invalid Query Parameters/,
@@ -141,13 +111,6 @@ export class SigninPage extends PasskeyPage {
     );
   }
 
-  async fillOutAuthenticationForm(code: string): Promise<void> {
-    await expect(this.authenticationFormHeading).toBeVisible();
-
-    await this.authenticationCodeTextbox.fill(code);
-    await this.confirmButton.click();
-  }
-
   async fillOutEmailFirstForm(email: string) {
     await expect(this.emailTextbox).toBeVisible();
     // l10n re-mount can drop onChange (button stays disabled); retry until it enables.
@@ -159,7 +122,7 @@ export class SigninPage extends PasskeyPage {
   }
 
   async fillOutPasswordForm(password: string): Promise<void> {
-    await expect(this.passwordFormHeading).toBeVisible();
+    await expect(this.passwordTextbox).toBeVisible();
 
     await this.passwordTextbox.fill(password);
     await this.signInButton.click();

--- a/packages/functional-tests/pages/signinPasswordlessCode.ts
+++ b/packages/functional-tests/pages/signinPasswordlessCode.ts
@@ -9,19 +9,12 @@ export class SigninPasswordlessCodePage extends BaseTokenCodePage {
 
   get heading() {
     this.checkPath();
-    return this.page.getByRole('heading', {
-      name: /^(Enter confirmation code|Create your account)/,
-    });
+    return this.pageHeading;
   }
 
   get codeInput() {
     this.checkPath();
     return this.page.getByLabel('Enter 6-digit code');
-  }
-
-  get submitButton() {
-    this.checkPath();
-    return this.page.getByRole('button', { name: 'Confirm' });
   }
 
   get resendCodeButton() {

--- a/packages/functional-tests/pages/signinRecoveryChoice.ts
+++ b/packages/functional-tests/pages/signinRecoveryChoice.ts
@@ -3,14 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { BaseLayout } from './layout';
-import { expect } from '@playwright/test';
 
 export class SigninRecoveryChoicePage extends BaseLayout {
   readonly path = '/signin_recovery_choice';
-
-  get heading() {
-    return this.page.getByRole('heading', { name: 'Sign in' });
-  }
 
   get errorBanner() {
     return this.page.locator('.banner.error');
@@ -29,7 +24,8 @@ export class SigninRecoveryChoicePage extends BaseLayout {
   }
 
   get continueButton() {
-    return this.page.getByRole('button', { name: 'Continue' });
+    this.checkPath();
+    return this.formSubmitButton;
   }
 
   async clickChoosePhone() {

--- a/packages/functional-tests/pages/signinRecoveryPhone.ts
+++ b/packages/functional-tests/pages/signinRecoveryPhone.ts
@@ -18,10 +18,6 @@ export class SigninRecoveryPhonePage extends BaseTokenCodePage {
     return this.page.getByRole('button', { name: 'Resend code' });
   }
 
-  get confirmButton() {
-    return this.page.getByRole('button', { name: 'Confirm' });
-  }
-
   get backButton() {
     return this.page.getByRole('button', { name: 'Back' });
   }
@@ -39,7 +35,7 @@ export class SigninRecoveryPhonePage extends BaseTokenCodePage {
   }
 
   async clickConfirm() {
-    await this.confirmButton.click();
+    await this.submitButton.click();
   }
 
   async clickBack() {

--- a/packages/functional-tests/pages/signinTokenCode.ts
+++ b/packages/functional-tests/pages/signinTokenCode.ts
@@ -9,7 +9,7 @@ export class SigninTokenCodePage extends BaseTokenCodePage {
 
   get heading() {
     this.checkPath();
-    return this.page.getByRole('heading', { name: /^Enter confirmation code/ });
+    return this.pageHeading;
   }
 
   get codeInput() {

--- a/packages/functional-tests/pages/signinUnblock.ts
+++ b/packages/functional-tests/pages/signinUnblock.ts
@@ -9,12 +9,7 @@ export class SigninUnblockPage extends BaseTokenCodePage {
 
   get heading() {
     this.checkPath();
-    return this.page.getByRole('heading', { name: /^Authorize this sign-in/ });
-  }
-
-  get submitButton() {
-    this.checkPath();
-    return this.page.getByRole('button', { name: 'Continue' });
+    return this.pageHeading;
   }
 
   get codeInput() {

--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -9,24 +9,12 @@ import { getReactFeatureFlagUrl } from '../lib/react-flag';
 export class SignupPage extends BaseLayout {
   readonly path = 'signup';
 
-  get emailFormHeading() {
-    // Match by role/level only — the heading text can be overridden by CMS
-    // configuration per relying party, so asserting on copy is fragile.
-    return this.page.getByRole('heading', { level: 1 });
-  }
-
   get emailTextbox() {
     return this.page.getByRole('textbox', { name: 'Enter your email' });
   }
 
   get submitButton() {
-    return this.page
-      .getByRole('button')
-      .and(this.page.locator('button[type="submit"]'));
-  }
-
-  get signupFormHeading() {
-    return this.page.getByRole('heading', { name: 'Create a password' });
+    return this.formSubmitButton;
   }
 
   get passwordTextbox() {
@@ -48,7 +36,7 @@ export class SignupPage extends BaseLayout {
   }
 
   get createAccountButton() {
-    return this.page.getByRole('button', { name: 'Create account' });
+    return this.formSubmitButton;
   }
 
   get changeEmailLink() {
@@ -79,7 +67,6 @@ export class SignupPage extends BaseLayout {
   }
 
   async fillOutEmailForm(email: string) {
-    await expect(this.emailFormHeading).toBeVisible();
     await expect(this.emailTextbox).toBeVisible();
 
     await this.emailTextbox.fill(email);
@@ -87,14 +74,14 @@ export class SignupPage extends BaseLayout {
   }
 
   async fillOutSignupForm(password: string) {
-    await expect(this.signupFormHeading).toBeVisible();
+    await expect(this.passwordTextbox).toBeVisible();
 
     await this.passwordTextbox.fill(password);
     await this.createAccountButton.click();
   }
 
   async fillOutSyncSignupForm(password: string) {
-    await expect(this.signupFormHeading).toBeVisible();
+    await expect(this.passwordTextbox).toBeVisible();
 
     await this.passwordTextbox.fill(password);
     await this.verifyPasswordTextbox.fill(password);

--- a/packages/functional-tests/pages/signupConfirmedSync.ts
+++ b/packages/functional-tests/pages/signupConfirmedSync.ts
@@ -14,8 +14,12 @@ export class SignupConfirmedSyncPage extends BaseLayout {
     });
   }
 
+  // Outside a form with no `type`, so the Glean id is the only stable hook.
   get pairLink() {
-    return this.page.getByRole('button', { name: 'Add another device' });
+    this.checkPath();
+    return this.page.locator(
+      'button[data-glean-id="signup_confirmed_sync_pair_link"]'
+    );
   }
 
   async clickPairLink() {

--- a/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
@@ -80,6 +80,6 @@ async function removeAccount(
   await settings.deleteAccountButton.click();
   await deleteAccount.deleteAccount(password);
 
-  await expect(signin.emailFirstHeading).toBeVisible();
+  await expect(signin.emailTextbox).toBeVisible();
   await expect(page.getByText('Account deleted successfully')).toBeVisible();
 }

--- a/packages/functional-tests/tests/misc/errorViews.spec.ts
+++ b/packages/functional-tests/tests/misc/errorViews.spec.ts
@@ -14,7 +14,7 @@ test.describe('error views', () => {
     await expect(fourOhFour.homeLink).toBeVisible();
     await fourOhFour.homeLink.click();
     await page.waitForLoadState();
-    await expect(signin.emailFirstHeading).toBeVisible();
+    await expect(signin.emailTextbox).toBeVisible();
   });
 
   test('app error view renders for an invalid query parameter', async ({
@@ -35,6 +35,6 @@ test.describe('error views', () => {
     }
 
     await expect(signin.badRequestHeading).toBeVisible();
-    await expect(signin.emailFirstHeading).toBeHidden();
+    await expect(signin.emailTextbox).toBeHidden();
   });
 });

--- a/packages/functional-tests/tests/misc/relayIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/relayIntegration.spec.ts
@@ -25,9 +25,11 @@ test.describe('relay integration', () => {
 
     await page.waitForURL(/signup/);
 
+    // Fluent wraps brand terms in bidi isolates, so a plain string spanning
+    // "Mozilla" never matches.
     await expect(
       signup.page.getByText(
-        'A password is needed to securely manage your masked emails and access Mozilla’s security tools.'
+        /A password is needed to securely manage your masked emails/
       )
     ).toBeVisible();
 

--- a/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
@@ -36,7 +36,7 @@ test.describe('vpn integration', () => {
       await signin.goto('/authorization', vpnMobileOAuthQueryParams);
 
       // User is already signed in — cached signin view, no password required
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();
 
       // "Use a different account" link is hidden when signed into Firefox with

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -25,7 +25,7 @@ test.describe('severity-2 #smoke', () => {
       await relier.clickEmailFirst();
 
       // Email first page does not prefill an email
-      await expect(signup.emailFormHeading).toBeVisible();
+      await expect(signup.emailTextbox).toBeVisible();
       await expect(signup.emailTextbox).toHaveValue('');
     });
 
@@ -44,14 +44,14 @@ test.describe('severity-2 #smoke', () => {
 
       await page.waitForURL(`${target.contentServerUrl}/oauth/signup**`);
 
-      await expect(signup.signupFormHeading).toBeVisible();
+      await expect(signup.passwordTextbox).toBeVisible();
       // email provided as login hint is displayed on the signup page
       await expect(page.getByText(email)).toBeVisible();
 
       await signup.changeEmailLink.click();
 
       // Email first page has email input prefilled
-      await expect(signup.emailFormHeading).toBeVisible();
+      await expect(signup.emailTextbox).toBeVisible();
       await expect(signup.emailTextbox).toHaveValue(email);
     });
 
@@ -66,7 +66,7 @@ test.describe('severity-2 #smoke', () => {
         await relier.clickEmailFirst();
 
         // Email is prefilled
-        await expect(signin.passwordFormHeading).toBeVisible();
+        await expect(signin.passwordTextbox).toBeVisible();
         await expect(page.getByText(credentials.email)).toBeVisible();
 
         await signin.useDifferentAccountLink.click();

--- a/packages/functional-tests/tests/oauth/loginHintCachedCredentials.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHintCachedCredentials.spec.ts
@@ -33,7 +33,7 @@ test.describe('severity-2 #smoke', () => {
       await page.waitForURL(/signin/);
 
       // Email is prefilled
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await expect(page.getByText(loginHintCredentials.email)).toBeVisible();
 
       await signin.useDifferentAccountLink.click();

--- a/packages/functional-tests/tests/oauth/serverSideScopeResolution.spec.ts
+++ b/packages/functional-tests/tests/oauth/serverSideScopeResolution.spec.ts
@@ -131,7 +131,7 @@ test.describe('server-side scope resolution', () => {
         '/authorization',
         smartWindowDesktopOAuthQueryParamsNoScope
       );
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await signin.signInButton.click();
 
       const scope = await getOAuthLoginScope(signin);

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -38,7 +38,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickEmailFirst();
 
       // Email is prefilled
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
 
       await signin.signInButton.click();
@@ -63,7 +63,7 @@ test.describe('severity-1 #smoke', () => {
       // Attempt to sign back in with cached user
       await relier.clickEmailFirst();
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
 
       await signin.signInButton.click();
@@ -125,7 +125,7 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(`${target.contentServerUrl}/oauth/**`);
 
       // Cached user detected
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();
 
       await signin.signInButton.click();
@@ -155,7 +155,7 @@ test.describe('severity-1 #smoke', () => {
       // now suggest a cached login
       await relier.goto();
       await relier.clickChooseFlow();
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
 
       await signin.signInButton.click();
       await expect(page).toHaveURL(/confirm_signup_code/);

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -58,7 +58,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickSignIn();
 
       // By default, we should see the most recent signed in email
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();
     });
 
@@ -84,7 +84,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickEmailFirst();
 
       // FxA sees the existing session and shows cached account
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await signin.signInButton.click();
 
       // We get a signin code, because we are using a restmail address, and forces
@@ -132,7 +132,7 @@ test.describe('severity-1 #smoke', () => {
 
       // SmartWindow recognizes the browser user and offers a cached sign-in.
       await signin.goto('/authorization', smartWindowDesktopOAuthQueryParams);
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
       await signin.signInButton.click();
 
@@ -174,7 +174,7 @@ test.describe('severity-1 #smoke', () => {
 
       await gotoSyncSession(page, target);
 
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();
 
       await signin.fillOutPasswordForm(password);

--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -83,7 +83,7 @@ test.describe('severity-1 #smoke', () => {
 
       // Land on /signin's password form, then pick passkey instead of typing.
       await signin.fillOutEmailFirstForm(email);
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
 
       await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
         await signin.passkeySigninButton.click();
@@ -439,7 +439,7 @@ test.describe('severity-1 #smoke', () => {
       // divert the RP bounces and the user loops on the cached-signin screen.
       await relier.goto();
       await relier.clickRequireProfileAAL2();
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await signin.signInButton.click();
 
       // No TOTP on the account, so FxA must divert to inline TOTP setup.
@@ -484,7 +484,7 @@ test.describe('severity-1 #smoke', () => {
       // and the grant completes.
       await relier.goto();
       await relier.clickRequireProfileAAL2();
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await signin.signInButton.click();
       await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
 
@@ -600,7 +600,7 @@ test.describe('severity-1 #smoke', () => {
 
       await page.goto(`${target.relierUrl}/api/prompt_login`);
       await signin.fillOutEmailFirstForm(email);
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await expect(signin.passkeySigninButton).toBeVisible();
       await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
         await signin.passkeySigninButton.click();

--- a/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
+++ b/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
@@ -699,7 +699,7 @@ test.describe('severity-1 #smoke', () => {
         await signin.fillOutEmailFirstForm(credentials.email);
 
         // Should redirect to password form, not passwordless
-        await expect(signin.passwordFormHeading).toBeVisible();
+        await expect(signin.passwordTextbox).toBeVisible();
         await expect(page).not.toHaveURL(/signin_passwordless_code/);
       });
 
@@ -967,7 +967,7 @@ test.describe('severity-2', () => {
       await page.goto(target.contentServerUrl);
 
       await expect(page).not.toHaveURL(/signin_passwordless_code/);
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
     });
 
     test('passwordless account with cached session navigating to /signin sees cached signin page', async ({
@@ -991,12 +991,12 @@ test.describe('severity-2', () => {
       await page.goto(target.contentServerUrl);
 
       await expect(page).not.toHaveURL(/signin_passwordless_code/);
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
 
       // Navigate to /signin directly — same behavior
       await page.goto(`${target.contentServerUrl}/signin?email=${email}`);
       await expect(page).not.toHaveURL(/signin_passwordless_code/);
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
     });
 
     test('passwordless signup via Settings then navigating to / shows cached signin (not OTP)', async ({
@@ -1019,7 +1019,7 @@ test.describe('severity-2', () => {
       // Navigate to / — cached session should show signin, not OTP
       await page.goto(target.contentServerUrl);
       await expect(page).not.toHaveURL(/signin_passwordless_code/);
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
     });
   });
 
@@ -1117,7 +1117,7 @@ test.describe('severity-2', () => {
       await relier.goto('force_passwordless=true');
       await relier.clickEmailFirst();
       await signin.fillOutEmailFirstForm(email);
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await expect(page).not.toHaveURL(/signin_passwordless_code/);
 
       // Second account is still passwordless — should get passwordless flow

--- a/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
@@ -22,7 +22,7 @@ test.describe('force auth react', () => {
     );
     await page.goto(url);
 
-    await expect(signin.passwordFormHeading).toBeVisible();
+    await expect(signin.passwordTextbox).toBeVisible();
     await expect(page.getByText(credentials.email)).toBeVisible();
     await expect(signin.signInButton).toBeVisible();
   });
@@ -41,7 +41,10 @@ test.describe('force auth react', () => {
     );
     await page.goto(url);
 
-    await expect(signup.signupFormHeading).toBeVisible();
+    // URL guard: the signin password step labels its field identically, so the
+    // field alone does not prove we routed to signup.
+    await expect(page).toHaveURL(/signup/);
+    await expect(signup.verifyPasswordTextbox).toBeVisible();
     await expect(page.getByText(unregisteredEmail)).toBeVisible();
     await expect(signup.createAccountButton).toBeVisible();
   });

--- a/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
@@ -33,7 +33,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       await page.waitForURL(/oauth/);
-      await expect(signup.signupFormHeading).toBeVisible();
+      await expect(signup.passwordTextbox).toBeVisible();
     });
 
     test('fails RP that is not allowed', async ({
@@ -121,7 +121,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       await page.waitForURL(/oauth/);
-      await expect(signup.signupFormHeading).toBeVisible();
+      await expect(signup.passwordTextbox).toBeVisible();
     });
 
     test('fails if account is not verified', async ({
@@ -239,7 +239,7 @@ test.describe('severity-1 #smoke', () => {
         await page.waitForResponse(/api\/oauth\?error=login_required/);
         // RP handled it by taking the user back to sign in
         await page.waitForURL(/oauth\/signin/);
-        await expect(signin.passwordFormHeading).toBeVisible();
+        await expect(signin.passwordTextbox).toBeVisible();
       }
     });
 

--- a/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
@@ -43,7 +43,7 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/oauth\/signin/);
       await expect(page).toHaveURL(/oauth\/signin/);
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       // Email is prefilled
       await expect(page.getByText(credentials.email)).toBeVisible();
 
@@ -71,7 +71,7 @@ test.describe('severity-1 #smoke', () => {
       // Attempt to sign back in with cached user
       await relier.clickEmailFirst();
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       // Email is prefilled
       await expect(page.getByText(credentials.email)).toBeVisible();
 
@@ -139,7 +139,7 @@ test.describe('severity-1 #smoke', () => {
 
       // Cached user detected
       // redirect is slow, wait for the cached signin heading to appear
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       // Email is prefilled
       await expect(page.getByText(email)).toBeVisible();
       await signin.signInButton.click();
@@ -164,7 +164,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickChooseFlow();
 
       await signup.fillOutEmailForm(email);
-      await expect(signup.signupFormHeading).toBeVisible();
+      await expect(signup.passwordTextbox).toBeVisible();
       await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
@@ -178,7 +178,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.goto();
       await relier.clickChooseFlow();
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();
 
       await signin.signInButton.click();

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -49,7 +49,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickEmailFirst();
 
       // wait for navigation, and get search params
-      await expect(signup.emailFormHeading).toBeVisible();
+      await expect(signup.emailTextbox).toBeVisible();
       const path = new URL(page.url()).pathname;
       const params = new URL(page.url()).searchParams;
       params.delete('redirect_uri');
@@ -92,7 +92,7 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.fillOutEmailForm(email);
 
-      await expect(signup.signupFormHeading).toBeVisible();
+      await expect(signup.passwordTextbox).toBeVisible();
 
       await signup.fillOutSyncSignupForm(password);
 
@@ -123,7 +123,7 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.fillOutEmailForm(email);
 
-      await expect(signup.signupFormHeading).toBeVisible();
+      await expect(signup.passwordTextbox).toBeVisible();
 
       await signup.fillOutSyncSignupForm(password);
 

--- a/packages/functional-tests/tests/react-conversion/signIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signIn.spec.ts
@@ -23,7 +23,7 @@ test.describe('severity-2 #smoke', () => {
       // Sign out
       await settings.signOut();
 
-      await expect(signin.emailFirstHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
     });
 
     test('sign in as an existing user with incorrect email case', async ({
@@ -44,7 +44,7 @@ test.describe('severity-2 #smoke', () => {
       // Sign out
       await settings.signOut();
 
-      await expect(signin.emailFirstHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/react-conversion/signInCached.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInCached.spec.ts
@@ -25,7 +25,7 @@ test.describe('severity-2 #smoke', () => {
       // Return to sign in without signing out
       await signin.goto();
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       // email is prefilled and password is not required to sign in
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.signInButton.click();

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -92,7 +92,7 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.fillOutEmailForm(email);
 
-      await expect(signup.signupFormHeading).toBeVisible();
+      await expect(signup.passwordTextbox).toBeVisible();
 
       await signup.respondToWebChannelMessage(eventDetailLinkAccount);
 

--- a/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
@@ -16,7 +16,7 @@ test.describe('severity-2 #smoke', () => {
         undefined,
         new URLSearchParams('context=fx_desktop_v3&service=sync&action=email')
       );
-      await expect(signin.syncSignInHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -79,7 +79,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.signOut();
 
       // Sign in with old password
-      await expect(signin.emailFirstHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
       await signin.fillOutEmailFirstForm(newEmail);
       await signin.fillOutPasswordForm(initialPassword);
 

--- a/packages/functional-tests/tests/settings/redirect.spec.ts
+++ b/packages/functional-tests/tests/settings/redirect.spec.ts
@@ -112,8 +112,8 @@ test.describe('severity-2 #smoke', () => {
       page,
       pages: { signup, settings },
     }) => {
-      page.goto(settings.url);
-      await expect(signup.emailFormHeading).toBeVisible();
+      await page.goto(settings.url);
+      await expect(signup.emailTextbox).toBeVisible();
     });
 
     test('redirects to sign in when session token is invalid', async ({

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -44,7 +44,7 @@ test.describe('severity-2 #smoke', () => {
       await expect(
         page.getByRole('heading', { name: /Bad Request/ })
       ).toBeVisible();
-      await expect(signin.emailFirstHeading).toBeHidden();
+      await expect(signin.emailTextbox).toBeHidden();
     });
 
     test('does not allow bogus redirect_to parameter', async ({

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -159,7 +159,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Verify user redirected to login page
       // in backbone, user currently redirected to /signup
-      await expect(signin.emailFirstHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
       await expect(signin.emailTextbox).toHaveValue('');
     });
   });

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -26,7 +26,7 @@ test.describe('severity-2 #smoke', () => {
       await signin.clearSessionStorage();
       await page.goto(target.contentServerUrl);
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();
 
       await signin.signInButton.click();
@@ -56,7 +56,7 @@ test.describe('severity-2 #smoke', () => {
 
       await signin.denormalizeStoredEmail(email);
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(email)).toBeVisible();
 
       await signin.signInButton.click();
@@ -85,7 +85,7 @@ test.describe('severity-2 #smoke', () => {
         page.getByText('Session expired. Sign in to continue.')
       ).toBeVisible();
 
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await signin.fillOutPasswordForm(credentials.password);
 
       //Verify logged in on Settings page
@@ -181,7 +181,7 @@ test.describe('severity-2 #smoke', () => {
       await expect(settings.primaryEmail.status).toHaveText(credentials1.email);
       await settings.signOut();
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
 
       // Check that suggested cached account is the sync account
       await expect(page.getByText(credentials2.email)).toBeVisible();

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -44,7 +44,7 @@ test.describe('severity-2 #smoke', () => {
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
 
-      await expect(signin.syncSignInHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
       await expect(signin.emailTextbox).toHaveValue('');
     });
 
@@ -81,7 +81,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       // password confirmation required to sign in to sync
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
     });
 
@@ -119,7 +119,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       // email param takes precedence
       await expect(page.getByText(credentials.email)).toBeVisible();
     });
@@ -144,7 +144,7 @@ test.describe('severity-2 #smoke', () => {
           target.contentServerUrl
         }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
       );
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
     });
   });

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
@@ -74,7 +74,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       // account signed into browser suggested
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
     });
 
@@ -140,7 +140,7 @@ test.describe('severity-2 #smoke', () => {
       await signin.respondToWebChannelMessage(eventDetailStatusSync);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       // currently signed in local account takes precedence
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.signInButton.click();
@@ -183,7 +183,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       // email param takes precedence over user signed into the browser
       await expect(page.getByText(credentials.email)).toBeVisible();
     });
@@ -226,7 +226,7 @@ test.describe('severity-2 #smoke', () => {
       };
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
     });
   });

--- a/packages/functional-tests/tests/syncV3/oauthSignIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/oauthSignIn.spec.ts
@@ -31,7 +31,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.goto();
       await relier.clickEmailFirst();
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.signInButton.click();
 
@@ -41,7 +41,7 @@ test.describe('severity-1 #smoke', () => {
       // Attempt to sign back in
       await relier.clickEmailFirst();
 
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.signInButton.click();
 
@@ -50,7 +50,7 @@ test.describe('severity-1 #smoke', () => {
       // Disconnect sync otherwise we can have flaky tests.
       await settings.disconnectSync(credentials);
 
-      await expect(signin.emailFirstHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -26,7 +26,7 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(`${target.contentServerUrl}?${queryParam.toString()}`);
 
       //Check prefilled email
-      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(signin.passwordTextbox).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.fillOutPasswordForm(credentials.password);
 
@@ -41,7 +41,7 @@ test.describe('severity-2 #smoke', () => {
       // the account settings would be loaded for the sync credential account
 
       await page.goto(target.contentServerUrl);
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       // suggests most recently signed in account
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.signInButton.click();
@@ -50,10 +50,10 @@ test.describe('severity-2 #smoke', () => {
       await settings.signOut();
 
       // falls back to suggesting the account signed in to the browser
-      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
       await signin.useDifferentAccountLink.click();
-      await expect(signin.emailFirstHeading).toBeVisible();
+      await expect(signin.emailTextbox).toBeVisible();
     });
 
     test('sign in with desktop context then no context, desktop credentials should persist', async ({

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -309,6 +309,26 @@ describe('SigninPasswordlessCode page', () => {
       ).toBeInTheDocument();
     });
 
+    it('renders the CMS headline and primary button text when provided', () => {
+      // Local fixture: MOCK_CMS_INFO has no SigninPasswordlessCodePage yet.
+      const cmsPage = {
+        headline: 'CMS: Check your email',
+        description: 'CMS: for your sign-in code',
+        primaryButtonText: 'CMS: Continue',
+        pageTitle: 'CMS: Check your email',
+      };
+      const integration = createOAuthNativeIntegration(true, {
+        ...MOCK_CMS_INFO,
+        SigninPasswordlessCodePage: cmsPage,
+      });
+      render({ integration, isSignup: false });
+
+      expect(screen.getByText(cmsPage.headline)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: cmsPage.primaryButtonText })
+      ).toBeInTheDocument();
+    });
+
     it('does not render additional accessibility info when CMS info is absent', () => {
       render({ isSignup: false });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
@@ -105,10 +105,22 @@ describe('SigninRecoveryChoice', () => {
     });
     renderSigninRecoveryChoice({ integration: mockIntegrationWithCms });
     expect(
-      screen.getByText(MOCK_CMS_INFO.SigninRecoveryChoicePage!.headline!)
+      screen.getByText(MOCK_CMS_INFO.SigninRecoveryChoicePage.headline)
     ).toBeInTheDocument();
     expect(
-      screen.getByText(MOCK_CMS_INFO.SigninRecoveryChoicePage!.description!)
+      screen.getByText(MOCK_CMS_INFO.SigninRecoveryChoicePage.description)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the CMS primary button text when provided', () => {
+    const mockIntegrationWithCms = createMockSigninWebIntegration({
+      cmsInfo: MOCK_CMS_INFO,
+    });
+    renderSigninRecoveryChoice({ integration: mockIntegrationWithCms });
+    expect(
+      screen.getByRole('button', {
+        name: MOCK_CMS_INFO.SigninRecoveryChoicePage.primaryButtonText,
+      })
     ).toBeInTheDocument();
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -180,7 +180,12 @@ describe('PageSigninRecoveryCode', () => {
       screen.getByText(MOCK_CMS_INFO.SigninRecoveryCodePage!.headline!)
     ).toBeInTheDocument();
     expect(
-      screen.getByText(MOCK_CMS_INFO.SigninRecoveryCodePage!.description!)
+      screen.getByText(MOCK_CMS_INFO.SigninRecoveryCodePage.description)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: MOCK_CMS_INFO.SigninRecoveryCodePage.primaryButtonText,
+      })
     ).toBeInTheDocument();
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.test.tsx
@@ -54,7 +54,11 @@ describe('SigninRecoveryPhone', () => {
   });
 
   it('renders as expected', async () => {
-    renderWithLocalizationProvider(<MemoryRouter><SigninRecoveryPhone {...defaultProps} /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <SigninRecoveryPhone {...defaultProps} />
+      </MemoryRouter>
+    );
 
     expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
     expect(
@@ -90,13 +94,36 @@ describe('SigninRecoveryPhone', () => {
       </MemoryRouter>
     );
     expect(
-      screen.getByText(MOCK_CMS_INFO.SigninRecoveryPhonePage!.headline!)
+      screen.getByText(MOCK_CMS_INFO.SigninRecoveryPhonePage.headline)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the CMS primary button text when provided', () => {
+    const mockIntegrationWithCms = createMockSigninWebIntegration({
+      cmsInfo: MOCK_CMS_INFO,
+    });
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <SigninRecoveryPhone
+          {...defaultProps}
+          integration={mockIntegrationWithCms}
+        />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('button', {
+        name: MOCK_CMS_INFO.SigninRecoveryPhonePage.primaryButtonText,
+      })
     ).toBeInTheDocument();
   });
 
   it('has expected glean click events', async () => {
     const user = userEvent.setup();
-    renderWithLocalizationProvider(<MemoryRouter><SigninRecoveryPhone {...defaultProps} /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <SigninRecoveryPhone {...defaultProps} />
+      </MemoryRouter>
+    );
 
     await waitFor(() => user.type(screen.getByRole('textbox'), '123456'));
 
@@ -120,7 +147,11 @@ describe('SigninRecoveryPhone', () => {
   });
 
   it('submits with valid code', async () => {
-    renderWithLocalizationProvider(<MemoryRouter><SigninRecoveryPhone {...defaultProps} /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <SigninRecoveryPhone {...defaultProps} />
+      </MemoryRouter>
+    );
 
     const input = screen.getByRole('textbox');
 
@@ -132,7 +163,11 @@ describe('SigninRecoveryPhone', () => {
   });
 
   it('handles invalid code with backup codes available', async () => {
-    renderWithLocalizationProvider(<MemoryRouter><SigninRecoveryPhone {...propsWithError} /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <SigninRecoveryPhone {...propsWithError} />
+      </MemoryRouter>
+    );
 
     const input = screen.getByRole('textbox');
 
@@ -177,7 +212,11 @@ describe('SigninRecoveryPhone', () => {
   });
 
   it('handles resend code', async () => {
-    renderWithLocalizationProvider(<MemoryRouter><SigninRecoveryPhone {...defaultProps} /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <SigninRecoveryPhone {...defaultProps} />
+      </MemoryRouter>
+    );
 
     userEvent.click(screen.getByRole('button', { name: 'Resend code' }));
 
@@ -185,7 +224,11 @@ describe('SigninRecoveryPhone', () => {
   });
 
   it('handles `Are you locked out?` link', async () => {
-    renderWithLocalizationProvider(<MemoryRouter><SigninRecoveryPhone {...defaultProps} /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <SigninRecoveryPhone {...defaultProps} />
+      </MemoryRouter>
+    );
 
     const link = screen.getByRole('link', { name: /Are you locked out/i });
     expect(link).toHaveAttribute(

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -142,6 +142,18 @@ describe('SigninTokenCode page', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the CMS headline when provided', () => {
+    render({
+      integration: createOAuthNativeIntegration(true, MOCK_CMS_INFO),
+    });
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: MOCK_CMS_INFO.SigninTokenCodePage.headline,
+      })
+    ).toBeInTheDocument();
+  });
+
   it('emits a metrics event on render', () => {
     render();
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
@@ -381,7 +393,9 @@ describe('SigninTokenCode page', () => {
 
         await expectSuccessGleanEvents();
         expect(mockOnSessionVerified).toHaveBeenCalledTimes(1);
-        expect(mockNavigate).toHaveBeenCalledWith('/settings', { replace: false });
+        expect(mockNavigate).toHaveBeenCalledWith('/settings', {
+          replace: false,
+        });
       });
       it('when verificationReason is a force password change', async () => {
         session = mockSession();

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -95,7 +95,11 @@ describe('Sign in with TOTP code page', () => {
   });
 
   it('renders as expected', () => {
-    renderWithLocalizationProvider(<MemoryRouter><Subject /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <Subject />
+      </MemoryRouter>
+    );
 
     const headingEl = screen.getByRole('heading', { level: 2 });
     expect(headingEl).toHaveTextContent('Enter two-step authentication code');
@@ -108,7 +112,11 @@ describe('Sign in with TOTP code page', () => {
   });
 
   it('enables submit button when code entered', async () => {
-    renderWithLocalizationProvider(<MemoryRouter><Subject /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <Subject />
+      </MemoryRouter>
+    );
 
     const inputEl = screen.getByLabelText('Enter 6-digit code');
     await waitFor(() => userEvent.type(inputEl, '123456'));
@@ -137,10 +145,25 @@ describe('Sign in with TOTP code page', () => {
       </MemoryRouter>
     );
     expect(
-      screen.getByText(MOCK_CMS_INFO.SigninTotpCodePage!.headline!)
+      screen.getByText(MOCK_CMS_INFO.SigninTotpCodePage.headline)
     ).toBeInTheDocument();
     expect(
-      screen.getByText(MOCK_CMS_INFO.SigninTotpCodePage!.description!)
+      screen.getByText(MOCK_CMS_INFO.SigninTotpCodePage.description)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the CMS primary button text when provided', () => {
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <Subject
+          integration={mockOAuthNativeSigninIntegration(false, MOCK_CMS_INFO)}
+        />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('button', {
+        name: MOCK_CMS_INFO.SigninTotpCodePage.primaryButtonText,
+      })
     ).toBeInTheDocument();
   });
 
@@ -159,7 +182,11 @@ describe('Sign in with TOTP code page', () => {
   });
 
   it('emits a metrics event on render', () => {
-    renderWithLocalizationProvider(<MemoryRouter><Subject /></MemoryRouter>);
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <Subject />
+      </MemoryRouter>
+    );
     expect(GleanMetrics.totpForm.view).toHaveBeenCalledTimes(1);
     expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(0);
     expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(0);
@@ -205,7 +232,9 @@ describe('Sign in with TOTP code page', () => {
       expect(GleanMetrics.totpForm.view).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(1);
-      expect(mockNavigate).toHaveBeenCalledWith('/settings', { replace: false });
+      expect(mockNavigate).toHaveBeenCalledWith('/settings', {
+        replace: false,
+      });
     });
 
     describe('fxaLogin webchannel message', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -151,6 +151,24 @@ describe('SigninUnblock', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the CMS headline and primary button text when provided', () => {
+    renderWithSuccess(
+      undefined,
+      createMockSigninOAuthIntegration({ cmsInfo: MOCK_CMS_INFO })
+    );
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: MOCK_CMS_INFO.SigninUnblockCodePage.headline,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: MOCK_CMS_INFO.SigninUnblockCodePage.primaryButtonText,
+      })
+    ).toBeInTheDocument();
+  });
+
   it('emits the expected metrics on render', () => {
     renderWithSuccess();
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);

--- a/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.test.tsx
@@ -18,6 +18,7 @@ import {
 import { handleNavigation } from '../../utils';
 import {
   MOCK_AVATAR_NON_DEFAULT,
+  MOCK_CMS_INFO,
   MOCK_EMAIL,
   MOCK_SESSION_TOKEN,
   MOCK_UID,
@@ -87,6 +88,10 @@ describe('SigninCached', () => {
     screen.getByAltText('Your avatar');
     screen.getByText(MOCK_EMAIL);
     screen.getByRole('button', { name: 'Sign in' });
+    expect(screen.getByTestId('cached-signin-submit')).toHaveAttribute(
+      'type',
+      'submit'
+    );
     screen.getByRole('link', { name: 'Use a different account' });
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
     expect(
@@ -95,6 +100,29 @@ describe('SigninCached', () => {
     expect(
       screen.queryByRole('link', { name: 'Forgot password?' })
     ).not.toBeInTheDocument();
+  });
+
+  it('renders the CMS headline and primary button text when provided', () => {
+    // Local fixture: MOCK_CMS_INFO deliberately omits SigninCachedPage so the
+    // Signin suite can cover the fallback path.
+    const cachedPageCms = {
+      headline: 'CMS: Sign in to continue',
+      description: 'CMS: with your saved account',
+      primaryButtonText: 'CMS: Continue',
+      pageTitle: 'CMS: Sign in to continue',
+    };
+    renderSigninCached({
+      integration: createMockSigninWebIntegration({
+        cmsInfo: { ...MOCK_CMS_INFO, SigninCachedPage: cachedPageCms },
+      }),
+    });
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: cachedPageCms.headline })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: cachedPageCms.primaryButtonText })
+    ).toBeInTheDocument();
   });
 
   it('renders the same cached UI for passwordless users (hasPassword=false)', () => {

--- a/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninCached/index.tsx
@@ -262,6 +262,9 @@ const SigninCached = ({
           <FtlMsg id="signin-button">
             <CmsButtonWithFallback
               type="submit"
+              // Functional tests identify this step by test id: it shares
+              // /signin with the password step and all its copy is CMS-driven.
+              data-testid="cached-signin-submit"
               disabled={signinLoading}
               buttonColor={cmsInfo?.shared.buttonColor}
               buttonText={cachedPageCms?.primaryButtonText}

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.test.tsx
@@ -10,6 +10,7 @@ import { createMockIntegration, Subject } from './mocks';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import { firefox } from '../../../lib/channels/firefox';
 import { RelierCmsInfo } from '../../../models';
+import { MOCK_CMS_INFO } from '../../mocks';
 
 function mockReactUtilsModule() {
   jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
@@ -116,5 +117,28 @@ describe('SignupConfirmedSync', () => {
 
     const cmsImg = screen.getByRole('img', { name: 'sync is on' });
     expect(cmsImg).toHaveAttribute('src', 'https://example.com/sync.png');
+  });
+
+  it('renders the CMS headline and primary button text when provided', () => {
+    renderWithLocalizationProvider(
+      <Subject
+        integration={createMockIntegration(
+          // the pair CTA only renders for desktop sync
+          true,
+          MOCK_CMS_INFO
+        )}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: MOCK_CMS_INFO.SignupConfirmedSyncPage.headline,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: MOCK_CMS_INFO.SignupConfirmedSyncPage.primaryButtonText,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -315,6 +315,11 @@ describe('Signup page', () => {
       name: MOCK_CMS_INFO.SignupSetPasswordPage.headline,
     });
     screen.getByText(MOCK_CMS_INFO.SignupSetPasswordPage.description);
+    expect(
+      screen.getByRole('button', {
+        name: MOCK_CMS_INFO.SignupSetPasswordPage.primaryButtonText,
+      })
+    ).toBeInTheDocument();
   });
 
   it('renders as expected when cms enabled and on mobile', async () => {

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -7,7 +7,7 @@ import * as LoadingSpinnerModule from 'fxa-react/components/LoadingSpinner';
 import { MozServices } from '../lib/types';
 import { SyncEngines, WebChannelServices } from '../lib/channels/firefox';
 import { MOCK_ACCOUNT } from '../models/mocks';
-import { Integration, IntegrationType } from '../models';
+import { Integration, IntegrationType, RelierCmsInfo } from '../models';
 import PLACEHOLDER_IMAGE_URL from './cat.jpg';
 
 export const MOCK_EMAIL = MOCK_ACCOUNT.primaryEmail.email;
@@ -96,6 +96,8 @@ export const PLACEHOLDER_QR_CODE =
 export const MOCK_CMS_PRIMARY_IMAGE_URL =
   'https://raw.githubusercontent.com/mozilla/fxa/9b124e626c48067a653518ecb4af420679256a5f/assets/other/cms/fox_with_devices.svg';
 
+// `satisfies`, not an annotation: keeps literal types so tests can index in
+// without optional chaining.
 export const MOCK_CMS_INFO = {
   clientId: 'dcdb5ae7add825d2',
   entrypoint: 'app',
@@ -214,7 +216,7 @@ export const MOCK_CMS_INFO = {
       altText: 'CMS: A cartoon fox with a laptop and a smartphone',
     },
   },
-};
+} satisfies RelierCmsInfo;
 
 export const createMockIntegrationWithCms = () =>
   ({


### PR DESCRIPTION
## Because

- The Sync send-tab smoke test failed against production in 342.2. That relying party's CMS config renders the confirm-signup-code CTA as "Continue", but the page object matched only "Confirm" or "Start syncing".
- A locator that matches default English copy fails precisely when the CMS is working as intended.
- This is the third time this class of failure has been patched per-incident, with the convention written down nowhere.

## This pull request

- Adds structural `formSubmitButton` and `pageHeading` helpers in `packages/functional-tests/pages/layout.ts` and `baseTokenCode.ts`, and routes the CTA getters through them.
- Replaces the five copy-matched heading getters with the elements that identify each step: the email and password fields, whose labels are FTL-only, and a new `data-testid="cached-signin-submit"` for the cached step, which shares `/signin` with the password step.
- Locates the signup-confirmed-sync pair CTA by its Glean id, since that button renders outside a form with no `type`.
- Matches only the brand-free portion of the Relay set-password copy, which Fluent renders with bidi isolation marks around the brand term.
- Moves the copy assertions down to the `fxa-settings` component tests and constrains `MOCK_CMS_INFO` with `satisfies RelierCmsInfo`.
- Records the convention, including the strict-mode hazard, in `.claude/rules/testing/functional-pages.md`.

## Issue that this pull request solves

Closes: FXA-13790

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `pages/layout.ts` and `pages/baseTokenCode.ts` for the shared getters, and `SigninCached/index.tsx` for the only production change.
- Suggested review order: `.claude/rules/testing/functional-pages.md` for the reasoning, then the page objects, then the spec sweep.
- Risky or complex parts: the spec migration is broad but mechanical.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Full local functional run is green, including the two specs that previously failed deterministically. Not yet validated against a CMS-configured relying party on stage or prod.

`SigninTokenCode` never passes `primaryButtonText` to its CTA, so CMS button text is silently ignored there. Pre-existing and out of scope; worth its own ticket.
