### PR TITLE
feat(settings): add mobile Connect this device card

### DIFF
--- a/libs/shared/assets/src/styles/links.css
+++ b/libs/shared/assets/src/styles/links.css
@@ -18,6 +18,11 @@
     active:text-grey-700;
 }
 
+.link-dark-grey {
+  @apply underline text-base text-grey-900 mt-4 py-2
+    dark:text-grey-10
+}
+
 .link-white {
   @apply underline text-white rounded-sm focus:shadow-input-grey-focus focus-visible:shadow-input-grey-focus focus-visible:outline-none active:text-grey-200;
 }
@@ -28,6 +33,9 @@
   }
   .link-grey:hover {
     @apply text-grey-600;
+  }
+  .link-dark-grey:hover {
+    @apply text-grey-600 dark:text-grey-100;
   }
   .link-white:hover {
     @apply text-grey-100;

--- a/packages/fxa-react/styles/links.css
+++ b/packages/fxa-react/styles/links.css
@@ -18,6 +18,11 @@
     active:text-grey-700;
 }
 
+.link-dark-grey {
+  @apply underline text-base text-grey-900 mt-4 py-2
+    dark:text-grey-10
+}
+
 .link-white {
   @apply underline text-white rounded-sm focus:shadow-input-grey-focus focus-visible:shadow-input-grey-focus focus-visible:outline-none active:text-grey-200;
 }
