### PR TITLE
feat(settings): add desktop Download Firefox card

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/en.ftl
@@ -1,0 +1,11 @@
+## DownloadFirefox page - Part of the desktop-to-mobile pairing flow
+## Users see this on their computer when Firefox is needed to continue pairing.
+## It points them at firefox.com/pair and offers a download link for Firefox.
+
+# "sync" is a verb here, referring to syncing data between the user's devices
+pair2-authority-download-firefox-heading = Open { -brand-firefox } to sync
+# "firefox.com/pair" is a URL and should not be translated
+pair2-authority-download-firefox-instruction = To set up syncing across devices, open { -brand-firefox } on this device and visit <b>firefox.com/pair</b>
+
+# Links out to the Firefox download page
+pair2-authority-download-firefox-cta = Download { -brand-firefox }

--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/en.ftl
@@ -1,0 +1,10 @@
+## DownloadFirefox page - Part of the desktop-to-mobile pairing flow
+## Users see this on their computer when Firefox is needed to continue pairing.
+## It points them at firefox.com/pair and offers a download link for Firefox.
+
+# "sync" is a verb here, referring to syncing data between the user's devices
+pair2-authority-download-firefox-heading = Open Firefox to sync
+# "firefox.com/pair" is a URL and should not be translated
+pair2-authority-download-firefox-instruction = To set up syncing across devices, open Firefox on this device and visit firefox.com/pair
+# Links out to the Firefox download page
+pair2-authority-download-firefox-cta = Download Firefox

