### PR TITLE
feat(settings): require OTP for inline TOTP enroll

### DIFF
--- a/packages/functional-tests/pages/inlineTotpSetup.tsx
+++ b/packages/functional-tests/pages/inlineTotpSetup.tsx
@@ -22,4 +22,32 @@ export class InlineTotpSetupPage extends BaseLayout {
   get continueButton() {
     return this.page.getByRole('button', { name: 'Continue' });
   }
+
+  get mfaGuardHeading() {
+    return this.page.getByRole('heading', { name: 'Enter confirmation code' });
+  }
+
+  async confirmMfaGuard(email: string) {
+    await this.mfaGuardHeading.waitFor();
+    const code =
+      await this.target.emailClient.getVerifyAccountChangeCode(email);
+    await this.page
+      .getByRole('textbox', { name: 'Enter 6-digit code' })
+      .fill(code);
+    await this.page.getByRole('button', { name: 'Confirm' }).click();
+  }
+
+  async confirmMfaGuardIfVisible(email: string) {
+    // The guard modal and the setup UI are mutually exclusive on this route.
+    // Wait for whichever renders first so this doesn't race a not-yet-shown
+    // modal (a bare isVisible() check can skip a guard that is still mounting),
+    // then confirm only when it is the guard.
+    await Promise.race([
+      this.mfaGuardHeading.waitFor({ state: 'visible' }),
+      this.introHeading.waitFor({ state: 'visible' }),
+    ]);
+    if (await this.mfaGuardHeading.isVisible()) {
+      await this.confirmMfaGuard(email);
+    }
+  }
 }

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -248,6 +248,9 @@ export class TotpPage extends SettingsLayout {
     recoveryPhoneAvailable: boolean
   ): Promise<string> {
     await this.page.waitForURL(/inline_totp_setup/);
+    // Conditional: some callers confirm the guard themselves (e.g. to assert
+    // the passkey banner) before reaching this helper.
+    await inlineTotpSetup.confirmMfaGuardIfVisible(credentials.email);
     await expect(inlineTotpSetup.introHeading).toBeVisible();
     await inlineTotpSetup.continueButton.click();
     const secret = await this.setUp2faAppWithManualCode(credentials);

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -81,6 +81,7 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/inline_totp_setup/);
 
+      await inlineTotpSetup.confirmMfaGuard(credentials.email);
       await expect(inlineTotpSetup.introHeading).toBeVisible();
       await inlineTotpSetup.continueButton.click();
       await expect(totp.setup2faAppHeading).toBeVisible();
@@ -118,6 +119,7 @@ test.describe('OAuth totp with recovery phone (local only)', () => {
 
     await page.waitForURL(/inline_totp_setup/);
 
+    await inlineTotpSetup.confirmMfaGuard(credentials.email);
     await expect(inlineTotpSetup.introHeading).toBeVisible();
     await inlineTotpSetup.continueButton.click();
     await expect(totp.setup2faAppHeading).toBeVisible();

--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -248,6 +248,9 @@ test.describe('severity-1 #smoke', () => {
         await page.waitForURL(/inline_totp_setup/);
       });
 
+      // Inline TOTP enrolment is gated by an MFA email-OTP (FXA-14311); the
+      // setup UI (incl. the passkey banner) only renders once the guard passes.
+      await inlineTotpSetup.confirmMfaGuard(credentials.email);
       // The passkey context must survive the divert, so the page explains why
       // 2FA is still needed rather than implying the passkey was insufficient.
       await expect(inlineTotpSetup.passkeySuccessBanner).toBeVisible();
@@ -477,6 +480,9 @@ test.describe('severity-1 #smoke', () => {
         await page.waitForURL(/inline_totp_setup/);
       });
 
+      // The setup UI renders only after the MFA email-OTP guard is satisfied
+      // (FXA-14311).
+      await inlineTotpSetup.confirmMfaGuard(email);
       await expect(inlineTotpSetup.passkeySuccessBanner).toBeVisible();
     });
 
