### PR TITLE
chore(blender): dry-run automerge to stop endless re-approvals

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -4,6 +4,14 @@ repo_name: "Firefox Accounts (mozilla/fxa)"
 node_version: "24.15.0"
 install_command: "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable --inline-builds"
 
+automerge:
+  # Dry-run to stop endless re-approvals: fxa has no required status checks,
+  # so an approved PR goes "clean" immediately and GitHub refuses to arm
+  # auto-merge — BLEnder then re-approves every sweep and approvals pile up as
+  # noise. Re-enable once mozilla/blender#120 (idempotent approval + direct
+  # merge when clean) lands.
+  dry_run: true
+
 investigate:
   # Disabled: BLEnder's alert remediation is npm-only (npm audit fix +
   # package-lock.json). fxa is a yarn repo, so remediate always fails, the


### PR DESCRIPTION
**Because:** fxa has no required status checks, so an approved Dependabot PR goes "clean" immediately and GitHub refuses to arm auto-merge. BLEnder then re-approves each safe PR every sweep — approvals pile up as noise (postcss #20923 hit ~30). Dry-run keeps BLEnder installed and evaluating, but stops it posting reviews.

**This PR:** Sets `automerge.dry_run: true` for BLEnder on fxa, which will silence the incessant comments.

Auto-merge can't actually complete on fxa today anyway. Revert once mozilla/blender#120 (idempotent approval + direct-merge when clean) lands.