### PR TITLE
fix(auth): Use `verifiedSessionToken` on sign out 

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.spec.ts
@@ -87,6 +87,22 @@ describe('lib/routes/auth-schemes/verified-session-token', () => {
     }
   });
 
+  // `/account/device/destroy` chains this strategy ahead of `refreshToken`,
+  // and mobile reaches it with a plain `Bearer <hex>` refresh token. Hapi only
+  // advances to the next strategy when the error carries `isMissing`, so
+  // losing that flag would 401 every mobile disconnect.
+  it('flags a non-Hawk authorization header as missing so the chain falls through', async () => {
+    request.headers.authorization = `Bearer ${'a'.repeat(64)}`;
+
+    const authStrategy = strategy(getCredentialsFunc, db, config, statsd)();
+
+    await expect(authStrategy.authenticate(request, h)).rejects.toMatchObject({
+      isMissing: true,
+    });
+    expect(getCredentialsFunc).not.toHaveBeenCalled();
+    expect(h.authenticated).not.toHaveBeenCalled();
+  });
+
   it('fails when token not found', async () => {
     getCredentialsFunc = jest.fn().mockResolvedValue(null);
 

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -831,7 +831,14 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICE_DESTROY_POST,
         auth: {
-          strategies: ['sessionTokenBearer', 'sessionToken', 'refreshToken'],
+          // Destroying a device revokes its sessions and refresh tokens, so it
+          // needs the same bar as /account/attached_client/destroy. Mobile
+          // reaches this with a refreshToken, which is unaffected.
+          strategies: [
+            'verifiedSessionTokenBearer',
+            'verifiedSessionToken',
+            'refreshToken',
+          ],
         },
         validate: {
           payload: isA.object({

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.spec.ts
@@ -1325,6 +1325,7 @@ describe('/account/device/destroy', () => {
   let mockLog: any;
   let mockDB: any;
   let mockPush: any;
+  let accountRoutes: any;
 
   beforeEach(() => {
     uid = crypto.randomBytes(16).toString('hex');
@@ -1334,9 +1335,25 @@ describe('/account/device/destroy', () => {
     mockLog = createMock<AuthLogger>();
     mockDB = mocks.mockDB();
     mockPush = mocks.mockPush();
+    accountRoutes = makeRoutes({
+      db: mockDB,
+      devices: mockDevices,
+      log: mockLog,
+      push: mockPush,
+    });
   });
 
-  it('should destory the device record', () => {
+  it('requires verifiedSessionToken or refreshToken auth strategies', () => {
+    const routeConfig = getRoute(accountRoutes, '/account/device/destroy');
+
+    expect(routeConfig.options.auth.strategies).toEqual([
+      'verifiedSessionTokenBearer',
+      'verifiedSessionToken',
+      'refreshToken',
+    ]);
+  });
+
+  it('destroys the device record', () => {
     const mockRequest = mocks.mockRequest({
       credentials: {
         uid: uid,
@@ -1346,12 +1363,6 @@ describe('/account/device/destroy', () => {
       payload: {
         id: deviceId,
       },
-    });
-    const accountRoutes = makeRoutes({
-      db: mockDB,
-      devices: mockDevices,
-      log: mockLog,
-      push: mockPush,
     });
     const route = getRoute(accountRoutes, '/account/device/destroy');
 

--- a/packages/fxa-auth-server/test/remote/device_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/device_tests.in.spec.ts
@@ -66,8 +66,6 @@ describe.each(testVersions)(
       expect(devices[0].pushPublicKey).toBe('');
       expect(devices[0].pushAuthKey).toBe('');
       expect(devices[0].pushEndpointExpired).toBeFalsy();
-
-      await client.destroyDevice(devices[0].id);
     });
 
     it('device registration without optional parameters', async () => {
@@ -101,8 +99,22 @@ describe.each(testVersions)(
       expect(devices[0].pushPublicKey == null).toBe(true);
       expect(devices[0].pushAuthKey == null).toBe(true);
       expect(devices[0].pushEndpointExpired).toBe(false);
+    });
 
-      await client.destroyDevice(devices[0].id);
+    it('device disconnect fails on an unconfirmed account', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const device = await client.updateDevice({ name: 'test device', type: 'mobile' });
+
+      try {
+        await client.destroyDevice(device.id);
+        throw new Error('request should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(104);
+      }
     });
 
     it('device registration with unicode characters in the name', async () => {


### PR DESCRIPTION
## Because

- Make `POST /account/device/destroy` require a verifiedSessionToken

## This pull request

- Gates the route in `devices-and-sessions.js` on `verifiedSessionTokenBearer` and `verifiedSessionToken`, matching the sibling `/account/attached_client/destroy`, and keeps `refreshToken` so the AAL checks never apply to mobile.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14033

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information