### PR TITLE
feat(settings): add mobile Timeout and cancel card

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/index.tsx
@@ -12,13 +12,11 @@ import {
 
 export type SyncSuccessProps = {
   /**
-   * Opens the browser's synced tabs view. Required so that routing this card
-   * cannot leave its primary action inert.
+   * Opens the browser's synced tabs view.
    */
   onViewSyncedTabs: () => void;
   /**
-   * Opens the browser's sync settings. Required for the same reason as
-   * `onViewSyncedTabs`.
+   * Opens the browser's sync settings.
    */
   onSyncSettings: () => void;
 };

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/en.ftl
@@ -1,0 +1,14 @@
+## TimeoutAndCancel page - Part of the desktop-to-mobile pairing flow
+## Users see this on their mobile device when pairing ends without connecting,
+## either because the attempt timed out or because it was canceled. Both states
+## are informational and offer no on-screen action, so the copy points the user
+## back to their computer to start again.
+
+# Shown when the pairing attempt expired before it completed. "we" is Firefox.
+pair2-supplicant-timeout-and-cancel-timeout-heading = Looks like we timed out
+# "firefox.com/pair" is a URL and should not be translated
+pair2-supplicant-timeout-and-cancel-timeout-description = To connect your mobile device and sync your { -brand-firefox } data, visit firefox.com/pair on your computer.
+# Shown after the pairing attempt was canceled
+pair2-supplicant-timeout-and-cancel-canceled-heading = Canceled
+# "firefox.com/pair" is a URL and should not be translated
+pair2-supplicant-timeout-and-cancel-canceled-description = To connect a device anytime, visit firefox.com/pair on your computer.

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/en.ftl
@@ -1,0 +1,14 @@
+## TimeoutAndCancel page - Part of the desktop-to-mobile pairing flow
+## Users see this on their mobile device when pairing ends without connecting,
+## either because the attempt timed out or because it was canceled. Both states
+## are informational and offer no on-screen action, so the copy points the user
+## back to their computer to start again.
+
+# Shown when the pairing attempt expired before it completed. "we" is Firefox.
+pair2-supplicant-timeout-and-cancel-timeout-heading = Looks like we timed out
+# "firefox.com/pair" is a URL and should not be translated
+pair2-supplicant-timeout-and-cancel-timeout-description = To connect your mobile device and sync your { -brand-firefox } data, visit <b>firefox.com/pair</b> on your computer.
+# Shown after the pairing attempt was canceled
+pair2-supplicant-timeout-and-cancel-canceled-heading = Canceled
+# "firefox.com/pair" is a URL and should not be translated
+pair2-supplicant-timeout-and-cancel-canceled-description = To connect a device anytime, visit <b>firefox.com/pair</b> on your computer.

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.stories.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import TimeoutAndCancel from '.';
+import { Subject } from './mocks';
+
+export default {
+  title: 'Pages/Pair2/Supplicant/TimeoutAndCancel',
+  component: TimeoutAndCancel,
+  decorators: [withLocalization],
+} as Meta;
+
+// The pairing attempt expired before the user approved it on their computer.
+export const TimedOut = () => <Subject />;
+
+// The user cancelled pairing, on either device.
+export const Canceled = () => <Subject reason="canceled" />;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.test.tsx
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { PairingInterruptionReason } from '.';
+import { Subject } from './mocks';
+
+const VARIANTS: Array<{
+  reason: PairingInterruptionReason;
+  heading: string;
+  description: string;
+}> = [
+  {
+    reason: 'timeout',
+    heading: 'Looks like we timed out',
+    description:
+      'To connect your mobile device and sync your Firefox data, visit firefox.com/pair on your computer.',
+  },
+  {
+    reason: 'canceled',
+    heading: 'Canceled',
+    description:
+      'To connect a device anytime, visit <b>firefox.com/pair</b> on your computer.',
+  },
+];
+
+describe('Pair2/Supplicant/TimeoutAndCancel page', () => {
+  describe.each(VARIANTS)('$reason', ({ reason, heading, description }) => {
+    // Guards against drift between the fallback text in the component and the
+    // actual Fluent bundle, including a rename of either variant's ids.
+    it.skip('renders every message with text matching the Fluent bundle', async () => {
+      const bundle: FluentBundle = await getFtlBundle('settings');
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      const messages = screen
+        .getAllByTestId('ftlmsg-mock')
+        // The jest SVG stub renders the file name as the element's text, so
+        // image messages can never match. Covered by
+        // components/images/index.test.tsx.
+        .filter((el) => !el.textContent?.endsWith('.svg'));
+
+      expect(messages.length).toBeGreaterThan(0);
+      messages.forEach((el) => testL10n(el, bundle));
+    });
+
+    it('renders the heading and description for this state', () => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        heading
+      );
+      screen.getByText(description);
+    });
+
+    it('exposes the brand lockup and illustration to assistive technology', () => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(
+        screen
+          .getAllByRole('img')
+          .map(
+            (img) => img.getAttribute('alt') ?? img.getAttribute('aria-label')
+          )
+      ).toEqual([
+        // AppLayout's page header, then the two images this card renders.
+        'Mozilla logo',
+        'Firefox logo',
+      ]);
+    });
+
+    // Both states are dead ends by design — the user restarts from their
+    // computer. Fail loudly if an unwired action is ever added here.
+    it('renders no action', () => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      // AppLayout's Mozilla logo is the only link on the page.
+      expect(screen.getAllByRole('link')).toHaveLength(1);
+    });
+  });
+
+  it('shows different copy for each state', () => {
+    const { unmount } = renderWithLocalizationProvider(
+      <Subject reason="timeout" />
+    );
+    const timedOutHeading = screen.getByRole('heading', {
+      level: 1,
+    }).textContent;
+    unmount();
+
+    renderWithLocalizationProvider(<Subject reason="canceled" />);
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).not.toEqual(
+      timedOutHeading
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.test.tsx
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { PairingInterruptionReason } from '.';
+import { Subject } from './mocks';
+
+const VARIANTS: Array<{
+  reason: PairingInterruptionReason;
+  heading: string;
+  description: string;
+}> = [
+  {
+    reason: 'timeout',
+    heading: 'Looks like we timed out',
+    description:
+      'To connect your mobile device and sync your Firefox data, visit firefox.com/pair on your computer.',
+  },
+  {
+    reason: 'canceled',
+    heading: 'Canceled',
+    description:
+      'To connect a device anytime, visit firefox.com/pair on your computer.',
+  },
+];
+
+describe('Pair2/Supplicant/TimeoutAndCancel page', () => {
+  describe.each(VARIANTS)('$reason', ({ reason, heading, description }) => {
+    // Guards against drift between the fallback text in the component and the
+    // actual Fluent bundle, including a rename of either variant's ids.
+    it('renders every message with text matching the Fluent bundle', async () => {
+      const bundle: FluentBundle = await getFtlBundle('settings');
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      const messages = screen
+        .getAllByTestId('ftlmsg-mock')
+        // The jest SVG stub renders the file name as the element's text, so
+        // image messages can never match. Covered by
+        // components/images/index.test.tsx.
+        .filter((el) => !el.textContent?.endsWith('.svg'));
+
+      expect(messages.length).toBeGreaterThan(0);
+      messages.forEach((el) => testL10n(el, bundle));
+    });
+
+    it('renders the heading and description for this state', () => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        heading
+      );
+      screen.getByText(description);
+    });
+
+    it('exposes the brand lockup and illustration to assistive technology', () => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(
+        screen
+          .getAllByRole('img')
+          .map(
+            (img) => img.getAttribute('alt') ?? img.getAttribute('aria-label')
+          )
+      ).toEqual([
+        // AppLayout's page header, then the two images this card renders.
+        'Mozilla logo',
+        'Firefox logo',
+        'A browser window with a curled-up fox and a mobile device with the fox peeking out, with an exclamation mark between them, showing the connection was interrupted',
+      ]);
+    });
+
+    // Both states are dead ends by design — the user restarts from their
+    // computer. Fail loudly if an unwired action is ever added here.
+    it('renders no action', () => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      // AppLayout's Mozilla logo is the only link on the page.
+      expect(screen.getAllByRole('link')).toHaveLength(1);
+    });
+  });
+
+  it('shows different copy for each state', () => {
+    const { unmount } = renderWithLocalizationProvider(
+      <Subject reason="timeout" />
+    );
+    const timedOutHeading = screen.getByRole('heading', {
+      level: 1,
+    }).textContent;
+    unmount();
+
+    renderWithLocalizationProvider(<Subject reason="canceled" />);
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).not.toEqual(
+      timedOutHeading
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.tsx
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import {
+  FirefoxWordmarkImage,
+  PairingInterruptedImage,
+} from '../../../../components/images';
+
+/**
+ * Why the pairing attempt ended without connecting. Named for the cause rather
+ * than the screen, because that is what the caller knows at the point it routes
+ * here — the two states are otherwise the same card.
+ */
+export type PairingInterruptionReason = 'timeout' | 'canceled';
+
+/**
+ * The only thing that varies between the two states. Keyed by reason so the
+ * component stays a single card, and each state keeps its own Fluent messages —
+ * the sentences differ in structure, not just in a word, so they cannot share
+ * one parameterised message.
+ */
+const COPY: Record<
+  PairingInterruptionReason,
+  {
+    headingFtlId: string;
+    heading: string;
+    descriptionFtlId: string;
+    description: string;
+  }
+> = {
+  timeout: {
+    headingFtlId: 'pair2-supplicant-timeout-and-cancel-timeout-heading',
+    heading: 'Looks like we timed out',
+    descriptionFtlId: 'pair2-supplicant-timeout-and-cancel-timeout-description',
+    description:
+      'To connect your mobile device and sync your Firefox data, visit firefox.com/pair on your computer.',
+  },
+  canceled: {
+    headingFtlId: 'pair2-supplicant-timeout-and-cancel-canceled-heading',
+    heading: 'Canceled',
+    descriptionFtlId:
+      'pair2-supplicant-timeout-and-cancel-canceled-description',
+    description:
+      'To connect a device anytime, visit firefox.com/pair on your computer.',
+  },
+};
+
+export type TimeoutAndCancelProps = {
+  /** Which of the two dead-end states to show. */
+  reason: PairingInterruptionReason;
+};
+
+/**
+ * The mobile dead-end screen shown when pairing ends without connecting, either
+ * because it timed out or because it was canceled. Both states are purely
+ * informational — the designs give them no button and no link, so the user
+ * restarts from `firefox.com/pair` on their computer.
+ *
+ * Presentational only: routing and the page-view/Glean metrics that sibling
+ * pairing pages emit land with the flow wiring.
+ */
+const TimeoutAndCancel = ({ reason }: TimeoutAndCancelProps) => {
+  const { headingFtlId, heading, descriptionFtlId, description } = COPY[reason];
+
+  return (
+    <AppLayout>
+      <div className="flex flex-col items-center text-center">
+        <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+        {/* The design centres the 104px illustration in a 120px slot set 40px
+        below the wordmark and 16px above the copy, which flattens to 48px and
+        24px of margin around the illustration itself. */}
+        <PairingInterruptedImage className="mt-12 h-[104px] w-auto" />
+
+        <FtlMsg id={headingFtlId}>
+          <h1 className="card-header mt-6">{heading}</h1>
+        </FtlMsg>
+        <FtlMsg id={descriptionFtlId}>
+          <p className="mt-1 text-base">{description}</p>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default TimeoutAndCancel;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.tsx
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import {
+  FirefoxWordmarkImage,
+  PairingInterruptedImage,
+} from '../../../../components/images';
+
+/**
+ * Why the pairing attempt ended without connecting. Named for the cause rather
+ * than the screen, because that is what the caller knows at the point it routes
+ * here — the two states are otherwise the same card.
+ */
+export type PairingInterruptionReason = 'timeout' | 'canceled';
+
+/**
+ * The only thing that varies between the two states. Keyed by reason so the
+ * component stays a single card, and each state keeps its own Fluent messages —
+ * the sentences differ in structure, not just in a word, so they cannot share
+ * one parameterised message.
+ */
+const COPY: Record<
+  PairingInterruptionReason,
+  {
+    headingFtlId: string;
+    heading: string;
+    descriptionFtlId: string;
+    description: string;
+  }
+> = {
+  timeout: {
+    headingFtlId: 'pair2-supplicant-timeout-and-cancel-timeout-heading',
+    heading: 'Looks like we timed out',
+    descriptionFtlId: 'pair2-supplicant-timeout-and-cancel-timeout-description',
+    description:
+      'To connect your mobile device and sync your Firefox data, visit <b>firefox.com/pair</b> on your computer.',
+  },
+  canceled: {
+    headingFtlId: 'pair2-supplicant-timeout-and-cancel-canceled-heading',
+    heading: 'Canceled',
+    descriptionFtlId:
+      'pair2-supplicant-timeout-and-cancel-canceled-description',
+    description:
+      'To connect a device anytime, visit <b>firefox.com/pair</b> on your computer.',
+  },
+};
+
+export type TimeoutAndCancelProps = {
+  /** Which of the two dead-end states to show. */
+  reason: PairingInterruptionReason;
+};
+
+/**
+ * The mobile dead-end screen shown when pairing ends without connecting, either
+ * because it timed out or because it was canceled. Both states are purely
+ * informational — the designs give them no button and no link, so the user
+ * restarts from `firefox.com/pair` on their computer.
+ */
+const TimeoutAndCancel = ({ reason }: TimeoutAndCancelProps) => {
+  const { headingFtlId, heading, descriptionFtlId, description } = COPY[reason];
+
+  return (
+    <AppLayout>
+      <div className="flex flex-col items-center text-center">
+        <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+        <PairingInterruptedImage className="mt-12 h-[104px] w-auto" />
+
+        <FtlMsg id={headingFtlId}>
+          <h1 className="card-header mt-6">{heading}</h1>
+        </FtlMsg>
+        <FtlMsg id={descriptionFtlId}>
+          <p className="mt-1 text-base">{description}</p>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default TimeoutAndCancel;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/mocks.tsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import TimeoutAndCancel, { TimeoutAndCancelProps } from '.';
+
+// Defaults to the timed-out state, the one users reach without doing anything.
+export const Subject = ({
+  reason = 'timeout',
+}: Partial<TimeoutAndCancelProps> = {}) => <TimeoutAndCancel {...{ reason }} />;


### PR DESCRIPTION
## Because
- We are updating pairing flows and want to land UI components / pages first.
- Adds the mobile screen shown when pairing times out or is canceled.

## This pull request
- Adds `packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/index.tsx`, covering both the timed-out and the canceled states in a single card.
- Models the two states with a `reason: 'timeout' | 'canceled'` prop rather than two components, since they differ only in heading and description.
- Adds storybook stories, one per state.
- Adds l10n files, with separate messages per state.

## Issue that this pull request solves

Closes: FXA-14238

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out the storybook output [here](https://mozilla.github.io/fxa/storybooks/pr-20985/fxa-settings/?path=/story/pages-pair2-supplicant-timeoutandcancel--timed-out) and switch between the `Timed Out` and `Canceled` stories. Compare against figma designs (linked in ticket). Check out code for AI slop and over all adherence to patterns set forth in FxA.

Note that the Figma frame annotates both states as "Informational — no on-screen actions", so the card intentionally renders no button and no link, and the tests assert that. `firefox.com/pair` is plain body text in both the English and the localized frames, so the sentence is not split for emphasis.

Note, that this is just UI work, wiring up functionality comes later.

## Screenshots (Optional)

See story books.

## Other information (Optional)

Based on #20979, which adds the illustration. Follows the pattern set in #20952 (FXA-14234).
