### PR TITLE
feat(settings): add mobile Ready to scan card

### DIFF
--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -16,6 +16,8 @@ export const MOZILLA_ACCOUNTS_TOS_URL =
   'https://www.mozilla.org/about/legal/terms/services/';
 export const MOZILLA_ACCOUNTS_PRIVACY_URL =
   'https://www.mozilla.org/privacy/mozilla-accounts/';
+export const SYNC_SUPPORT_URL =
+  'https://support.mozilla.org/kb/how-do-i-set-sync-my-computer';
 
 export enum ENTRYPOINTS {
   FIREFOX_IOS_OAUTH_ENTRYPOINT = 'ios_settings_manage',

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/en.ftl
@@ -1,0 +1,11 @@
+## ReadyToScan page - Part of the desktop-to-mobile pairing flow
+## Users see this on their mobile device before pairing starts. It tells them
+## to open firefox.com/pair on their computer, which is where the QR code they
+## scan with the mobile device comes from.
+
+pair2-supplicant-ready-to-scan-heading = To connect a device
+# <b> emphasises the address the user types on their computer. It is not a link,
+# and the address itself must not be translated.
+pair2-supplicant-ready-to-scan-instruction = On your computer, open { -brand-firefox } and go to <b>firefox.com/pair</b>, and follow on screen instructions to connect this mobile device.
+# Opens a Mozilla support article about setting up sync
+pair2-supplicant-ready-to-scan-learn-more-link = Learn more

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.stories.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import ReadyToScan from '.';
+
+export default {
+  title: 'Pages/Pair2/Supplicant/ReadyToScan',
+  component: ReadyToScan,
+  decorators: [withLocalization],
+} as Meta;
+
+// The card takes no props, so there is only one state to show.
+export const Default = () => <ReadyToScan />;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.test.tsx
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import ReadyToScan from '.';
+
+// `testL10n` compares rendered text against the raw Fluent source, so a message
+// carrying a DOM overlay tag can never match it. This one is checked on its own
+// below instead.
+const INSTRUCTION_FTL_ID = 'pair2-supplicant-ready-to-scan-instruction';
+
+const getInstruction = () =>
+  screen
+    .getAllByTestId('ftlmsg-mock')
+    .find((el) => el.id === INSTRUCTION_FTL_ID)!;
+
+describe('Pair2/Supplicant/ReadyToScan page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle. No message on this card takes a variable, so no
+  // arguments are passed.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'))
+      .filter((el) => el.id !== INSTRUCTION_FTL_ID);
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('keeps the instruction fallback text in step with the Fluent message', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    const message = bundle.getMessage(INSTRUCTION_FTL_ID);
+    const source = bundle.formatPattern(message!.value!);
+
+    expect(getInstruction().textContent).toEqual(source.replace(/<\/?b>/g, ''));
+  });
+
+  it('renders the heading and the instruction, emphasising the pairing URL', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'To connect a device'
+    );
+    expect(getInstruction()).toHaveTextContent(
+      'On your computer, open Firefox and go to firefox.com/pair, and follow on screen instructions to connect this mobile device.'
+    );
+    // The URL is a placeable inside the sentence, not a fragment glued on, so
+    // the emphasis has to come from an element the message can wrap.
+    expect(screen.getByText('firefox.com/pair').tagName).toEqual('B');
+  });
+
+  it('links “Learn more” to the sync support article', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(screen.getByRole('link', { name: /Learn more/ })).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/kb/how-do-i-set-sync-my-computer'
+    );
+  });
+
+  it('renders no buttons — the next step happens on the computer', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('exposes the brand lockup and illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the two images this card renders.
+      'Mozilla logo',
+      'Firefox logo'
+    ]);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.test.tsx
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import ReadyToScan from '.';
+
+// `testL10n` compares rendered text against the raw Fluent source, so a message
+// carrying a DOM overlay tag can never match it. This one is checked on its own
+// below instead.
+const INSTRUCTION_FTL_ID = 'pair2-supplicant-ready-to-scan-instruction';
+
+const getInstruction = () =>
+  screen
+    .getAllByTestId('ftlmsg-mock')
+    .find((el) => el.id === INSTRUCTION_FTL_ID)!;
+
+describe('Pair2/Supplicant/ReadyToScan page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle. No message on this card takes a variable, so no
+  // arguments are passed.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'))
+      .filter((el) => el.id !== INSTRUCTION_FTL_ID);
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('keeps the instruction fallback text in step with the Fluent message', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    const message = bundle.getMessage(INSTRUCTION_FTL_ID);
+    const source = bundle.formatPattern(message!.value!);
+
+    expect(getInstruction().textContent).toEqual(source.replace(/<\/?b>/g, ''));
+  });
+
+  it('renders the heading and the instruction, emphasising the pairing URL', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'To connect a device'
+    );
+    expect(getInstruction()).toHaveTextContent(
+      'On your computer, open Firefox and go to firefox.com/pair, and follow on screen instructions to connect this mobile device.'
+    );
+    // The URL is a placeable inside the sentence, not a fragment glued on, so
+    // the emphasis has to come from an element the message can wrap.
+    expect(screen.getByText('firefox.com/pair').tagName).toEqual('B');
+  });
+
+  it('links “Learn more” to the sync support article', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(screen.getByRole('link', { name: /Learn more/ })).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/kb/how-do-i-set-sync-my-computer'
+    );
+  });
+
+  it('renders no buttons — the next step happens on the computer', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('exposes the brand lockup and illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<ReadyToScan />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the two images this card renders.
+      'Mozilla logo',
+      'Firefox logo',
+      'A laptop showing a QR code next to a mobile device with a scanning frame, with the Firefox flame and fox mascot alongside',
+    ]);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.tsx
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import AppLayout from '../../../../components/AppLayout';
+import {
+  FirefoxWordmarkImage,
+  LaptopQrCodeImage,
+} from '../../../../components/images';
+
+// The same Mozilla support article the legacy `Pair/Unsupported` page links to
+// from its equivalent "Learn more". There is no shared constant for it — every
+// SUMO link in fxa-settings is written inline at its call site.
+const SYNC_SUPPORT_URL =
+  'https://support.mozilla.org/kb/how-do-i-set-sync-my-computer';
+
+/**
+ * The mobile screen shown before pairing starts. It tells the user to open
+ * firefox.com/pair on their computer, which is where the QR code they scan
+ * with this device comes from.
+ *
+ * Presentational only, and deliberately actionless: there is nothing to do on
+ * the phone until the computer shows a code. Routing and the page-view/Glean
+ * metrics that sibling pairing pages emit land with the flow wiring.
+ */
+const ReadyToScan = () => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+      <LaptopQrCodeImage className="mt-14 h-[120px] w-auto" />
+
+      <FtlMsg id="pair2-supplicant-ready-to-scan-heading">
+        <h1 className="card-header mt-4">To connect a device</h1>
+      </FtlMsg>
+      {/* `firefox.com/pair` is emphasised inside the sentence, so it is a
+          placeable in the message rather than a separate string. */}
+      <FtlMsg
+        id="pair2-supplicant-ready-to-scan-instruction"
+        elems={{ b: <b className="whitespace-nowrap" /> }}
+      >
+        <p className="mt-1 text-base">
+          On your computer, open Firefox and go to{' '}
+          <b className="whitespace-nowrap">firefox.com/pair</b>, and follow on
+          screen instructions to connect this mobile device.
+        </p>
+      </FtlMsg>
+
+      <LinkExternal
+        href={SYNC_SUPPORT_URL}
+        className="text-base text-grey-900 underline dark:text-grey-10"
+      >
+        <FtlMsg id="pair2-supplicant-ready-to-scan-learn-more-link">
+          Learn more
+        </FtlMsg>
+      </LinkExternal>
+    </div>
+  </AppLayout>
+);
+
+export default ReadyToScan;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.tsx
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import AppLayout from '../../../../components/AppLayout';
+import {
+  FirefoxWordmarkImage,
+  LaptopQrCodeImage,
+} from '../../../../components/images';
+import { SYNC_SUPPORT_URL } from '../../../../constants';
+
+/**
+ * The mobile screen shown before pairing starts. It tells the user to open
+ * firefox.com/pair on their computer, which is where the QR code they scan
+ * with this device comes from.
+ *
+ * Presentational only, and deliberately actionless: there is nothing to do on
+ * the phone until the computer shows a code. Routing and the page-view/Glean
+ * metrics that sibling pairing pages emit land with the flow wiring.
+ */
+const ReadyToScan = () => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+      <LaptopQrCodeImage className="mt-14 h-[120px] w-auto" />
+
+      <FtlMsg id="pair2-supplicant-ready-to-scan-heading">
+        <h1 className="card-header mt-4">To connect a device</h1>
+      </FtlMsg>
+      <FtlMsg
+        id="pair2-supplicant-ready-to-scan-instruction"
+        elems={{ b: <b className="whitespace-nowrap" /> }}
+      >
+        <p className="mt-1 text-base">
+          On your computer, open Firefox and go to{' '}
+          <b className="whitespace-nowrap">firefox.com/pair</b>, and follow on
+          screen instructions to connect this mobile device.
+        </p>
+      </FtlMsg>
+
+      <LinkExternal
+        href={SYNC_SUPPORT_URL}
+        className="link-dark-grey"
+      >
+        <FtlMsg id="pair2-supplicant-ready-to-scan-learn-more-link">
+          Learn more
+        </FtlMsg>
+      </LinkExternal>
+    </div>
+  </AppLayout>
+);
+
+export default ReadyToScan;


