### PR TITLE
chore(deps): remove unused request and request-promise dependencies

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -131,7 +131,6 @@
     "@types/node": "^22.13.5",
     "@types/node-zendesk": "^2.0.2",
     "@types/nodemailer": "^7.0.4",
-    "@types/request": "2.48.5",
     "@types/sass": "^1",
     "@types/verror": "^1.10.4",
     "@types/webpack": "5.28.5",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -152,8 +152,6 @@
     "postcss-import": "^16.1.0",
     "prettier": "^3.5.3",
     "proxyquire": "^2.1.3",
-    "request": "^2.88.2",
-    "request-promise": "4.2.6",
     "sinon": "4.5.0",
     "sinon-chai": "^4.0.0",
     "sinon-express-mock": "^2.2.1",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -56,7 +56,6 @@
     "pm2": "^7.0.0",
     "prettier": "^3.5.3",
     "proxyquire": "^2.1.3",
-    "request": "^2.88.2",
     "restify-clients": "^4.2.0",
     "sinon": "^9.0.3",
     "tap": "^16.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21368,18 +21368,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/request@npm:2.48.5":
-  version: 2.48.5
-  resolution: "@types/request@npm:2.48.5"
-  dependencies:
-    "@types/caseless": "npm:*"
-    "@types/node": "npm:*"
-    "@types/tough-cookie": "npm:*"
-    form-data: "npm:^2.5.0"
-  checksum: 10c0/13baebe500b4f5b2221dcbfbf864023a48d305f5093325c2ab8978b39c316a28256a69ee1c4dd22af9ac0d334845bee35fd56f3ddfc8d18c0889fee17bf594b4
-  languageName: node
-  linkType: hard
-
 "@types/request@npm:^2.48.8":
   version: 2.48.12
   resolution: "@types/request@npm:2.48.12"
@@ -25484,7 +25472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:3.x.x, bluebird@npm:>=2.2.2, bluebird@npm:^3.4.6, bluebird@npm:^3.5.0, bluebird@npm:^3.5.5, bluebird@npm:^3.7.2":
+"bluebird@npm:3.x.x, bluebird@npm:>=2.2.2, bluebird@npm:^3.4.6, bluebird@npm:^3.5.5, bluebird@npm:^3.7.2":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
   checksum: 10c0/680de03adc54ff925eaa6c7bb9a47a0690e8b5de60f4792604aae8ed618c65e6b63a7893b57ca924beaf53eee69c5af4f8314148c08124c550fe1df1add897d2
@@ -33769,7 +33757,6 @@ __metadata:
     "@types/node": "npm:^22.13.5"
     "@types/node-zendesk": "npm:^2.0.2"
     "@types/nodemailer": "npm:^7.0.4"
-    "@types/request": "npm:2.48.5"
     "@types/sass": "npm:^1"
     "@types/verror": "npm:^1.10.4"
     "@types/webpack": "npm:5.28.5"
@@ -33969,8 +33956,6 @@ __metadata:
     postcss-loader: "npm:8.1.1"
     prettier: "npm:^3.5.3"
     proxyquire: "npm:^2.1.3"
-    request: "npm:^2.88.2"
-    request-promise: "npm:4.2.6"
     sass-loader: "npm:^16.0.3"
     serve-static: "npm:^1.16.0"
     sinon: "npm:4.5.0"
@@ -34027,7 +34012,6 @@ __metadata:
     pm2: "npm:^7.0.0"
     prettier: "npm:^3.5.3"
     proxyquire: "npm:^2.1.3"
-    request: "npm:^2.88.2"
     restify-clients: "npm:^4.2.0"
     sinon: "npm:^9.0.3"
     tap: "npm:^16.3.0"
