### PR TITLE
feat(settings): support step-up auth in sign-in flow

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -3179,6 +3179,7 @@ export default class AuthClient {
     options: {
       access_type?: string;
       acr_values?: string;
+      max_age?: number;
       keys_jwe?: string;
       redirect_uri?: string;
       response_type?: string;
@@ -3205,6 +3206,7 @@ export default class AuthClient {
       {
         access_type: options.access_type,
         acr_values: options.acr_values,
+        max_age: options.max_age,
         client_id: clientId,
         code_challenge: options.code_challenge,
         code_challenge_method: options.code_challenge_method,

--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -12,6 +12,8 @@ const DESCRIPTIONS = {
   acrValues:
     'A space-separated list of ACR values specifying acceptable levels of user authentication that the token should have a claim for. Specifying `AAL2` will require the token to have an authentication assuarance level >= 2 which ensures that the user has been authenticated with 2FA before authorizing the requested grant.',
   active: 'Boolean indicator of whether the presented token is active.',
+  maxAge:
+    'The maximum permissible elapsed time in seconds since the user last authenticated. If the session is older, a fresh second-factor challenge (step-up authentication) is required before the grant is authorized.',
   activePrice:
     'Whether the price can be used for new purchases. Defaults to true.',
   amount:

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -6,7 +6,7 @@ const { Container } = require('typedi');
 
 const { CapabilityService } = require('../payments/capability');
 const { config } = require('../../config');
-const { OauthError } = require('@fxa/accounts/errors');
+const { OauthError, AppError } = require('@fxa/accounts/errors');
 const db = require('./db');
 const util = require('./util');
 const ScopeSet = require('fxa-shared').oauth.scopes;
@@ -15,6 +15,14 @@ const sub = require('./jwt_sub');
 
 const ACR_VALUE_AAL2 = 'AAL2';
 const ACCESS_TYPE_OFFLINE = 'offline';
+
+// Leeway (seconds) applied to the `max_age` freshness comparison. Without it a
+// tight `max_age` (especially 0) could never be satisfied: the challenge →
+// re-authorize round-trip always advances the clock past `auth_time`, so the RP
+// would re-challenge in a loop. A few seconds of grace lets a just-completed
+// challenge satisfy the request while relaxing larger `max_age` values only
+// negligibly.
+const MAX_AGE_LEEWAY_SECONDS = 5;
 
 const SCOPE_OPENID = ScopeSet.fromArray(['openid']);
 const { OAUTH_SCOPE_SESSION_TOKEN } = require('fxa-shared/oauth/constants');
@@ -74,13 +82,30 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
   requestedGrant.scope = requestedGrant.scope || ScopeSet.fromArray([]);
 
   // If the grant request is for specific ACR values, do the identity claims support them?
+  // Throw errno 170 (INSUFFICIENT_ACR_VALUES) — the signal the frontend routes to a
+  // second-factor challenge (see pages/Signin/utils.ts, lib/oauth/hooks.tsx).
   if (requestedGrant.acr_values) {
     const acrTokens = requestedGrant.acr_values.trim().split(/\s+/g);
     if (
       acrTokens.includes(ACR_VALUE_AAL2) &&
       !(verifiedClaims['fxa-aal'] >= 2)
     ) {
-      throw OauthError.mismatchAcr(verifiedClaims['fxa-aal']);
+      throw AppError.insufficientACRValues(String(verifiedClaims['fxa-aal']));
+    }
+  }
+
+  // RFC 9470 step-up: if the RP requested a maximum authentication age, require a
+  // fresh challenge when the session's authentication event is older than that.
+  // `fxa-lastAuthAt` is in seconds; MAX_AGE_LEEWAY_SECONDS keeps a just-completed
+  // challenge from being treated as stale. Fail closed if the auth time is missing.
+  if (requestedGrant.max_age != null) {
+    const authAt = verifiedClaims['fxa-lastAuthAt'];
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (
+      authAt == null ||
+      nowSeconds - authAt > requestedGrant.max_age + MAX_AGE_LEEWAY_SECONDS
+    ) {
+      throw AppError.insufficientACRValues(String(verifiedClaims['fxa-aal']));
     }
   }
 

--- a/packages/fxa-auth-server/lib/oauth/grant.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/grant.spec.ts
@@ -109,7 +109,9 @@ describe('validateRequestedGrant', () => {
     };
     await expect(
       validateRequestedGrant(CLAIMS, CLIENT, requestedGrant)
-    ).rejects.toThrow('Mismatch acr value');
+      // errno 170 (INSUFFICIENT_ACR_VALUES) is the signal the frontend routes to
+      // a second-factor challenge.
+    ).rejects.toMatchObject({ errno: 170 });
     let grant = await validateRequestedGrant(
       { ...CLAIMS, 'fxa-aal': 2 },
       CLIENT,
@@ -130,7 +132,7 @@ describe('validateRequestedGrant', () => {
     };
     await expect(
       validateRequestedGrant(CLAIMS, CLIENT, requestedGrant)
-    ).rejects.toThrow('Mismatch acr value');
+    ).rejects.toMatchObject({ errno: 170 });
     const grant = await validateRequestedGrant(
       { ...CLAIMS, 'fxa-aal': 2 },
       CLIENT,
@@ -176,6 +178,50 @@ describe('validateRequestedGrant', () => {
         requestedGrant
       )
     ).rejects.toThrow('Requested scopes are not allowed');
+  });
+
+  describe('max_age (RFC 9470 freshness)', () => {
+    // `fxa-lastAuthAt` is seconds since epoch, compared against Date.now()/1000.
+    const nowSeconds = () => Math.floor(Date.now() / 1000);
+    const claimsAuthedAt = (secondsAgo: number) => ({
+      ...CLAIMS,
+      'fxa-lastAuthAt': nowSeconds() - secondsAgo,
+    });
+
+    it('requires step-up (errno 170) when the session is older than max_age', async () => {
+      await expect(
+        validateRequestedGrant(claimsAuthedAt(3600), CLIENT, { max_age: 60 })
+      ).rejects.toMatchObject({ errno: 170 });
+    });
+
+    it('passes when the session is within max_age', async () => {
+      const grant = await validateRequestedGrant(claimsAuthedAt(10), CLIENT, {
+        max_age: 3600,
+      });
+      expect(grant.aal).toBe(1);
+    });
+
+    it('treats max_age=0 as satisfied by a just-completed challenge (within leeway)', async () => {
+      const grant = await validateRequestedGrant(claimsAuthedAt(0), CLIENT, {
+        max_age: 0,
+      });
+      expect(grant.aal).toBe(1);
+    });
+
+    it('requires step-up for max_age=0 when the session is older than the leeway', async () => {
+      await expect(
+        validateRequestedGrant(claimsAuthedAt(60), CLIENT, { max_age: 0 })
+      ).rejects.toMatchObject({ errno: 170 });
+    });
+
+    it('skips the freshness check entirely when max_age is absent', async () => {
+      const grant = await validateRequestedGrant(
+        claimsAuthedAt(99999),
+        CLIENT,
+        {}
+      );
+      expect(grant.aal).toBe(1);
+    });
   });
 });
 

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -420,6 +420,12 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
               .optional()
               .allow(null)
               .description(DESCRIPTION.acrValues),
+            max_age: Joi.number()
+              .integer()
+              .min(0)
+              .optional()
+              .allow(null)
+              .description(DESCRIPTION.maxAge),
             resource: validators.resourceUrl
               .when('response_type', {
                 is: RESPONSE_TYPE_TOKEN,
@@ -515,6 +521,12 @@ module.exports = ({ log, oauthDB, config, statsd }) => {
               .allow(null)
               .optional()
               .description(DESCRIPTION.acrValues),
+            max_age: Joi.number()
+              .integer()
+              .min(0)
+              .allow(null)
+              .optional()
+              .description(DESCRIPTION.maxAge),
             assertion: Joi.forbidden(),
             resource: Joi.forbidden(),
             service: validators.service

--- a/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
@@ -1036,8 +1036,13 @@ describe('#integration - /v1', function () {
           .then(function (res) {
             expect(res.statusCode).toBe(400);
             assertSecurityHeaders(res);
-            expect(res.result.message).toBe('Mismatch acr value');
-            expect(res.result.errno).toBe(120);
+            // errno 170 (INSUFFICIENT_ACR_VALUES) is the signal the frontend
+            // routes to a second-factor (step-up) challenge; errno 120 was not
+            // recognized by the frontend step-up handlers.
+            expect(res.result.message).toBe(
+              'Required Authentication Context Reference values could not be satisfied'
+            );
+            expect(res.result.errno).toBe(170);
           });
       });
 

--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -159,6 +159,11 @@ async function getOAuthData(
   if (integration.data.prompt) {
     opts.prompt = integration.data.prompt;
   }
+  // Forward max_age so the server can enforce authentication freshness and
+  // require step-up when the session is too old (RFC 9470 / FXA-12856).
+  if (integration.data.maxAge != null) {
+    opts.max_age = integration.data.maxAge;
+  }
 
   const result: OAuthData | null = await authClient.createOAuthCode(
     sessionToken,

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
@@ -39,6 +39,36 @@ describe('models/integrations/oauth-relier', function () {
     expect(model).toBeDefined();
   });
 
+  describe('wantsLogin', () => {
+    function getIntegration(params: Record<string, unknown>) {
+      return new OAuthWebIntegration(
+        new GenericData({ scope: 'profile', ...params }),
+        new GenericData({ scope: 'profile' }),
+        {
+          scopedKeysEnabled: true,
+          scopedKeysValidation: {},
+          isPromptNoneEnabled: true,
+          isPromptNoneEnabledClientIds: [],
+        }
+      );
+    }
+
+    it('returns true when prompt=login', () => {
+      expect(getIntegration({ prompt: 'login' }).wantsLogin()).toBe(true);
+    });
+
+    // Step-up auth must NOT prompt for a password; max_age drives a second-factor
+    // challenge via the backend instead (FXA-12861 / FXA-12856).
+    it('does not force login for max_age=0', () => {
+      // Query-param values are strings in the data store.
+      expect(getIntegration({ max_age: '0' }).wantsLogin()).toBe(false);
+    });
+
+    it('returns false when neither prompt=login nor a password reason is present', () => {
+      expect(getIntegration({}).wantsLogin()).toBe(false);
+    });
+  });
+
   describe('scope', () => {
     const SCOPE = 'profile:email profile:uid';
     const SCOPE_PROFILE = 'profile';

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -181,7 +181,11 @@ export class OAuthWebIntegration extends GenericIntegration<
   }
 
   wantsLogin() {
-    return this.data.prompt === OAuthPrompt.LOGIN || this.data.maxAge === 0;
+    // `max_age` used to force a password prompt here (via `maxAge === 0`). Step-up
+    // auth must NOT prompt for a password — `max_age` is forwarded to the backend
+    // and drives a second-factor challenge instead (RFC 9470 / FXA-12856). Only
+    // `prompt=login` still forces password re-entry.
+    return this.data.prompt === OAuthPrompt.LOGIN;
   }
 
   wantsPromptNone() {

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -588,6 +588,10 @@ describe('Signin utils', () => {
       };
 
       it('diverts to /inline_totp_setup when the account has no TOTP', async () => {
+        // An AAL2 RP may check account-level AAL2 (profile:amr), where passkeys
+        // don't count, so a passkey session with no account TOTP is still forced
+        // to enroll to avoid the AMO bounce loop. (Distinguishing session- vs
+        // account-level AAL2 is FXA-14312.)
         const finishOAuthFlowHandler = jest.fn();
         const navigationOptions = buildPasskeyOAuthOptions({
           accountHasTotp: false,
@@ -664,6 +668,57 @@ describe('Signin utils', () => {
 
         expect(finishOAuthFlowHandler).toHaveBeenCalledTimes(1);
         expect(hardNavigateSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('AAL upgrade / step-up routing', () => {
+      // /settings is the carve-out for Settings-originated AAL upgrades only.
+      // RP-initiated step-up is not flagged isSessionAALUpgrade and completes
+      // the OAuth flow back to the RP.
+      it('completes the OAuth flow to the RP for an RP-initiated step-up', async () => {
+        const integration = createMockSigninOAuthIntegration();
+        integration.wantsTwoStepAuthentication = jest
+          .fn()
+          .mockReturnValue(true);
+        const finishOAuthFlowHandler = jest
+          .fn()
+          .mockResolvedValue(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
+
+        const navigationOptions = createBaseNavigationOptions({
+          integration,
+          // Not a Settings upgrade; account already AAL2 so the TOTP-setup gate
+          // is skipped and the grant completes.
+          accountHasTotp: true,
+          finishOAuthFlowHandler,
+        });
+
+        await handleNavigation(navigationOptions);
+
+        expect(mockNavigate).not.toHaveBeenCalledWith('/settings');
+        expect(finishOAuthFlowHandler).toHaveBeenCalledTimes(1);
+        expect(hardNavigateSpy).toHaveBeenCalledWith(
+          MOCK_OAUTH_FLOW_HANDLER_RESPONSE.redirect,
+          undefined,
+          undefined,
+          true
+        );
+      });
+
+      it('returns a Settings-originated AAL upgrade to /settings', async () => {
+        const integration = createMockSigninOAuthIntegration();
+        const finishOAuthFlowHandler = jest.fn();
+
+        const navigationOptions = createBaseNavigationOptions({
+          integration,
+          isSessionAALUpgrade: true,
+          finishOAuthFlowHandler,
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(finishOAuthFlowHandler).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith('/settings');
       });
     });
 

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -223,12 +223,12 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
     integration.wantsTwoStepAuthentication();
   const wantsKeys = integration.wantsKeys();
 
-  // If this is an AAL upgrade, the user was redirected from Settings to enter TOTP.
-  // RP redirects won't get into this state since they'll be taken to the RP and
-  // never Settings. This flow doesn't need Sync web channel messages or care about
-  // skipping navigating either because if a Sync user is inside Settings, we probably
-  // don't have the oauth query parameters required to begin a sign-in flow
-  // anyway. Just take all users back to /settings.
+  // Settings-originated AAL upgrades return to /settings. This is the one
+  // carve-out: the user was redirected from Settings to enter TOTP (they don't
+  // have the OAuth query parameters to begin a sign-in flow). Every other
+  // step-up — RP-initiated, i.e. acr_values/max_age — is NOT flagged
+  // isSessionAALUpgrade and falls through to complete the OAuth flow back to the
+  // RP below. This flow also doesn't need Sync web channel messages.
   if (navigationOptions.isSessionAALUpgrade) {
     navigate('/settings');
     return { error: undefined };


### PR DESCRIPTION
## Because

* RFC 9470 step-up requires the authorization endpoint to re-challenge when a session doesn't meet the requested authentication level or is older than max_age; max_age was rejected with a 400 and no freshness check existed
* an RP requesting step-up (acr_values=AAL2 / max_age) must be challenged for a second factor without prompting for a password, and passkey users were wrongly forced into TOTP enrollment they don't need

## This pull request

* accepts max_age in both /authorization payload schemas
* enforces max_age freshness in validateRequestedGrant, with a small leeway so a just-completed challenge (incl. max_age=0) is not looped
* throws INSUFFICIENT_ACR_VALUES (errno 170) for both acr_values and max_age failures, the signal the frontend routes to step-up (was 120, which the frontend ignored)
* decouples max_age from the password prompt and forwards max_age to the backend so it can enforce authentication freshness
* does not force TOTP enrollment for passkey sessions (already AAL2)

## Issue that this pull request solves

Closes: FXA-12856, FXA-12861

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