### PR DESCRIPTION
## Because
- We are updating pairing flows and want to land UI components / pages first.
- Adds the mobile screen telling the user how to start pairing from their computer.

## This pull request
- Adds `packages/fxa-settings/src/pages/Pair2/Supplicant/ReadyToScan/index.tsx`.
- Adds storybook stories for the page.
- Adds l10n files.

## Issue that this pull request solves

Closes: FXA-14237

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out the storybook output [here](https://mozilla.github.io/fxa/storybooks/pr-20986/fxa-settings/?path=/story/pages-pair2-supplicant-readytoscan--default). Compare against figma designs (linked in ticket). Check out code for AI slop and over all adherence to patterns set forth in FxA.

Note, that this is just UI work, wiring up functionality comes later. This card has no buttons by design — the user's next step happens on their computer.

## Screenshots (Optional)

See story books.

## Other information (Optional)

Based on #20979, which adds the illustration. Follows the pattern set in #20952 (FXA-14234).

The "Learn more" link points at `https://support.mozilla.org/kb/how-do-i-set-sync-my-computer`, the same article the legacy `Pair/Unsupported` page links to. There is no shared constant for it — every SUMO link in `fxa-settings` is written inline at its call site — so it is a module-level constant in the card. Happy to extract a shared one if we'd rather.