### PR TITLE
feat(settings): add desktop Approve sign in card

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/en.ftl
@@ -1,0 +1,13 @@
+## ApproveSignIn page - Part of the desktop-to-mobile pairing flow
+## Users see this on their computer, which is already signed in, after their
+## mobile device scans the pairing QR code. It asks them to approve the
+## sign-in, and shows the requesting device's details so they can verify it.
+
+# Asks the user to confirm the sign-in that another one of their devices just started
+pair2-authority-approve-sign-in-heading = Approve sign-in?
+# Submit button confirming that the user started the pairing and approves the
+# other device being added to their account
+pair2-authority-approve-sign-in-confirm-button = Yes, approve sign in
+# "Not you?" asks whether someone other than the user started this sign-in.
+# The text inside <changePassword> links to the page for changing the password.
+pair2-authority-approve-sign-in-change-password = Not you? <changePassword>Change your password</changePassword>

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/en.ftl
@@ -1,0 +1,13 @@
+## ApproveSignIn page - Part of the desktop-to-mobile pairing flow
+## Users see this on their computer, which is already signed in, after their
+## mobile device scans the pairing QR code. It asks them to approve the
+## sign-in, and shows the requesting device's details so they can verify it.
+
+# Asks the user to confirm the sign-in that another one of their devices just started
+pair2-authority-approve-sign-in-heading = Approve sign-in?
+# Submit button confirming that the user started the pairing and approves the
+# other device being added to their account
+pair2-authority-approve-sign-in-confirm-button = Yes, approve sign-in
+# "Not you?" asks whether someone other than the user started this sign-in.
+# The text inside <changePassword> links to the page for changing the password.
+pair2-authority-approve-sign-in-change-password = Not you? <changePassword>Change your password</changePassword>

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.stories.tsx
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import ApproveSignIn from '.';
+import {
+  MOCK_METADATA_UNKNOWN_LOCATION,
+  MOCK_METADATA_WITH_LOCATION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import {
+  MOCK_LONG_EMAIL,
+  MOCK_METADATA_LONG_DEVICE_NAME,
+  Subject,
+} from './mocks';
+
+export default {
+  title: 'Pages/Pair2/Authority/ApproveSignIn',
+  component: ApproveSignIn,
+  decorators: [withLocalization],
+} as Meta;
+
+export const WithDeviceName = () => <Subject />;
+
+// No device name on the pairing payload, so the device line falls back to the OS.
+export const WithoutDeviceName = () => (
+  <Subject remoteMetadata={MOCK_METADATA_WITH_LOCATION} />
+);
+
+// Geo lookup resolved nothing, so the location line reads "Location unknown".
+export const WithUnknownLocation = () => (
+  <Subject remoteMetadata={MOCK_METADATA_UNKNOWN_LOCATION} />
+);
+
+export const WithLongDeviceName = () => (
+  <Subject remoteMetadata={MOCK_METADATA_LONG_DEVICE_NAME} />
+);
+
+export const WithLongEmail = () => <Subject email={MOCK_LONG_EMAIL} />;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.test.tsx
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import {
+  MOCK_CITY,
+  MOCK_COUNTRY,
+  MOCK_DEVICE_FAMILY,
+  MOCK_DEVICE_NAME,
+  MOCK_IP_ADDRESS,
+  MOCK_REGION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import { MOCK_EMAIL, Subject } from './mocks';
+
+const FTL_ARGS = {
+  browserName: MOCK_DEVICE_FAMILY,
+  deviceName: MOCK_DEVICE_NAME,
+  city: MOCK_CITY,
+  region: MOCK_REGION,
+  country: MOCK_COUNTRY,
+  ipAddress: MOCK_IP_ADDRESS,
+};
+
+// `testL10n` compares the bundle message against the element's text, so it
+// can't check a message whose bundle text still carries the DOM-overlay tags
+// that `elems` swaps for real elements. This one is checked tag-stripped below.
+const CHANGE_PASSWORD_FTL_ID =
+  'pair2-authority-approve-sign-in-change-password';
+
+describe('Pair2/Authority/ApproveSignIn page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle — including a rename of the `device-info-*` ids that
+  // DeviceInfoBlock owns.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<Subject />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'))
+      .filter((el) => el.id !== CHANGE_PASSWORD_FTL_ID);
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle, FTL_ARGS));
+  });
+
+  it('renders the change password sentence with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    const message = bundle.getMessage(CHANGE_PASSWORD_FTL_ID);
+    renderWithLocalizationProvider(<Subject />);
+
+    const withoutOverlayTags = bundle
+      .formatPattern(message!.value!)
+      .replace(/<\/?changePassword>/g, '');
+
+    expect(
+      screen
+        .getAllByTestId('ftlmsg-mock')
+        .find((el) => el.id === CHANGE_PASSWORD_FTL_ID)
+    ).toHaveTextContent(withoutOverlayTags);
+  });
+
+  it('renders the heading and the account email', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Approve sign-in?'
+    );
+    screen.getByText(MOCK_EMAIL);
+  });
+
+  it('exposes the illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the one image this card renders. Desktop
+      // cards have no Firefox lockup.
+      'Mozilla logo',
+      'A desktop browser window and a mobile phone, both syncing, with the Firefox mascot alongside them',
+    ]);
+  });
+
+  it('renders the device info block with the device name inline', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    screen.getByText('Firefox on Ultron');
+    screen.getByText('Vancouver, British Columbia, Canada (estimated)');
+    screen.getByText('IP address: XX.XX.XXX.XXX');
+    expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('calls onApprove when the approve button is clicked', async () => {
+    const user = userEvent.setup();
+    const onApprove = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onApprove }} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Yes, approve sign in' })
+    );
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onChangePassword when the change password link is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangePassword = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onChangePassword }} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Change your password' })
+    );
+
+    expect(onChangePassword).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.test.tsx
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import {
+  MOCK_CITY,
+  MOCK_COUNTRY,
+  MOCK_DEVICE_FAMILY,
+  MOCK_DEVICE_NAME,
+  MOCK_IP_ADDRESS,
+  MOCK_REGION,
+} from '../../../../components/DeviceInfoBlock/mocks';
+import { MOCK_EMAIL, Subject } from './mocks';
+
+const FTL_ARGS = {
+  browserName: MOCK_DEVICE_FAMILY,
+  deviceName: MOCK_DEVICE_NAME,
+  city: MOCK_CITY,
+  region: MOCK_REGION,
+  country: MOCK_COUNTRY,
+  ipAddress: MOCK_IP_ADDRESS,
+};
+
+// `testL10n` compares the bundle message against the element's text, so it
+// can't check a message whose bundle text still carries the DOM-overlay tags
+// that `elems` swaps for real elements. This one is checked tag-stripped below.
+const CHANGE_PASSWORD_FTL_ID =
+  'pair2-authority-approve-sign-in-change-password';
+
+describe('Pair2/Authority/ApproveSignIn page', () => {
+  // Guards against drift between the fallback text in the component and the
+  // actual Fluent bundle — including a rename of the `device-info-*` ids that
+  // DeviceInfoBlock owns.
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<Subject />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'))
+      .filter((el) => el.id !== CHANGE_PASSWORD_FTL_ID);
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle, FTL_ARGS));
+  });
+
+  it('renders the change password sentence with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    const message = bundle.getMessage(CHANGE_PASSWORD_FTL_ID);
+    renderWithLocalizationProvider(<Subject />);
+
+    const withoutOverlayTags = bundle
+      .formatPattern(message!.value!)
+      .replace(/<\/?changePassword>/g, '');
+
+    expect(
+      screen
+        .getAllByTestId('ftlmsg-mock')
+        .find((el) => el.id === CHANGE_PASSWORD_FTL_ID)
+    ).toHaveTextContent(withoutOverlayTags);
+  });
+
+  it('renders the heading and the account email', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Approve sign-in?'
+    );
+    screen.getByText(MOCK_EMAIL);
+  });
+
+  it('exposes the illustration to assistive technology', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
+    ).toEqual([
+      // AppLayout's page header, then the one image this card renders. Desktop
+      // cards have no Firefox lockup.
+      'Mozilla logo',
+      'A desktop browser window and a mobile phone, both syncing, with the Firefox mascot alongside them',
+    ]);
+  });
+
+  it('renders the device info block with the device name inline', () => {
+    renderWithLocalizationProvider(<Subject />);
+
+    screen.getByText('Firefox on Ultron');
+    screen.getByText('Vancouver, British Columbia, Canada (estimated)');
+    screen.getByText('IP address: XX.XX.XXX.XXX');
+    expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('calls onApprove when the approve button is clicked', async () => {
+    const user = userEvent.setup();
+    const onApprove = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onApprove }} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Yes, approve sign-in' })
+    );
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onChangePassword when the change password link is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangePassword = jest.fn();
+    renderWithLocalizationProvider(<Subject {...{ onChangePassword }} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Change your password' })
+    );
+
+    expect(onChangePassword).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.tsx
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import DeviceInfoBlock from '../../../../components/DeviceInfoBlock';
+import { SyncDevicesImage } from '../../../../components/images';
+import { RemoteMetadata } from '../../../../lib/types';
+
+export type ApproveSignInProps = {
+  /** The signed-in account the pairing request would be granted against. */
+  email: string;
+  /**
+   * Details of the device that scanned the pairing code, shown so the user can
+   * confirm the request came from their own phone. Supplied by the caller —
+   * this component does not read the pairing channel itself.
+   */
+  remoteMetadata: RemoteMetadata;
+  /** Grants the pairing request. */
+  onApprove: () => void;
+  /**
+   * Sends the user to change their password, the recovery path when they don't
+   * recognize the request. An internal route rather than an external URL, so it
+   * arrives as a callback instead of a `Link` — that keeps router context out of
+   * this card's stories and tests.
+   */
+  onChangePassword: () => void;
+};
+
+/**
+ * The desktop approval screen, shown on the already-signed-in computer once a
+ * phone has scanned its pairing code. It names the account, shows the
+ * requesting device's details for verification, and asks the user to approve.
+ */
+const ApproveSignIn = ({
+  email,
+  remoteMetadata,
+  onApprove,
+  onChangePassword,
+}: ApproveSignInProps) => (
+  <AppLayout>
+    <div className="text-center">
+      <FtlMsg id="pair2-authority-approve-sign-in-heading">
+        <h1 className="card-header">Approve sign-in?</h1>
+      </FtlMsg>
+
+      <p className="mt-1 break-all text-base">{email}</p>
+
+      <SyncDevicesImage className="mt-8 mb-4 h-[160px] w-auto mx-auto" />
+
+      <DeviceInfoBlock
+        {...{ remoteMetadata }}
+        deviceNameDisplay="inline"
+        className="mt-4 w-full rounded-md border border-grey-100 px-4 py-3 text-grey-500 dark:border-grey-500 dark:text-grey-300"
+      />
+
+      <FtlMsg id="pair2-authority-approve-sign-in-confirm-button">
+        <button
+          type="button"
+          onClick={onApprove}
+          className="cta-primary cta-xl mt-6 w-full"
+        >
+          Yes, approve sign-in
+        </button>
+      </FtlMsg>
+
+      <FtlMsg
+        id="pair2-authority-approve-sign-in-change-password"
+        elems={{
+          changePassword: (
+            <button
+              type="button"
+              onClick={onChangePassword}
+              className="text-grey-900 underline dark:text-grey-10"
+            />
+          ),
+        }}
+      >
+        <p className="mt-6 text-xs">
+          Not you?{' '}
+          {/* This can be replaced with a link to account settings to change their password. */}
+          <button
+            type="button"
+            onClick={onChangePassword}
+            className="text-grey-900 underline dark:text-grey-10"
+          >
+            Change your password
+          </button>
+        </p>
+      </FtlMsg>
+    </div>
+  </AppLayout>
+);
+
+export default ApproveSignIn;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.tsx
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../../components/AppLayout';
+import DeviceInfoBlock from '../../../../components/DeviceInfoBlock';
+import { SyncDevicesImage } from '../../../../components/images';
+import { RemoteMetadata } from '../../../../lib/types';
+
+export type ApproveSignInProps = {
+  /** The signed-in account the pairing request would be granted against. */
+  email: string;
+  /**
+   * Details of the device that scanned the pairing code, shown so the user can
+   * confirm the request came from their own phone. Supplied by the caller —
+   * this component does not read the pairing channel itself.
+   */
+  remoteMetadata: RemoteMetadata;
+  /** Grants the pairing request. */
+  onApprove: () => void;
+  /**
+   * Sends the user to change their password, the recovery path when they don't
+   * recognize the request. An internal route rather than an external URL, so it
+   * arrives as a callback instead of a `Link` — that keeps router context out of
+   * this card's stories and tests.
+   */
+  onChangePassword: () => void;
+};
+
+/**
+ * The desktop approval screen, shown on the already-signed-in computer once a
+ * phone has scanned its pairing code. It names the account, shows the
+ * requesting device's details for verification, and asks the user to approve.
+ *
+ * Presentational only: routing and the page-view/Glean metrics that sibling
+ * pairing pages emit land with the flow wiring.
+ */
+const ApproveSignIn = ({
+  email,
+  remoteMetadata,
+  onApprove,
+  onChangePassword,
+}: ApproveSignInProps) => (
+  <AppLayout>
+    <div className="text-center">
+      <FtlMsg id="pair2-authority-approve-sign-in-heading">
+        <h1 className="card-header">Approve sign-in?</h1>
+      </FtlMsg>
+      {/* Raw account data, so it is deliberately outside any `FtlMsg`. */}
+      <p className="mt-1 break-all text-base">{email}</p>
+
+      {/* Figma leaves 32px above and below the illustration; the 16px here plus
+          the device block's own `mt-4` make up the gap underneath it. */}
+      <SyncDevicesImage className="mt-8 mb-4 h-[160px] w-auto mx-auto" />
+
+      <DeviceInfoBlock
+        {...{ remoteMetadata }}
+        deviceNameDisplay="inline"
+        className="mt-4 w-full rounded-md border border-grey-100 px-4 py-3 text-grey-500 dark:border-grey-500 dark:text-grey-300"
+      />
+
+      <FtlMsg id="pair2-authority-approve-sign-in-confirm-button">
+        <button
+          type="button"
+          onClick={onApprove}
+          className="cta-primary cta-xl mt-6 w-full"
+        >
+          Yes, approve sign in
+        </button>
+      </FtlMsg>
+
+      <FtlMsg
+        id="pair2-authority-approve-sign-in-change-password"
+        elems={{
+          changePassword: (
+            <button
+              type="button"
+              onClick={onChangePassword}
+              className="text-grey-900 underline dark:text-grey-10"
+            />
+          ),
+        }}
+      >
+        <p className="mt-4 text-xs">
+          Not you?{' '}
+          <button
+            type="button"
+            onClick={onChangePassword}
+            className="text-grey-900 underline dark:text-grey-10"
+          >
+            Change your password
+          </button>
+        </p>
+      </FtlMsg>
+    </div>
+  </AppLayout>
+);
+
+export default ApproveSignIn;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/mocks.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ApproveSignIn, { ApproveSignInProps } from '.';
+import { MOCK_METADATA_WITH_DEVICE_NAME } from '../../../../components/DeviceInfoBlock/mocks';
+import { RemoteMetadata } from '../../../../lib/types';
+
+export const MOCK_EMAIL = 'jane.doe@example.com';
+
+// Long enough to need wrapping in the 480px card.
+export const MOCK_LONG_EMAIL = 'prettylongusername@longerdomain.example.com';
+
+// No dashes or spaces, so the only way this fits is if the block wraps it.
+export const MOCK_METADATA_LONG_DEVICE_NAME: RemoteMetadata = {
+  ...MOCK_METADATA_WITH_DEVICE_NAME,
+  deviceName: 'LaurelsExtremelyLongMacBookPro16inch2023',
+};
+
+export const Subject = ({
+  email = MOCK_EMAIL,
+  remoteMetadata = MOCK_METADATA_WITH_DEVICE_NAME,
+  onApprove = () => {},
+  onChangePassword = () => {},
+}: Partial<ApproveSignInProps> = {}) => (
+  <ApproveSignIn {...{ email, remoteMetadata, onApprove, onChangePassword }} />
+);


### PR DESCRIPTION
## Because

- We are updating pairing flows and want to land UI components / pages first.
- Adds the desktop screen asking the user to approve a pairing sign-in, showing the account email, the requesting device's browser, estimated location, and IP.

## This pull request

- Adds `packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.tsx`, the desktop twin of the merged `Pair2/Supplicant/ApproveSignIn`.
- Adds storybook stories for the page.
- Adds l10n files under the `pair2-authority-approve-sign-in-` prefix.
- Adds unit tests for the rendered copy, the illustration's accessible name, the device info block, and both callbacks.

## Issue that this pull request solves

Closes: FXA-14242

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Check out the storybook output [here](https://mozilla.github.io/fxa/storybooks/pr-20990/fxa-settings/?path=/story/pages-pair2-authority-approvesignin--with-device-name). Compare against the Figma designs (linked in the ticket). Check the code for AI slop and overall adherence to patterns set forth in FxA.

Note that this is just UI work; wiring up functionality comes later. The two actions are required callback props rather than wired handlers. For the route ticket, the legacy equivalent `pages/Pair/AuthAllow` does:

- **Approve** — `PairingAuthorityIntegration.authorize()`, falling back to `firefox.pairAuthorize(channelId)`, then navigates to `/pair/auth/wait_for_supp`.
- **Change your password** — links to the internal route `/settings/change_password`.

## Screenshots (Optional)

See storybooks.

## Other information (Optional)

Follows the pattern set in #20952 (FXA-14234).
