### PR TITLE
feat(oauth): add acr and auth_time to JWT access token and introspect

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/accessToken.js
+++ b/packages/fxa-auth-server/lib/oauth/db/accessToken.js
@@ -19,7 +19,10 @@ AccessToken.generate = function (
   scope,
   profileChangedAt,
   expiresAt,
-  ttl
+  ttl,
+  authAt,
+  amr,
+  aal
 ) {
   const token = unique.token();
   const tokenId = encrypt.hash(token);
@@ -36,7 +39,13 @@ AccessToken.generate = function (
     profileChangedAt || 0,
     expiresAt || new Date(Date.now() + (ttl * 1000 || MAX_TTL)),
     // This is the one and only time the caller can get at the unhashed token.
-    token
+    token,
+    'bearer',
+    // Authentication-event metadata for RFC 9470 step-up (undefined when the
+    // grant did not carry them).
+    authAt,
+    amr,
+    aal
   );
 };
 

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -134,7 +134,12 @@ class OauthDB extends ConnectedServicesDb {
       vals.scope,
       vals.profileChangedAt,
       vals.expiresAt,
-      vals.ttl
+      vals.ttl,
+      // Authentication-event metadata carried on the grant, persisted so token
+      // introspection can report acr/auth_time/amr (RFC 9470 §6.2).
+      vals.authAt,
+      vals.amr,
+      vals.aal
     );
     if (
       JWT_ACCESS_TOKENS_ENABLED &&

--- a/packages/fxa-auth-server/lib/oauth/db/index.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/db/index.spec.ts
@@ -16,6 +16,7 @@ const REDIS_DOWN = new Error('ECONNREFUSED');
 
 type RedisMock = {
   getAccessToken: jest.Mock;
+  setAccessToken: jest.Mock;
   removeAccessToken: jest.Mock;
   getAccessTokens: jest.Mock;
   removeAccessTokensForUser: jest.Mock;
@@ -25,6 +26,7 @@ type RedisMock = {
 function buildRedisMock(): RedisMock {
   return {
     getAccessToken: jest.fn().mockResolvedValue(MOCK_ACCESS_TOKEN),
+    setAccessToken: jest.fn().mockResolvedValue(undefined),
     removeAccessToken: jest.fn().mockResolvedValue(true),
     getAccessTokens: jest.fn().mockResolvedValue([MOCK_ACCESS_TOKEN]),
     removeAccessTokensForUser: jest.fn().mockResolvedValue(undefined),
@@ -66,6 +68,44 @@ describe('lib/oauth/db - access tokens', () => {
 
       expect(result).toBeUndefined();
       expect(result).not.toBeNull();
+    });
+  });
+
+  describe('generateAccessToken', () => {
+    // The grant carries authAt/amr/aal; they must be persisted on the access
+    // token so introspection can report acr/auth_time/amr (RFC 9470 §6.2).
+    it('persists authAt/amr/aal from the grant onto the access token', async () => {
+      const token = await oauthDb.generateAccessToken({
+        clientId: Buffer.from('deadbeef', 'hex'),
+        name: 'client',
+        canGrant: false,
+        publicClient: false,
+        userId: Buffer.from('feedcafe', 'hex'),
+        scope: 'profile',
+        authAt: 1_700_000_000,
+        amr: ['pwd', 'otp'],
+        aal: 2,
+      });
+
+      expect(token.authAt).toBe(1_700_000_000);
+      expect(token.amr).toEqual(['pwd', 'otp']);
+      expect(token.aal).toBe(2);
+      expect(redis.setAccessToken).toHaveBeenCalledWith(token);
+    });
+
+    it('leaves the metadata undefined when the grant carries none', async () => {
+      const token = await oauthDb.generateAccessToken({
+        clientId: Buffer.from('deadbeef', 'hex'),
+        name: 'client',
+        canGrant: false,
+        publicClient: false,
+        userId: Buffer.from('feedcafe', 'hex'),
+        scope: 'profile',
+      });
+
+      expect(token.authAt).toBeUndefined();
+      expect(token.amr).toBeUndefined();
+      expect(token.aal).toBeUndefined();
     });
   });
 

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -243,10 +243,14 @@ async function generateIdToken(grant, accessToken) {
     claims['fxa-aal'] = grant.aal;
     claims.acr = 'AAL' + grant.aal;
   }
-  // For legacy reasons auth_time was stored as authAt in our db. It also
-  // needs to be converted to seconds.
+  // auth_time is the authentication event, in seconds since the epoch.
+  // grant.authAt is already in seconds (it comes from fxa-lastAuthAt /
+  // session_token.lastAuthAt(), and is the same value emitted as `auth_at` on
+  // the token response and as `auth_time` on the JWT access token), so emit it
+  // directly. It previously divided by 1000 again, yielding a value ~1000x too
+  // small.
   if (grant.authAt) {
-    claims.auth_time = Math.floor(grant.authAt / 1000);
+    claims.auth_time = grant.authAt;
   }
 
   return jwt.sign(claims);

--- a/packages/fxa-auth-server/lib/oauth/grant.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/grant.spec.ts
@@ -281,10 +281,11 @@ describe('generateTokens', () => {
   });
 
   it('should return authAt from grant', async () => {
-    const now = Date.now();
-    requestedGrant.authAt = now;
+    // authAt is seconds since the epoch (from session_token.lastAuthAt()).
+    const authAtSeconds = 1_700_000_000;
+    requestedGrant.authAt = authAtSeconds;
     const result = await generateTokens(requestedGrant);
-    expect(result.auth_at).toBe(now);
+    expect(result.auth_at).toBe(authAtSeconds);
   });
 
   it('should return keysJwe from grant', async () => {
@@ -320,12 +321,15 @@ describe('generateTokens', () => {
     ]);
   });
 
-  it('should propagate auth_time in claims', async () => {
+  it('propagates auth_time (seconds) in id_token claims without re-dividing', async () => {
     requestedGrant.scope = ScopeSet.fromArray(['openid']);
-    requestedGrant.authAt = Date.now();
+    // authAt is already seconds since the epoch; auth_time must equal it, not
+    // authAt/1000 (the previous bug produced a value ~1000x too small).
+    const authAtSeconds = 1_700_000_000;
+    requestedGrant.authAt = authAtSeconds;
     const result = await generateTokens(requestedGrant);
     expect(result.id_token).toBeTruthy();
     const jwt = decodeJWT(result.id_token);
-    expect(jwt.claims.auth_time).toBe(Math.floor(requestedGrant.authAt / 1000));
+    expect(jwt.claims.auth_time).toBe(authAtSeconds);
   });
 });

--- a/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
@@ -57,6 +57,19 @@ exports.create = async function generateJWTAccessToken(accessToken, grant) {
     claims['fxa-profileChangedAt'] = grant.profileChangedAt;
   }
 
+  // RFC 9470 §5: reflect the session's authentication level (acr) and the time of
+  // the authentication event (auth_time) on the access token, mirroring the ID
+  // token (see grant.js `generateIdToken`). `grant.authAt` is already in seconds
+  // (the same value emitted as `auth_at` on the token response), so it is emitted
+  // directly without further conversion.
+  if (grant.aal) {
+    claims.acr = 'AAL' + grant.aal;
+  }
+
+  if (grant.authAt) {
+    claims.auth_time = grant.authAt;
+  }
+
   return {
     ...accessToken,
     jwt_token: await exports.sign(claims),

--- a/packages/fxa-auth-server/lib/oauth/jwt_access_token.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/jwt_access_token.spec.ts
@@ -109,6 +109,41 @@ describe('lib/jwt_access_token', () => {
       );
     });
 
+    it('propagates `acr` derived from the grant AAL', async () => {
+      requestedGrant.aal = 2;
+      await JWTAccessToken.create(mockAccessToken, requestedGrant);
+      const signedClaims = mockSign.mock.calls[0][0];
+      expect(Object.keys(signedClaims)).toHaveLength(8);
+
+      expect(signedClaims.acr).toBe('AAL2');
+    });
+
+    it('reflects a lower AAL in the `acr` claim', async () => {
+      requestedGrant.aal = 1;
+      await JWTAccessToken.create(mockAccessToken, requestedGrant);
+      const signedClaims = mockSign.mock.calls[0][0];
+
+      expect(signedClaims.acr).toBe('AAL1');
+    });
+
+    it('propagates `auth_time` directly (already in seconds, no /1000)', async () => {
+      // grant.authAt is seconds-since-epoch, matching the token response `auth_at`.
+      requestedGrant.authAt = 1_700_000_000;
+      await JWTAccessToken.create(mockAccessToken, requestedGrant);
+      const signedClaims = mockSign.mock.calls[0][0];
+      expect(Object.keys(signedClaims)).toHaveLength(8);
+
+      expect(signedClaims.auth_time).toBe(1_700_000_000);
+    });
+
+    it('omits `acr` and `auth_time` when the grant carries no aal/authAt', async () => {
+      await JWTAccessToken.create(mockAccessToken, requestedGrant);
+      const signedClaims = mockSign.mock.calls[0][0];
+
+      expect(signedClaims).not.toHaveProperty('acr');
+      expect(signedClaims).not.toHaveProperty('auth_time');
+    });
+
     it('defaults oldsync scope to tokenserver audience', async () => {
       requestedGrant.scope = ScopeSet.fromString(OAUTH_SCOPE_OLD_SYNC);
       await JWTAccessToken.create(mockAccessToken, requestedGrant);

--- a/packages/fxa-auth-server/lib/routes/oauth/introspect.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/introspect.js
@@ -50,8 +50,18 @@ module.exports = ({ oauthDB }) => ({
           .description(DESCRIPTION['fxa-lastUsedAt']),
         // RFC 9470 §6.2 — authentication level, event time, and methods of the
         // access token. Access tokens only; refresh tokens never carry these.
+        // NOTE on units: `auth_time` is SECONDS since the epoch (OIDC/RFC 9470),
+        // whereas this endpoint's `iat`/`exp` are historically emitted in
+        // MILLISECONDS (`.getTime()`). They therefore differ in magnitude by
+        // ~1000x; this is intentional to preserve backwards compatibility for
+        // RPs that already parse iat/exp as milliseconds.
         acr: Joi.string().optional(),
-        auth_time: Joi.number().optional(),
+        auth_time: Joi.number()
+          .optional()
+          .description(
+            'The authentication event time in seconds since the epoch (OIDC). ' +
+              'Note: iat/exp on this endpoint are in milliseconds.'
+          ),
         amr: Joi.array().items(Joi.string()).optional(),
       }),
     },
@@ -118,7 +128,10 @@ module.exports = ({ oauthDB }) => ({
         // access tokens. These are persisted only on access tokens, so a refresh
         // token never surfaces them — that is what keeps elevation from surviving
         // a token refresh. `auth_time` is seconds since epoch (as sourced from the
-        // grant's authAt), matching the token response's `auth_at`.
+        // grant's authAt), matching the token response's `auth_at`. This is
+        // intentionally a different unit from `iat`/`exp` above, which this
+        // endpoint has long emitted in milliseconds (`.getTime()`); changing
+        // those would break RPs that parse them as ms, so they are left as-is.
         if (tokenType === 'access_token') {
           if (token.aal) {
             response.acr = 'AAL' + token.aal;

--- a/packages/fxa-auth-server/lib/routes/oauth/introspect.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/introspect.js
@@ -48,6 +48,11 @@ module.exports = ({ oauthDB }) => ({
         'fxa-lastUsedAt': Joi.number()
           .optional()
           .description(DESCRIPTION['fxa-lastUsedAt']),
+        // RFC 9470 §6.2 — authentication level, event time, and methods of the
+        // access token. Access tokens only; refresh tokens never carry these.
+        acr: Joi.string().optional(),
+        auth_time: Joi.number().optional(),
+        amr: Joi.array().items(Joi.string()).optional(),
       }),
     },
     handler: async function introspectEndpoint(req) {
@@ -107,6 +112,23 @@ module.exports = ({ oauthDB }) => ({
 
         if (token.lastUsedAt) {
           response['fxa-lastUsedAt'] = token.lastUsedAt.getTime();
+        }
+
+        // RFC 9470 §6.2: report the session's authentication level and event on
+        // access tokens. These are persisted only on access tokens, so a refresh
+        // token never surfaces them — that is what keeps elevation from surviving
+        // a token refresh. `auth_time` is seconds since epoch (as sourced from the
+        // grant's authAt), matching the token response's `auth_at`.
+        if (tokenType === 'access_token') {
+          if (token.aal) {
+            response.acr = 'AAL' + token.aal;
+          }
+          if (token.authAt) {
+            response.auth_time = token.authAt;
+          }
+          if (token.amr) {
+            response.amr = token.amr;
+          }
         }
       }
 

--- a/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
@@ -3611,6 +3611,12 @@ describe('#integration - /v1', function () {
       expect(result.iat).toBeLessThan(Date.now());
       expect(result.sub).toBe(USERID);
       expect(result['fxa-lastUsedAt']).toBeUndefined();
+      // RFC 9470 §6.2: the access token reports the session's authentication
+      // level, event time (seconds), and methods. GOOD_CLAIMS is AAL1, so even a
+      // non-step-up token surfaces its achieved level.
+      expect(result.acr).toBe(ACR);
+      expect(result.auth_time).toBe(AUTH_AT);
+      expect(result.amr).toEqual(AMR);
     });
 
     it('should return { active: false } if token is an access token, but token_type_hint=refresh_token', async () => {
@@ -3679,6 +3685,12 @@ describe('#integration - /v1', function () {
       expect(result.sub).toBe(USERID);
       expect(typeof result['fxa-lastUsedAt']).toBe('number');
       expect(result['fxa-lastUsedAt']).toBeLessThan(Date.now());
+      // Elevation must not survive a token refresh: refresh tokens carry none of
+      // the authentication-event metadata (they are MySQL-backed and never
+      // stamped with authAt/amr/aal).
+      expect(result.acr).toBeUndefined();
+      expect(result.auth_time).toBeUndefined();
+      expect(result.amr).toBeUndefined();
     });
 
     it('should return { active: false } if token is an refresh token, but token_type_hint=access_token', async () => {

--- a/packages/fxa-shared/db/models/auth/access-token.ts
+++ b/packages/fxa-shared/db/models/auth/access-token.ts
@@ -17,7 +17,12 @@ export class AccessToken {
     public profileChangedAt: number,
     public expiresAt: Date,
     public token: Buffer | null,
-    public type: string = 'bearer'
+    public type: string = 'bearer',
+    // Authentication-event metadata for RFC 9470 step-up. Present on tokens
+    // minted from a grant that carried them; undefined for legacy/other tokens.
+    public authAt?: number, // seconds since epoch (the authentication event)
+    public amr?: string[],
+    public aal?: number
   ) {}
 
   get clientCanGrant() {
@@ -52,6 +57,11 @@ export class AccessToken {
       createdAt: this.createdAt.getTime(),
       profileChangedAt: this.profileChangedAt,
       expiresAt: this.expiresAt.getTime(),
+      // JSON.stringify omits these keys when undefined, so tokens without
+      // authentication-event metadata serialize exactly as before.
+      authAt: this.authAt,
+      amr: this.amr,
+      aal: this.aal,
     };
   }
 
@@ -81,7 +91,11 @@ export class AccessToken {
       new Date(json.createdAt),
       json.profileChangedAt,
       new Date(json.expiresAt),
-      null
+      null,
+      'bearer',
+      json.authAt,
+      json.amr,
+      json.aal
     );
   }
 }

--- a/packages/fxa-shared/test/db/models/auth/access-token.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/access-token.spec.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import 'mocha';
+
+import { assert } from 'chai';
+
+import { AccessToken } from '../../../../db/models/auth/access-token';
+
+// Deterministic. authAt is seconds since epoch; the others are ms.
+const MOCK_CREATED_AT = 1_700_000_000_000;
+const MOCK_EXPIRES_AT = 1_700_000_100_000;
+const MOCK_AUTH_AT = 1_700_000_000;
+
+const baseJson = {
+  clientId: 'deadbeef',
+  name: 'client',
+  canGrant: false,
+  publicClient: false,
+  userId: 'feedcafe',
+  scope: 'profile',
+  token: 'ffff',
+  createdAt: MOCK_CREATED_AT,
+  profileChangedAt: MOCK_CREATED_AT,
+  expiresAt: MOCK_EXPIRES_AT,
+};
+
+describe('AccessToken authentication-event metadata (RFC 9470)', () => {
+  it('round-trips authAt, amr, and aal through toJSON/parse', () => {
+    const token = AccessToken.parse(
+      JSON.stringify({
+        ...baseJson,
+        authAt: MOCK_AUTH_AT,
+        amr: ['pwd', 'otp'],
+        aal: 2,
+      })
+    );
+
+    assert.strictEqual(token.authAt, MOCK_AUTH_AT);
+    assert.deepEqual(token.amr, ['pwd', 'otp']);
+    assert.strictEqual(token.aal, 2);
+
+    const json = token.toJSON() as any;
+    assert.strictEqual(json.authAt, MOCK_AUTH_AT);
+    assert.deepEqual(json.amr, ['pwd', 'otp']);
+    assert.strictEqual(json.aal, 2);
+
+    // A full re-hydration preserves the model, including the new fields.
+    const reparsed = AccessToken.parse(JSON.stringify(json));
+    assert.deepEqual(reparsed, token);
+  });
+
+  it('omits the metadata keys when the token carries none', () => {
+    const token = AccessToken.parse(JSON.stringify(baseJson));
+
+    assert.isUndefined(token.authAt);
+    assert.isUndefined(token.amr);
+    assert.isUndefined(token.aal);
+
+    // JSON.stringify drops undefined values, so tokens without the metadata
+    // serialize exactly as they did before this field was added.
+    const serialized = JSON.stringify(token.toJSON());
+    assert.notInclude(serialized, 'authAt');
+    assert.notInclude(serialized, 'amr');
+    assert.notInclude(serialized, 'aal');
+  });
+});


### PR DESCRIPTION
## Because

* RFC 9470 section 5 requires the authorization server to include acr and auth_time on the access token, but the JWT access token builder emitted neither
* the ID token already carries both; the access token should match
* RFC 9470 section 6.2 adds acr and auth_time as top-level introspection members, but these values were unreachable — they lived only on the codes row, which is deleted at token exchange and never copied onto the access token
 
## This pull request

* emits acr ("AAL" + aal) and auth_time on the JWT access token, mirroring the ID token, whenever the grant carries aal/authAt
* sources auth_time from grant.authAt directly, which is already in seconds (matching the token response auth_at) — no extra conversion
* persists authAt, amr, and aal on the Redis-backed access token (model constructor, toJSON, and parse; threaded through AccessToken.generate and generateAccessToken from the grant)
* returns acr ("AAL" + aal), auth_time (seconds, from authAt), and amr from /introspect for access tokens, and adds them to the Joi schema
* leaves refresh tokens untouched, so elevation does not survive a token refresh

## Issue that this pull request solves

Closes: FXA-14309 / FXA-14310

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
