### PR TITLE
feat(settings): Add CAD button in Connected Services when signed into Fx Desktop

### DIFF
--- a/packages/fxa-settings/src/components/FirefoxPromoBanner/bannerState.ts
+++ b/packages/fxa-settings/src/components/FirefoxPromoBanner/bannerState.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { isPairingSupported } from '../../lib/utilities';
+
 export type BannerState =
   | 'firefox-pair'
   | 'switch-desktop'
@@ -22,13 +24,14 @@ export function getBannerState({
   isMobile: boolean;
   isSignedIntoBrowser: boolean;
 }): BannerState {
+  if (isPairingSupported({ isFirefox, isMobile }) && isSignedIntoBrowser) {
+    return 'firefox-pair';
+  }
+  // Firefox mobile already has the app. Desktop without a browser session gets
+  // no banner, though the Connected Services button still shows there: it only
+  // needs `isPairingSupported`, since /pair can obtain the session itself.
   if (isFirefox) {
-    // Firefox mobile users already have the app, so there is nothing to promo.
-    if (isMobile) {
-      return 'hidden';
-    }
-    // Desktop Firefox: only promote pairing to users signed into the browser.
-    return isSignedIntoBrowser ? 'firefox-pair' : 'hidden';
+    return 'hidden';
   }
   return isMobile ? 'switch-mobile' : 'switch-desktop';
 }