@@ -50590,31 +50574,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"request-promise-core@npm:1.1.4":
-  version: 1.1.4
-  resolution: "request-promise-core@npm:1.1.4"
-  dependencies:
-    lodash: "npm:^4.17.19"
-  peerDependencies:
-    request: ^2.34
-  checksum: 10c0/103eb9043450b9312c005ed859c2150825a555b72e4c0a83841f6793d368eddeacde425f8688effa215eb3eb14ff8c486a3c3e80f6246e9c195628db2bf9020e
-  languageName: node
-  linkType: hard
-
-"request-promise@npm:4.2.6":
-  version: 4.2.6
-  resolution: "request-promise@npm:4.2.6"
-  dependencies:
-    bluebird: "npm:^3.5.0"
-    request-promise-core: "npm:1.1.4"
-    stealthy-require: "npm:^1.1.1"
-    tough-cookie: "npm:^2.3.3"
-  peerDependencies:
-    request: ^2.34
-  checksum: 10c0/17ddb9eb558b2a86b5b448292123e889985be2f52d67ed9ed67834bd380b95449f50b820dadc7c555e10c57a88bca00663c2b3abe2bfcb114beb442d34743073
-  languageName: node
-  linkType: hard
-
 "request@npm:2.88.2, request@npm:>=2.39.0, request@npm:^2.88.0, request@npm:^2.88.2":
   version: 2.88.2
   resolution: "request@npm:2.88.2"
@@ -53447,13 +53406,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stealthy-require@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "stealthy-require@npm:1.1.1"
-  checksum: 10c0/714b61e152ba03a5e098b5364cc3076d8036edabc2892143fe3c64291194a401b74f071fadebba94551fb013a02f3bcad56a8be29a67b3c644ac78ffda921f80
-  languageName: node
-  linkType: hard
-
 "stop-iteration-iterator@npm:^1.0.0, stop-iteration-iterator@npm:^1.1.0":
   version: 1.1.0
   resolution: "stop-iteration-iterator@npm:1.1.0"
@@ -55524,16 +55476,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^2.3.3, tough-cookie@npm:~2.5.0":
-  version: 2.5.0
-  resolution: "tough-cookie@npm:2.5.0"
-  dependencies:
-    psl: "npm:^1.1.28"
-    punycode: "npm:^2.1.1"
-  checksum: 10c0/e1cadfb24d40d64ca16de05fa8192bc097b66aeeb2704199b055ff12f450e4f30c927ce250f53d01f39baad18e1c11d66f65e545c5c6269de4c366fafa4c0543
-  languageName: node
-  linkType: hard
-
 "tough-cookie@npm:^3.0.0":
   version: 3.0.1
   resolution: "tough-cookie@npm:3.0.1"
@@ -55563,6 +55505,16 @@ __metadata:
   dependencies:
     tldts: "npm:^6.1.32"
   checksum: 10c0/5f95023a47de0f30a902bba951664b359725597d8adeabc66a0b93a931c3af801e1e697dae4b8c21a012056c0ea88bd2bf4dfe66b2adcf8e2f42cd9796fe0626
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:~2.5.0":
+  version: 2.5.0
+  resolution: "tough-cookie@npm:2.5.0"
+  dependencies:
+    psl: "npm:^1.1.28"
+    punycode: "npm:^2.1.1"
+  checksum: 10c0/e1cadfb24d40d64ca16de05fa8192bc097b66aeeb2704199b055ff12f450e4f30c927ce250f53d01f39baad18e1c11d66f65e545c5c6269de4c366fafa4c0543
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- `request` and `request-promise` are deprecated and unmaintained upstream (request/request#3142).
- Three packages declared them as `devDependencies` but never imported them.

## This pull request

- Drops `request` and `request-promise` from `fxa-content-server`, `request` from `fxa-customs-server`, and `@types/request` from `fxa-auth-server` — all dev dependencies with no source references.
- Keeps `request` for the remaining call sites, to be converted to native `fetch` in follow-up PRs.

## Issue that this pull request solves

Closes: FXA-4897

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information (Optional)

This is part 1 of a series of PRs that will remove `request-promise` and replace `request` with native `fetch`: https://mozilla-hub.atlassian.net/browse/FXA-4892