@@ -27,6 +32,9 @@
     @apply text-blue-600 dark:text-blue-300;
   }
   .link-grey:hover {
+    @apply text-grey-600 dark:text-grey-100;
+  }
+  .link-dark-grey:hover {
     @apply text-grey-600 dark:text-grey-100;
   }
   .link-white:hover {

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/en.ftl
@@ -1,0 +1,13 @@
+## ConnectThisDevice page - Part of the desktop-to-mobile pairing flow
+## Users see this on their mobile device after scanning the pairing QR code
+## shown on their computer. It asks them to confirm connecting the mobile
+## device to their account, and shows that computer's details so they can
+## verify the request.
+
+# "this device" is the mobile device the user is holding, not the computer
+# whose details are shown below the heading
+pair2-supplicant-connect-this-device-heading = Connect this device to your account?
+# Confirms the pairing attempt
+pair2-supplicant-connect-this-device-connect-button = Connect
+# Dismisses the pairing attempt
+pair2-supplicant-connect-this-device-cancel-button = Cancel

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.stories.tsx
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import ConnectThisDevice from '.';
+import {
+  MOCK_METADATA_UNKNOWN_LOCATION,
+  MOCK_METADATA_WITH_LOCATION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import {
+  MOCK_LONG_EMAIL,
+  MOCK_METADATA_LONG_DEVICE_NAME,
+  Subject,
+} from './mocks';
+
+export default {
+  title: 'Pages/Pair2/Supplicant/ConnectThisDevice',
+  component: ConnectThisDevice,
+  decorators: [withLocalization],
+} as Meta;
+
+export const WithDeviceName = () => <Subject />;
+
+// No device name on the pairing payload, so the device line falls back to the OS.
+export const WithoutDeviceName = () => (
+  <Subject remoteMetadata={MOCK_METADATA_WITH_LOCATION} />
+);
+
+// Geo lookup resolved nothing, so the location line reads "Location unknown".
+export const WithUnknownLocation = () => (
+  <Subject remoteMetadata={MOCK_METADATA_UNKNOWN_LOCATION} />
+);
+
+export const WithLongDeviceName = () => (
+  <Subject remoteMetadata={MOCK_METADATA_LONG_DEVICE_NAME} />
+);
+
+export const WithLongEmail = () => <Subject email={MOCK_LONG_EMAIL} />;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.test.tsx
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import {
+  MOCK_CITY,
+  MOCK_COUNTRY,
+  MOCK_DEVICE_FAMILY,
+  MOCK_DEVICE_NAME,
+  MOCK_IP_ADDRESS,
+  MOCK_REGION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import { MOCK_EMAIL } from '../../../mocks';
+import { Subject } from './mocks';
+
+const FTL_ARGS = {
+  browserName: MOCK_DEVICE_FAMILY,
+  deviceName: MOCK_DEVICE_NAME,
+  city: MOCK_CITY,
+  region: MOCK_REGION,
+  country: MOCK_COUNTRY,
+  ipAddress: MOCK_IP_ADDRESS,
+};
+
+describe('Pair2/Supplicant/ConnectThisDevice page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle — including a rename of the `device-info-*` ids that
+  // DeviceInfoBlock owns.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<Subject />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'));
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle, FTL_ARGS));
+  });
+
+  it('renders the heading and the account email', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Connect this device to your account?'
+    );
+    screen.getByText(MOCK_EMAIL);
+  });
+
+  it('exposes the brand lockup and illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the two images this card renders.
+      'Mozilla logo',
+      'Firefox logo',
+      'A desktop browser window and a mobile phone, both syncing, with the Firefox mascot alongside them',
+    ]);
+  });
+
+  it('renders the device info block with the device name inline', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    screen.getByText('Firefox on Ultron');
+    screen.getByText('Vancouver, British Columbia, Canada (estimated)');
+    screen.getByText('IP address: XX.XX.XXX.XXX');
+    expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('calls onConnect when the connect button is clicked', async () => {
+    const user = userEvent.setup();
+    const onConnect = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onConnect }} />);
+
+    await user.click(screen.getByRole('button', { name: 'Connect' }));
+
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when the cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onCancel }} />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import DeviceInfoBlock from '../../../../components/DeviceInfoBlock';
+import {
+  FirefoxWordmarkImage,
+  SyncDevicesImage,
+} from '../../../../components/images';
+import { RemoteMetadata } from '../../../../lib/types';
+
+export type ConnectThisDeviceProps = {
+  /**
+   * The account this device would be connected to, shown so the user can
+   * confirm it is the one they meant to pair with.
+   */
+  email: string;
+  /**
+   * Details of the device that started pairing, shown so the user can confirm
+   * the request came from their own computer. Supplied by the caller — this
+   * component does not read the pairing channel itself.
+   */
+  remoteMetadata: RemoteMetadata;
+  /**
+   * Completes pairing. Required so that routing this card cannot leave an
+   * action inert — the flow logic itself lands with the route.
+   */
+  onConnect: () => void;
+  /**
+   * Aborts pairing. Required for the same reason as `onConnect`.
+   */
+  onCancel: () => void;
+};
+
+/**
+ * The mobile screen shown after the user scans the pairing QR code, asking
+ * them to confirm connecting this device to their account. It shows the
+ * requesting computer's details so they can verify the request.
+ *
+ * Presentational only: routing and the page-view/Glean metrics that sibling
+ * pairing pages emit land with the flow wiring.
+ */
+const ConnectThisDevice = ({
+  email,
+  remoteMetadata,
+  onConnect,
+  onCancel,
+}: ConnectThisDeviceProps) => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+      <SyncDevicesImage className="mt-10 h-[120px] w-auto" />
+
+      <FtlMsg id="pair2-supplicant-connect-this-device-heading">
+        <h1 className="card-header mt-4">
+          Connect this device to your account?
+        </h1>
+      </FtlMsg>
+      {/* Raw user data, so it is deliberately not wrapped in FtlMsg. */}
+      <p className="break-word mt-1 text-base">{email}</p>
+
+      <DeviceInfoBlock
+        {...{ remoteMetadata }}
+        deviceNameDisplay="inline"
+        className="mt-4 w-full rounded-md border border-grey-100 px-4 py-3 text-grey-500 dark:border-grey-500 dark:text-grey-300"
+      />
+
+      <FtlMsg id="pair2-supplicant-connect-this-device-connect-button">
+        <button
+          type="button"
+          onClick={onConnect}
+          className="cta-primary cta-xl mt-6 w-full"
+        >
+          Connect
+        </button>
+      </FtlMsg>
+      <FtlMsg id="pair2-supplicant-connect-this-device-cancel-button">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="mt-4 py-2 text-base text-grey-900 underline dark:text-grey-10"
+        >
+          Cancel
+        </button>
+      </FtlMsg>
+    </div>
+  </AppLayout>
+);
+
+export default ConnectThisDevice;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
@@ -12,7 +12,12 @@ import {
 } from '../../../../components/images';
 import { RemoteMetadata } from '../../../../lib/types';
 
