### PR TITLE
feat(settings): add mobile Download Firefox card

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/en.ftl
@@ -1,0 +1,11 @@
+## DownloadFirefox page - Part of the desktop-to-mobile pairing flow
+## Users see this on their mobile device when pairing reaches a device that
+## does not have Firefox installed yet. It explains what syncing gets them and
+## sends them off to install the browser.
+
+pair2-supplicant-download-firefox-heading = Get { -brand-firefox } on this device
+# "sync" is a verb here, referring to syncing data between the user's devices.
+# <linkExternal> is an anchor tag linking to a page explaining what sync does.
+pair2-supplicant-download-firefox-description = Download { -brand-firefox } to sync bookmarks, history, and more across devices. <linkExternal>Learn more</linkExternal>
+# Primary action. Sends the user to the Firefox download page.
+pair2-supplicant-download-firefox-continue-button = Continue in { -brand-firefox }

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/en.ftl
@@ -1,0 +1,11 @@
+## DownloadFirefox page - Part of the desktop-to-mobile pairing flow
+## Users see this on their mobile device when pairing reaches a device that
+## does not have Firefox installed yet. It explains what syncing gets them and
+## sends them off to install the browser.
+
+pair2-supplicant-download-firefox-heading = Get { -brand-firefox } on this device
+# "sync" is a verb here, referring to syncing data between the user's devices.
+# <linkExternal> is an anchor tag linking to a page explaining what sync does.
+pair2-supplicant-download-firefox-description = Download { -brand-firefox } to sync bookmarks, history, and more across devices. <linkExternal>Learn more</linkExternal>
+# Primary action. Sends the user to the { -brand-firefox } download page.
+pair2-supplicant-download-firefox-continue-button = Continue in { -brand-firefox }

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.stories.tsx
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import DownloadFirefox from '.';
+
+export default {
+  title: 'Pages/Pair2/Supplicant/DownloadFirefox',
+  component: DownloadFirefox,
+  decorators: [withLocalization],
+} as Meta;
+
+// The card takes no props — both actions are static external links — so there
+// is a single state to review.
+export const Default = () => <DownloadFirefox />;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.stories.tsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import DownloadFirefox from '.';
+
+export default {
+  title: 'Pages/Pair2/Supplicant/DownloadFirefox',
+  component: DownloadFirefox,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Default = () => <DownloadFirefox />;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.test.tsx
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { LINK } from '../../../../constants';
+import { Constants } from '../../../../lib/constants';
+import DownloadFirefox from '.';
+
+// The subcopy embeds the "Learn more" link with a Fluent DOM overlay, so the
+// Fluent message carries `<linkExternal>` tags that never reach the DOM.
+const SUBCOPY_FTL_ID = 'pair2-supplicant-download-firefox-description';
+
+const stripOverlayTags = (message: string) =>
+  message.replace(/<\/?[a-zA-Z]+>/g, '');
+
+// The subcopy is not addressable by text — the inline link splits it across
+// nodes — so it is reached through the mocked FtlMsg that wraps it.
+const getSubcopy = () =>
+  screen.getAllByTestId('ftlmsg-mock').find((el) => el.id === SUBCOPY_FTL_ID);
+
+describe('Pair2/Supplicant/DownloadFirefox page', () => {
+  let bundle: FluentBundle;
+  beforeAll(async () => {
+    bundle = await getFtlBundle('settings');
+  });
+
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle.
+  it('renders every message with text matching the Fluent bundle', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'))
+      // `testL10n` compares rendered text against the raw Fluent message, which
+      // an overlay message can never satisfy. Covered by the test below.
+      .filter((el) => el.id !== SUBCOPY_FTL_ID);
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('renders the subcopy fallback matching the Fluent overlay message', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    const message = bundle.getMessage(SUBCOPY_FTL_ID);
+    const formatted = bundle.formatPattern(message!.value!);
+
+    // The link has to be a placeable inside the sentence, not a hand-split
+    // fragment, or translators cannot move it.
+    expect(formatted).toContain('<linkExternal>Learn more</linkExternal>');
+    expect(getSubcopy()).toHaveTextContent(stripOverlayTags(formatted));
+  });
+
+  it('renders the heading and subcopy', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Get Firefox on this device'
+    );
+    expect(getSubcopy()).toHaveTextContent(
+      'Download Firefox to sync bookmarks, history, and more across devices. Learn more'
+    );
+  });
+
+  it('exposes the brand lockup and illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the two images this card renders.
+      'Mozilla logo',
+      'Firefox logo',
+      'A desktop browser window and a mobile phone, both syncing, with the Firefox mascot alongside them',
+    ]);
+  });
+
+  it('points the primary action at the mobile Firefox download page', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(
+      screen.getByRole('link', { name: /Continue in Firefox/ })
+    ).toHaveAttribute('href', Constants.FIREFOX_MOBILE_DOWNLOAD_URL);
+  });
+
+  it('points the inline Learn more link at the sync explainer', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(screen.getByRole('link', { name: /Learn more/ })).toHaveAttribute(
+      'href',
+      LINK.FX_SYNC
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.test.tsx
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { LINK } from '../../../../constants';
+import { Constants } from '../../../../lib/constants';
+import DownloadFirefox from '.';
+
+// The subcopy embeds the "Learn more" link with a Fluent DOM overlay, so the
+// Fluent message carries `<linkExternal>` tags that never reach the DOM.
+const SUBCOPY_FTL_ID = 'pair2-supplicant-download-firefox-description';
+
+const stripOverlayTags = (message: string) =>
+  message.replace(/<\/?[a-zA-Z]+>/g, '');
+
+// The subcopy is not addressable by text — the inline link splits it across
+// nodes — so it is reached through the mocked FtlMsg that wraps it.
+const getSubcopy = () =>
+  screen.getAllByTestId('ftlmsg-mock').find((el) => el.id === SUBCOPY_FTL_ID);
+
+describe('Pair2/Supplicant/DownloadFirefox page', () => {
+  let bundle: FluentBundle;
+  beforeAll(async () => {
+    bundle = await getFtlBundle('settings');
+  });
+
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle.
+  it('renders every message with text matching the Fluent bundle', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'))
+      // `testL10n` compares rendered text against the raw Fluent message, which
+      // an overlay message can never satisfy. Covered by the test below.
+      .filter((el) => el.id !== SUBCOPY_FTL_ID);
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  it('renders the subcopy fallback matching the Fluent overlay message', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    const message = bundle.getMessage(SUBCOPY_FTL_ID);
+    const formatted = bundle.formatPattern(message!.value!);
+
+    // The link has to be a placeable inside the sentence, not a hand-split
+    // fragment, or translators cannot move it.
+    expect(formatted).toContain('<linkExternal>Learn more</linkExternal>');
+    expect(getSubcopy()).toHaveTextContent(stripOverlayTags(formatted));
+  });
+
+  it('renders the heading and subcopy', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Get Firefox on this device'
+    );
+    expect(getSubcopy()).toHaveTextContent(
+      'Download Firefox to sync bookmarks, history, and more across devices. Learn more'
+    );
+  });
+
+  it('exposes the brand lockup and illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the two images this card renders.
+      'Mozilla logo',
+      'Firefox logo',
+      "A desktop browser window and a mobile phone, both syncing, with the Firefox mascot alongside them",
+    ]);
+  });
+
+  it('points the primary action at the mobile Firefox download page', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(
+      screen.getByRole('link', { name: /Continue in Firefox/ })
+    ).toHaveAttribute('href', Constants.FIREFOX_MOBILE_DOWNLOAD_URL);
+  });
+
+  it('points the inline Learn more link at the sync explainer', () => {
+    renderWithLocalizationProvider(<DownloadFirefox />);
+
+    expect(screen.getByRole('link', { name: /Learn more/ })).toHaveAttribute(
+      'href',
+      LINK.FX_SYNC
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.tsx
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import AppLayout from '../../../../components/AppLayout';
+import {
+  FirefoxWordmarkImage,
+  SyncDevicesImage,
+} from '../../../../components/images';
+import { LINK } from '../../../../constants';
+import { Constants } from '../../../../lib/constants';
+
+const learnMoreLink = (
+  <LinkExternal
+    href={LINK.FX_SYNC}
+    className="link-dark-grey"
+  >
+    Learn more
+  </LinkExternal>
+);
+
+/**
+ * The mobile screen shown when pairing reaches a device that does not have
+ * Firefox yet. It explains what syncing gets the user and sends them off to
+ * install the browser.
+ *
+ * Both actions are static external URLs, so both are wired here and the card
+ * takes no props. The primary CTA uses the shared mobile download target
+ * rather than a per-platform App Store / Play Store link: picking between the
+ * two needs user-agent sniffing and runtime config (see `PocPairInit`), which
+ * would make this card non-presentational for no user-visible gain —
+ * mozilla.org already routes mobile visitors to the right store.
+ */
+const DownloadFirefox = () => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+      <SyncDevicesImage className="mt-10 h-[120px] w-auto" />
+
+      <FtlMsg id="pair2-supplicant-download-firefox-heading">
+        <h1 className="card-header mt-4">Get Firefox on this device</h1>
+      </FtlMsg>
+      <FtlMsg
+        id="pair2-supplicant-download-firefox-description"
+        elems={{ linkExternal: learnMoreLink }}
+      >
+        <p className="mt-1 text-base">
+          Download Firefox to sync bookmarks, history, and more across devices.{' '}
+          {learnMoreLink}
+        </p>
+      </FtlMsg>
+
+      <div className="mt-6 flex w-full">
+        <FtlMsg id="pair2-supplicant-download-firefox-continue-button">
+          <LinkExternal
+            href={Constants.FIREFOX_MOBILE_DOWNLOAD_URL}
+            className="cta-primary cta-xl"
+          >
+            Continue in Firefox
+          </LinkExternal>
+        </FtlMsg>
+      </div>
+    </div>
+  </AppLayout>
+);
+
+export default DownloadFirefox;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.tsx
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import AppLayout from '../../../../components/AppLayout';
+import {
+  FirefoxWordmarkImage,
+  SyncDevicesImage,
+} from '../../../../components/images';
+import { LINK } from '../../../../constants';
+import { Constants } from '../../../../lib/constants';
+
+/**
+ * Declared once and passed to both `elems` and the fallback children, so the
+ * href and styling cannot drift between the translated and untranslated
+ * renders. Fluent's DOM overlay clones this element and swaps in the
+ * translated link text, so the "Learn more" below is only the en fallback.
+ */
+const learnMoreLink = (
+  <LinkExternal
+    href={LINK.FX_SYNC}
+    className="text-grey-900 underline dark:text-grey-10"
+  >
+    Learn more
+  </LinkExternal>
+);
+
+/**
+ * The mobile screen shown when pairing reaches a device that does not have
+ * Firefox yet. It explains what syncing gets the user and sends them off to
+ * install the browser.
+ *
+ * Both actions are static external URLs, so both are wired here and the card
+ * takes no props. The primary CTA uses the shared mobile download target
+ * rather than a per-platform App Store / Play Store link: picking between the
+ * two needs user-agent sniffing and runtime config (see `PocPairInit`), which
+ * would make this card non-presentational for no user-visible gain —
+ * mozilla.org already routes mobile visitors to the right store.
+ *
+ * Presentational only: routing and the page-view/Glean metrics that sibling
+ * pairing pages emit land with the flow wiring.
+ */
+const DownloadFirefox = () => (
+  <AppLayout>
+    <div className="flex flex-col items-center text-center">
+      <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+      <SyncDevicesImage className="mt-10 h-[120px] w-auto" />
+
+      <FtlMsg id="pair2-supplicant-download-firefox-heading">
+        <h1 className="card-header mt-4">Get Firefox on this device</h1>
+      </FtlMsg>
+      <FtlMsg
+        id="pair2-supplicant-download-firefox-description"
+        elems={{ linkExternal: learnMoreLink }}
+      >
+        <p className="mt-1 text-base">
+          Download Firefox to sync bookmarks, history, and more across devices.{' '}
+          {learnMoreLink}
+        </p>
+      </FtlMsg>
+
+      {/* `cta-xl` sizes the button with `flex-1`, so the CTA needs a row flex
+          parent to fill the card width. */}
+      <div className="mt-6 flex w-full">
+        <FtlMsg id="pair2-supplicant-download-firefox-continue-button">
+          <LinkExternal
+            href={Constants.FIREFOX_MOBILE_DOWNLOAD_URL}
+            className="cta-primary cta-xl"
+          >
+            Continue in Firefox
+          </LinkExternal>
+        </FtlMsg>
+      </div>
+    </div>
+  </AppLayout>
+);
+
+export default DownloadFirefox;


### PR DESCRIPTION
## Because
- We are updating pairing flows and want to land UI components / pages first.
- Adds the mobile screen prompting the user to install Firefox to sync.

## This pull request
- Adds `packages/fxa-settings/src/pages/Pair2/Supplicant/DownloadFirefox/index.tsx`.
- Adds storybook stories for the page.
- Adds l10n files.

## Issue that this pull request solves

Closes: FXA-14236

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out the storybook output [here](https://mozilla.github.io/fxa/storybooks/pr-20987/fxa-settings/?path=/story/pages-pair2-supplicant-downloadfirefox--default). Compare against figma designs (linked in ticket). Check out code for AI slop and over all adherence to patterns set forth in FxA.

Note, that this is just UI work, wiring up functionality comes later.

Worth a look on review: both actions here are static external URLs, so both are wired rather than left as callback props. The primary CTA uses `Constants.FIREFOX_MOBILE_DOWNLOAD_URL` rather than a per-platform App Store / Play Store link, since picking between the two needs UA sniffing plus runtime config (see `PocPairInit`) and mozilla.org already routes mobile visitors to the right store. The inline "Learn more" uses `LINK.FX_SYNC` and is embedded in the sentence with a Fluent DOM overlay so translators can move it.

## Screenshots (Optional)

See story books.

## Other information (Optional)

Follows the pattern set in #20952 (FXA-14234).