@@ -631,7 +637,7 @@ test.describe('severity-1 #smoke', () => {
 
     test('forces /inline_totp_setup when password sign-in on an account with a passkey enrolled hits an AAL2 RP', async ({
       target,
-      pages: { page, relier, settings, settingsPasskeyAdd, signin },
+      pages: { page, relier, settings, settingsPasskeyAdd, signin, inlineTotpSetup },
       testAccountTracker,
     }) => {
       // Passkey enrolment alone doesn't satisfy AAL2 for a password session,
@@ -652,6 +658,7 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutPasswordForm(credentials.password);
 
       await page.waitForURL(/inline_totp_setup/);
+      await inlineTotpSetup.confirmMfaGuard(credentials.email);
       await expect(
         page.getByRole('heading', { name: /Set up two-step authentication/i })
       ).toBeVisible();

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -2667,7 +2667,7 @@ export default class AuthClient {
    */
   async completeTotpSetupWithJwt(
     jwt: string,
-    options: { metricsContext?: MetricsContext } = {},
+    options: { service?: string; metricsContext?: MetricsContext } = {},
     headers?: Headers
   ): Promise<{ success: boolean }> {
     return this.jwtPost(

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -814,6 +814,7 @@ module.exports = (
         },
         validate: {
           payload: isA.object({
+            service: validators.service,
             metricsContext: METRICS_CONTEXT_SCHEMA,
           }),
         },

--- a/packages/fxa-auth-server/lib/routes/totp.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/totp.spec.ts
@@ -666,6 +666,35 @@ describe('totp', () => {
     });
   });
 
+  describe('/mfa/totp/setup/complete', () => {
+    function getPayloadSchema() {
+      const builtRoutes = makeRoutes({});
+      return getRoute(builtRoutes, '/mfa/totp/setup/complete').options.validate
+        .payload;
+    }
+
+    // The auth server validates payloads with stripUnknown:true (see server.js),
+    // so any field not declared in the schema is silently dropped before the
+    // handler reads it. `service` must therefore be declared to reach the
+    // shared completion handler (which uses it for the confirmation email).
+    it('keeps an optional service in the payload under stripUnknown validation', () => {
+      const { error, value } = getPayloadSchema().validate(
+        { service: 'sync' },
+        { stripUnknown: true }
+      );
+      expect(error).toBeUndefined();
+      expect(value.service).toBe('sync');
+    });
+
+    it('rejects a service that violates the service validator', () => {
+      const { error } = getPayloadSchema().validate(
+        { service: 'not a valid service!' },
+        { stripUnknown: true }
+      );
+      expect(error).toBeDefined();
+    });
+  });
+
   // This endpoint is used for password reset only
   describe('/totp/verify', () => {
     it('should verify a valid totp code', async () => {

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/MfaGuardCore.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/MfaGuardCore.test.tsx
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockAppContext, renderWithRouter } from '../../../models/mocks';
+import { MfaGuardCore } from './MfaGuardCore';
+import { JwtTokenCache, MfaOtpRequestCache } from '../../../lib/cache';
+import { AppContext } from '../../../models';
+import { MfaReason } from '../../../lib/types';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+
+const mockSessionToken = 'session-core';
+const mockScope = 'test';
+const mockAuthClient = {
+  mfaRequestOtp: jest.fn().mockResolvedValue(undefined),
+  mfaOtpVerify: jest.fn(),
+};
+
+jest.mock('../../../models', () => ({
+  ...jest.requireActual('../../../models'),
+  useAuthClient: () => mockAuthClient,
+}));
+
+jest.mock('@sentry/react', () => ({ captureException: jest.fn() }));
+
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    accountPref: { mfaGuardView: jest.fn(), mfaGuardSubmitSuccess: jest.fn() },
+  },
+}));
+
+const onDismiss = jest.fn();
+const onSessionInvalid = jest.fn();
+const onFatalError = jest.fn();
+
+function renderCore() {
+  renderWithRouter(
+    <AppContext.Provider value={mockAppContext()}>
+      <MfaGuardCore
+        requiredScope={mockScope}
+        reason={MfaReason.test}
+        email="user@example.com"
+        sessionToken={mockSessionToken}
+        onDismiss={onDismiss}
+        onSessionInvalid={onSessionInvalid}
+        onFatalError={onFatalError}
+      >
+        <div>secured content</div>
+      </MfaGuardCore>
+    </AppContext.Provider>
+  );
+}
+
+const guardHeading = () =>
+  screen.findByRole('heading', { name: 'Enter confirmation code' });
+
+describe('MfaGuardCore', () => {
+  beforeEach(() => {
+    JwtTokenCache.removeToken(mockSessionToken, mockScope);
+    // Clear the debounce marker so each test's mount issues a fresh OTP request.
+    MfaOtpRequestCache.remove(mockSessionToken, mockScope);
+    jest.clearAllMocks();
+    mockAuthClient.mfaRequestOtp.mockReset().mockResolvedValue(undefined);
+    mockAuthClient.mfaOtpVerify.mockReset();
+  });
+
+  it('blocks children and requests an OTP when no JWT is cached', async () => {
+    renderCore();
+
+    expect(screen.queryByText('secured content')).not.toBeInTheDocument();
+    expect(await guardHeading()).toBeInTheDocument();
+    expect(mockAuthClient.mfaRequestOtp).toHaveBeenCalledWith(
+      mockSessionToken,
+      mockScope
+    );
+  });
+
+  it('renders children (no OTP request) when a JWT is already cached', () => {
+    JwtTokenCache.setToken(mockSessionToken, mockScope, 'jwt-present');
+
+    renderCore();
+
+    expect(screen.getByText('secured content')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Enter confirmation code' })
+    ).not.toBeInTheDocument();
+    expect(mockAuthClient.mfaRequestOtp).not.toHaveBeenCalled();
+  });
+
+  it('calls onSessionInvalid when the OTP request rejects with an invalid token', async () => {
+    mockAuthClient.mfaRequestOtp.mockRejectedValueOnce({
+      errno: AuthUiErrors.INVALID_TOKEN.errno,
+    });
+
+    renderCore();
+
+    await waitFor(() => expect(onSessionInvalid).toHaveBeenCalled());
+    expect(onFatalError).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('keeps the modal open (not fatal) when the OTP request is rate limited', async () => {
+    mockAuthClient.mfaRequestOtp.mockRejectedValueOnce({ code: 429 });
+
+    renderCore();
+
+    // A 429 is recoverable: the modal stays up for the user to retry rather
+    // than bouncing them out.
+    expect(await guardHeading()).toBeInTheDocument();
+    expect(onFatalError).not.toHaveBeenCalled();
+    expect(onSessionInvalid).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('reports a fatal error and dismisses on an unexpected OTP request failure', async () => {
+    mockAuthClient.mfaRequestOtp.mockRejectedValueOnce(new Error('boom'));
+
+    renderCore();
+
+    await waitFor(() =>
+      expect(onFatalError).toHaveBeenCalledWith(expect.any(String))
+    );
+    expect(onDismiss).toHaveBeenCalled();
+    expect(onSessionInvalid).not.toHaveBeenCalled();
+  });
+
+  it('caches the JWT and renders children after a successful OTP verification', async () => {
+    const user = userEvent.setup();
+    mockAuthClient.mfaOtpVerify.mockResolvedValue({
+      accessToken: 'verified-jwt',
+    });
+
+    renderCore();
+    await guardHeading();
+
+    await user.type(screen.getByRole('textbox'), '123456');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(await screen.findByText('secured content')).toBeInTheDocument();
+    expect(JwtTokenCache.hasToken(mockSessionToken, mockScope)).toBe(true);
+    expect(mockAuthClient.mfaOtpVerify).toHaveBeenCalledWith(
+      mockSessionToken,
+      '123456',
+      mockScope
+    );
+  });
+
+  it('keeps blocking children when OTP verification fails', async () => {
+    const user = userEvent.setup();
+    mockAuthClient.mfaOtpVerify.mockRejectedValue(new Error('bad code'));
+
+    renderCore();
+    await guardHeading();
+
+    await user.type(screen.getByRole('textbox'), '123456');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => expect(mockAuthClient.mfaOtpVerify).toHaveBeenCalled());
+    expect(screen.queryByText('secured content')).not.toBeInTheDocument();
+    expect(JwtTokenCache.hasToken(mockSessionToken, mockScope)).toBe(false);
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/MfaGuardCore.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/MfaGuardCore.tsx
@@ -1,0 +1,229 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+
+import { useAuthClient, useConfig, useFtlMsgResolver } from '../../../models';
+import Modal from '../ModalMfaProtected';
+import { JwtTokenCache, MfaOtpRequestCache } from '../../../lib/cache';
+import { MfaReason, MfaScope } from '../../../lib/types';
+import { ERRNO } from '@fxa/accounts/errors';
+import * as Sentry from '@sentry/react';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
+import GleanMetrics from '../../../lib/glean';
+import { MfaContext, MfaSessionTokenContext } from '../../../lib/hooks';
+
+/**
+ * Host-agnostic core of the MFA email-OTP guard. It blocks its children behind
+ * an email-OTP → JWT exchange (scope `mfa:<requiredScope>`), caching the JWT in
+ * `JwtTokenCache`, and provides the scope via `MfaContext` so children can use
+ * `useMfaErrorHandler`.
+ *
+ * Everything host-specific is injected via props so this can be used both inside
+ * Settings (see the `MfaGuard` wrapper in ./index) and in the Signin inline
+ * enrolment flow (FXA-14311). It deliberately does NOT read `useAccount`,
+ * `useAlertBar`, the global cached session token, or navigate directly.
+ */
+export const MfaGuardCore = ({
+  children,
+  requiredScope,
+  reason,
+  email,
+  sessionToken,
+  onDismiss,
+  onSessionInvalid,
+  onFatalError,
+  debounceIntervalMs = 3000,
+}: {
+  children: ReactNode;
+  requiredScope: MfaScope;
+  reason: MfaReason;
+  /** Address shown in the OTP modal (host supplies it; not read from a model). */
+  email: string;
+  /** Session token used to request/verify the OTP and key the JWT cache. */
+  sessionToken: string;
+  /** Called when the user dismisses the modal or after a fatal error — host decides where to go. */
+  onDismiss: () => void;
+  /** Called when the session token is rejected as invalid/expired — host redirects to sign-in. */
+  onSessionInvalid: () => void;
+  /** Called with an already-localized message for an unrecoverable OTP-request error. */
+  onFatalError: (localizedMessage: string) => void;
+  debounceIntervalMs?: number;
+}) => {
+  const config = useConfig();
+  const authClient = useAuthClient();
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const [localizedErrorBannerMessage, setLocalizedErrorBannerMessage] =
+    useState<string | undefined>(undefined);
+  const [resendCodeLoading, setResendCodeLoading] = useState(false);
+  const [showResendSuccessBanner, setShowResendSuccessBanner] = useState(false);
+
+  const resetStates = useCallback(() => {
+    setLocalizedErrorBannerMessage(undefined);
+    setShowResendSuccessBanner(false);
+  }, []);
+
+  // Reactive state: if the store state changes, a re-render is triggered
+  const jwtState = useSyncExternalStore(
+    JwtTokenCache.subscribe,
+    JwtTokenCache.getSnapshot
+  );
+
+  const dismiss = useCallback(() => {
+    resetStates();
+    onDismiss();
+  }, [resetStates, onDismiss]);
+
+  // jwtState should always return
+  if (!jwtState) {
+    throw new Error('Invalid state. Missing jwt cache.');
+  }
+
+  const debounce = useCallback(
+    (limitInMs: number) => {
+      const lastRequest = MfaOtpRequestCache.get(sessionToken, requiredScope);
+      return lastRequest != null && Date.now() - lastRequest < limitInMs;
+    },
+    [sessionToken, requiredScope]
+  );
+
+  // Modal Setup
+  useEffect(() => {
+    (async () => {
+      // To avoid requesting multiple OTPs on mount
+      if (JwtTokenCache.hasToken(sessionToken, requiredScope)) {
+        return;
+      }
+
+      // Avoid bombarding the user with emails just because they open
+      // the dialog
+      const limitInMs = config.mfa.otp.expiresInMinutes * 60 * 1000;
+      if (debounce(limitInMs)) {
+        return;
+      }
+
+      try {
+        MfaOtpRequestCache.set(sessionToken, requiredScope);
+        await authClient.mfaRequestOtp(sessionToken, requiredScope);
+      } catch (err) {
+        MfaOtpRequestCache.remove(sessionToken, requiredScope);
+
+        // If session token is invalid (destroyed/expired), redirect to signin
+        if (err?.errno === ERRNO.INVALID_TOKEN) {
+          onSessionInvalid();
+          return;
+        }
+
+        if (err.code === 429) {
+          setShowResendSuccessBanner(false);
+          setLocalizedErrorBannerMessage(
+            getLocalizedErrorMessage(ftlMsgResolver, err)
+          );
+          return;
+        }
+
+        Sentry.captureException(err);
+        onFatalError(getLocalizedErrorMessage(ftlMsgResolver, err));
+        dismiss();
+      }
+    })();
+  }, [
+    jwtState,
+    sessionToken,
+    requiredScope,
+    authClient,
+    ftlMsgResolver,
+    dismiss,
+    onSessionInvalid,
+    onFatalError,
+    config.mfa.otp.expiresInMinutes,
+    debounce,
+  ]);
+
+  const onSubmitOtp = async (code: string) => {
+    try {
+      const result = await authClient.mfaOtpVerify(
+        sessionToken,
+        code,
+        requiredScope
+      );
+      GleanMetrics.accountPref.mfaGuardSubmitSuccess({
+        event: { reason },
+      });
+      JwtTokenCache.setToken(sessionToken, requiredScope, result.accessToken);
+      resetStates();
+    } catch (err) {
+      setShowResendSuccessBanner(false);
+      setLocalizedErrorBannerMessage(
+        getLocalizedErrorMessage(ftlMsgResolver, err)
+      );
+    }
+  };
+
+  const handleResendCode = async () => {
+    // Stop users from hammering the resend button...
+    if (debounce(debounceIntervalMs)) {
+      return;
+    }
+
+    setResendCodeLoading(true);
+    try {
+      MfaOtpRequestCache.set(sessionToken, requiredScope);
+      await authClient.mfaRequestOtp(sessionToken, requiredScope);
+      setLocalizedErrorBannerMessage(undefined);
+      setShowResendSuccessBanner(true);
+    } catch (err) {
+      MfaOtpRequestCache.remove(sessionToken, requiredScope);
+      setShowResendSuccessBanner(false);
+      setLocalizedErrorBannerMessage(
+        getLocalizedErrorMessage(ftlMsgResolver, err)
+      );
+    } finally {
+      setResendCodeLoading(false);
+    }
+  };
+
+  const expirationTime = config.mfa.otp.expiresInMinutes;
+
+  const getModal = () => (
+    <Modal
+      {...{
+        email,
+        expirationTime,
+        onSubmit: onSubmitOtp,
+        onDismiss: dismiss,
+        handleResendCode,
+        clearErrorMessage: () => setLocalizedErrorBannerMessage(undefined),
+        resendCodeLoading,
+        showResendSuccessBanner,
+        localizedErrorBannerMessage,
+        reason,
+      }}
+    >
+      <p>Re-verify Account!</p>
+    </Modal>
+  );
+
+  // If we don't have a JWT, we need to open the modal to prompt for it.
+  if (!JwtTokenCache.hasToken(sessionToken, requiredScope)) {
+    return getModal();
+  }
+
+  // Provide the scope and session token via context so child components can use
+  // useMfaErrorHandler against the same session this guard is keyed on.
+  return (
+    <MfaContext.Provider value={requiredScope}>
+      <MfaSessionTokenContext.Provider value={sessionToken}>
+        {children}
+      </MfaSessionTokenContext.Provider>
+    </MfaContext.Provider>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
@@ -2,39 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useState,
-  useSyncExternalStore,
-} from 'react';
+import React, { ReactNode, useCallback } from 'react';
 
-import {
-  useAccount,
-  useAlertBar,
-  useAuthClient,
-  useConfig,
-  useFtlMsgResolver,
-} from '../../../models';
-import Modal from '../ModalMfaProtected';
-import {
-  JwtTokenCache,
-  MfaOtpRequestCache,
-  sessionToken as getSessionToken,
-} from '../../../lib/cache';
+import { useAccount, useAlertBar } from '../../../models';
+import { sessionToken as getSessionToken } from '../../../lib/cache';
 import { MfaReason, MfaScope } from '../../../lib/types';
-import { ERRNO } from '@fxa/accounts/errors';
 import { useNavigate } from 'react-router';
-import * as Sentry from '@sentry/react';
-import { getLocalizedErrorMessage } from '../../../lib/error-utils';
-import GleanMetrics from '../../../lib/glean';
-import { MfaContext } from '../../../lib/hooks';
+import { MfaGuardCore } from './MfaGuardCore';
+
+export { MfaGuardCore } from './MfaGuardCore';
 
 /**
- * This is a guard component designed to wrap around components that perform
- * security-sensitive actions. It blocks access to the child components until
- * a JWT is obtained through an OTP code exchange.
+ * Settings-flavored MFA guard. A thin wrapper over {@link MfaGuardCore} that
+ * supplies the Settings-specific bits — the account email, the alert bar for
+ * fatal errors, the globally-cached session token, and navigation back to
+ * `/settings` / `/signin`. Behavior and public API are unchanged; the reusable
+ * logic now lives in `MfaGuardCore` (see FXA-14311).
  */
 export const MfaGuard = ({
   children,
@@ -49,182 +32,34 @@ export const MfaGuard = ({
   debounceIntervalMs?: number;
   reason: MfaReason;
 }) => {
-  const config = useConfig();
-  const [localizedErrorBannerMessage, setLocalizedErrorBannerMessage] =
-    useState<string | undefined>(undefined);
-
-  const [resendCodeLoading, setResendCodeLoading] = useState(false);
-  const [showResendSuccessBanner, setShowResendSuccessBanner] = useState(false);
-
-  const resetStates = useCallback(() => {
-    setLocalizedErrorBannerMessage(undefined);
-    setShowResendSuccessBanner(false);
-  }, []);
-
-  // Reactive state: if the store state changes, a re-render is triggered
-  const jwtState = useSyncExternalStore(
-    JwtTokenCache.subscribe,
-    JwtTokenCache.getSnapshot
-  );
   const account = useAccount();
-  const authClient = useAuthClient();
+  const alertBar = useAlertBar();
   const navigate = useNavigate();
   const sessionToken = getSessionToken();
-
-  const ftlMsgResolver = useFtlMsgResolver();
-
-  const alertBar = useAlertBar();
-
-  const onDismiss = useCallback(() => {
-    onDismissCallback().then(() => {
-      resetStates();
-      navigate('/settings');
-    });
-  }, [navigate, resetStates, onDismissCallback]);
 
   // If no session token exists, kick them to sign-in
   if (!sessionToken) {
     throw new Error('Invalid state. Missing sessionToken');
   }
 
-  // jwtState should always return
-  if (!jwtState) {
-    throw new Error('Invalid state. Missing jwt cache.');
-  }
+  const onDismiss = useCallback(() => {
+    onDismissCallback().then(() => {
+      navigate('/settings');
+    });
+  }, [navigate, onDismissCallback]);
 
-  const debounce = useCallback(
-    (limitInMs: number) => {
-      const lastRequest = MfaOtpRequestCache.get(sessionToken, requiredScope);
-      return lastRequest != null && Date.now() - lastRequest < limitInMs;
-    },
-    [sessionToken, requiredScope]
-  );
-
-  // Modal Setup
-  useEffect(() => {
-    (async () => {
-      // To avoid requesting multiple OTPs on mount
-      if (JwtTokenCache.hasToken(sessionToken, requiredScope)) {
-        return;
-      }
-
-      // Avoid bombarding the user with emails just because they open
-      // the dialog
-      const limitInMs = config.mfa.otp.expiresInMinutes * 60 * 1000;
-      if (debounce(limitInMs)) {
-        return;
-      }
-
-      try {
-        MfaOtpRequestCache.set(sessionToken, requiredScope);
-        await authClient.mfaRequestOtp(sessionToken, requiredScope);
-      } catch (err) {
-        MfaOtpRequestCache.remove(sessionToken, requiredScope);
-
-        // If session token is invalid (destroyed/expired), redirect to signin
-        if (err?.errno === ERRNO.INVALID_TOKEN) {
-          navigate('/signin');
-          return;
-        }
-
-        if (err.code === 429) {
-          setShowResendSuccessBanner(false);
-          setLocalizedErrorBannerMessage(
-            getLocalizedErrorMessage(ftlMsgResolver, err)
-          );
-          return;
-        }
-
-        Sentry.captureException(err);
-        alertBar.error(getLocalizedErrorMessage(ftlMsgResolver, err));
-        onDismiss();
-      }
-    })();
-  }, [
-    jwtState,
-    sessionToken,
-    requiredScope,
-    authClient,
-    alertBar,
-    ftlMsgResolver,
-    onDismiss,
-    config.mfa.otp.expiresInMinutes,
-    debounce,
-    navigate,
-  ]);
-
-  const onSubmitOtp = async (code: string) => {
-    try {
-      const result = await authClient.mfaOtpVerify(
-        sessionToken,
-        code,
-        requiredScope
-      );
-      GleanMetrics.accountPref.mfaGuardSubmitSuccess({
-        event: { reason },
-      });
-      JwtTokenCache.setToken(sessionToken, requiredScope, result.accessToken);
-      resetStates();
-    } catch (err) {
-      setShowResendSuccessBanner(false);
-      setLocalizedErrorBannerMessage(
-        getLocalizedErrorMessage(ftlMsgResolver, err)
-      );
-    }
-  };
-
-  const handleResendCode = async () => {
-    // Stop users from hammering the resend button...
-    if (debounce(debounceIntervalMs)) {
-      return;
-    }
-
-    setResendCodeLoading(true);
-    try {
-      MfaOtpRequestCache.set(sessionToken, requiredScope);
-      await authClient.mfaRequestOtp(sessionToken, requiredScope);
-      setLocalizedErrorBannerMessage(undefined);
-      setShowResendSuccessBanner(true);
-    } catch (err) {
-      MfaOtpRequestCache.remove(sessionToken, requiredScope);
-      setShowResendSuccessBanner(false);
-      setLocalizedErrorBannerMessage(
-        getLocalizedErrorMessage(ftlMsgResolver, err)
-      );
-    } finally {
-      setResendCodeLoading(false);
-    }
-  };
-
-  const email = account.email;
-  const expirationTime = config.mfa.otp.expiresInMinutes;
-
-  const getModal = () => (
-    <Modal
-      {...{
-        email,
-        expirationTime,
-        onSubmit: onSubmitOtp,
-        onDismiss,
-        handleResendCode,
-        clearErrorMessage: () => setLocalizedErrorBannerMessage(undefined),
-        resendCodeLoading,
-        showResendSuccessBanner,
-        localizedErrorBannerMessage,
-        reason,
-      }}
-    >
-      <p>Re-verify Account!</p>
-    </Modal>
-  );
-
-  // If we don't have a JWT, we need to open the modal to prompt for it.
-  if (!JwtTokenCache.hasToken(sessionToken, requiredScope)) {
-    return getModal();
-  }
-
-  // Provide the scope via context so child components can use useMfaErrorHandler
   return (
-    <MfaContext.Provider value={requiredScope}>{children}</MfaContext.Provider>
+    <MfaGuardCore
+      requiredScope={requiredScope}
+      reason={reason}
+      email={account.email}
+      sessionToken={sessionToken}
+      debounceIntervalMs={debounceIntervalMs}
+      onDismiss={onDismiss}
+      onSessionInvalid={() => navigate('/signin')}
+      onFatalError={(localizedMessage) => alertBar.error(localizedMessage)}
+    >
+      {children}
+    </MfaGuardCore>
   );
 };

--- a/packages/fxa-settings/src/lib/hooks/useMfaErrorHandler/index.ts
+++ b/packages/fxa-settings/src/lib/hooks/useMfaErrorHandler/index.ts
@@ -9,12 +9,22 @@ import { clearMfaAndJwtCacheOnInvalidJwt } from '../../mfa-guard-utils';
 /** Scope of the MfaGuard wrapping the current subtree; undefined outside one. */
 export const MfaContext = createContext<MfaScope | undefined>(undefined);
 
+// The session token the active guard is keyed on. Provided by `MfaGuardCore`
+// so `useMfaErrorHandler` clears the correct session's cache even when the host
+// (e.g. the Signin inline flows) injects a session token other than the global
+// one. Left undefined by Settings stories/mocks, where the global token is
+// correct, so the hook falls back to it.
+export const MfaSessionTokenContext = createContext<string | undefined>(
+  undefined
+);
+
 /**
  * Hook to handle MFA-related errors in child components.
  * The returned function returns true if the error was handled, false otherwise.
  */
 export const useMfaErrorHandler = () => {
   const scope = useContext(MfaContext);
+  const sessionToken = useContext(MfaSessionTokenContext);
 
   if (!scope) {
     throw new Error('useMfaErrorHandler must be used within an MfaGuard');
@@ -23,8 +33,8 @@ export const useMfaErrorHandler = () => {
   // Memoize to prevent unnecessary re-renders
   return useCallback(
     (error: unknown) => {
-      return clearMfaAndJwtCacheOnInvalidJwt(error, scope);
+      return clearMfaAndJwtCacheOnInvalidJwt(error, scope, sessionToken);
     },
-    [scope]
+    [scope, sessionToken]
   );
 };

--- a/packages/fxa-settings/src/lib/mfa-guard-utils.ts
+++ b/packages/fxa-settings/src/lib/mfa-guard-utils.ts
@@ -16,13 +16,18 @@ import { MfaScope } from './types';
  * Use this when checking the response from the auth server for an invalid JWT.
  * @param e - The error to check, must have code and errno properties.
  * @param scope - The scope to clear from the MFA and JWT cache.
+ * @param sessionTokenOverride - Session token whose cache entries should be
+ *   cleared. Defaults to the globally-cached session token. Pass this in hosts
+ *   (e.g. the Signin inline flows) whose guard is keyed on an injected session
+ *   token rather than the global one.
  * @returns true if the cache was cleared, false otherwise.
  */
 export const clearMfaAndJwtCacheOnInvalidJwt = (
   e: any,
-  scope: MfaScope
+  scope: MfaScope,
+  sessionTokenOverride?: string
 ): boolean => {
-  const sessionToken = getSessionToken();
+  const sessionToken = sessionTokenOverride ?? getSessionToken();
   if (!sessionToken) {
     // noop - we can't do anything without a session token
     return false;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
@@ -33,6 +33,17 @@ import {
 } from '../../lib/oauth/hooks';
 import { SensitiveData } from '../../lib/sensitive-data-client';
 import { mockWindowLocation } from 'fxa-react/lib/test-utils/mockWindowLocation';
+import { ReactNode } from 'react';
+import { JwtTokenCache } from '../../lib/cache';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+
+// The MFA email-OTP guard is unit-tested separately (MfaGuardCore); here it is a
+// pass-through so the recovery setup (its children) renders directly. A mfa:2fa
+// JWT is seeded in setMocks so the JWT-guarded completion call resolves.
+jest.mock('../../components/Settings/MfaGuard', () => ({
+  __esModule: true,
+  MfaGuardCore: ({ children }: { children: ReactNode }) => children,
+}));
 
 let mockLocationState = {};
 const search = '?' + new URLSearchParams(MOCK_QUERY_PARAMS);
@@ -131,7 +142,7 @@ jest.mock('./index', () => {
   };
 });
 
-let mockCompleteTotpSetup = jest.fn().mockResolvedValue({ success: true });
+let mockCompleteTotpSetupWithJwt = jest.fn().mockResolvedValue({ success: true });
 let mockCheckTotpTokenExists = jest.fn();
 
 function setMocks() {
@@ -144,10 +155,17 @@ function setMocks() {
   mockCheckTotpTokenExists.mockResolvedValue({ exists: false, verified: false });
   (InlineRecoverySetupModule.default as jest.Mock).mockReset();
   mockNavigateHook.mockReset();
-  mockCompleteTotpSetup.mockClear();
+  mockCompleteTotpSetupWithJwt.mockClear();
   mockCheckTotpTokenExists.mockClear();
-  (mockAuthClient as any).completeTotpSetup = mockCompleteTotpSetup;
+  (mockAuthClient as any).completeTotpSetupWithJwt = mockCompleteTotpSetupWithJwt;
   (mockAuthClient as any).checkTotpTokenExists = mockCheckTotpTokenExists;
+  // Seed the mfa:2fa JWT the completion reads (obtained by the guard via email
+  // OTP; pre-seeded here so the guard pass-through renders the flow).
+  JwtTokenCache.setToken(
+    MOCK_SIGNIN_RECOVERY_LOCATION_STATE.sessionToken,
+    '2fa',
+    'test-jwt'
+  );
   (useFinishOAuthFlowHandler as jest.Mock).mockImplementation(() => ({
     finishOAuthFlowHandler: jest
       .fn()
@@ -161,6 +179,7 @@ function setMocks() {
     oAuthKeysCheckError: null,
   }));
   recoveryPhoneFn.mockClear();
+  confirmRecoveryPhoneFn.mockClear();
 }
 
 const defaultProps = {
@@ -303,6 +322,35 @@ describe('InlineRecoverySetupContainer', () => {
       });
     });
 
+    it('completes setup with the protocol service value, not the display serviceName', async () => {
+      // The server's `service` validator rejects display labels like
+      // "Firefox Sync" (spaces, > 16 chars); the protocol value from
+      // getService() ("sync") must be sent instead.
+      render({
+        integration: {
+          ...defaultProps.integration,
+          getService: () => 'sync',
+        },
+        serviceName: MozServices.FirefoxSync,
+      });
+      const latestArgs = () =>
+        (InlineRecoverySetupModule.default as jest.Mock).mock.calls.slice(
+          -1
+        )[0][0];
+      await waitFor(() => {
+        expect(InlineRecoverySetupModule.default).toHaveBeenCalled();
+      });
+      await waitFor(async () => {
+        await latestArgs().backupChoiceCb('code');
+      });
+      await waitFor(async () => {
+        await latestArgs().completeBackupCodeSetup('wibble');
+      });
+      expect(mockCompleteTotpSetupWithJwt).toHaveBeenCalledWith('test-jwt', {
+        service: 'sync',
+      });
+    });
+
     describe('callbacks', () => {
       let args: any;
 
@@ -347,7 +395,49 @@ describe('InlineRecoverySetupContainer', () => {
             '010431',
             '12345678900'
           );
-          expect(mockCompleteTotpSetup).toHaveBeenCalledTimes(1);
+          expect(mockCompleteTotpSetupWithJwt).toHaveBeenCalledTimes(1);
+        });
+
+        it('rejects (so the flow does not advance) when TOTP completion fails', async () => {
+          // If completion fails the confirm-code step must not navigate forward
+          // to the success screen while 2FA is still disabled.
+          mockCompleteTotpSetupWithJwt.mockRejectedValueOnce(
+            new Error('server error')
+          );
+          await waitFor(async () => {
+            await args.verifyPhoneNumber('12345678900');
+          });
+          args = (InlineRecoverySetupModule.default as jest.Mock).mock.calls[
+            (InlineRecoverySetupModule.default as jest.Mock).mock.calls.length - 1
+          ][0];
+
+          await expect(args.verifySmsCode('010431')).rejects.toThrow(
+            'cannot enable TOTP'
+          );
+        });
+
+        it('does not re-consume the SMS code when retrying after a failed completion', async () => {
+          await waitFor(async () => {
+            await args.verifyPhoneNumber('12345678900');
+          });
+          args = (InlineRecoverySetupModule.default as jest.Mock).mock.calls[
+            (InlineRecoverySetupModule.default as jest.Mock).mock.calls.length - 1
+          ][0];
+
+          // First attempt: phone confirms, then TOTP completion fails.
+          mockCompleteTotpSetupWithJwt.mockRejectedValueOnce(
+            new Error('server error')
+          );
+          await expect(args.verifySmsCode('010431')).rejects.toThrow(
+            'cannot enable TOTP'
+          );
+
+          // Retry (fresh JWT): completion succeeds. The single-use SMS code must
+          // not be submitted again, or the phone confirm would fail.
+          await args.verifySmsCode('010431');
+
+          expect(confirmRecoveryPhoneFn).toHaveBeenCalledTimes(1);
+          expect(mockCompleteTotpSetupWithJwt).toHaveBeenCalledTimes(2);
         });
       });
 
@@ -364,7 +454,40 @@ describe('InlineRecoverySetupContainer', () => {
             await args.completeBackupCodeSetup('wibble');
           });
           expect(setRecoveryCodesFn).toHaveBeenCalledWith(['wibble', 'quux']);
-          expect(mockCompleteTotpSetup).toHaveBeenCalledTimes(1);
+          expect(mockCompleteTotpSetupWithJwt).toHaveBeenCalledTimes(1);
+        });
+
+        it('clears the cached JWT when completion fails with an invalid MFA token', async () => {
+          const invalidJwtError = Object.assign(new Error('invalid mfa token'), {
+            errno: AuthUiErrors.INVALID_MFA_TOKEN.errno,
+          });
+          mockCompleteTotpSetupWithJwt.mockRejectedValueOnce(invalidJwtError);
+
+          expect(
+            JwtTokenCache.hasToken(
+              MOCK_SIGNIN_RECOVERY_LOCATION_STATE.sessionToken,
+              '2fa'
+            )
+          ).toBe(true);
+
+          await waitFor(async () => {
+            await args.backupChoiceCb('code');
+          });
+          args = (InlineRecoverySetupModule.default as jest.Mock).mock.calls[
+            (InlineRecoverySetupModule.default as jest.Mock).mock.calls.length - 1
+          ][0];
+          await waitFor(async () => {
+            await args.completeBackupCodeSetup('wibble');
+          });
+
+          // Stale JWT dropped so MfaGuardCore can re-prompt for a fresh email OTP
+          // instead of dead-ending the recovery step.
+          expect(
+            JwtTokenCache.hasToken(
+              MOCK_SIGNIN_RECOVERY_LOCATION_STATE.sessionToken,
+              '2fa'
+            )
+          ).toBe(false);
         });
       });
 

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
@@ -10,7 +10,7 @@ import {
   useOAuthKeysCheck,
 } from '../../lib/oauth/hooks';
 import AppLayout from '../../components/AppLayout';
-import { MozServices } from '../../lib/types';
+import { MfaReason, MozServices } from '../../lib/types';
 import {
   Integration,
   useAccount,
@@ -19,6 +19,9 @@ import {
   useFtlMsgResolver,
   useSensitiveDataClient,
 } from '../../models';
+import { MfaGuardCore } from '../../components/Settings/MfaGuard';
+import { JwtTokenCache } from '../../lib/cache';
+import { clearMfaAndJwtCacheOnInvalidJwt } from '../../lib/mfa-guard-utils';
 import InlineRecoverySetup from './index';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { SigninRecoveryLocationState } from './interfaces';
@@ -150,26 +153,50 @@ export const InlineRecoverySetupContainer = ({
 
   const verifyTotpHandler = useCallback(async () => {
     try {
-      await authClient.completeTotpSetup(
+      // Completing TOTP setup requires the MFA email-OTP proof (JWT), not just
+      // the session token (FXA-14311).
+      const jwt = JwtTokenCache.getToken(
         signinRecoveryLocationState!.sessionToken,
-        { service: serviceName }
+        '2fa'
       );
+      await authClient.completeTotpSetupWithJwt(jwt, {
+        // Send the protocol service value (e.g. `sync`), not the `serviceName`
+        // display label — the server's `service` validator rejects spaces and
+        // strings over 16 chars, which most display names are (FXA-14311).
+        service: integration.getService(),
+      });
       return true;
     } catch (err) {
+      // The short-lived mfa:2fa JWT can expire during the (multi-step) recovery
+      // setup. On a stale/invalid JWT, drop it so MfaGuardCore re-prompts for a
+      // fresh email OTP rather than dead-ending on a generic error.
+      clearMfaAndJwtCacheOnInvalidJwt(
+        err,
+        '2fa',
+        signinRecoveryLocationState!.sessionToken
+      );
       // todo handle this error better
       // auth-server may return more specific errors (including throttling)
       return false;
     }
-  }, [authClient, signinRecoveryLocationState, serviceName]);
+  }, [authClient, signinRecoveryLocationState, integration]);
 
   const [phoneData, setPhoneData] = useState<{
     phoneNumber: string;
     nationalFormat: string | undefined;
   }>({ phoneNumber: '', nationalFormat: '' });
+  // confirmRecoveryPhone consumes a one-time SMS code and finalizes the phone.
+  // If TOTP completion then fails (e.g. a stale MFA JWT triggers a guard
+  // re-prompt), the user retries on the same step — but the code is already
+  // spent. Track that the phone was confirmed so the retry skips
+  // confirmRecoveryPhone and only re-runs the TOTP completion.
+  const phoneConfirmedRef = useRef(false);
   const verifyPhoneNumber = useCallback(
     async (phoneNumberInput: string) => {
       const { nationalFormat } =
         await account.addRecoveryPhone(phoneNumberInput);
+      // A newly entered phone must be re-confirmed.
+      phoneConfirmedRef.current = false;
       setPhoneData({
         phoneNumber: phoneNumberInput,
         nationalFormat,
@@ -184,8 +211,19 @@ export const InlineRecoverySetupContainer = ({
 
   const verifySmsCode = useCallback(
     async (code: string) => {
-      await account.confirmRecoveryPhone(code, phoneData.phoneNumber);
-      await verifyTotpHandler();
+      // Skip on retry — the SMS code is single-use and the phone is already
+      // finalized (see phoneConfirmedRef).
+      if (!phoneConfirmedRef.current) {
+        await account.confirmRecoveryPhone(code, phoneData.phoneNumber);
+        phoneConfirmedRef.current = true;
+      }
+      const success = await verifyTotpHandler();
+      if (!success) {
+        // Completing TOTP failed — don't advance to the success screen with 2FA
+        // still disabled. On a stale MFA JWT the guard re-prompts (the JWT was
+        // cleared); retrying re-runs only verifyTotpHandler with the fresh JWT.
+        throw new Error('cannot enable TOTP');
+      }
     },
     [account, phoneData.phoneNumber, verifyTotpHandler]
   );
@@ -292,29 +330,41 @@ export const InlineRecoverySetupContainer = ({
     return <OAuthDataError error={oAuthKeysCheckError} />;
   }
 
+  // Gate completing TOTP setup behind an MFA email-OTP so a hijacked session
+  // cannot finalize a second factor (FXA-14311).
   return (
-    <InlineRecoverySetup
-      {...{
-        flowHasPhoneChoice: account.recoveryPhone.available,
-        serviceName,
-        email: signinRecoveryLocationState.email,
-        currentStep,
-        backupMethod,
-        backupCodes,
-        generatingCodes,
-        phoneData,
-        navigateForward,
-        navigateBackward,
-        backupChoiceCb,
-        backupCodeError,
-        setBackupCodeError,
-        sendSmsCode,
-        verifyPhoneNumber,
-        verifySmsCode,
-        completeBackupCodeSetup,
-        successfulSetupHandler,
-      }}
-    />
+    <MfaGuardCore
+      requiredScope="2fa"
+      reason={MfaReason.createTotp}
+      email={signinRecoveryLocationState.email}
+      sessionToken={signinRecoveryLocationState.sessionToken}
+      onDismiss={() => navigateWithQuery('/signin')}
+      onSessionInvalid={() => navigateWithQuery('/signin')}
+      onFatalError={() => navigateWithQuery('/signin')}
+    >
+      <InlineRecoverySetup
+        {...{
+          flowHasPhoneChoice: account.recoveryPhone.available,
+          serviceName,
+          email: signinRecoveryLocationState.email,
+          currentStep,
+          backupMethod,
+          backupCodes,
+          generatingCodes,
+          phoneData,
+          navigateForward,
+          navigateBackward,
+          backupChoiceCb,
+          backupCodeError,
+          setBackupCodeError,
+          sendSmsCode,
+          verifyPhoneNumber,
+          verifySmsCode,
+          completeBackupCodeSetup,
+          successfulSetupHandler,
+        }}
+      />
+    </MfaGuardCore>
   );
 };
 

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -21,6 +21,8 @@ import {
 import { screen, waitFor } from '@testing-library/react';
 import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { MOCK_FLOW_ID } from '../Signin/mocks';
+import { ReactNode } from 'react';
+import { JwtTokenCache } from '../../lib/cache';
 
 const mockLocationHook = jest.fn();
 const mockNavigateHook = jest.fn();
@@ -33,9 +35,9 @@ jest.mock('react-router', () => {
 });
 
 const mockSessionHook = jest.fn();
-const mockVerifyTotpSetupCode = jest.fn();
+const mockVerifyTotpSetupCodeWithJwt = jest.fn();
 const mockSendVerificationCode = jest.fn();
-const mockCreateTotpToken = jest.fn();
+const mockCreateTotpTokenWithJwt = jest.fn();
 const mockCheckTotpTokenExists = jest.fn();
 
 jest.mock('../../models', () => {
@@ -43,12 +45,20 @@ jest.mock('../../models', () => {
     ...jest.requireActual('../../models'),
     useSession: () => mockSessionHook(),
     useAuthClient: () => ({
-      verifyTotpSetupCode: mockVerifyTotpSetupCode,
-      createTotpToken: mockCreateTotpToken,
+      verifyTotpSetupCodeWithJwt: mockVerifyTotpSetupCodeWithJwt,
+      createTotpTokenWithJwt: mockCreateTotpTokenWithJwt,
       checkTotpTokenExists: mockCheckTotpTokenExists,
     }),
   };
 });
+
+// The MFA email-OTP guard is unit-tested separately (MfaGuardCore); here it is a
+// pass-through so the enrolment (its children) renders directly. A mfa:2fa JWT
+// is seeded in setMocks so the JWT-guarded enrolment calls resolve.
+jest.mock('../../components/Settings/MfaGuard', () => ({
+  __esModule: true,
+  MfaGuardCore: ({ children }: { children: ReactNode }) => children,
+}));
 
 jest.mock('../../lib/glean', () => ({
   __esModule: true,
@@ -72,20 +82,24 @@ function setMocks() {
     search,
     state: MOCK_SIGNIN_LOCATION_STATE,
   });
-  mockVerifyTotpSetupCode.mockReset();
+  mockVerifyTotpSetupCodeWithJwt.mockReset();
   mockSendVerificationCode.mockReset();
-  mockCreateTotpToken.mockReset();
+  mockCreateTotpTokenWithJwt.mockReset();
   mockCheckTotpTokenExists.mockReset();
   mockSessionHook.mockReturnValue({
     isSessionVerified: async () => true,
     sendVerificationCode: mockSendVerificationCode,
   });
   // Default: TOTP doesn't exist, so we need to create one
-  mockCheckTotpTokenExists.mockResolvedValue({
-    exists: false,
-    verified: false,
-  });
-  mockCreateTotpToken.mockResolvedValue(MOCK_TOTP_TOKEN);
+  mockCheckTotpTokenExists.mockResolvedValue({ exists: false, verified: false });
+  mockCreateTotpTokenWithJwt.mockResolvedValue(MOCK_TOTP_TOKEN);
+  // Seed the mfa:2fa JWT the enrolment reads (the guard would have obtained it
+  // via email OTP; here it's pre-seeded so the guard pass-through renders).
+  JwtTokenCache.setToken(
+    MOCK_SIGNIN_LOCATION_STATE.sessionToken,
+    '2fa',
+    'test-jwt'
+  );
   jest.spyOn(InlineTotpSetupModule, 'default');
   (InlineTotpSetupModule.default as jest.Mock).mockReset();
   mockNavigateHook.mockReset();
@@ -226,7 +240,7 @@ describe('InlineTotpSetupContainer', () => {
 
       // Wait a bit to ensure the component has mounted
       await new Promise((resolve) => setTimeout(resolve, 100));
-      expect(mockCreateTotpToken).not.toHaveBeenCalled();
+      expect(mockCreateTotpTokenWithJwt).not.toHaveBeenCalled();
     });
 
     it('does not call createTotpToken when TOTP is already verified', async () => {
@@ -243,7 +257,7 @@ describe('InlineTotpSetupContainer', () => {
       await waitFor(() => {
         expect(mockNavigateHook).toHaveBeenCalled();
       });
-      expect(mockCreateTotpToken).not.toHaveBeenCalled();
+      expect(mockCreateTotpTokenWithJwt).not.toHaveBeenCalled();
     });
   });
 
@@ -299,7 +313,7 @@ describe('InlineTotpSetupContainer', () => {
     describe('callbacks', () => {
       describe('verifyCodeHandler', () => {
         it('throws an error when the server rejects the code', async () => {
-          mockVerifyTotpSetupCode.mockRejectedValue(new Error('bad'));
+          mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(new Error('bad'));
           render();
           await waitFor(() => {
             expect(InlineTotpSetupModule.default).toHaveBeenCalled();
@@ -320,7 +334,7 @@ describe('InlineTotpSetupContainer', () => {
         });
 
         it('throws an error when checking the code errors', async () => {
-          mockVerifyTotpSetupCode.mockRejectedValue(new Error('err'));
+          mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(new Error('err'));
           render();
           await waitFor(() => {
             expect(InlineTotpSetupModule.default).toHaveBeenCalled();
@@ -340,8 +354,35 @@ describe('InlineTotpSetupContainer', () => {
           }
         });
 
+        it('clears the cached JWT and rethrows the original error when the MFA token is invalid', async () => {
+          const invalidJwtError = Object.assign(new Error('invalid mfa token'), {
+            errno: AuthUiErrors.INVALID_MFA_TOKEN.errno,
+          });
+          mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(invalidJwtError);
+          render();
+          await waitFor(() => {
+            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
+          });
+          const args = (InlineTotpSetupModule.default as jest.Mock).mock
+            .calls[0][0];
+          const verifyCodeHandler = args.verifyCodeHandler;
+
+          expect(
+            JwtTokenCache.hasToken(MOCK_SIGNIN_LOCATION_STATE.sessionToken, '2fa')
+          ).toBe(true);
+
+          // Rethrown as-is, not mislabeled as INVALID_TOTP_CODE.
+          await expect(verifyCodeHandler('1010')).rejects.toBe(invalidJwtError);
+
+          // Token dropped so MfaGuardCore re-prompts for a fresh email OTP
+          // instead of retrying the dead JWT.
+          expect(
+            JwtTokenCache.hasToken(MOCK_SIGNIN_LOCATION_STATE.sessionToken, '2fa')
+          ).toBe(false);
+        });
+
         it('redirects to inline_recovery_setup when the code is valid', async () => {
-          mockVerifyTotpSetupCode.mockResolvedValue({ success: true });
+          mockVerifyTotpSetupCodeWithJwt.mockResolvedValue({ success: true });
           render();
           await waitFor(() => {
             expect(InlineTotpSetupModule.default).toHaveBeenCalled();

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -6,7 +6,7 @@ import { useLocation } from 'react-router';
 import { useNavigateWithQuery } from '../../lib/hooks';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import InlineTotpSetup from '.';
-import { MozServices, TotpInfo } from '../../lib/types';
+import { MfaReason, MozServices, TotpInfo } from '../../lib/types';
 import AppLayout from '../../components/AppLayout';
 import { Integration, useSession, useAuthClient } from '../../models';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
@@ -17,6 +17,118 @@ import { QueryParams } from '../..';
 import { queryParamsToMetricsContext } from '../../lib/metrics';
 import GleanMetrics from '../../lib/glean';
 import * as Sentry from '@sentry/browser';
+import { MfaGuardCore } from '../../components/Settings/MfaGuard';
+import { JwtTokenCache } from '../../lib/cache';
+import { clearMfaAndJwtCacheOnInvalidJwt } from '../../lib/mfa-guard-utils';
+
+type MetricsContext = ReturnType<typeof queryParamsToMetricsContext>;
+
+type NavTo = (
+  uri:
+    | '/'
+    | '/signin_token_code'
+    | '/signin_totp_code'
+    | '/inline_recovery_setup',
+  state?: SigninLocationState | SigninRecoveryLocationState
+) => void;
+
+/**
+ * Runs the actual TOTP enrolment. Rendered as a child of `MfaGuardCore`, so a
+ * `mfa:2fa` JWT is already cached and the enrolment calls use the JWT-guarded
+ * `/mfa/totp/*` routes (FXA-14311).
+ */
+const InlineTotpEnrolment = ({
+  sessionToken,
+  signinState,
+  serviceName,
+  integration,
+  metricsContext,
+  navTo,
+}: {
+  sessionToken: string;
+  signinState: SigninLocationState;
+  serviceName: MozServices;
+  integration: Integration;
+  metricsContext: MetricsContext;
+  navTo: NavTo;
+}) => {
+  const authClient = useAuthClient();
+  const [totp, setTotp] = useState<TotpInfo>();
+  const isTotpCreating = useRef(false);
+
+  // Trigger TOTP setup once the guard has provided the JWT.
+  useEffect(() => {
+    if (totp !== undefined || isTotpCreating.current) {
+      return;
+    }
+    (async () => {
+      isTotpCreating.current = true;
+      try {
+        const jwt = JwtTokenCache.getToken(sessionToken, '2fa');
+        const totpResp = await authClient.createTotpTokenWithJwt(jwt, {
+          metricsContext,
+        });
+        setTotp(totpResp);
+      } catch (error) {
+        // The short-lived mfa:2fa JWT can expire mid-flow. On a stale/invalid
+        // JWT, drop it so MfaGuardCore re-prompts for a fresh email OTP rather
+        // than bouncing the user out. Keyed on the guard's `sessionToken`, not
+        // the global one, since this flow supplies its own.
+        if (clearMfaAndJwtCacheOnInvalidJwt(error, '2fa', sessionToken)) {
+          isTotpCreating.current = false;
+          return;
+        }
+        Sentry.captureException(error);
+        navTo('/');
+      }
+    })();
+  }, [authClient, metricsContext, navTo, totp, sessionToken]);
+
+  const verifyCodeHandler = useCallback(
+    async (code: string) => {
+      try {
+        const jwt = JwtTokenCache.getToken(sessionToken, '2fa');
+        await authClient.verifyTotpSetupCodeWithJwt(jwt, code, {
+          metricsContext,
+        });
+
+        const state = {
+          ...Object.assign({}, signinState),
+          ...(totp ? { totp } : {}),
+        };
+        GleanMetrics.accountPref.twoStepAuthQrCodeSuccess();
+        navTo(
+          '/inline_recovery_setup',
+          Object.keys(state).length > 0 ? state : undefined
+        );
+      } catch (error) {
+        // A stale/expired MFA JWT surfaces here as an invalid-JWT error, not a
+        // bad code. Clearing it drops the cached token so MfaGuardCore
+        // re-prompts for a fresh email OTP; genuine verification failures fall
+        // through to INVALID_TOTP_CODE. (The thrown value is not user-visible —
+        // the parent collapses any rejection into a generic error.)
+        if (clearMfaAndJwtCacheOnInvalidJwt(error, '2fa', sessionToken)) {
+          throw error;
+        }
+        // TODO: handle this error better
+        // auth-server may return more specific errors (including throttling)
+        throw AuthUiErrors.INVALID_TOTP_CODE;
+      }
+    },
+    [authClient, navTo, totp, signinState, sessionToken, metricsContext]
+  );
+
+  if (totp === undefined) {
+    return <AppLayout loading />;
+  }
+
+  return (
+    <InlineTotpSetup
+      {...{ totp, serviceName, verifyCodeHandler, integration }}
+      signedInWithPasskey={!!signinState.isPasskeySession}
+    />
+  );
+};
 
 export const InlineTotpSetupContainer = ({
   isSignedIn,
@@ -29,7 +141,6 @@ export const InlineTotpSetupContainer = ({
   serviceName: MozServices;
   flowQueryParams: QueryParams;
 }) => {
-  const [totp, setTotp] = useState<TotpInfo>();
   const [sessionVerified, setSessionVerified] = useState<boolean | undefined>(
     undefined
   );
@@ -47,20 +158,12 @@ export const InlineTotpSetupContainer = ({
   const metricsContext = queryParamsToMetricsContext(
     flowQueryParams as unknown as Record<string, string>
   );
-  const isTotpCreating = useRef(false);
   const isTotpStatusChecked = useRef(false);
 
   const signinState = getSigninState(location.state);
 
-  const navTo = useCallback(
-    (
-      uri:
-        | '/'
-        | '/signin_token_code'
-        | '/signin_totp_code'
-        | '/inline_recovery_setup',
-      state?: SigninLocationState | SigninRecoveryLocationState
-    ) => {
+  const navTo: NavTo = useCallback(
+    (uri, state) => {
       navigateWithQuery(uri, { state });
     },
     [navigateWithQuery]
@@ -100,40 +203,6 @@ export const InlineTotpSetupContainer = ({
     })();
   }, [session, sessionVerified, setSessionVerified]);
 
-  // Determine if a totp needs to be setup, and if so trigger setup.
-  useEffect(() => {
-    if (
-      totp !== undefined ||
-      totpStatus?.verified ||
-      isTotpCreating.current ||
-      totpStatusLoading ||
-      !signinState?.sessionToken
-    ) {
-      return;
-    }
-    (async () => {
-      isTotpCreating.current = true;
-      try {
-        const totpResp = await authClient.createTotpToken(
-          signinState.sessionToken,
-          { metricsContext }
-        );
-        setTotp(totpResp);
-      } catch (error) {
-        Sentry.captureException(error);
-        navTo('/');
-      }
-    })();
-  }, [
-    authClient,
-    metricsContext,
-    navTo,
-    totpStatus,
-    totpStatusLoading,
-    totp,
-    signinState?.sessionToken,
-  ]);
-
   // Once state has settled, determine if user should be directed to another page
   useEffect(() => {
     if (!isSignedIn || !signinState) {
@@ -164,50 +233,41 @@ export const InlineTotpSetupContainer = ({
     navigateWithQuery,
   ]);
 
-  const verifyCodeHandler = useCallback(
-    async (code: string) => {
-      try {
-        await authClient.verifyTotpSetupCode(signinState!.sessionToken, code, {
-          metricsContext,
-        });
-
-        const state = {
-          ...Object.assign({}, signinState),
-          ...(totp ? { totp } : {}),
-        };
-        GleanMetrics.accountPref.twoStepAuthQrCodeSuccess();
-        navTo(
-          '/inline_recovery_setup',
-          Object.keys(state).length > 0 ? state : undefined
-        );
-      } catch (error) {
-        // TODO: handle this error better
-        // auth-server may return more specific errors (including throttling)
-        throw AuthUiErrors.INVALID_TOTP_CODE;
-      }
-    },
-    [authClient, navTo, totp, signinState, metricsContext]
-  );
-
   if (!isSignedIn || !signinState) {
     return <AppLayout loading />;
   }
 
+  // Still resolving sanity checks, or a redirect effect above is about to fire.
   if (
-    !isSignedIn ||
-    !signinState ||
     totpStatusLoading ||
-    totp === undefined ||
-    sessionVerified === undefined
+    sessionVerified === undefined ||
+    totpStatus?.verified ||
+    sessionVerified === false
   ) {
     return <AppLayout loading />;
   }
 
+  // Gate enrolment behind an MFA email-OTP so a hijacked session cannot silently
+  // add a second factor (FXA-14311).
   return (
-    <InlineTotpSetup
-      {...{ totp, serviceName, verifyCodeHandler, integration }}
-      signedInWithPasskey={!!signinState.isPasskeySession}
-    />
+    <MfaGuardCore
+      requiredScope="2fa"
+      reason={MfaReason.createTotp}
+      email={signinState.email}
+      sessionToken={signinState.sessionToken}
+      onDismiss={() => navTo('/')}
+      onSessionInvalid={() => navigateWithQuery('/signin')}
+      onFatalError={() => navTo('/')}
+    >
+      <InlineTotpEnrolment
+        sessionToken={signinState.sessionToken}
+        signinState={signinState}
+        serviceName={serviceName}
+        integration={integration}
+        metricsContext={metricsContext}
+        navTo={navTo}
+      />
+    </MfaGuardCore>
   );
 };
 


### PR DESCRIPTION
## Because

* step-up requires no password, so inline TOTP enrolment on a live session had no proof beyond the session token — a hijacked session could add a second factor and satisfy step-up

## This pull request

* extracts a host-agnostic MfaGuardCore from the Settings MfaGuard (context + core + thin wrapper; public API unchanged)
* routes inline TOTP enrolment (InlineTotpSetup, InlineRecoverySetupFlow) through the email-OTP mfa:2fa JWT path (/mfa/totp/*) via the guard
* adds `service` to completeTotpSetupWithJwt in fxa-auth-client
* covers the guard's block-without-JWT behavior and updates the container tests

## Issue that this pull request solves

Closes: #FXA-14311

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
