### PR TITLE
fix(auth-server): never return the full recovery phone number

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -312,17 +312,15 @@ describe('RecoveryPhoneService', () => {
       ).toHaveBeenCalledWith(uid);
     });
 
-    it('can return stripped phone number', async () => {
+    it('returns the national format when one is stored', async () => {
       mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockReturnValueOnce({
         phoneNumber,
+        nationalFormat: '(500) 555-1234',
       });
 
-      const result = await service.hasConfirmed(uid, 4);
+      const result = await service.hasConfirmed(uid);
 
-      expect(result.phoneNumber).toEqual('1234');
-      expect(
-        mockRecoveryPhoneManager.getConfirmedPhoneNumber
-      ).toHaveBeenCalledWith(uid);
+      expect(result.nationalFormat).toEqual('(500) 555-1234');
     });
 
     it('can determine confirmed phone number does not exist', async () => {
@@ -347,6 +345,89 @@ describe('RecoveryPhoneService', () => {
       );
 
       expect(service.hasConfirmed(uid)).rejects.toEqual(mockError);
+    });
+  });
+
+  describe('has confirmed masked', () => {
+    it('returns only the last 4 digits of the phone number', async () => {
+      mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockResolvedValueOnce({
+        phoneNumber,
+      });
+
+      const result = await service.hasConfirmedMasked(uid);
+
+      expect(result).toStrictEqual({
+        exists: true,
+        phoneNumber: '1234',
+        nationalFormat: undefined,
+      });
+    });
+
+    it('strips the national format down to the last 4 digits', async () => {
+      mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockResolvedValueOnce({
+        phoneNumber,
+        nationalFormat: '(500) 555-1234',
+      });
+
+      const result = await service.hasConfirmedMasked(uid);
+
+      expect(result).toStrictEqual({
+        exists: true,
+        phoneNumber: '1234',
+        nationalFormat: '1234',
+      });
+    });
+
+    it('keeps the separators when keepFormatting is set', async () => {
+      mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockResolvedValueOnce({
+        phoneNumber,
+        nationalFormat: '(500) 555-1234',
+      });
+
+      const result = await service.hasConfirmedMasked(uid, {
+        keepFormatting: true,
+      });
+
+      expect(result).toStrictEqual({
+        exists: true,
+        phoneNumber: '•••••••1234',
+        nationalFormat: '(•••) •••-1234',
+      });
+    });
+
+    // keepFormatting must never widen disclosure beyond the last 4 digits.
+    it.each([{ keepFormatting: false }, { keepFormatting: true }])(
+      'never returns a dialable number with keepFormatting $keepFormatting',
+      async (opts) => {
+        mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockResolvedValueOnce({
+          phoneNumber,
+          nationalFormat: '(500) 555-1234',
+        });
+
+        const result = await service.hasConfirmedMasked(uid, opts);
+
+        expect(result.phoneNumber).not.toContain('500');
+        expect(result.nationalFormat).not.toContain('500');
+      }
+    );
+
+    it('returns exists false when no phone number is confirmed', async () => {
+      mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockRejectedValueOnce(
+        new RecoveryNumberNotExistsError(uid)
+      );
+
+      const result = await service.hasConfirmedMasked(uid);
+
+      expect(result).toStrictEqual({ exists: false });
+    });
+
+    it('can propagate unexpected error', async () => {
+      const mockError = new Error(uid);
+      mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockRejectedValueOnce(
+        mockError
+      );
+
+      await expect(service.hasConfirmedMasked(uid)).rejects.toEqual(mockError);
     });
   });
 
@@ -749,6 +830,36 @@ describe('RecoveryPhoneService', () => {
     it('can handle being passed an empty string', () => {
       const phoneNumber = '';
       expect(service.stripPhoneNumber(phoneNumber, 4)).toEqual('');
+    });
+  });
+
+  describe('mask national format', () => {
+    it.each([
+      { input: '(123) 456-7890', expected: '(•••) •••-7890' },
+      { input: '+33 9 87 65 43 21', expected: '+•• • •• •• 43 21' },
+      { input: '+15005551234', expected: '+•••••••1234' },
+    ])('masks $input as $expected', ({ input, expected }) => {
+      expect(service.maskNationalFormat(input)).toEqual(expected);
+    });
+
+    it('shows the requested number of trailing digits', () => {
+      expect(service.maskNationalFormat('(123) 456-7890', 2)).toEqual(
+        '(•••) •••-••90'
+      );
+    });
+
+    it('is a no-op on an already masked number', () => {
+      expect(service.maskNationalFormat('(•••) •••-7890')).toEqual(
+        '(•••) •••-7890'
+      );
+    });
+
+    it('masks nothing when the number has 4 or fewer digits', () => {
+      expect(service.maskNationalFormat('7890')).toEqual('7890');
+    });
+
+    it('can handle being passed an empty string', () => {
+      expect(service.maskNationalFormat('')).toEqual('');
     });
   });
 

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -372,18 +372,13 @@ export class RecoveryPhoneService {
   }
 
   /**
-   * Checks if the given uid has confirmed a phone number.
-   * @param uid Account id
-   * @param phoneNumberMask When provided will mask the number so the full value is not shown.
-   * @returns If the account has confirmed, returns {exists:true, phoneNumber }. If not returns {exists:false}
+   * Checks if the given uid has confirmed a phone number. Returns the full
+   * number, so anything reaching a client must use {@link hasConfirmedMasked}.
    *
-   * @remarks The value provided for phoneNumberMask will preserve the last N digits of of the phone number.
-   * e.g. If the phone number was +15005551234 and phoneNumberMask was 4, the result would be +*******1234.
+   * @param uid Account id
+   * @returns If the account has confirmed, returns {exists:true, phoneNumber }. If not returns {exists:false}
    */
-  public async hasConfirmed(
-    uid: string,
-    phoneNumberStrip?: number
-  ): Promise<{
+  public async hasConfirmed(uid: string): Promise<{
     exists: boolean;
     phoneNumber?: string;
     nationalFormat?: string;
@@ -394,10 +389,8 @@ export class RecoveryPhoneService {
 
       return {
         exists: true,
-        phoneNumber: this.stripPhoneNumber(phoneNumber, phoneNumberStrip),
-        nationalFormat: nationalFormat
-          ? this.stripPhoneNumber(nationalFormat, phoneNumberStrip)
-          : undefined,
+        phoneNumber,
+        nationalFormat: nationalFormat || undefined,
       };
     } catch (err) {
       if (err instanceof RecoveryNumberNotExistsError) {
@@ -414,6 +407,50 @@ export class RecoveryPhoneService {
   }
 
   /**
+   * Like {@link hasConfirmed}, but never divulges the full phone number. Use
+   * this for anything that reaches a client.
+   *
+   * Both modes expose the last 4 digits and nothing more. keepFormatting only
+   * decides whether the separators survive, which still reveals length and
+   * region.
+   *
+   * @param uid Account id
+   * @param keepFormatting Keep separators, e.g. `(•••) •••-1234` over `1234`
+   */
+  public async hasConfirmedMasked(
+    uid: string,
+    { keepFormatting = false }: { keepFormatting?: boolean } = {}
+  ): Promise<{
+    exists: boolean;
+    phoneNumber?: string;
+    nationalFormat?: string;
+  }> {
+    const { phoneNumber, nationalFormat } = await this.hasConfirmed(uid);
+
+    if (!phoneNumber) {
+      return { exists: false };
+    }
+
+    if (!keepFormatting) {
+      return {
+        exists: true,
+        phoneNumber: this.stripPhoneNumber(phoneNumber, 4),
+        nationalFormat: nationalFormat
+          ? this.stripPhoneNumber(nationalFormat, 4)
+          : undefined,
+      };
+    }
+
+    return {
+      exists: true,
+      phoneNumber: this.maskPhoneNumber(phoneNumber),
+      nationalFormat: nationalFormat
+        ? this.maskNationalFormat(nationalFormat)
+        : undefined,
+    };
+  }
+
+  /**
    * Masks a phone number so as to not divulge the entire value.
    *
    * @param phoneNumber The actual phone number
@@ -421,7 +458,6 @@ export class RecoveryPhoneService {
    * @returns The last N number of digits of the phone number
    */
   public stripPhoneNumber(phoneNumber: string, lastN?: number) {
-    // No stripping needed, session is verified
     if (lastN === undefined) {
       return phoneNumber;
     }
@@ -453,6 +489,21 @@ export class RecoveryPhoneService {
     const numMasked = Math.max(digits.length - lastN, 0);
     const mask = '•'.repeat(numMasked);
     return `${mask}${visible}`;
+  }
+
+  /**
+   * Masks in place so that, unlike {@link maskPhoneNumber}, Twilio's separators
+   * survive: `(415) 555-1234` becomes `(•••) •••-1234`. Re-masking is a no-op.
+   *
+   * @param nationalFormat The nationally formatted phone number
+   * @param lastN The number of digits at the end of the phone number to show
+   */
+  public maskNationalFormat(nationalFormat: string, lastN = 4): string {
+    const digitCount = nationalFormat.replace(/\D/g, '').length;
+    let remainingToMask = Math.max(digitCount - lastN, 0);
+    return nationalFormat.replace(/\d/g, (digit) =>
+      remainingToMask-- > 0 ? '•' : digit
+    );
   }
 
   /**

--- a/packages/fxa-auth-server/docs/swagger/recovery-phone-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-phone-api.ts
@@ -159,7 +159,7 @@ const RECOVERY_PHONE_GET = {
     dedent`
       🔒 Authenticated with session token or password forgot token
 
-      Return whether a recovery phone exists and, if permitted, the masked phone number information.
+      Return whether a recovery phone exists, along with the masked phone number information. The full phone number is never returned.
     `,
   ],
 };

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -257,7 +257,7 @@ const makeRoutes = function (options: any = {}, requireMocks: any = {}) {
     getCountForUserId: jest.fn().mockResolvedValue(0),
   });
   Container.set(RecoveryPhoneService, {
-    hasConfirmed: jest.fn().mockResolvedValue(false),
+    hasConfirmedMasked: jest.fn().mockResolvedValue({ exists: false }),
     available: jest.fn().mockResolvedValue(false),
   });
 
@@ -4878,7 +4878,7 @@ describe('/account', () => {
 
     it('should pass geo countryCode to the service', () => {
       const mockService = {
-        hasConfirmed: jest
+        hasConfirmedMasked: jest
           .fn()
           .mockResolvedValue({ exists: false, phoneNumber: null }),
         available: jest.fn().mockResolvedValue(true),
@@ -4905,7 +4905,7 @@ describe('/account', () => {
         allowedRegions: ['US'],
       });
       Container.set(RecoveryPhoneService, {
-        hasConfirmed: jest
+        hasConfirmedMasked: jest
           .fn()
           .mockResolvedValue({ exists: false, phoneNumber: null }),
         available: jest.fn().mockResolvedValue(false),
@@ -4921,7 +4921,7 @@ describe('/account', () => {
         allowedRegions: ['US'],
       });
       Container.set(RecoveryPhoneService, {
-        hasConfirmed: jest
+        hasConfirmedMasked: jest
           .fn()
           .mockResolvedValue({ exists: false, phoneNumber: null }),
         available: jest.fn().mockRejectedValue(new Error('service error')),
@@ -4942,13 +4942,40 @@ describe('/account', () => {
         allowedRegions: ['US'],
       });
       Container.set(RecoveryPhoneService, {
-        hasConfirmed: jest
+        hasConfirmedMasked: jest
           .fn()
           .mockResolvedValue({ exists: false, phoneNumber: null }),
         available: jest.fn().mockResolvedValue(false),
       });
       return runTest(route, noGeoRequest, (result: any) => {
         expect(result.recoveryPhone.available).toBe(false);
+      });
+    });
+
+    // Reachable with only a password-derived session.
+    it('delegates to hasConfirmedMasked and merges available into recoveryPhone', () => {
+      const mockService = {
+        hasConfirmed: jest.fn(),
+        hasConfirmedMasked: jest
+          .fn()
+          .mockResolvedValue({ exists: true, phoneNumber: '1234' }),
+        available: jest.fn().mockResolvedValue(false),
+      };
+      const route = buildRouteWithRecoveryPhone({
+        enabled: true,
+        allowedRegions: ['US'],
+      });
+      Container.set(RecoveryPhoneService, mockService);
+      return runTest(route, request, (result: any) => {
+        expect(result.recoveryPhone).toEqual({
+          exists: true,
+          phoneNumber: '1234',
+          available: false,
+        });
+        expect(mockService.hasConfirmedMasked).toHaveBeenCalledWith(uid, {
+          keepFormatting: expect.any(Boolean),
+        });
+        expect(mockService.hasConfirmed).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -2519,7 +2519,10 @@ export class AccountHandler {
       this.db.totpToken(uid),
       Container.get(BackupCodeManager).getCountForUserId(uid),
       this.db.getRecoveryKeyRecordWithHint(uid),
-      Container.get(RecoveryPhoneService).hasConfirmed(uid),
+      // Masked either way; the flag only affects formatting, not digits.
+      Container.get(RecoveryPhoneService).hasConfirmedMasked(uid, {
+        keepFormatting: requestHelper.isPastMustVerifyGate(request),
+      }),
       request.app.geo?.location?.countryCode
         ? Container.get(RecoveryPhoneService).available(
             uid,
@@ -3352,8 +3355,9 @@ export const accountRoutes = (
             recoveryPhone: isA
               .object({
                 exists: isA.boolean().required(),
-                phoneNumber: isA.string().allow(null).optional(),
-                nationalFormat: isA.string().allow(null).optional(),
+                // Masked: at most the last 4 digits survive either field.
+                phoneNumber: validators.maskedPhoneNumber,
+                nationalFormat: validators.maskedPhoneNumber,
                 available: isA.boolean().required(),
               })
               .optional(),

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
@@ -69,6 +69,7 @@ describe('/recovery_phone', () => {
     removePhoneNumber: jest.fn(),
     stripPhoneNumber: jest.fn(),
     hasConfirmed: jest.fn(),
+    hasConfirmedMasked: jest.fn(),
     onMessageStatusUpdate: jest.fn(),
     validateTwilioWebhookCallback: jest.fn(),
     validateSetupCode: jest.fn(),
@@ -1022,31 +1023,50 @@ describe('/recovery_phone', () => {
   });
 
   describe('GET /recovery_phone', () => {
-    it('gets a recovery phone', async () => {
-      mockRecoveryPhoneService.hasConfirmed = jest.fn().mockReturnValue({
-        exists: true,
-        phoneNumber,
-      });
+    const maskedPhone = { exists: true, phoneNumber: '1234' };
 
-      const resp = await makeRequest({
-        method: 'GET',
-        path: '/recovery_phone',
-        credentials: { uid, emailVerified: true },
-      });
+    // Masking itself is asserted in the service spec; this covers the wiring.
+    it.each([
+      {
+        name: 'a session still owing confirmation',
+        credentials: { emailVerified: true, mustVerify: true },
+        keepFormatting: false,
+      },
+      {
+        name: 'an unverified session',
+        credentials: { emailVerified: false },
+        keepFormatting: false,
+      },
+      {
+        name: 'a confirmed session',
+        credentials: { emailVerified: true, tokenVerified: true },
+        keepFormatting: true,
+      },
+    ])(
+      'delegates to hasConfirmedMasked with keepFormatting $keepFormatting for $name',
+      async ({ credentials, keepFormatting }) => {
+        mockRecoveryPhoneService.hasConfirmedMasked = jest
+          .fn()
+          .mockResolvedValue(maskedPhone);
 
-      expect(resp).toBeDefined();
-      expect(mockRecoveryPhoneService.hasConfirmed).toHaveBeenCalledTimes(1);
-      expect(mockRecoveryPhoneService.hasConfirmed).toHaveBeenNthCalledWith(
-        1,
-        uid,
-        expect.anything()
-      );
-    });
+        const resp = await makeRequest({
+          method: 'GET',
+          path: '/recovery_phone',
+          credentials: { uid, ...credentials },
+        });
 
-    it('indicates  error', async () => {
-      mockRecoveryPhoneService.hasConfirmed = jest
+        expect(resp).toEqual(maskedPhone);
+        expect(
+          mockRecoveryPhoneService.hasConfirmedMasked
+        ).toHaveBeenCalledWith(uid, { keepFormatting });
+        expect(mockRecoveryPhoneService.hasConfirmed).not.toHaveBeenCalled();
+      }
+    );
+
+    it('wraps a hasConfirmedMasked rejection in backendServiceFailure', async () => {
+      mockRecoveryPhoneService.hasConfirmedMasked = jest
         .fn()
-        .mockReturnValue(Promise.reject(new Error('BOOM')));
+        .mockRejectedValue(new Error('BOOM'));
       const promise = makeRequest({
         method: 'GET',
         path: '/recovery_phone',
@@ -1057,27 +1077,6 @@ describe('/recovery_phone', () => {
         'System unavailable, try again soon'
       );
       expect(mockGlean.twoStepAuthPhoneRemove.success).toHaveBeenCalledTimes(0);
-    });
-
-    it('returns masked phone number for unverified session', async () => {
-      mockRecoveryPhoneService.hasConfirmed = jest.fn().mockReturnValue({
-        exists: true,
-        phoneNumber,
-      });
-      const resp = await makeRequest({
-        method: 'GET',
-        path: '/recovery_phone',
-        credentials: { uid, mustVerify: true },
-      });
-      expect(resp).toBeDefined();
-      expect(resp.exists).toBeDefined();
-      expect(resp.phoneNumber).toBeDefined();
-      expect(mockRecoveryPhoneService.hasConfirmed).toHaveBeenCalledTimes(1);
-      expect(mockRecoveryPhoneService.hasConfirmed).toHaveBeenNthCalledWith(
-        1,
-        uid,
-        4
-      );
     });
   });
 

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -26,7 +26,8 @@ import {
   AuthRequest,
   SessionTokenAuthCredential,
 } from '../types';
-import { E164_NUMBER } from './validators';
+import { E164_NUMBER, maskedPhoneNumber } from './validators';
+import requestHelper from './utils/request_helper';
 import { AppError } from '@fxa/accounts/errors';
 import Localizer from '../l10n';
 import NodeRendererBindings from '../senders/renderer/bindings-node';
@@ -975,29 +976,14 @@ class RecoveryPhoneHandler {
   }
 
   async exists(request: AuthRequest) {
-    // To ensure no data is leaked, we will never expose the full phone number, if
-    // the session is not verified. e.g. The user has entered the correct password,
-    // but failed to provide 2FA.
-    const shouldStripNumber = (() => {
-      if (
-        request.auth.strategy === 'multiStrategySessionToken' ||
-        request.auth.strategy === 'multiStrategySessionTokenBearer'
-      ) {
-        const { emailVerified, mustVerify, tokenVerified } = request.auth
-          .credentials as SessionTokenAuthCredential;
-        return !emailVerified || (mustVerify && !tokenVerified);
-      }
-      return true;
-    })();
-
-    const phoneNumberStrip = shouldStripNumber ? 4 : undefined;
     const { uid } = request.auth.credentials as AuthCredential;
+    // Masked either way; the flag only affects formatting, not digits.
+    const keepFormatting = requestHelper.isPastMustVerifyGate(request);
 
     try {
-      return await this.recoveryPhoneService.hasConfirmed(
-        uid,
-        phoneNumberStrip
-      );
+      return await this.recoveryPhoneService.hasConfirmedMasked(uid, {
+        keepFormatting,
+      });
     } catch (error) {
       throw AppError.backendServiceFailure(
         'RecoveryPhoneService',
@@ -1358,6 +1344,13 @@ export const recoveryPhoneRoutes = (
             'multiStrategySessionToken',
             'multiStrategyPasswordForgotToken',
           ],
+        },
+        response: {
+          schema: isA.object({
+            exists: isA.boolean().required(),
+            phoneNumber: maskedPhoneNumber,
+            nationalFormat: maskedPhoneNumber,
+          }),
         },
       },
       handler: function (request: AuthRequest) {

--- a/packages/fxa-auth-server/lib/routes/utils/request_helper.js
+++ b/packages/fxa-auth-server/lib/routes/utils/request_helper.js
@@ -14,6 +14,25 @@ function wantsKeys(request) {
   return !!(request.query && request.query.keys);
 }
 
+/**
+ * Returns `true` if the request's session is past the `mustVerify` gate: the
+ * account email is verified, and the session owes no confirmation. This is the
+ * same check `makeAssertionJWT` in `oauth/util.js` makes.
+ *
+ * This is not a measure of assurance. A password-only session that was never
+ * asked to confirm passes, and so do passkey and third-party sessions, which
+ * involve no password at all. Non-session tokens carry none of these fields,
+ * so they do not pass.
+ *
+ * @param request
+ * @returns {boolean}
+ */
+function isPastMustVerifyGate(request) {
+  const { emailVerified, mustVerify, tokenVerified } =
+    request.auth?.credentials || {};
+  return !!emailVerified && !(mustVerify && !tokenVerified);
+}
+
 function urlSafeBase64(hex) {
   return Buffer.from(hex, 'hex')
     .toString('base64')
@@ -24,5 +43,6 @@ function urlSafeBase64(hex) {
 
 module.exports = {
   wantsKeys,
+  isPastMustVerifyGate,
   urlSafeBase64,
 };

--- a/packages/fxa-auth-server/lib/routes/utils/request_helper.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/request_helper.spec.ts
@@ -7,8 +7,50 @@ const requestHelper = require('./request_helper');
 describe('requestHelper', () => {
   it('interface is correct', () => {
     expect(typeof requestHelper).toBe('object');
-    expect(Object.keys(requestHelper).length).toBe(2);
+    expect(Object.keys(requestHelper).length).toBe(3);
     expect(typeof requestHelper.wantsKeys).toBe('function');
+    expect(typeof requestHelper.isPastMustVerifyGate).toBe('function');
+  });
+
+  describe('isPastMustVerifyGate', () => {
+    const withCredentials = (credentials: object) => ({
+      auth: { credentials },
+    });
+
+    it.each([
+      { name: 'a confirmed session', emailVerified: true, tokenVerified: true },
+      {
+        // The gate is not a measure of assurance: this session proved only the
+        // password, and a passkey or third-party session proves no password.
+        name: 'a password-only session that was never asked to confirm',
+        emailVerified: true,
+        mustVerify: false,
+        tokenVerified: false,
+      },
+    ])('is true for $name', ({ name, ...credentials }) => {
+      expect(
+        requestHelper.isPastMustVerifyGate(withCredentials(credentials))
+      ).toBe(true);
+    });
+
+    it.each([
+      { name: 'an unverified email', emailVerified: false },
+      {
+        name: 'a session still owing confirmation',
+        emailVerified: true,
+        mustVerify: true,
+        tokenVerified: false,
+      },
+      { name: 'a token carrying no session fields', other: 'value' },
+    ])('is false for $name', ({ name, ...credentials }) => {
+      expect(
+        requestHelper.isPastMustVerifyGate(withCredentials(credentials))
+      ).toBe(false);
+    });
+
+    it('is false when the request carries no credentials', () => {
+      expect(requestHelper.isPastMustVerifyGate({})).toBe(false);
+    });
   });
 
   it('wantsKeys', () => {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -619,6 +619,14 @@ module.exports.subscriptionsMozillaSubscriptionsValidator = isA
   })
   .unknown(true);
 
+// Caps a phone number in a response at 4 digits, so one that would leak the
+// full value fails validation instead of shipping.
+module.exports.maskedPhoneNumber = isA
+  .string()
+  .regex(/^(?:\D*\d){0,4}\D*$/)
+  .allow(null)
+  .optional();
+
 module.exports.ppidSeed = isA.number().integer().min(0).max(1024);
 
 module.exports.scopes = isA.array().items(scope).default([]).optional();

--- a/packages/fxa-auth-server/lib/routes/validators.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/validators.spec.ts
@@ -824,4 +824,33 @@ describe('lib/routes/validators:', () => {
     expect(validators.isValidEmailAddress('foo\u200b@example.com')).toBe(false);
     expect(validators.isValidEmailAddress('foo\u200f@example.com')).toBe(false);
   });
+
+  describe('maskedPhoneNumber:', () => {
+    // The rejection cases are the point: this is what enforces the invariant.
+    it.each([
+      { value: '1234', label: 'the last 4 digits' },
+      {
+        value: '(\u2022\u2022\u2022) \u2022\u2022\u2022-1234',
+        label: 'a masked national format',
+      },
+      {
+        value: '+\u2022\u2022\u2022\u2022\u2022\u2022\u20221234',
+        label: 'a masked E.164 number',
+      },
+      { value: null, label: 'null' },
+    ])('accepts $label', ({ value }) => {
+      expect(
+        validators.maskedPhoneNumber.validate(value).error
+      ).toBeUndefined();
+    });
+
+    it.each([
+      { value: '+14155551234', label: 'a full E.164 number' },
+      { value: '(415) 555-1234', label: 'a full national format' },
+      { value: '4155551234', label: 'bare unmasked digits' },
+      { value: '12345', label: 'more than 4 digits' },
+    ])('rejects $label', ({ value }) => {
+      expect(validators.maskedPhoneNumber.validate(value).error).toBeDefined();
+    });
+  });
 });

--- a/packages/fxa-auth-server/test/remote/recovery_phone.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/recovery_phone.in.spec.ts
@@ -153,7 +153,10 @@ describe('#integration - recovery phone', () => {
     expect(codeSent).toBeDefined();
     expect(confirmResp.status).toBe('success');
     expect(checkResp.exists).toBe(true);
-    expect(checkResp.phoneNumber).toBe(phoneNumber);
+    // Masked either way; what matters is that it is never dialable.
+    expect(checkResp.phoneNumber).not.toBe(phoneNumber);
+    expect(checkResp.phoneNumber).toContain(phoneNumber.slice(-4));
+    expect(checkResp.phoneNumber).not.toContain('415');
   });
 
   it('can send, confirm code, verify session, and remove totp', async () => {

--- a/packages/fxa-auth-server/test/remote/subscription_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.in.spec.ts
@@ -299,7 +299,7 @@ describe('#integration - remote subscriptions (enabled)', () => {
       getCountForUserId: async () => ({ hasBackupCodes: false, count: 0 }),
     });
     Container.set(RecoveryPhoneService, {
-      hasConfirmed: async () => ({ exists: false, phoneNumber: null }),
+      hasConfirmedMasked: async () => ({ exists: false }),
     });
     Container.set(PriceManager, { retrieve: jest.fn() });
     Container.set(ProductConfigurationManager, {


### PR DESCRIPTION
## Because

- `GET /account` is gated only by a bare `sessionToken`, with no `tokenVerified` or assurance-level check. A caller holding nothing but the account password received the unmasked E.164 number in `recoveryPhone.phoneNumber` — the credential needed to mount a SIM swap and defeat TOTP.
- `GET /recovery_phone` chose whether to mask from `emailVerified` / `mustVerify` / `tokenVerified`, and that check decided whether the number leaked at all. A session that cleared it without reaching AAL2 received the full number.

## This pull request

- Adds `RecoveryPhoneService.hasConfirmedMasked()` in `recovery-phone.service.ts` and points both read endpoints at it. Neither mode returns a dialable number; the `keepFormatting` option only chooses how much of the shape survives, so the session check no longer decides whether the number leaks.
- Adds `maskNationalFormat()` to mask in place while keeping Twilio's separators, so `(415) 555-1234` becomes `(•••) •••-1234`.
- Removes the `phoneNumberStrip` parameter from `hasConfirmed()`. Defaulting it to "do not mask" is what made the leak possible; the raw accessor is now server-side only, used by the email, setup and change paths that need a dialable number.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14028

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**No UI changes.** Entirely server-side — `fxa-settings` is untouched. Every screen renders exactly what it does today: sessions that previously received the full number now receive `(•••) •••-1234`, which the client already masks to the identical string, and sessions that previously received the last four still do.

The one unavoidable difference: the remove-recovery-phone page previously printed the full `(415) 555-1234` and now shows `(•••) •••-1234`. That page was rendering the leaked value. It needs no code change to pick up the masked one.