### PR TITLE
feat(settings): show more account history events

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/en.ftl
@@ -3,6 +3,8 @@
 ## These are displayed as a list with the date when the event occured
 
 recent-activity-title = Recent account activity
+# Clicking this button reveals the older account activity that is hidden at first.
+recent-activity-show-more-button = Show more
 
 recent-activity-account-create-v2 = Account created
 recent-activity-account-disable-v2 = Account disabled

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
@@ -4,8 +4,9 @@
 
 import 'mutationobserver-shim';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithRouter, mockAppContext } from '../../../models/mocks';
-import PageRecentActivity from '.';
+import PageRecentActivity, { INITIAL_EVENT_COUNT } from '.';
 import { Account, AppContext } from '../../../models';
 import { MOCK_SECURITY_EVENTS } from './mocks';
 import { HIDDEN_SECURITY_EVENT_NAMES } from './SecurityEvent';
@@ -24,68 +25,69 @@ const render = (acct: Account = account) =>
     </AppContext.Provider>
   );
 
+// One label per mapped event name in SecurityEventName, excluding the
+// events listed in HIDDEN_SECURITY_EVENT_NAMES. The order matches
+// MOCK_SECURITY_EVENTS, which is generated from the same enum.
+const expectedLabels = [
+  'Account created',
+  'Account disabled',
+  'Account enabled',
+  'Account login initiated',
+  'Password reset initiated',
+  'Email bounces cleared',
+  'Account login attempt failed',
+  'Two-step authentication enabled',
+  'Two-step authentication requested',
+  'Two-step authentication failed',
+  'Two-step authentication successful',
+  'Two-step authentication removed',
+  'Password reset requested',
+  'Password reset successful',
+  'Account recovery key enabled',
+  'Account recovery key verification failed',
+  'Account recovery key verification successful',
+  'Account recovery key removed',
+  'New password added',
+  'Password changed',
+  'Secondary email address added',
+  'Secondary email address removed',
+  'Primary and secondary emails swapped',
+  'Logged out of session',
+  'Recovery phone code sent',
+  'Recovery phone setup completed',
+  'Sign-in with recovery phone completed',
+  'Sign-in with recovery phone failed',
+  'Recovery phone removed',
+  'Recovery codes replaced',
+  'Recovery codes created',
+  'Sign-in with recovery codes completed',
+  'Reset password confirmation code sent',
+  'Reset password confirmation code verified',
+  'Password reset required',
+  'Password reset with recovery phone completed',
+  'Password reset with recovery phone failed',
+  'Recovery phone replaced',
+  'Recovery phone replacement failed',
+  'Two-step authentication replaced',
+  'Two-step authentication replacement failed',
+  'Recovery phone setup failed',
+  'Account change authorization requested',
+  'Account change authorized',
+  'Account change authorization failed',
+  'Passkey added',
+  'Passkey registration failed',
+  'Passkey removed',
+  'Sign-in with passkey completed',
+  'Sign-in with passkey failed',
+  'Passwordless sign-in code sent',
+  'Passwordless sign-in code failed',
+  'Passwordless sign-in code verified',
+  'Passwordless account registration completed',
+  'Recovery codes set',
+];
+
 describe('Recent Account Activity', () => {
   it('renders', async () => {
-    // One label per mapped event name in SecurityEventName, excluding the
-    // events listed in HIDDEN_SECURITY_EVENT_NAMES.
-    const expectedLabels = [
-      'Account created',
-      'Account disabled',
-      'Account enabled',
-      'Account login initiated',
-      'Password reset initiated',
-      'Email bounces cleared',
-      'Account login attempt failed',
-      'Two-step authentication enabled',
-      'Two-step authentication requested',
-      'Two-step authentication failed',
-      'Two-step authentication successful',
-      'Two-step authentication removed',
-      'Password reset requested',
-      'Password reset successful',
-      'Account recovery key enabled',
-      'Account recovery key verification failed',
-      'Account recovery key verification successful',
-      'Account recovery key removed',
-      'New password added',
-      'Password changed',
-      'Secondary email address added',
-      'Secondary email address removed',
-      'Primary and secondary emails swapped',
-      'Logged out of session',
-      'Recovery phone code sent',
-      'Recovery phone setup completed',
-      'Sign-in with recovery phone completed',
-      'Sign-in with recovery phone failed',
-      'Recovery phone removed',
-      'Recovery codes replaced',
-      'Recovery codes created',
-      'Sign-in with recovery codes completed',
-      'Reset password confirmation code sent',
-      'Reset password confirmation code verified',
-      'Password reset required',
-      'Password reset with recovery phone completed',
-      'Password reset with recovery phone failed',
-      'Recovery phone replaced',
-      'Recovery phone replacement failed',
-      'Two-step authentication replaced',
-      'Two-step authentication replacement failed',
-      'Recovery phone setup failed',
-      'Account change authorization requested',
-      'Account change authorized',
-      'Account change authorization failed',
-      'Passkey added',
-      'Passkey registration failed',
-      'Passkey removed',
-      'Sign-in with passkey completed',
-      'Sign-in with passkey failed',
-      'Passwordless sign-in code sent',
-      'Passwordless sign-in code failed',
-      'Passwordless sign-in code verified',
-      'Passwordless account registration completed',
-      'Recovery codes set',
-    ];
-
     render();
 
     expect(screen.getByTestId('flow-container')).toBeInTheDocument();
@@ -96,9 +98,54 @@ describe('Recent Account Activity', () => {
 
     expect(await screen.findByText(expectedLabels[0])).toBeInTheDocument();
     expect(account.getSecurityEvents).toHaveBeenCalled();
-    for (const label of expectedLabels.slice(1)) {
+  });
+
+  it(`renders only the first ${INITIAL_EVENT_COUNT} events before "Show more"`, async () => {
+    render();
+
+    expect(await screen.findByText(expectedLabels[0])).toBeInTheDocument();
+    for (const label of expectedLabels.slice(1, INITIAL_EVENT_COUNT)) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
+    expect(
+      screen.queryByText(expectedLabels[INITIAL_EVENT_COUNT])
+    ).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(INITIAL_EVENT_COUNT);
+  });
+
+  it('renders the remaining events after "Show more" is clicked', async () => {
+    const user = userEvent.setup();
+    render();
+
+    await user.click(await screen.findByRole('button', { name: 'Show more' }));
+
+    for (const label of expectedLabels) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(
+      screen.queryByRole('button', { name: 'Show more' })
+    ).not.toBeInTheDocument();
+  });
+
+  it(`omits "Show more" when there are at most ${INITIAL_EVENT_COUNT} events`, async () => {
+    const accountWithFewEvents = {
+      primaryEmail: { email: 'foxy@mozilla.com' },
+      getSecurityEvents: jest
+        .fn()
+        .mockResolvedValue(
+          MOCK_SECURITY_EVENTS.filter(
+            (securityEvent) =>
+              !HIDDEN_SECURITY_EVENT_NAMES.has(securityEvent.name)
+          ).slice(0, INITIAL_EVENT_COUNT)
+        ),
+    } as unknown as Account;
+
+    render(accountWithFewEvents);
+
+    expect(await screen.findByText(expectedLabels[0])).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Show more' })
+    ).not.toBeInTheDocument();
   });
 
   it('filters HIDDEN_SECURITY_EVENT_NAMES before rendering', async () => {
@@ -121,6 +168,18 @@ describe('Recent Account Activity', () => {
     // assertion below would fail.
     expect(await screen.findByText('Account created')).toBeInTheDocument();
     expect(screen.queryAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('keeps HIDDEN_SECURITY_EVENT_NAMES filtered after "Show more" is clicked', async () => {
+    const user = userEvent.setup();
+    // MOCK_SECURITY_EVENTS covers every event name, hidden ones included.
+    render();
+
+    await user.click(await screen.findByRole('button', { name: 'Show more' }));
+
+    expect(screen.queryAllByRole('listitem')).toHaveLength(
+      expectedLabels.length
+    );
   });
 
   it('falls back to "Other account activity" for unrecognized event names', async () => {

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
@@ -8,11 +8,16 @@ import {
   HIDDEN_SECURITY_EVENT_NAMES,
   SecurityEvent as SecurityEventSection,
 } from './SecurityEvent';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import React, { useState, useEffect } from 'react';
+
+// Number of events shown before the user asks for more.
+export const INITIAL_EVENT_COUNT = 20;
 
 export const PageRecentActivity = () => {
   const account = useAccount();
   const [securityEvents, setSecurityEvents] = useState(account.securityEvents);
+  const [showAll, setShowAll] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -23,6 +28,15 @@ export const PageRecentActivity = () => {
 
   const ftlMsgResolver = useFtlMsgResolver();
 
+  // Filter first, then cap, so the page shows a full list of rows.
+  const visibleEvents = (securityEvents ?? []).filter(
+    (securityEvent) => !HIDDEN_SECURITY_EVENT_NAMES.has(securityEvent.name)
+  );
+  const eventsToShow = showAll
+    ? visibleEvents
+    : visibleEvents.slice(0, INITIAL_EVENT_COUNT);
+  const hasMore = visibleEvents.length > INITIAL_EVENT_COUNT;
+
   return (
     <FlowContainer
       title={ftlMsgResolver.getMsg(
@@ -31,22 +45,27 @@ export const PageRecentActivity = () => {
       )}
     >
       <ol className="mt-5 relative border-s border-gray-100">
-        {!!securityEvents &&
-          securityEvents
-            .filter(
-              (securityEvent) =>
-                !HIDDEN_SECURITY_EVENT_NAMES.has(securityEvent.name)
-            )
-            .map((securityEvent) => (
-              <SecurityEventSection
-                key={securityEvent.name + securityEvent.createdAt}
-                {...{
-                  name: securityEvent.name,
-                  createdAt: securityEvent.createdAt,
-                }}
-              />
-            ))}
+        {eventsToShow.map((securityEvent) => (
+          <SecurityEventSection
+            key={securityEvent.name + securityEvent.createdAt}
+            {...{
+              name: securityEvent.name,
+              createdAt: securityEvent.createdAt,
+            }}
+          />
+        ))}
       </ol>
+      {!showAll && hasMore && (
+        <FtlMsg id="recent-activity-show-more-button">
+          <button
+            type="button"
+            className="cta-neutral cta-base-p mt-4 w-full"
+            onClick={() => setShowAll(true)}
+          >
+            Show more
+          </button>
+        </FtlMsg>
+      )}
     </FlowContainer>
   );
 };

--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -81,6 +81,9 @@ export const EVENT_NAMES = {
 
 export type SecurityEventNames = keyof typeof EVENT_NAMES;
 
+// Default number of events returned to the account history endpoint.
+export const SECURITY_EVENTS_LIMIT = 100;
+
 export function sanitizeIp(addr: string) {
   addr = addr.trim();
 
@@ -178,7 +181,7 @@ export class SecurityEvent extends BaseAuthModel {
     return !!result;
   }
 
-  static async findByUid(uid: string) {
+  static async findByUid(uid: string, limit = SECURITY_EVENTS_LIMIT) {
     const id = uuidTransformer.to(uid);
     return this.query()
       .select(
@@ -195,7 +198,7 @@ export class SecurityEvent extends BaseAuthModel {
       )
       .where('securityEvents.uid', id)
       .orderBy('securityEvents.createdAt', 'DESC')
-      .limit(20);
+      .limit(limit);
   }
 
   static async findByUidAndIP(uid: string, ipAddr: string, ipHmacKey: string) {


### PR DESCRIPTION
## Because

- Account History stopped at 20 security events, so users could not see older activity.
- The cap was the `.limit(20)` in `SecurityEvent.findByUid`. The page itself never capped anything.

## This pull request

- Adds an optional `limit` argument to `SecurityEvent.findByUid` and raises the default to 100 (`security-event.ts`).
- Renders the first 20 events on the Recent account activity page, with a "Show more" button for the rest (`PageRecentActivity/index.tsx`).
- Caps the list after the `HIDDEN_SECURITY_EVENT_NAMES` filter, so 20 visible rows show and hidden events stay hidden once expanded.
- Adds the `recent-activity-show-more-button` string and tests for the cap, the button, and the filter.

One side effect worth knowing: `GET /account` returns this same list, so it now returns up to 100 entries. The page seeds its first render from that field, so both sources need the same limit.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14318

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:** open Settings, then "Recent account activity". An account with more than 20 events shows 20 rows and a "Show more" button that reveals the rest.
