### PR TITLE
fix(auth-server): stop check-users spec from leaving fixture files in the repo

### DIFF
--- a/packages/fxa-auth-server/test/scripts/check-users.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/check-users.in.spec.ts
@@ -4,6 +4,7 @@
 
 import cp from 'child_process';
 import util from 'util';
+import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import {
@@ -35,9 +36,12 @@ describe('#integration - scripts/check-users:', () => {
   let server: TestServerInstance;
   let validClient: any;
   let invalidClient: any;
+  let tmpDir: string;
   let filename: string;
 
   beforeAll(async () => {
+    // Write test files outside the repo so no fixtures are left behind.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fxa-check-users-'));
     server = await getSharedTestServer();
 
     validClient = await Client.create(
@@ -57,12 +61,16 @@ describe('#integration - scripts/check-users:', () => {
     let csvData = `${validClient.email}:${PASSWORD_VALID}\n`;
     csvData = csvData + `${invalidClient.email}:wrong_password\n`;
     csvData = csvData + `invalid@email.com:wrong_password\n`;
-    filename = `./test/scripts/fixtures/${Math.random()}_two_email_passwords.txt`;
+    filename = path.join(tmpDir, 'two_email_passwords.txt');
     fs.writeFileSync(filename, csvData);
   });
 
   afterAll(async () => {
-    await server.stop();
+    try {
+      if (server) await server.stop();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('fails if no input file', async () => {
@@ -78,9 +86,9 @@ describe('#integration - scripts/check-users:', () => {
   });
 
   it('creates csv file with user stats', async () => {
-    const outfile = `./test/scripts/fixtures/${Math.random()}_stats.csv`;
+    const outfile = path.join(tmpDir, 'stats.csv');
     await execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/check-users -i ${filename} -o ${outfile}`,
+      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/check-users -i "${filename}" -o "${outfile}"`,
       execOptions
     );
 

--- a/packages/fxa-auth-server/test/scripts/dump-users.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/dump-users.in.spec.ts
@@ -4,6 +4,7 @@
 
 const { promisify } = require('util');
 const cp = require('child_process');
+const os = require('os');
 const path = require('path');
 const mocks = require('../../test/mocks');
 const crypto = require('crypto');
@@ -69,47 +70,42 @@ const execOptions = {
 
 describe('#integration - scripts/dump-users', () => {
   let db: any,
+    tmpDir: string,
     oneEmailFilename: string,
     twoEmailsFilename: string,
     oneUidFilename: string,
     twoUidsFilename: string;
 
   beforeAll(async () => {
+    // Write test files outside the repo so no fixtures are left behind.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fxa-dump-users-'));
     db = await DB.connect(config);
     await db.createAccount(account1Mock);
     await db.createAccount(account2Mock);
 
     const data = `${account1Mock.email}\n`;
-    oneEmailFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_one_email.txt`;
+    oneEmailFilename = path.join(tmpDir, 'one_email.txt');
     fs.writeFileSync(oneEmailFilename, data);
 
     const data2 = `${account1Mock.uid}\n`;
-    oneUidFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_one_uid.txt`;
+    oneUidFilename = path.join(tmpDir, 'one_uid.txt');
     fs.writeFileSync(oneUidFilename, data2);
 
     const data3 = `${account1Mock.email}\n${account2Mock.email}\n`;
-    twoEmailsFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_two_emails.txt`;
+    twoEmailsFilename = path.join(tmpDir, 'two_emails.txt');
     fs.writeFileSync(twoEmailsFilename, data3);
 
     const data4 = `${account1Mock.uid}\n${account2Mock.uid}\n`;
-    twoUidsFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_two_uids.txt`;
+    twoUidsFilename = path.join(tmpDir, 'two_uids.txt');
     fs.writeFileSync(twoUidsFilename, data4);
   });
 
   afterAll(async () => {
-    await db.close();
-    fs.unlinkSync(oneEmailFilename);
-    fs.unlinkSync(oneUidFilename);
-    fs.unlinkSync(twoEmailsFilename);
-    fs.unlinkSync(twoUidsFilename);
+    try {
+      if (db) await db.close();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('fails if neither --emails nor --uids is specified', async () => {
@@ -201,9 +197,7 @@ describe('#integration - scripts/dump-users', () => {
 
   it('succeeds with --uids and --input containing 1 uid', async () => {
     const { stdout: output } = await cp.execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --uids --input ${
-        '../' + oneUidFilename
-      }`,
+      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --uids --input "${oneUidFilename}"`,
       execOptions
     );
     const result = JSON.parse(output);
@@ -215,9 +209,7 @@ describe('#integration - scripts/dump-users', () => {
 
   it('succeeds with --uids and --input containing 2 uids', async () => {
     const { stdout: output } = await cp.execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --uids --input ${
-        '../' + twoUidsFilename
-      }`,
+      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --uids --input "${twoUidsFilename}"`,
       execOptions
     );
     const result = JSON.parse(output);
@@ -271,9 +263,7 @@ describe('#integration - scripts/dump-users', () => {
 
   it('succeeds with --emails and --input containing 1 email', async () => {
     const { stdout: output } = await cp.execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --emails --input ${
-        '../' + oneEmailFilename
-      }`,
+      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --emails --input "${oneEmailFilename}"`,
       execOptions
     );
     const result = JSON.parse(output);
@@ -285,9 +275,7 @@ describe('#integration - scripts/dump-users', () => {
 
   it('succeeds with --emails and --input containing 2 email', async () => {
     const { stdout: output } = await cp.execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --emails --input ${
-        '../' + twoEmailsFilename
-      }`,
+      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --emails --input "${twoEmailsFilename}"`,
       execOptions
     );
     const result = JSON.parse(output);

--- a/packages/fxa-auth-server/test/scripts/must-reset.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/must-reset.in.spec.ts
@@ -4,6 +4,7 @@
 
 const { promisify } = require('util');
 const cp = require('child_process');
+const os = require('os');
 const path = require('path');
 const mocks = require('../../test/mocks');
 const crypto = require('crypto');
@@ -58,53 +59,48 @@ const DB = createDB(config, log, Token, UnblockCode);
 
 describe('#integration - scripts/must-reset', () => {
   let db: any,
+    tmpDir: string,
     oneEmailFilename: string,
     oneUidFilename: string,
     twoEmailsFilename: string,
     twoUidsFilename: string;
 
   beforeAll(async () => {
+    // Write test files outside the repo so no fixtures are left behind.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fxa-must-reset-'));
     db = await DB.connect(config);
     await db.createAccount(account1Mock);
     await db.createAccount(account2Mock);
 
     const data = `${account1Mock.email}\n`;
-    oneEmailFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_one_email.txt`;
+    oneEmailFilename = path.join(tmpDir, 'one_email.txt');
     fs.writeFileSync(oneEmailFilename, data);
 
     const data2 = `${account1Mock.uid}\n`;
-    oneUidFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_one_uid.txt`;
+    oneUidFilename = path.join(tmpDir, 'one_uid.txt');
     fs.writeFileSync(oneUidFilename, data2);
 
     const data3 = `${account1Mock.email}\n${account2Mock.email}\n`;
-    twoEmailsFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_two_emails.txt`;
+    twoEmailsFilename = path.join(tmpDir, 'two_emails.txt');
     fs.writeFileSync(twoEmailsFilename, data3);
 
     const data4 = `${account1Mock.uid}\n${account2Mock.uid}\n`;
-    twoUidsFilename = `./test/scripts/fixtures/${crypto
-      .randomBytes(16)
-      .toString('hex')}_two_uids.txt`;
+    twoUidsFilename = path.join(tmpDir, 'two_uids.txt');
     fs.writeFileSync(twoUidsFilename, data4);
   });
 
   afterAll(async () => {
-    await db.close();
-    fs.unlinkSync(oneEmailFilename);
-    fs.unlinkSync(oneUidFilename);
-    fs.unlinkSync(twoEmailsFilename);
-    fs.unlinkSync(twoUidsFilename);
+    try {
+      if (db) await db.close();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('fails if -i is not specified', async () => {
     try {
       await cp.execAsync(
-        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset ${oneEmailFilename}`,
+        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset "${oneEmailFilename}"`,
         {
           cwd,
         }
@@ -118,7 +114,7 @@ describe('#integration - scripts/must-reset', () => {
   it('fails if neither --emails nor --uids is specified', async () => {
     try {
       await cp.execAsync(
-        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset -i ${oneEmailFilename}`,
+        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset -i "${oneEmailFilename}"`,
         {
           cwd,
         }
@@ -132,7 +128,7 @@ describe('#integration - scripts/must-reset', () => {
   it('fails if both --emails and --uids are specified', async () => {
     try {
       await cp.execAsync(
-        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --emails --uids -i ${oneEmailFilename}`,
+        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --emails --uids -i "${oneEmailFilename}"`,
         {
           cwd,
         }
@@ -230,7 +226,7 @@ describe('#integration - scripts/must-reset', () => {
   it('succeeds with --uids and --input containing 1 uid', async () => {
     try {
       await cp.execAsync(
-        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --uids --input ${oneUidFilename}`,
+        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --uids --input "${oneUidFilename}"`,
         {
           cwd,
         }
@@ -247,7 +243,7 @@ describe('#integration - scripts/must-reset', () => {
   it('succeeds with --emails and --input containing 1 email', async () => {
     try {
       await cp.execAsync(
-        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --emails --input ${oneEmailFilename}`,
+        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --emails --input "${oneEmailFilename}"`,
         {
           cwd,
         }
@@ -264,7 +260,7 @@ describe('#integration - scripts/must-reset', () => {
   it('succeeds with --uids and --input containing 2 uids', async () => {
     try {
       await cp.execAsync(
-        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --uids --input ${twoUidsFilename}`,
+        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --uids --input "${twoUidsFilename}"`,
         {
           cwd,
         }
@@ -287,7 +283,7 @@ describe('#integration - scripts/must-reset', () => {
   it('succeeds with --emails and --input containing 2 emails', async () => {
     try {
       await cp.execAsync(
-        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --emails --input ${twoEmailsFilename}`,
+        `node -r ts-node/register/transpile-only -r tsconfig-paths/register  scripts/must-reset --emails --input "${twoEmailsFilename}"`,
         {
           cwd,
         }


### PR DESCRIPTION
## Because

- `check-users.in.spec.ts` wrote its input file and the script output into the tracked `test/scripts/fixtures/` directory, and never removed them.
- Each run of the `scripts` Jest project left two more untracked files. `git status` filled with noise, and it was easy to commit the files by accident.
- The `Math.random()` names in those paths also broke the deterministic test value rule.

## This pull request

- Makes a temporary directory under `os.tmpdir()` in `beforeAll`, and writes both files there.
- Deletes that directory in `afterAll`, after the shared test server stops.
- Leaves the assertions unchanged.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14299

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.
