### PR TITLE
feat(auth-server): refresh session auth event on 2f challenges

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -341,12 +341,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       async handler(request) {
         log.begin('session.verify.recoveryCode', request);
 
-        const {
-          email,
-          id: tokenId,
-          tokenVerified,
-          uid,
-        } = request.auth.credentials;
+        const { email, id: tokenId, uid } = request.auth.credentials;
 
         await customs.checkAuthenticated(
           request,
@@ -361,15 +356,11 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
           log.info('account.recoveryCode.consumedAllCodes', { uid });
         }
 
-        if (
-          !tokenVerified ||
-          // If the token is already verified but the auth assurance level needs
-          // to be upgraded, then this user was redirected from Settings to
-          // our TOTP page and entered a recovery code to upgrade their session
-          request.auth.credentials.authenticatorAssuranceLevel <= 1
-        ) {
-          await db.verifyTokensWithMethod(tokenId, 'recovery-code');
-        }
+        // A consumed backup authentication code always refreshes the session's
+        // authentication event, including on an already-AAL2 session (a step-up
+        // re-challenge). `recovery-code` maps to AAL2, so this can never lower the
+        // session's assurance level.
+        await db.verifyTokensWithMethod(tokenId, 'recovery-code');
 
         const account = await db.account(uid);
         const { acceptLanguage, clientAddress: ip, geo, ua } = request.app;

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.spec.ts
@@ -291,5 +291,23 @@ describe('backup authentication codes', () => {
         }
       );
     });
+
+    it('refreshes the authentication event on an already-AAL2 session (step-up)', async () => {
+      // A step-up re-challenge on a session that already reached AAL2 must still
+      // refresh the authentication event. `recovery-code` maps to AAL2, so this
+      // never lowers the session's assurance level.
+      requestOptions.credentials.id = 'sessionTokenId';
+      requestOptions.credentials.tokenVerified = true;
+      requestOptions.credentials.authenticatorAssuranceLevel = 2;
+      db.consumeRecoveryCode = jest.fn((_code: any) => {
+        return Promise.resolve({ remaining: 4 });
+      });
+      await runTest('/session/verify/recoveryCode', requestOptions);
+      expect(db.verifyTokensWithMethod).toHaveBeenCalledTimes(1);
+      expect(db.verifyTokensWithMethod).toHaveBeenCalledWith(
+        'sessionTokenId',
+        'recovery-code'
+      );
+    });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
@@ -6,7 +6,7 @@ import { Container } from 'typedi';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { StatsD } from 'hot-shots';
 import { AppError } from '@fxa/accounts/errors';