--- a/packages/fxa-settings/src/components/FirefoxPromoBanner/index.test.tsx
+++ b/packages/fxa-settings/src/components/FirefoxPromoBanner/index.test.tsx
@@ -21,6 +21,7 @@ jest.mock('../../models', () => ({
 
 jest.mock('../../lib/utilities', () => ({
   __esModule: true,
+  ...jest.requireActual('../../lib/utilities'),
   isMobileDevice: jest.fn(),
   isMobileOrTabletDevice: jest.fn(),
 }));

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/en.ftl
@@ -14,6 +14,10 @@ cs-logged-out-2 = Logged out of { $service }
 cs-refresh-button =
   .title = Refresh connected services
 
+# Button under the "Connected services" header that starts the flow to pair
+# another device to the user's account.
+cs-connect-device-button = Connect a device
+
 # Link text to a support page on missing or duplicate devices
 cs-missing-device-help = Missing or duplicate items?
 

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.stories.tsx
@@ -33,13 +33,16 @@ const accountWithBrowserServices = {
   attachedClients: MOCK_BROWSER_SERVICES,
 } as unknown as Account;
 
-const storyWithContext = (account: Partial<Account>) => {
+const storyWithContext = (
+  account: Partial<Account>,
+  showConnectDeviceButton = false
+) => {
   const context = { account: account as Account };
 
   const story = () => (
     <MemoryRouter>
       <AppContext.Provider value={mockAppContext(context)}>
-        <ConnectedServices />
+        <ConnectedServices {...{ showConnectDeviceButton }} />
       </AppContext.Provider>
     </MemoryRouter>
   );
@@ -50,6 +53,12 @@ export const Default = storyWithContext(accountWithManyServices);
 
 // Shows ConnectAnotherDevicePromo if no mobile devices in the list
 export const NoMobileServices = storyWithContext(accountWithoutMobileDevice);
+
+// Shows the "Connect a device" button
+export const WithConnectDeviceButton = storyWithContext(
+  accountWithManyServices,
+  true
+);
 
 // Demonstrates the read-only scope sub-entries shown under a refresh-token
 // browser entry when the token's scope includes Relay and/or VPN.

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -604,6 +604,30 @@ describe('Connected Services', () => {
     });
   });
 
+  describe('connect a device button', () => {
+    const renderWithButton = (showConnectDeviceButton: boolean) =>
+      renderWithRouter(
+        <AppContext.Provider value={mockAppContext({ account })}>
+          <ConnectedServices {...{ showConnectDeviceButton }} />
+        </AppContext.Provider>
+      );
+
+    it('links to the pairing flow', async () => {
+      renderWithButton(true);
+      expect(
+        await screen.findByRole('link', { name: 'Connect a device' })
+      ).toHaveAttribute('href', '/pair');
+    });
+
+    it('does not render when showConnectDeviceButton is false', async () => {
+      renderWithButton(false);
+      await screen.findByTestId('settings-connected-services');
+      expect(
+        screen.queryByRole('link', { name: 'Connect a device' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe('scope-based sub row', () => {
     const baseMockClient = {
       deviceId: null,

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -6,6 +6,7 @@ import { Localized, useLocalization } from '@fluent/react';
 import { LinkExternal } from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import React, { forwardRef, useCallback, useState } from 'react';
+import { Link, useLocation } from 'react-router';
 import { clearSignedInAccountUid, setSigningOut } from '../../../lib/cache';
 import { logViewEvent } from '../../../lib/metrics';
 import { isMobileDevice } from '../../../lib/utilities';
@@ -26,14 +27,13 @@ const DEVICES_SUPPORT_URL =
 export function sortAndFilterConnectedClients(
   attachedClients: Array<AttachedClient>
 ) {
-  const groupedByName = attachedClients.reduce<Record<string, AttachedClient[]>>(
-    (acc, client) => {
-      const key = String(client.name);
-      acc[key] = acc[key] ? [...acc[key], client] : [client];
-      return acc;
-    },
-    {}
-  );
+  const groupedByName = attachedClients.reduce<
+    Record<string, AttachedClient[]>
+  >((acc, client) => {
+    const key = String(client.name);
+    acc[key] = acc[key] ? [...acc[key], client] : [client];
+    return acc;
+  }, {});
 
   // get a unique (by name) list and sort by time last accessed
   const sortedAndUniqueClients = Object.keys(groupedByName)
@@ -56,9 +56,13 @@ export function sortAndFilterConnectedClients(
   return { groupedByName, sortedAndUniqueClients };
 }
 
-export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
+export const ConnectedServices = forwardRef<
+  HTMLDivElement,
+  { showConnectDeviceButton?: boolean }
+>(({ showConnectDeviceButton = false }, ref) => {
   const alertBar = useAlertBar();
   const account = useAccount();
+  const location = useLocation();
   const attachedClients = account.attachedClients;
   const { groupedByName, sortedAndUniqueClients } =
     sortAndFilterConnectedClients([...attachedClients]);
@@ -218,19 +222,36 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
         <Localized id="cs-heading">Connected Services</Localized>
       </h2>
       <div className="bg-white dark:bg-grey-700 tablet:rounded-xl shadow px-4 tablet:px-6 pt-7 pb-8">
-        <div className="flex justify-between mb-4">
+        <div className="flex justify-between items-center gap-4 mb-4">
           <Localized id="cs-description">
             <p>Everything you are using and signed into.</p>
           </Localized>
-          <Localized id="cs-refresh-button" attrs={{ title: true }}>
-            <ButtonIconReload
-              title="Refresh connected services"
-              classNames="hidden mobileLandscape:inline-block"
-              testId="connected-services-refresh"
-              disabled={isRefreshingClients}
-              onClick={handleRefreshClients}
-            />
-          </Localized>
+          <div className="flex items-center gap-3 shrink-0">
+            <Localized id="cs-refresh-button" attrs={{ title: true }}>
+              <ButtonIconReload
+                title="Refresh connected services"
+                classNames="hidden mobileLandscape:inline-block"
+                testId="connected-services-refresh"
+                disabled={isRefreshingClients}
+                onClick={handleRefreshClients}
+              />
+            </Localized>
+            {/* Permanent pairing CTA, shown to any desktop Firefox user. No
+                browser sign-in check: /pair signs a signed-out user in itself.
+                Broader than the FirefoxPromoBanner's "Connect a device" CTA,
+                which also requires a sign-in and can be dismissed. */}
+            {showConnectDeviceButton && (
+              <Localized id="cs-connect-device-button">
+                <Link
+                  className="cta-primary cta-base-p w-auto py-1 text-sm whitespace-nowrap"
+                  data-glean-id="account_pref_connect_device_submit"
+                  to={`/pair${location.search}`}
+                >
+                  Connect a device
+                </Link>
+              </Localized>
+            )}
+          </div>
         </div>
 
         {!!sortedAndUniqueClients.length &&

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
@@ -10,7 +10,12 @@ import ConnectedServices from '../ConnectedServices';
 import LinkedAccounts from '../LinkedAccounts';
 
 import * as Metrics from '../../../lib/metrics';
-import { useAccount, useAlertBar, useFtlMsgResolver } from '../../../models';
+import {
+  isProbablyFirefox,
+  useAccount,
+  useAlertBar,
+  useFtlMsgResolver,
+} from '../../../models';
 import { SETTINGS_PATH } from 'fxa-settings/src/constants';
 import { Localized } from '@fluent/react';
 import DataCollection from '../DataCollection';
@@ -34,6 +39,10 @@ import {
 import FirefoxPromoBanner, {
   shouldShowFirefoxPromo,
 } from '../../FirefoxPromoBanner';
+import {
+  isMobileOrTabletDevice,
+  isPairingSupported,
+} from '../../../lib/utilities';
 
 export const PageSettings = ({
   integration,
@@ -207,7 +216,13 @@ export const PageSettings = ({
         {eligibleForRecoveryKeyPromo && <AccountRecoveryKeyPromoBanner />}
         <Profile ref={profileRef} />
         <Security ref={securityRef} />
-        <ConnectedServices ref={connectedServicesRef} />
+        <ConnectedServices
+          ref={connectedServicesRef}
+          showConnectDeviceButton={isPairingSupported({
+            isFirefox: isProbablyFirefox(),
+            isMobile: isMobileOrTabletDevice(),
+          })}
+        />
         <LinkedAccounts ref={linkedAccountsRef} />
         <DataCollection ref={dataCollectionRef} />
         <div className="flex mx-4 tablet:mx-0" id="delete-account">

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -123,6 +123,19 @@ export function isMobileOrTabletDevice() {
   return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
 }
 
+// Whether the pairing flow is supported here: `/pair` is desktop-Firefox only
+// and redirects anything else to /pair/unsupported. It ignores whether the user
+// is signed into the browser because /pair can take the user to sign into Sync.
+export function isPairingSupported({
+  isFirefox,
+  isMobile,
+}: {
+  isFirefox: boolean;
+  isMobile: boolean;
+}) {
+  return isFirefox && !isMobile;
+}
+
 // Crockford base32 Regex. Case insensitive and excludes I, L, O, U
 const B32_STRING = /^[0-9A-HJ-KM-NP-TV-Z]+$/i;
 export function isBase32Crockford(value: string) {


### PR DESCRIPTION
Because:
* We want a more persistent 'pair' button near connected services in Settings. The current CaD promo can be dismissed

This commit:
* Adds this button, and is displayed under (mostly) the same condition as the promo banner - Firefox Desktop. Leaves the case for the promo banner for if the user is signed in to Firefox.

closes FXA-13797

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Sign into Firefox desktop and go to Settings. See the button.

**Note**, the button here has a little more left/right padding than in Figma. That's what our standard buttons use.
**Note2**, there is a known issue here which is that for both the Firefox Promo and this link, pairing doesn't work if the browser doesn't have the sync key. Since for a huge majority of users it _will_ work and we do not have a way to tell "is sync on" essentially yet, we'll land this anyway.

## Screenshots (Optional)

<img width="301" height="189" alt="image" src="https://github.com/user-attachments/assets/a832b207-8e7b-4c3b-bec5-2b090ee31bf8" />

