### PR TITLE
chore(deps): replace request with native fetch

### DIFF
--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -3,7 +3,6 @@
 var config = require('./config').getProperties();
 
 var crypto = require('crypto');
-var request = require('request');
 var querystring = require('querystring');
 var { JWTool } = require('./lib/jwtool');
 
@@ -45,7 +44,7 @@ function verifyIdToken(oauthConfig, token) {
     });
 }
 
-function setupOAuthFlow(req, action, options = {}, cb) {
+async function setupOAuthFlow(req, action, options = {}, cb) {
   var params = {
     access_type: 'offline',
     client_id: config.client_id,
@@ -66,44 +65,43 @@ function setupOAuthFlow(req, action, options = {}, cb) {
     params.max_age = options.max_age;
   }
 
-  request.get(
+  var r, body;
+  try {
+    r = await fetch(config.issuer_uri + '/.well-known/openid-configuration');
+    body = await r.text();
+  } catch (err) {
+    return cb(err);
+  }
+  if (r.status >= 400) {
+    return cb('Config lookup error: ' + body);
+  }
+  // Named to avoid shadowing the module's own `config`, which is read above.
+  var issuerConfig;
+  try {
+    issuerConfig = JSON.parse(body);
+  } catch (err) {
+    return cb(err);
+  }
+
+  // eslint-disable-next-line fxa/async-crypto-random
+  params.state = crypto.randomBytes(32).toString('hex');
+  req.session.state = params.state;
+  oauthFlows[params.state] = { params: params, config: issuerConfig };
+
+  // Clear stale profile-AAL2 enforcement so an abandoned flow can't leak.
+  req.session.profileAal2Required = null;
+  req.session.profileAal2Bounced = null;
+
+  return cb(
+    null,
     {
-      uri: config.issuer_uri + '/.well-known/openid-configuration',
+      ...params,
+      // propagate query parameters out to the request, overriding
+      // the default values. This is used by the functional tests
+      // to, e.g., override the client_id or propagate an email.
+      ...req.query,
     },
-    function (err, r, body) {
-      if (err) {
-        return cb(err);
-      }
-      if (r.status >= 400) {
-        return cb('Config lookup error: ' + body);
-      }
-      try {
-        var config = JSON.parse(body);
-      } catch (err) {
-        return cb(err);
-      }
-
-      // eslint-disable-next-line fxa/async-crypto-random
-      params.state = crypto.randomBytes(32).toString('hex');
-      req.session.state = params.state;
-      oauthFlows[params.state] = { params: params, config: config };
-
-      // Clear stale profile-AAL2 enforcement so an abandoned flow can't leak.
-      req.session.profileAal2Required = null;
-      req.session.profileAal2Bounced = null;
-
-      return cb(
-        null,
-        {
-          ...params,
-          // propagate query parameters out to the request, overriding
-          // the default values. This is used by the functional tests
-          // to, e.g., override the client_id or propagate an email.
-          ...req.query,
-        },
-        config
-      );
-    }
+    issuerConfig
   );
 }
 
@@ -237,7 +235,7 @@ module.exports = function (app, db) {
     );
   });
 
-  app.get('/api/oauth', function (req, res) {
+  app.get('/api/oauth', async function (req, res) {
     var state = req.query.state;
     var code = req.query.code;
 
@@ -268,91 +266,101 @@ module.exports = function (app, db) {
       delete oauthFlows[state];
       delete req.session.state;
 
-      request.post(
-        {
-          uri: oauthConfig.token_endpoint,
-          json: {
+      var r, body;
+      try {
+        r = await fetch(oauthConfig.token_endpoint, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
             code: code,
             client_id: config.client_id,
             client_secret: config.client_secret,
-          },
-        },
-        function (err, r, body) {
-          if (err) {
-            return res.send(r.status, err);
-          }
-
-          console.log(err, body); //eslint-disable-line no-console
-          req.session.scopes = body.scopes;
-          req.session.token_type = body.token_type;
-          req.session.keys_jwe = body.keys_jwe;
-          var token = (req.session.token = body.access_token);
-          var id_token = body.id_token;
-
-          // Verify signature and extract claims from id_token
-          verifyIdToken(oauthConfig, id_token)
-            .then(function (claims) {
-              req.session.uid = claims.sub;
-              req.session.amr = claims.amr;
-              req.session.acr = claims.acr;
-              // Fetch additional profile data.
-              request.get(
-                {
-                  uri: oauthConfig.userinfo_endpoint,
-                  headers: {
-                    Authorization: 'Bearer ' + token,
-                  },
-                },
-                function (err, r, body) {
-                  console.log(err, body); //eslint-disable-line no-console
-                  if (err || r.status >= 400) {
-                    return res.send(r ? r.status : 400, err || body);
-                  }
-                  var profile = JSON.parse(body);
-                  var accountAal2 = !!profile.twoFactorAuthentication;
-
-                  // Passkey-only account with required profile AAL2: bounce
-                  // once to FxA to force TOTP enrolment. The bounced flag
-                  // caps it at one pass if the FxA divert is broken.
-                  if (
-                    req.session.profileAal2Required &&
-                    !accountAal2 &&
-                    !req.session.profileAal2Bounced
-                  ) {
-                    req.session.profileAal2Bounced = true;
-                    return res.redirect('/api/profile_aal2');
-                  }
-
-                  req.session.email = profile.email;
-                  req.session.subscriptions = profile.subscriptions;
-                  req.session.account_aal2 = accountAal2;
-                  req.session.profileAal2Required = null;
-                  req.session.profileAal2Bounced = null;
-
-                  // ensure the redirect goes to the correct place for either
-                  // the redirect or iframe OAuth flows.
-                  var referrer = req.get('referrer') || '';
-                  var isIframe = referrer.indexOf('/iframe') > -1;
-                  if (isIframe) {
-                    res.redirect('/iframe');
-                  } else {
-                    res.redirect('/');
-                  }
-                }
-              );
-            })
-            .catch(function (err) {
-              if (err.message === 'malformed') {
-                return res
-                  .status(400)
-                  .send(
-                    'Error: Client secret mismatch, please verify secret or obtain from an Admin.'
-                  );
-              }
-              return res.send(400, err);
-            });
+          }),
+        });
+        // Tolerate a non-JSON body so an error page is reported as-is
+        // rather than throwing here.
+        var text = await r.text();
+        try {
+          body = JSON.parse(text);
+        } catch (e) {
+          body = text;
         }
-      );
+      } catch (err) {
+        return res.send(r ? r.status : 400, err);
+      }
+
+      console.log(body); //eslint-disable-line no-console
+      if (r.status >= 400) {
+        return res.send(r.status, body);
+      }
+
+      req.session.scopes = body.scopes;
+      req.session.token_type = body.token_type;
+      req.session.keys_jwe = body.keys_jwe;
+      var token = (req.session.token = body.access_token);
+      var id_token = body.id_token;
+
+      try {
+        // Verify signature and extract claims from id_token
+        var claims = await verifyIdToken(oauthConfig, id_token);
+        req.session.uid = claims.sub;
+        req.session.amr = claims.amr;
+        req.session.acr = claims.acr;
+
+        // Fetch additional profile data.
+        var profileRes = await fetch(oauthConfig.userinfo_endpoint, {
+          headers: {
+            Authorization: 'Bearer ' + token,
+          },
+        });
+        var profileBody = await profileRes.text();
+        console.log(profileBody); //eslint-disable-line no-console
+        if (profileRes.status >= 400) {
+          return res.send(profileRes.status, profileBody);
+        }
+
+        var profile = JSON.parse(profileBody);
+        var accountAal2 = !!profile.twoFactorAuthentication;
+
+        // Passkey-only account with required profile AAL2: bounce
+        // once to FxA to force TOTP enrolment. The bounced flag
+        // caps it at one pass if the FxA divert is broken.
+        if (
+          req.session.profileAal2Required &&
+          !accountAal2 &&
+          !req.session.profileAal2Bounced
+        ) {
+          req.session.profileAal2Bounced = true;
+          return res.redirect('/api/profile_aal2');
+        }
+
+        req.session.email = profile.email;
+        req.session.subscriptions = profile.subscriptions;
+        req.session.account_aal2 = accountAal2;
+        req.session.profileAal2Required = null;
+        req.session.profileAal2Bounced = null;
+
+        // ensure the redirect goes to the correct place for either
+        // the redirect or iframe OAuth flows.
+        var referrer = req.get('referrer') || '';
+        var isIframe = referrer.indexOf('/iframe') > -1;
+        if (isIframe) {
+          res.redirect('/iframe');
+        } else {
+          res.redirect('/');
+        }
+      } catch (err) {
+        if (err.message === 'malformed') {
+          return res
+            .status(400)
+            .send(
+              'Error: Client secret mismatch, please verify secret or obtain from an Admin.'
+            );
+        }
+        return res.send(400, err);
+      }
     } else if (req.session.email) {
       // already logged in
       res.redirect('/');

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -28,8 +28,7 @@
     "cookie-session": "^2.1.0",
     "express": "^4.21.2",
     "ioredis": "^5.0.6",
-    "morgan": "^1.11.0",
-    "request": "^2.88.2"
+    "morgan": "^1.11.0"
   },
   "devDependencies": {
     "@types/cookie-session": "^2",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -113,7 +113,6 @@
     "punycode.js": "2.3.0",
     "qrcode": "^1.5.1",
     "redlock": "^5.0.0-beta.2",
-    "request": "^2.88.2",
     "uuid": "^11.1.1",
     "verror": "^1.10.1",
     "web-push": "3.4.4"

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -8,8 +8,6 @@ module.exports = (config) => {
   const EventEmitter = require('events').EventEmitter;
   const util = require('util');
 
-  const request = require('request');
-
   const tokens = require('../../lib/tokens')({ trace: function () {} }, config);
 
   util.inherits(ClientApi, EventEmitter);
@@ -36,7 +34,7 @@ module.exports = (config) => {
     return `Hawk id="${verify.credentials.id}"`;
   }
 
-  ClientApi.prototype.doRequest = function (
+  ClientApi.prototype.doRequest = async function (
     method,
     url,
     token,
@@ -44,61 +42,83 @@ module.exports = (config) => {
     headers,
     ignoreCors
   ) {
-    return new Promise((resolve, reject) => {
-      if (typeof headers === 'undefined') {
-        headers = {};
+    if (typeof headers === 'undefined') {
+      headers = {};
+    }
+    // We do a shallow clone to avoid tainting the caller's copy of `headers`.
+    headers = Object.assign({}, headers);
+    if (token && !headers.Authorization) {
+      headers.Authorization = hawkHeader(
+        token,
+        method,
+        url,
+        payload,
+        this.timeOffset
+      );
+    }
+    // Fetch defaults `accept-language: *` when unset.
+    // Avoid storing this on server as a user pref.
+    if (!headers['accept-language']) {
+      headers['accept-language'] = '';
+    }
+    const options = {
+      url: url,
+      method: method,
+      headers: headers,
+      json: payload || true,
+    };
+    this.emit('startRequest', options);
+
+    const requestHeaders = new Headers(headers);
+    if (payload && !requestHeaders.has('content-type')) {
+      requestHeaders.set('content-type', 'application/json');
+    }
+
+    let res, body;
+    try {
+      res = await fetch(url, {
+        method,
+        headers: requestHeaders,
+        body: payload ? JSON.stringify(payload) : undefined,
+      });
+      // Tolerate a non-JSON body so an error page stays inspectable by the
+      // caller rather than throwing here.
+      const text = await res.text();
+      try {
+        body = JSON.parse(text);
+      } catch (e) {
+        body = text;
       }
-      // We do a shallow clone to avoid tainting the caller's copy of `headers`.
-      headers = Object.assign({}, headers);
-      if (token && !headers.Authorization) {
-        headers.Authorization = hawkHeader(
-          token,
-          method,
-          url,
-          payload,
-          this.timeOffset
+    } catch (err) {
+      this.emit('endRequest', options, err, res);
+      throw err;
+    }
+
+    const timestamp = res.headers.get('timestamp');
+    if (timestamp) {
+      // Record time skew
+      this.timeOffset = Date.now() - parseInt(timestamp, 10) * 1000;
+    }
+
+    this.emit('endRequest', options, null, res);
+    if (body.error || res.status !== 200) {
+      throw body;
+    }
+
+    const allowedOrigin = res.headers.get('access-control-allow-origin');
+    if (!ignoreCors && allowedOrigin) {
+      // Requiring config outside this condition causes the local tests to fail
+      // because tokenLifetimes.passwordChangeToken is -1
+      const { config } = require('../../config');
+      const corsOrigin = config.get('corsOrigin');
+      if (corsOrigin.indexOf(allowedOrigin) < 0) {
+        throw new Error(
+          `Unexpected allowed origin: ${allowedOrigin} not in ${corsOrigin}`
         );
       }
-      const options = {
-        url: url,
-        method: method,
-        headers: headers,
-        json: payload || true,
-      };
-      if (headers['accept-language'] === undefined) {
-        delete headers['accept-language'];
-      }
-      this.emit('startRequest', options);
-      request(options, (err, res, body) => {
-        if (res && res.headers.timestamp) {
-          // Record time skew
-          this.timeOffset =
-            Date.now() - parseInt(res.headers.timestamp, 10) * 1000;
-        }
+    }
 
-        this.emit('endRequest', options, err, res);
-        if (err || body.error || res.statusCode !== 200) {
-          return reject(err || body);
-        }
-
-        const allowedOrigin = res.headers['access-control-allow-origin'];
-        if (!ignoreCors && allowedOrigin) {
-          // Requiring config outside this condition causes the local tests to fail
-          // because tokenLifetimes.passwordChangeToken is -1
-          const { config } = require('../../config');
-          const corsOrigin = config.get('corsOrigin');
-          if (corsOrigin.indexOf(allowedOrigin) < 0) {
-            return reject(
-              new Error(
-                `Unexpected allowed origin: ${allowedOrigin} not in ${corsOrigin}`
-              )
-            );
-          }
-        }
-
-        resolve(body);
-      });
-    });
+    return body;
   };
 
   ClientApi.prototype.doRequestWithBearerToken = function (

--- a/packages/fxa-geodb/lib/maxmind-db-downloader.js
+++ b/packages/fxa-geodb/lib/maxmind-db-downloader.js
@@ -9,7 +9,7 @@ var DEFAULTS = require('./defaults');
 var fs = require('fs');
 var mozlog = require('mozlog');
 var Promise = require('bluebird');
-var request = require('request');
+var { pipeline } = require('stream/promises');
 var zlib = require('zlib');
 
 // set up mozlog, default is `heka`
@@ -73,48 +73,37 @@ var MaxmindDbDownloader = function () {
 
   this.createDownloadPromise = function (url, targetFilePath) {
     // closure to separate multiple file-download
-    return function () {
-      return new Promise(function (resolve, reject) {
-        var stream = request(url);
-        var targetFilePathTemp = targetFilePath + '-temp';
+    return async function () {
+      var targetFilePathTemp = targetFilePath + '-temp';
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error('download responded with ' + res.status);
+        }
         // forces overwrite, even if file exists already
-        stream
-          .pipe(zlib.createGunzip())
-          .pipe(fs.createWriteStream(targetFilePathTemp))
-          .on('finish', function (err) {
-            if (err) {
-              logHelper('error', err);
-              reject(err);
-            } else {
-              // extraction is complete
-              logHelper('info', 'unzip complete');
-              try {
-                // load up geodb with the downloaded file
-                const geoDb = require('./fxa-geodb')({
-                  dbPath: targetFilePathTemp,
-                });
-                logHelper(
-                  'info',
-                  'checking if lookup works with downloaded file'
-                );
-                // check if lookup works with the downloaded file
-                geoDb(DEFAULTS.GEODB_TEST_IP);
-                // download worked, rename file
-                fs.renameSync(targetFilePathTemp, targetFilePath);
-                logHelper('info', 'lookup works, renaming downloaded file');
-                resolve();
-              } catch (err) {
-                // download resulted in an error, do not rename
-                // remove temp file
-                if (fs.existsSync(targetFilePathTemp)) {
-                  fs.unlinkSync(targetFilePathTemp);
-                }
-                logHelper('error', 'downloaded file not working');
-                reject(err);
-              }
-            }
-          });
-      });
+        await pipeline(
+          res.body,
+          zlib.createGunzip(),
+          fs.createWriteStream(targetFilePathTemp)
+        );
+        // extraction is complete
+        logHelper('info', 'unzip complete');
+        // load up geodb with the downloaded file
+        const geoDb = require('./fxa-geodb')({
+          dbPath: targetFilePathTemp,
+        });
+        logHelper('info', 'checking if lookup works with downloaded file');
+        // check if lookup works with the downloaded file
+        geoDb(DEFAULTS.GEODB_TEST_IP);
+        // download worked, rename file
+        fs.renameSync(targetFilePathTemp, targetFilePath);
+        logHelper('info', 'lookup works, renaming downloaded file');
+      } catch (err) {
+        // download or extraction resulted in an error, do not rename
+        fs.rmSync(targetFilePathTemp, { force: true });
+        logHelper('error', 'downloaded file not working');
+        throw err;
+      }
     };
   };
 

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -33,8 +33,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "cron": "4.1.3",
-    "mozlog": "^3.0.2",
-    "request": "^2.88.2"
+    "mozlog": "^3.0.2"
   },
   "devDependencies": {
     "audit-filter": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,6 @@ __metadata:
     morgan: "npm:^1.11.0"
     pm2: "npm:^7.0.0"
     prettier: "npm:^3.5.3"
-    request: "npm:^2.88.2"
   languageName: unknown
   linkType: soft
 
@@ -33841,7 +33840,6 @@ __metadata:
     qrcode: "npm:^1.5.1"
     read: "npm:3.0.1"
     redlock: "npm:^5.0.0-beta.2"
-    request: "npm:^2.88.2"
     rimraf: "npm:^6.0.1"
     sass: "npm:^1.80.4"
     simplesmtp: "npm:0.3.35"
@@ -34112,7 +34110,6 @@ __metadata:
     mozlog: "npm:^3.0.2"
     nyc: "npm:^17.1.0"
     prettier: "npm:^3.5.3"
-    request: "npm:^2.88.2"
     rimraf: "npm:^6.0.1"
     sinon: "npm:^14.0.0"
   languageName: unknown


### PR DESCRIPTION
## Because

- `request` is deprecated and unmaintained upstream (request/request#3142); native `fetch` is already the convention here.

## This pull request

- Converts the auth-server test client's `doRequest`, the geodb downloader, and 123done's three OAuth call sites to native `fetch`, and drops `request` from those package.json files.
- Fixes two latent bugs the swap surfaced: 123done read `r.status` off a `request` response (always `undefined`, so the `>= 400` guards never fired), and failed geodb downloads hung instead of rejecting.


## Issue that this pull request solves

Refs: FXA-4892

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information (Optional)
- `fetch` substitutes `accept-language: *` when the header is absent, and the server persists that as the account locale, so the test client now sends it empty. 
- This is part 2 of the `request` removal. `fxa-profile-server` will be handled in part 3; it needs a nock upgrade to mock `fetch`.
