### PR TITLE
feat(settings): add desktop Sync success card

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/en.ftl
@@ -1,0 +1,11 @@
+## SyncSuccess page - Part of the desktop-to-mobile pairing flow
+## Users see this on their computer once the mobile device has been paired.
+## It confirms that sync is on and offers the follow-up actions.
+
+# "syncing" here means copying data between the user's devices
+pair2-authority-sync-success-heading = You’re syncing
+pair2-authority-sync-success-description = Your tabs, bookmarks, passwords, and more are ready across your devices.
+# Opens the tabs that are open on the user's other synced devices
+pair2-authority-sync-success-view-tabs-button = View synced tabs
+# Opens the browser settings that control what is synced
+pair2-authority-sync-success-sync-settings-button = Sync settings

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.stories.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import SyncSuccess from '.';
+import { Subject } from './mocks';
+
+export default {
+  title: 'Pages/Pair2/Authority/SyncSuccess',
+  component: SyncSuccess,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Default = () => <Subject />;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.test.tsx
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { Subject } from './mocks';
+
+describe('Pair2/Authority/SyncSuccess page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle. No message on this card takes a variable, so no
+  // arguments are passed.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<Subject />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'));
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('renders the heading and description', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'You’re syncing'
+    );
+    screen.getByText(
+      'Your tabs, bookmarks, passwords, and more are ready across your devices.'
+    );
+  });
+
+  it('exposes the illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      'Mozilla logo'
+    ]);
+  });
+
+  it('calls onViewSyncedTabs when the primary button is clicked', async () => {
+    const user = userEvent.setup();
+    const onViewSyncedTabs = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onViewSyncedTabs }} />);
+
+    await user.click(screen.getByRole('button', { name: 'View synced tabs' }));
+
+    expect(onViewSyncedTabs).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSyncSettings when the sync settings button is clicked', async () => {
+    const user = userEvent.setup();
+    const onSyncSettings = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onSyncSettings }} />);
+
+    await user.click(screen.getByRole('button', { name: 'Sync settings' }));
+
+    expect(onSyncSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.test.tsx
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { Subject } from './mocks';
+
+describe('Pair2/Authority/SyncSuccess page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle. No message on this card takes a variable, so no
+  // arguments are passed.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<Subject />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'));
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('renders the heading and description', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'You’re syncing'
+    );
+    screen.getByText(
+      'Your tabs, bookmarks, passwords, and more are ready across your devices.'
+    );
+  });
+
+  it('exposes the illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the single image this card renders.
+      'Mozilla logo',
+      'The Firefox fox mascot looking up at floating cards showing an extension, a shield and a lock, and a list of saved items, representing data synced across devices',
+    ]);
+  });
+
+  it('calls onViewSyncedTabs when the primary button is clicked', async () => {
+    const user = userEvent.setup();
+    const onViewSyncedTabs = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onViewSyncedTabs }} />);
+
+    await user.click(screen.getByRole('button', { name: 'View synced tabs' }));
+
+    expect(onViewSyncedTabs).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSyncSettings when the sync settings button is clicked', async () => {
+    const user = userEvent.setup();
+    const onSyncSettings = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onSyncSettings }} />);
+
+    await user.click(screen.getByRole('button', { name: 'Sync settings' }));
+
+    expect(onSyncSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.tsx
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import { SyncSuccessImage } from '../../../../components/images';
+
+export type SyncSuccessProps = {
+  /**
+   * Opens the list of tabs open on the user's other synced devices. Required so
+   * that routing this card cannot leave the primary action inert — the browser
+   * channel call itself lands with the flow wiring.
+   */
+  onViewSyncedTabs: () => void;
+  /** Opens sync settings. Required for the same reason as `onViewSyncedTabs`. */
+  onSyncSettings: () => void;
+};
+
+/**
+ * The desktop screen shown once the mobile device has finished pairing and
+ * sync is active. It confirms what is now syncing and offers the two follow-up
+ * actions.
+ *
+ * Presentational only: routing and the page-view/Glean metrics that sibling
+ * pairing pages emit land with the flow wiring.
+ */
+const SyncSuccess = ({
+  onViewSyncedTabs,
+  onSyncSettings,
+}: SyncSuccessProps) => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FtlMsg id="pair2-authority-sync-success-heading">
+        <h1 className="card-header">You’re syncing</h1>
+      </FtlMsg>
+      <FtlMsg id="pair2-authority-sync-success-description">
+        <p className="text-base">
+          Your tabs, bookmarks, passwords, and more are ready across your
+          devices.
+        </p>
+      </FtlMsg>
+
+      <SyncSuccessImage className="mt-8 h-40 w-auto" />
+
+      <FtlMsg id="pair2-authority-sync-success-view-tabs-button">
+        <button
+          type="button"
+          onClick={onViewSyncedTabs}
+          className="cta-primary cta-xl mt-8 w-full"
+        >
+          View synced tabs
+        </button>
+      </FtlMsg>
+      <FtlMsg id="pair2-authority-sync-success-sync-settings-button">
+        <button
+          type="button"
+          onClick={onSyncSettings}
+          className="mt-4 py-2 text-base text-grey-900 underline dark:text-grey-10"
+        >
+          Sync settings
+        </button>
+      </FtlMsg>
+    </div>
+  </AppLayout>
+);
+
+export default SyncSuccess;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import { SyncSuccessImage } from '../../../../components/images';
+
+export type SyncSuccessProps = {
+  /**
+   * Opens the list of tabs open on the user's other synced devices. Required so
+   * that routing this card cannot leave the primary action inert — the browser
+   * channel call itself lands with the flow wiring.
+   */
+  onViewSyncedTabs: () => void;
+  /** Opens sync settings. Required for the same reason as `onViewSyncedTabs`. */
+  onSyncSettings: () => void;
+};
+
+/**
+ * The desktop screen shown once the mobile device has finished pairing and
+ * sync is active. It confirms what is now syncing and offers the two follow-up
+ * actions.
+ */
+const SyncSuccess = ({
+  onViewSyncedTabs,
+  onSyncSettings,
+}: SyncSuccessProps) => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FtlMsg id="pair2-authority-sync-success-heading">
+        <h1 className="card-header">You’re syncing</h1>
+      </FtlMsg>
+      <FtlMsg id="pair2-authority-sync-success-description">
+        <p className="text-base">
+          Your tabs, bookmarks, passwords, and more are ready across your
+          devices.
+        </p>
+      </FtlMsg>
+
+      <SyncSuccessImage className="mt-8 h-40 w-auto" />
+
+      <FtlMsg id="pair2-authority-sync-success-view-tabs-button">
+        <button
+          type="button"
+          onClick={onViewSyncedTabs}
+          className="cta-primary cta-xl mt-8 w-full"
+        >
+          View synced tabs
+        </button>
+      </FtlMsg>
+      <FtlMsg id="pair2-authority-sync-success-sync-settings-button">
+        <button
+          type="button"
+          onClick={onSyncSettings}
+          className="link-dark-grey"
+        >
+          Sync settings
+        </button>
+      </FtlMsg>
+    </div>
+  </AppLayout>
+);
+
+export default SyncSuccess;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/mocks.tsx
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import SyncSuccess, { SyncSuccessProps } from '.';
+
+export const Subject = ({
+  onViewSyncedTabs = () => {},
+  onSyncSettings = () => {},
+}: Partial<SyncSuccessProps> = {}) => (
+  <SyncSuccess {...{ onViewSyncedTabs, onSyncSettings }} />
+);


### PR DESCRIPTION
## Because
- We are updating pairing flows and want to land UI components / pages first.
- Adds the desktop screen confirming the device is connected and syncing.

## This pull request
- Adds `packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.tsx`.
- Adds storybook stories for the page.
- Adds l10n files.

## Issue that this pull request solves

Closes: FXA-14240

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out the storybook output [here](https://mozilla.github.io/fxa/storybooks/pr-20981/fxa-settings/?path=/story/pages-pair2-authority-syncsuccess--default). Compare against figma designs (linked in ticket). Check out code for AI slop and over all adherence to patterns set forth in FxA.

Note, that this is just UI work, wiring up functionality comes later.

## Screenshots (Optional)

See story books.

## Other information (Optional)

Based on #20979, which adds the illustration. Follows the pattern set in #20952 (FXA-14234).