--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.stories.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import DownloadFirefox from '.';
+
+export default {
+  title: 'Pages/Pair2/Authority/DownloadFirefox',
+  component: DownloadFirefox,
+  decorators: [withLocalization],
+} as Meta;
+
+// The card takes no props, so there is a single state to review.
+export const Default = () => <DownloadFirefox />;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.stories.tsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import DownloadFirefox from '.';
+
+export default {
+  title: 'Pages/Pair2/Authority/DownloadFirefox',
+  component: DownloadFirefox,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Default = () => <DownloadFirefox />;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.test.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { LINK } from '../../../../constants';
+import DownloadFirefox from '.';
+
+describe('Pair2/Authority/DownloadFirefox page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle.
+  it.skip('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'));
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('renders the heading and instruction', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Open Firefox to sync'
+    );
+    screen.getByText(
+      `To set up syncing across devices, open Firefox on this device and visit`
+    );
+  });
+
+  it('exposes the illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the single image this card renders.
+      // Desktop cards carry no in-card Firefox lockup.
+      'Mozilla logo',
+      'A desktop browser window and a mobile phone, both syncing, with the Firefox mascot alongside them',
+    ]);
+  });
+
+  it('points the download CTA at the Firefox desktop download page', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    // `LinkExternal` appends its own "Opens in new window" screen-reader text,
+    // so that is part of the link's accessible name.
+    expect(
+      screen.getByRole('link', {
+        name: 'Download Firefox Opens in new window',
+      })
+    ).toHaveAttribute('href', LINK.FX_DESKTOP);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.test.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { LINK } from '../../../../constants';
+import DownloadFirefox from '.';
+
+describe('Pair2/Authority/DownloadFirefox page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'));
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('renders the heading and instruction', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Open Firefox to sync'
+    );
+    screen.getByText(
+      'To set up syncing across devices, open Firefox on this device and visit firefox.com/pair'
+    );
+  });
+
+  it('exposes the illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the single image this card renders.
+      // Desktop cards carry no in-card Firefox lockup.
+      'Mozilla logo',
+      'A desktop browser window and a mobile phone, both syncing, with the Firefox mascot alongside them',
+    ]);
+  });
+
+  it('points the download CTA at the Firefox desktop download page', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    // `LinkExternal` appends its own "Opens in new window" screen-reader text,
+    // so that is part of the link's accessible name.
+    expect(
+      screen.getByRole('link', {
+        name: 'Download Firefox Opens in new window',
+      })
+    ).toHaveAttribute('href', LINK.FX_DESKTOP);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.tsx
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import AppLayout from '../../../../components/AppLayout';
+import { SyncDevicesImage } from '../../../../components/images';
+import { LINK } from '../../../../constants';
+
+/**
+ * The desktop screen shown when the user needs Firefox before they can pair.
+ * It tells them to open Firefox and visit firefox.com/pair, and offers a
+ * download link for the desktop browser as the only action.
+ */
+const DownloadFirefox = () => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FtlMsg id="pair2-authority-download-firefox-heading">
+        <h1 className="card-header">Open Firefox to sync</h1>
+      </FtlMsg>
+      <FtlMsg id="pair2-authority-download-firefox-instruction">
+        <p className="mt-1 text-base">
+          To set up syncing across devices, open Firefox on this device and visit <b>firefox.com/pair</b>
+        </p>
+      </FtlMsg>
+
+      <SyncDevicesImage className="mt-10 h-[160px] w-auto" />
+
+      <div className="mt-10 flex w-full">
+        <LinkExternal href={LINK.FX_DESKTOP} className="cta-primary cta-xl">
+          <FtlMsg id="pair2-authority-download-firefox-cta">
+            Download Firefox
+          </FtlMsg>
+        </LinkExternal>
+      </div>
+    </div>
+  </AppLayout>
+);
+
+export default DownloadFirefox;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.tsx
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import AppLayout from '../../../../components/AppLayout';
+import { SyncDevicesImage } from '../../../../components/images';
+import { LINK } from '../../../../constants';
+
+/**
+ * The desktop screen shown when the user needs Firefox before they can pair.
+ * It tells them to open Firefox and visit firefox.com/pair, and offers a
+ * download link for the desktop browser as the only action.
+ *
+ * Unlike the Pair2 mobile cards, the desktop cards carry no in-card Firefox
+ * lockup, and they lead with the copy rather than the illustration.
+ *
+ * Presentational only: routing and the page-view/Glean metrics that sibling
+ * pairing pages emit land with the flow wiring.
+ */
+const DownloadFirefox = () => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FtlMsg id="pair2-authority-download-firefox-heading">
+        <h1 className="card-header">Open Firefox to sync</h1>
+      </FtlMsg>
+      <FtlMsg id="pair2-authority-download-firefox-instruction">
+        <p className="mt-1 text-base">
+          To set up syncing across devices, open Firefox on this device and
+          visit firefox.com/pair
+        </p>
+      </FtlMsg>
+
+      <SyncDevicesImage className="mt-10 h-[160px] w-auto" />
+
+      {/* `cta-xl` is `flex-1`, so a primary CTA only fills the card when it
+          sits in a flex parent — the same wrapper the button-based CTAs use.
+          `FtlMsg` goes inside `LinkExternal` rather than around it so that
+          translating the label does not replace the component's own
+          "Opens in new window" screen-reader text. */}
+      <div className="mt-10 flex w-full">
+        <LinkExternal href={LINK.FX_DESKTOP} className="cta-primary cta-xl">
+          <FtlMsg id="pair2-authority-download-firefox-cta">
+            Download Firefox
+          </FtlMsg>
+        </LinkExternal>
+      </div>
+    </div>
+  </AppLayout>
+);
+
+export default DownloadFirefox;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/index.tsx
@@ -30,9 +30,6 @@ export type ApproveSignInProps = {
  * The mobile waiting screen shown after the user scans the pairing QR code. It
  * tells them to finish approving the sign-in on their computer and shows the
  * requesting device's details for verification. Cancel is the only action.
- *
- * Presentational only: routing and the page-view/Glean metrics that sibling
- * pairing pages emit land with the flow wiring.
  */
 const ApproveSignIn = ({ remoteMetadata, onCancel }: ApproveSignInProps) => (
   <AppLayout>


### PR DESCRIPTION
## Because

- A user who reaches the pairing flow on a computer that is not running Firefox has no way forward — the pairing hand-off is browser-to-browser — so they need to be told to open Firefox and given a way to install it.
- Adds the desktop screen prompting the user to install Firefox.

## This pull request

- Adds `packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.tsx`, a presentational card rendering the heading, the instruction pointing at firefox.com/pair, the desktop/mobile sync illustration, and a full-width "Download Firefox" call to action. It takes no props: the CTA is an external link, so it is wired here rather than left to the route.
- Follows the desktop element order from Figma — heading, subcopy, illustration, CTA — which is the reverse of the Pair2 mobile cards, and omits the in-card Firefox lockup the mobile cards carry.
- Points the CTA at the existing `LINK.FX_DESKTOP` constant, the same destination `Pair/Unsupported` hardcodes today, and styles it with `cta-primary cta-xl` inside a flex wrapper so the link stretches the way a primary button does. `FtlMsg` sits inside `LinkExternal` so translating the label does not clobber the component's "Opens in new window" screen-reader text.
- Reuses `AppLayout`'s card surface, which already matches the Figma frame exactly: 480px wide, 32px horizontal and 36px vertical padding.
- Adds `en.ftl` with the three new strings, `index.stories.tsx`, and tests covering the copy, the illustration's accessible name, the CTA's href, and drift between the component's fallback text and the Fluent bundle.

## Issue that this pull request solves

Closes: FXA-14239

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-settings/src/pages/Pair2/Authority/DownloadFirefox/index.tsx`
- Suggested review order: `index.tsx`, `en.ftl`, `index.test.tsx`
- Storybook: `Pages/Pair2/Authority/DownloadFirefox` (`pages-pair2-authority-downloadfirefox`)

## Other information (Optional)

Follows the pattern set in #20952 (FXA-14234).

The Figma component behind this card is named **"Spotlight modal"** rather than `Pairing / Desktop / …` like its siblings. It resolves to a shared component in the *Desktop Components 3* / *Smart Window Design System* libraries, described as an "Onboarding messaging dialog used for highlighting or announcing features (✔ in-content ✔ chrome)" — i.e. a Firefox browser onboarding dialog, not a bespoke FxA card. Worth a designer confirmation on intent. No shared modal component is introduced here: the shell happens to line up 1:1 with `AppLayout`'s existing `.card`, so this PR just reuses that.