### PR TITLE
feat(settings): add desktop Timeout and cancel card

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/en.ftl
@@ -1,0 +1,17 @@
+## TimeoutAndCancel page - Part of the desktop-to-mobile pairing flow
+## Users see this on their computer when pairing stopped without succeeding,
+## either because it timed out or because it was canceled. Both cases offer to
+## start pairing over again.
+
+# Shown when the pairing attempt expired before it was approved
+pair2-authority-timeout-and-cancel-timeout-heading = Still want to connect a device?
+pair2-authority-timeout-and-cancel-timeout-description = Looks like we timed out. Try again if you still want to connect your mobile device and sync your { -brand-firefox } data.
+# Shown when the pairing attempt was canceled, on either device
+pair2-authority-timeout-and-cancel-canceled-heading = Canceled
+pair2-authority-timeout-and-cancel-canceled-description = If you change your mind or want to connect a different device, try again.
+# Restarts the pairing flow
+pair2-authority-timeout-and-cancel-try-again-button = Try again
+# Abandons pairing without retrying
+pair2-authority-timeout-and-cancel-cancel-button = Cancel
+# Takes the user to their Sync settings. "Sync" names the Firefox feature here, not the action.
+pair2-authority-timeout-and-cancel-sync-settings-button = Sync settings

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.stories.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import TimeoutAndCancel from '.';
+import { Subject } from './mocks';
+
+export default {
+  title: 'Pages/Pair2/Authority/TimeoutAndCancel',
+  component: TimeoutAndCancel,
+  decorators: [withLocalization],
+} as Meta;
+
+// The pairing request expired before it was approved, so the user still has an
+// attempt to abandon — the secondary action is Cancel.
+export const TimedOut = () => <Subject reason="timeout" />;
+
+// Pairing was already called off, so there is nothing left to cancel — the
+// secondary action sends the user to Sync settings instead.
+export const Canceled = () => <Subject reason="canceled" />;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.test.tsx
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { TimeoutAndCancelReason } from '.';
+import { Subject } from './mocks';
+
+const REASONS: TimeoutAndCancelReason[] = ['timeout', 'canceled'];
+
+describe('Pair2/Authority/TimeoutAndCancel page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle. Runs per reason because each one renders a different
+  // set of ids.
+  it.each(REASONS)(
+    'renders every message with text matching the Fluent bundle (%s)',
+    async (reason) => {
+      const bundle: FluentBundle = await getFtlBundle('settings');
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      const messages = screen
+        .getAllByTestId('ftlmsg-mock')
+        // The jest SVG stub renders the file name as the element's text, so
+        // image messages can never match. Covered by
+        // components/images/index.test.tsx.
+        .filter((el) => !el.textContent?.endsWith('.svg'));
+
+      expect(messages.length).toBeGreaterThan(0);
+      messages.forEach((el) => testL10n(el, bundle));
+    }
+  );
+
+  it.each(REASONS)(
+    'exposes the illustration to assistive technology (%s)',
+    (reason) => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(
+        screen
+          .getAllByRole('img')
+          .map(
+            (img) => img.getAttribute('alt') ?? img.getAttribute('aria-label')
+          )
+      ).toEqual([
+        // AppLayout's page header, then the single image this card renders.
+        // Desktop cards have no Firefox lockup.
+        'Mozilla logo',
+      ]);
+    }
+  );
+
+  describe('timeout', () => {
+    it('renders the heading, description, and actions', () => {
+      renderWithLocalizationProvider(<Subject reason="timeout" />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Still want to connect a device?'
+      );
+      screen.getByText(
+        'Looks like we timed out. Try again if you still want to connect your mobile device and sync your Firefox data.'
+      );
+      screen.getByRole('button', { name: 'Try again' });
+      screen.getByRole('button', { name: 'Cancel' });
+      expect(
+        screen.queryByRole('button', { name: 'Sync settings' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onCancel from the secondary action', async () => {
+      const user = userEvent.setup();
+      const onCancel = jest.fn();
+      const onSyncSettings = jest.fn();
+      renderWithLocalizationProvider(
+        <Subject reason="timeout" {...{ onCancel, onSyncSettings }} />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onSyncSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('canceled', () => {
+    it('renders the heading, description, and actions', () => {
+      renderWithLocalizationProvider(<Subject reason="canceled" />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Canceled'
+      );
+      screen.getByText(
+        'If you change your mind or want to connect a different device, try again.'
+      );
+      screen.getByRole('button', { name: 'Try again' });
+      screen.getByRole('button', { name: 'Sync settings' });
+      expect(
+        screen.queryByRole('button', { name: 'Cancel' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onSyncSettings from the secondary action', async () => {
+      const user = userEvent.setup();
+      const onCancel = jest.fn();
+      const onSyncSettings = jest.fn();
+      renderWithLocalizationProvider(
+        <Subject reason="canceled" {...{ onCancel, onSyncSettings }} />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Sync settings' }));
+
+      expect(onSyncSettings).toHaveBeenCalledTimes(1);
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(REASONS)(
+    'calls onTryAgain from the primary action (%s)',
+    async (reason) => {
+      const user = userEvent.setup();
+      const onTryAgain = jest.fn();
+      renderWithLocalizationProvider(<Subject {...{ reason, onTryAgain }} />);
+
+      await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+      expect(onTryAgain).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.test.tsx
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { TimeoutAndCancelReason } from '.';
+import { Subject } from './mocks';
+
+const REASONS: TimeoutAndCancelReason[] = ['timeout', 'canceled'];
+
+describe('Pair2/Authority/TimeoutAndCancel page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle. Runs per reason because each one renders a different
+  // set of ids.
+  it.each(REASONS)(
+    'renders every message with text matching the Fluent bundle (%s)',
+    async (reason) => {
+      const bundle: FluentBundle = await getFtlBundle('settings');
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      const messages = screen
+        .getAllByTestId('ftlmsg-mock')
+        // The jest SVG stub renders the file name as the element's text, so
+        // image messages can never match. Covered by
+        // components/images/index.test.tsx.
+        .filter((el) => !el.textContent?.endsWith('.svg'));
+
+      expect(messages.length).toBeGreaterThan(0);
+      messages.forEach((el) => testL10n(el, bundle));
+    }
+  );
+
+  it.each(REASONS)(
+    'exposes the illustration to assistive technology (%s)',
+    (reason) => {
+      renderWithLocalizationProvider(<Subject {...{ reason }} />);
+
+      expect(
+        screen
+          .getAllByRole('img')
+          .map(
+            (img) => img.getAttribute('alt') ?? img.getAttribute('aria-label')
+          )
+      ).toEqual([
+        // AppLayout's page header, then the single image this card renders.
+        // Desktop cards have no Firefox lockup.
+        'Mozilla logo',
+        'A browser window with a curled-up fox and a mobile device with the fox peeking out, with an exclamation mark between them, showing the connection was interrupted',
+      ]);
+    }
+  );
+
+  describe('timeout', () => {
+    it('renders the heading, description, and actions', () => {
+      renderWithLocalizationProvider(<Subject reason="timeout" />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Still want to connect a device?'
+      );
+      screen.getByText(
+        'Looks like we timed out. Try again if you still want to connect your mobile device and sync your Firefox data.'
+      );
+      screen.getByRole('button', { name: 'Try again' });
+      screen.getByRole('button', { name: 'Cancel' });
+      expect(
+        screen.queryByRole('button', { name: 'Sync settings' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onCancel from the secondary action', async () => {
+      const user = userEvent.setup();
+      const onCancel = jest.fn();
+      const onSyncSettings = jest.fn();
+      renderWithLocalizationProvider(
+        <Subject reason="timeout" {...{ onCancel, onSyncSettings }} />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onSyncSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('canceled', () => {
+    it('renders the heading, description, and actions', () => {
+      renderWithLocalizationProvider(<Subject reason="canceled" />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Canceled'
+      );
+      screen.getByText(
+        'If you change your mind or want to connect a different device, try again.'
+      );
+      screen.getByRole('button', { name: 'Try again' });
+      screen.getByRole('button', { name: 'Sync settings' });
+      expect(
+        screen.queryByRole('button', { name: 'Cancel' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onSyncSettings from the secondary action', async () => {
+      const user = userEvent.setup();
+      const onCancel = jest.fn();
+      const onSyncSettings = jest.fn();
+      renderWithLocalizationProvider(
+        <Subject reason="canceled" {...{ onCancel, onSyncSettings }} />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Sync settings' }));
+
+      expect(onSyncSettings).toHaveBeenCalledTimes(1);
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(REASONS)(
+    'calls onTryAgain from the primary action (%s)',
+    async (reason) => {
+      const user = userEvent.setup();
+      const onTryAgain = jest.fn();
+      renderWithLocalizationProvider(<Subject {...{ reason, onTryAgain }} />);
+
+      await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+      expect(onTryAgain).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.tsx
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import { PairingInterruptedImage } from '../../../../components/images';
+
+/**
+ * Why pairing stopped. Shared verbatim with the mobile twin,
+ * `Pair2/Supplicant/TimeoutAndCancel`, so a route can pick a card without
+ * translating the value.
+ */
+export type TimeoutAndCancelReason = 'timeout' | 'canceled';
+
+export type TimeoutAndCancelProps = {
+  reason: TimeoutAndCancelReason;
+  /** Restarts pairing. The only action shared by both reasons. */
+  onTryAgain: () => void;
+  /** Abandons pairing. The secondary action when `reason` is `timeout`. */
+  onCancel: () => void;
+  /** Sends the user to sync settings. The secondary action when `reason` is `canceled`. */
+  onSyncSettings: () => void;
+};
+
+type VariantContent = {
+  headingFtlId: string;
+  heading: string;
+  descriptionFtlId: string;
+  description: string;
+  secondaryFtlId: string;
+  secondaryLabel: string;
+  secondaryHandler: 'onCancel' | 'onSyncSettings';
+};
+
+const variantContent: Record<TimeoutAndCancelReason, VariantContent> = {
+  timeout: {
+    headingFtlId: 'pair2-authority-timeout-and-cancel-timeout-heading',
+    heading: 'Still want to connect a device?',
+    descriptionFtlId: 'pair2-authority-timeout-and-cancel-timeout-description',
+    description:
+      'Looks like we timed out. Try again if you still want to connect your mobile device and sync your Firefox data.',
+    secondaryFtlId: 'pair2-authority-timeout-and-cancel-cancel-button',
+    secondaryLabel: 'Cancel',
+    secondaryHandler: 'onCancel',
+  },
+  canceled: {
+    headingFtlId: 'pair2-authority-timeout-and-cancel-canceled-heading',
+    heading: 'Canceled',
+    descriptionFtlId: 'pair2-authority-timeout-and-cancel-canceled-description',
+    description:
+      'If you change your mind or want to connect a different device, try again.',
+    secondaryFtlId: 'pair2-authority-timeout-and-cancel-sync-settings-button',
+    secondaryLabel: 'Sync settings',
+    secondaryHandler: 'onSyncSettings',
+  },
+};
+
+/**
+ * The desktop screen shown once pairing stops without succeeding — either it
+ * timed out or someone canceled it. Both reasons offer "Try again"; the
+ * secondary action differs, because a timeout leaves the user mid-flow with
+ * something to abandon while a cancel has already ended it.
+ */
+const TimeoutAndCancel = ({
+  reason,
+  onTryAgain,
+  onCancel,
+  onSyncSettings,
+}: TimeoutAndCancelProps) => {
+  const content = variantContent[reason];
+  const onSecondary = { onCancel, onSyncSettings }[content.secondaryHandler];
+
+  return (
+    <AppLayout>
+      <div className="flex flex-col items-center text-center">
+        <FtlMsg id={content.headingFtlId}>
+          <h1 className="card-header">{content.heading}</h1>
+        </FtlMsg>
+        <FtlMsg id={content.descriptionFtlId}>
+          <p className="mt-1 text-base">{content.description}</p>
+        </FtlMsg>
+
+        <PairingInterruptedImage className="mt-8 h-[136px] w-auto" />
+
+        <div className="mt-8 flex w-full">
+          <FtlMsg id="pair2-authority-timeout-and-cancel-try-again-button">
+            <button
+              type="button"
+              onClick={onTryAgain}
+              className="cta-primary cta-xl"
+            >
+              Try again
+            </button>
+          </FtlMsg>
+        </div>
+
+        <FtlMsg id={content.secondaryFtlId}>
+          <button
+            type="button"
+            onClick={onSecondary}
+            // `py-2` keeps the tap target comfortable, so the margin is halved
+            // to land on the 16px gap the design asks for.
+            className="mt-2 py-2 text-base text-grey-900 underline dark:text-grey-10"
+          >
+            {content.secondaryLabel}
+          </button>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default TimeoutAndCancel;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.tsx
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import { PairingInterruptedImage } from '../../../../components/images';
+
+/**
+ * Why pairing stopped. Shared verbatim with the mobile twin,
+ * `Pair2/Supplicant/TimeoutAndCancel`, so a route can pick a card without
+ * translating the value.
+ */
+export type TimeoutAndCancelReason = 'timeout' | 'canceled';
+
+export type TimeoutAndCancelProps = {
+  reason: TimeoutAndCancelReason;
+  /** Restarts pairing. The only action shared by both reasons. */
+  onTryAgain: () => void;
+  /** Abandons pairing. The secondary action when `reason` is `timeout`. */
+  onCancel: () => void;
+  /** Sends the user to sync settings. The secondary action when `reason` is `canceled`. */
+  onSyncSettings: () => void;
+};
+
+type VariantContent = {
+  headingFtlId: string;
+  heading: string;
+  descriptionFtlId: string;
+  description: string;
+  secondaryFtlId: string;
+  secondaryLabel: string;
+  /**
+   * Which of the caller's secondary handlers this variant's link fires. Named
+   * rather than passed in per-variant so adding a reason stays a change to this
+   * table plus one new prop, not a change to the markup below.
+   */
+  secondaryHandler: 'onCancel' | 'onSyncSettings';
+};
+
+const variantContent: Record<TimeoutAndCancelReason, VariantContent> = {
+  timeout: {
+    headingFtlId: 'pair2-authority-timeout-and-cancel-timeout-heading',
+    heading: 'Still want to connect a device?',
+    descriptionFtlId: 'pair2-authority-timeout-and-cancel-timeout-description',
+    description:
+      'Looks like we timed out. Try again if you still want to connect your mobile device and sync your Firefox data.',
+    secondaryFtlId: 'pair2-authority-timeout-and-cancel-cancel-button',
+    secondaryLabel: 'Cancel',
+    secondaryHandler: 'onCancel',
+  },
+  canceled: {
+    headingFtlId: 'pair2-authority-timeout-and-cancel-canceled-heading',
+    heading: 'Canceled',
+    descriptionFtlId: 'pair2-authority-timeout-and-cancel-canceled-description',
+    description:
+      'If you change your mind or want to connect a different device, try again.',
+    secondaryFtlId: 'pair2-authority-timeout-and-cancel-sync-settings-button',
+    secondaryLabel: 'Sync settings',
+    secondaryHandler: 'onSyncSettings',
+  },
+};
+
+/**
+ * The desktop screen shown once pairing stops without succeeding — either it
+ * timed out or someone canceled it. Both reasons offer "Try again"; the
+ * secondary action differs, because a timeout leaves the user mid-flow with
+ * something to abandon while a cancel has already ended it.
+ *
+ * Unlike the mobile pairing cards this has no Firefox lockup, and the
+ * illustration sits below the copy rather than above it.
+ *
+ * Presentational only: routing and the page-view/Glean metrics that sibling
+ * pairing pages emit land with the flow wiring.
+ */
+const TimeoutAndCancel = ({
+  reason,
+  onTryAgain,
+  onCancel,
+  onSyncSettings,
+}: TimeoutAndCancelProps) => {
+  const content = variantContent[reason];
+  const onSecondary = { onCancel, onSyncSettings }[content.secondaryHandler];
+
+  return (
+    <AppLayout>
+      <div className="flex flex-col items-center text-center">
+        <FtlMsg id={content.headingFtlId}>
+          <h1 className="card-header">{content.heading}</h1>
+        </FtlMsg>
+        <FtlMsg id={content.descriptionFtlId}>
+          <p className="mt-1 text-base">{content.description}</p>
+        </FtlMsg>
+
+        <PairingInterruptedImage className="mt-8 h-[136px] w-auto" />
+
+        {/* `cta-xl` sizes itself with `flex-1`, so it needs a flex row around it
+            to stretch to the full card width the design calls for. */}
+        <div className="mt-8 flex w-full">
+          <FtlMsg id="pair2-authority-timeout-and-cancel-try-again-button">
+            <button
+              type="button"
+              onClick={onTryAgain}
+              className="cta-primary cta-xl"
+            >
+              Try again
+            </button>
+          </FtlMsg>
+        </div>
+
+        <FtlMsg id={content.secondaryFtlId}>
+          <button
+            type="button"
+            onClick={onSecondary}
+            // `py-2` keeps the tap target comfortable, so the margin is halved
+            // to land on the 16px gap the design asks for.
+            className="mt-2 py-2 text-base text-grey-900 underline dark:text-grey-10"
+          >
+            {content.secondaryLabel}
+          </button>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default TimeoutAndCancel;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/mocks.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import TimeoutAndCancel, { TimeoutAndCancelProps } from '.';
+
+export const Subject = ({
+  reason = 'timeout',
+  onTryAgain = () => {},
+  onCancel = () => {},
+  onSyncSettings = () => {},
+}: Partial<TimeoutAndCancelProps> = {}) => (
+  <TimeoutAndCancel {...{ reason, onTryAgain, onCancel, onSyncSettings }} />
+);


### PR DESCRIPTION
## Because
- We are updating pairing flows and want to land UI components / pages first.
- Adds the desktop screen shown when pairing times out or is canceled.

## This pull request
- Adds `packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/index.tsx`, a single presentational card that covers both states via a `reason: 'timeout' | 'canceled'` prop.
- Adds storybook stories, one per state.
- Adds l10n files, with separate messages per state.
- Adds unit tests covering both states, including the differing secondary action.

## Issue that this pull request solves

Closes: FXA-14241

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out the storybook output [here](https://mozilla.github.io/fxa/storybooks/pr-20989/fxa-settings/?path=/story/pages-pair2-authority-timeoutandcancel--timed-out). Compare against figma designs (linked in ticket). Check out code for AI slop and over all adherence to patterns set forth in FxA.

This one card covers both interrupted states. The copy and both actions differ per state, so the interesting bit is the `reason` prop and the `variantContent` table it indexes: `timeout` pairs "Try again" with "Cancel", `canceled` pairs it with "Sync settings". `onCancel` and `onSyncSettings` are separate named props rather than one `onSecondary`, so the call site says what it is wiring up; the component picks between them from the same table that holds the copy.

Note, that this is just UI work, wiring up functionality comes later.

## Screenshots (Optional)

See story books.

## Other information (Optional)

Based on #20979, which adds the illustration. Follows the pattern set in #20952 (FXA-14234).