-import { AccountManager } from '@fxa/shared/account/account';
+import { AccountManager, VerificationMethods } from '@fxa/shared/account/account';
 import { AuthLogger } from '../types';
 import { installMockFxaMailer } from '../../test/fixtures/fxa-mailer';
 import {
@@ -776,6 +776,32 @@ describe('/recovery_phone', () => {
       expect(request.emitMetricsEvent).toHaveBeenCalledWith(
         'account.confirmed',
         { uid }
+      );
+    });
+
+    it('refreshes the authentication event on an already-AAL2 session (step-up)', async () => {
+      // A step-up re-challenge via recovery phone must refresh the session's
+      // authentication event even when it is already AAL2. `sms-2fa` maps to
+      // AAL2, so this never lowers the assurance level.
+      mockRecoveryPhoneService.confirmCode = jest.fn().mockReturnValue(true);
+
+      await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/signin/confirm',
+        credentials: {
+          uid,
+          email,
+          id: 'sessionTokenId',
+          authenticatorAssuranceLevel: 2,
+        },
+        payload: { code },
+      });
+
+      expect(mockAccountManager.verifySession).toHaveBeenCalledTimes(1);
+      expect(mockAccountManager.verifySession).toHaveBeenCalledWith(
+        uid,
+        'sessionTokenId',
+        VerificationMethods.sms2fa
       );
     });
 

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -514,9 +514,14 @@ module.exports = function (
 
         // If a valid code was sent, this verifies the session using the `email-2fa` method.
         // The assurance level will be ["pwd", "email"] or level 1.
+        // `email-2fa` maps to AAL1, so only refresh the authentication event when it
+        // would not *lower* an already-AAL2 session — otherwise a re-verification here
+        // would downgrade the session's assurance level (now load-bearing for auth_time).
         // **Note** the order of operations, to avoid any race conditions with push
         // notifications, we perform all DB operations first.
-        await db.verifyTokensWithMethod(sessionToken.id, 'email-2fa');
+        if (sessionToken.authenticatorAssuranceLevel <= 1) {
+          await db.verifyTokensWithMethod(sessionToken.id, 'email-2fa');
+        }
 
         // We have a matching code! Let's verify the account, session and send the
         // corresponding email and emit metrics.

--- a/packages/fxa-auth-server/lib/routes/session.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/session.spec.ts
@@ -1014,6 +1014,8 @@ describe('/session/verify_code', () => {
         ...signupCodeAccount,
         uaBrowser: 'Firefox',
         id: 'sessionTokenId',
+        // A session first reaching /session/verify_code is AAL1 (pwd only).
+        authenticatorAssuranceLevel: 1,
       },
       payload: {
         code: expectedCode,
@@ -1053,6 +1055,19 @@ describe('/session/verify_code', () => {
     expect(fxaMailer.sendPostVerifyEmail).toHaveBeenCalledTimes(1);
     expect(gleanMock.registration.accountVerified).toHaveBeenCalledTimes(1);
     expect(gleanMock.registration.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh the authentication event on an already-AAL2 session (no downgrade)', async () => {
+    // `email-2fa` maps to AAL1. If an already-AAL2 session reaches verify_code,
+    // refreshing the auth event here would lower its assurance level (now
+    // load-bearing for auth_time), so the refresh must be skipped.
+    setup({ emailVerified: true });
+    request.auth.credentials.authenticatorAssuranceLevel = 2;
+    const response = await runTest(route, request);
+    expect(response).toEqual({});
+    // The rest of the handler still runs; only the session-verify is skipped.
+    expect(db.account).toHaveBeenCalledTimes(1);
+    expect(db.verifyTokensWithMethod).not.toHaveBeenCalled();
   });
 
   it('should skip verify account and but still verify session with a valid code', async () => {

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -1146,8 +1146,12 @@ module.exports = (
 
         // This endpoint now only handles session/login verification using DB secret
 
-        // If a valid code was sent, this verifies the session using the `totp-2fa` method.
-        if (isValidCode && sessionToken.authenticatorAssuranceLevel <= 1) {
+        // If a valid code was sent, this verifies the session using the `totp-2fa`
+        // method. We always refresh the session's authentication event (even for
+        // an already-AAL2 session) so a step-up challenge is recorded via
+        // `verificationMethod`/`verifiedAt`. `totp-2fa` maps to AAL2, so this can
+        // never lower the session's assurance level.
+        if (isValidCode) {
           await db.verifyTokensWithMethod(sessionToken.id, 'totp-2fa');
         }
 

--- a/packages/fxa-auth-server/lib/routes/totp.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/totp.spec.ts
@@ -437,6 +437,40 @@ describe('totp', () => {
       });
     });
 
+    it('refreshes the authentication event on an already-AAL2 session (step-up)', () => {
+      // A step-up re-challenge on a session that already reached AAL2 must still
+      // refresh verificationMethod/verifiedAt. Previously an
+      // `authenticatorAssuranceLevel <= 1` guard skipped this, leaving no trace.
+      requestOptions.credentials.authenticatorAssuranceLevel = 2;
+      const authenticator = new otplib.authenticator.Authenticator();
+      authenticator.options = Object.assign({}, otplib.authenticator.options, {
+        secret,
+      });
+      requestOptions.payload = {
+        code: authenticator.generate(secret),
+        service: 'sync',
+      };
+
+      return setup(
+        {
+          db: { email: TEST_EMAIL },
+          totpTokenVerified: true,
+          totpTokenEnabled: true,
+        },
+        {},
+        '/session/verify/totp',
+        requestOptions
+      ).then((response: any) => {
+        expect(response.success).toBe(true);
+        expect(db.verifyTokensWithMethod).toHaveBeenCalledTimes(1);
+        expect(db.verifyTokensWithMethod).toHaveBeenNthCalledWith(
+          1,
+          sessionId,
+          'totp-2fa'
+        );
+      });
+    });
+
     it('should return false for invalid TOTP code', () => {
       requestOptions.payload = {
         code: 'NOTVALID',

--- a/packages/fxa-auth-server/lib/tokens/session_token.js
+++ b/packages/fxa-auth-server/lib/tokens/session_token.js
@@ -67,7 +67,14 @@ module.exports = (log, Token, config) => {
     }
 
     lastAuthAt() {
-      return Math.floor((this.authAt || this.createdAt) / 1000);
+      // Source auth_time from the authentication event, not just the password
+      // event: a session with a password at T1 and a second-factor challenge at
+      // T2 authenticated at T2. `verifiedAt` is refreshed by every AAL2 method,
+      // so max(authAt, verifiedAt) reflects the most recent authentication.
+      // Falls back to createdAt when neither is set (legacy/unverified tokens).
+      const authAt =
+        Math.max(this.authAt || 0, this.verifiedAt || 0) || this.createdAt;
+      return Math.floor(authAt / 1000);
     }
 
     get state() {

--- a/packages/fxa-auth-server/lib/tokens/session_token.spec.ts
+++ b/packages/fxa-auth-server/lib/tokens/session_token.spec.ts
@@ -313,6 +313,53 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
       expect(token.authenticatorAssuranceLevel).toBe(2);
     });
   });
+
+  describe('lastAuthAt', () => {
+    // Deterministic, in ms. verifiedAt is one minute after authAt.
+    const MOCK_CREATED_AT = 1_699_999_000_000;
+    const MOCK_AUTH_AT = 1_700_000_000_000;
+    const MOCK_VERIFIED_AT = 1_700_000_060_000;
+
+    it('returns verifiedAt (in seconds) when the second-factor event is more recent', () => {
+      const token = new SessionToken(
+        {},
+        {
+          createdAt: MOCK_CREATED_AT,
+          authAt: MOCK_AUTH_AT,
+          verifiedAt: MOCK_VERIFIED_AT,
+        }
+      );
+      expect(token.lastAuthAt()).toBe(Math.floor(MOCK_VERIFIED_AT / 1000));
+    });
+
+    it('returns authAt (in seconds) when it is more recent than verifiedAt', () => {
+      const token = new SessionToken(
+        {},
+        {
+          createdAt: MOCK_CREATED_AT,
+          authAt: MOCK_VERIFIED_AT,
+          verifiedAt: MOCK_AUTH_AT,
+        }
+      );
+      expect(token.lastAuthAt()).toBe(Math.floor(MOCK_VERIFIED_AT / 1000));
+    });
+
+    it('uses authAt when verifiedAt is null', () => {
+      const token = new SessionToken(
+        {},
+        { createdAt: MOCK_CREATED_AT, authAt: MOCK_AUTH_AT, verifiedAt: null }
+      );
+      expect(token.lastAuthAt()).toBe(Math.floor(MOCK_AUTH_AT / 1000));
+    });
+
+    it('falls back to createdAt when neither authAt nor verifiedAt is set', () => {
+      const token = new SessionToken(
+        {},
+        { createdAt: MOCK_CREATED_AT, authAt: 0, verifiedAt: null }
+      );
+      expect(token.lastAuthAt()).toBe(Math.floor(MOCK_CREATED_AT / 1000));
+    });
+  });
 });
 
 describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice === 0', () => {


### PR DESCRIPTION
## Because

* a step-up second-factor challenge on an already-AAL2 session left no trace — the upgrade-only guards skipped refreshing verificationMethod and verifiedAt, so auth_time never advanced
* auth_time was sourced from the password event rather than the actual authentication event

## This pull request

* removes the upgrade-only guard on the TOTP and recovery-code verify paths so any valid second-factor challenge refreshes the auth event
* sources lastAuthAt() from max(authAt, verifiedAt)
* guards the email-2fa verify path so it cannot lower an AAL2 session
* adds unit tests per method and a downgrade test

## Issue that this pull request solves

Closes: FXA-14308

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