-export type ApproveSignInProps = {
+export type ConnectThisDeviceProps = {
+  /**
+   * The account this device would be connected to, shown so the user can
+   * confirm it is the one they meant to pair with.
+   */
+  email: string;
   /**
    * Details of the device that started pairing, shown so the user can confirm
    * the request came from their own computer. Supplied by the caller — this
@@ -20,33 +25,40 @@ export type ApproveSignInProps = {
    */
   remoteMetadata: RemoteMetadata;
   /**
-   * Aborts pairing. Required so that routing this card cannot leave the only
-   * available action inert — the flow logic itself lands with the route.
+   * Completes pairing. Required so that routing this card cannot leave an
+   * action inert — the flow logic itself lands with the route.
+   */
+  onConnect: () => void;
+  /**
+   * Aborts pairing. Required for the same reason as `onConnect`.
    */
   onCancel: () => void;
 };
 
 /**
- * The mobile waiting screen shown after the user scans the pairing QR code. It
- * tells them to finish approving the sign-in on their computer and shows the
- * requesting device's details for verification. Cancel is the only action.
- *
- * Presentational only: routing and the page-view/Glean metrics that sibling
- * pairing pages emit land with the flow wiring.
+ * The mobile screen shown after the user scans the pairing QR code, asking
+ * them to confirm connecting this device to their account. It shows the
+ * requesting computer's details so they can verify the request.
  */
-const ApproveSignIn = ({ remoteMetadata, onCancel }: ApproveSignInProps) => (
+const ConnectThisDevice = ({
+  email,
+  remoteMetadata,
+  onConnect,
+  onCancel,
+}: ConnectThisDeviceProps) => (
   <AppLayout>
     <div className="flex flex-col items-center text-center">
       <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
 
       <SyncDevicesImage className="mt-10 h-[120px] w-auto" />
 
-      <FtlMsg id="pair2-supplicant-approve-sign-in-heading">
-        <h1 className="card-header mt-4">One last step to sync</h1>
+      <FtlMsg id="pair2-supplicant-connect-this-device-heading">
+        <h1 className="card-header mt-4">
+          Connect this device to your account?
+        </h1>
       </FtlMsg>
-      <FtlMsg id="pair2-supplicant-approve-sign-in-instruction">
-        <p className="mt-1 text-base">Approve the sign-in on your computer.</p>
-      </FtlMsg>
+      {/* Raw user data, so it is deliberately not wrapped in FtlMsg. */}
+      <p className="break-word mt-1 text-base">{email}</p>
 
       <DeviceInfoBlock
         {...{ remoteMetadata }}
@@ -54,7 +66,16 @@ const ApproveSignIn = ({ remoteMetadata, onCancel }: ApproveSignInProps) => (
         className="mt-4 w-full rounded-md border border-grey-100 px-4 py-3 text-grey-500 dark:border-grey-500 dark:text-grey-300"
       />
 
-      <FtlMsg id="pair2-supplicant-approve-sign-in-cancel-button">
+      <FtlMsg id="pair2-supplicant-connect-this-device-connect-button">
+        <button
+          type="button"
+          onClick={onConnect}
+          className="cta-primary cta-xl mt-6 w-full"
+        >
+          Connect
+        </button>
+      </FtlMsg>
+      <FtlMsg id="pair2-supplicant-connect-this-device-cancel-button">
         <button
           type="button"
           onClick={onCancel}
@@ -67,4 +88,4 @@ const ApproveSignIn = ({ remoteMetadata, onCancel }: ApproveSignInProps) => (
   </AppLayout>
 );
 
-export default ApproveSignIn;
+export default ConnectThisDevice;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/mocks.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ConnectThisDevice, { ConnectThisDeviceProps } from '.';
+import { MOCK_METADATA_WITH_DEVICE_NAME } from '../../../../components/DeviceInfoBlock/mocks';
+import { RemoteMetadata } from '../../../../lib/types';
+import { MOCK_EMAIL } from '../../../mocks';
+
+// No dashes or spaces, so the only way this fits is if the block wraps it.
+export const MOCK_METADATA_LONG_DEVICE_NAME: RemoteMetadata = {
+  ...MOCK_METADATA_WITH_DEVICE_NAME,
+  deviceName: 'LaurelsExtremelyLongMacBookPro16inch2023',
+};
+
+// Likewise: neither `@` nor `.` is a wrap opportunity, so this only fits if
+// the paragraph breaks mid-word.
+export const MOCK_LONG_EMAIL =
+  'laurelsextremelylongaccountname@anevenlongerexampledomainname.com';
+
+export const Subject = ({
+  email = MOCK_EMAIL,
+  remoteMetadata = MOCK_METADATA_WITH_DEVICE_NAME,
+  onConnect = () => {},
+  onCancel = () => {},
+}: Partial<ConnectThisDeviceProps> = {}) => (
+  <ConnectThisDevice {...{ email, remoteMetadata, onConnect, onCancel }} />
+);


### PR DESCRIPTION
## Because
- We are updating pairing flows and want to land UI components / pages first.
- Adds the mobile screen asking the user to confirm connecting this device to their account.

## This pull request
- Adds `packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx`.
- Adds storybook stories for the page.
- Adds l10n files.

## Issue that this pull request solves

Closes: FXA-14233

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out the storybook output [here](https://mozilla.github.io/fxa/storybooks/pr-20982/fxa-settings/?path=/story/pages-pair2-supplicant-connectthisdevice--with-device-name). Compare against figma designs (linked in ticket). Check out code for AI slop and over all adherence to patterns set forth in FxA.

Note, that this is just UI work, wiring up functionality comes later.

## Screenshots (Optional)

See story books.

## Other information (Optional)

Follows the pattern set in #20952 (FXA-14234).