### PR TITLE
Fix svgr webpack config

### DIFF
--- a/packages/fxa-react/configs/storybooks.js
+++ b/packages/fxa-react/configs/storybooks.js
@@ -122,6 +122,16 @@ const customizeWebpackConfig = ({ config }) => ({
                           overrides: {
                             // disable plugins
                             removeViewBox: false,
+                            // cleanupIds minifies ids to single letters one
+                            // file at a time, with no awareness of the other
+                            // SVGs it will share a page with. Every
+                            // illustration ends up declaring a, b, c... so on
+                            // a Docs page that renders several of them,
+                            // url(#c) resolves to the first match in the
+                            // document and illustrations steal each other's
+                            // gradients, patterns and clip paths. CRA sets
+                            // svgo: false, so this only ever bites Storybook.
+                            cleanupIds: false,
                           },
                         },
                       },


### PR DESCRIPTION
## Because

- svgr's default svgo preset runs cleanupIds, which minifies element ids
  to single letters (a, b, c...) one file at a time, with no awareness of
  the other SVGs it will share a page with.
- Every illustration therefore declares the same ids, so on a Storybook
  Docs page that renders several of them a reference like url(#c)
  resolves to the first match in the document and illustrations steal
  each other's gradients, patterns and clip paths.
- CRA sets svgo: false for its own svgr rule, so this only affects
  Storybook builds that use the fxa-react webpack config.

## This pull request

-  Adds cleanupIds: false to the preset-default overrides in the svgr
  loader options in packages/fxa-react/configs/storybooks.js, preserving
  the original ids from each SVG so cross-illustration collisions cannot
  happen.

## Issue that this pull request solves

Closes: FXA-14343

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)



## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This fixes issues called out [here](https://github.com/mozilla/fxa/pull/20984#issuecomment-5259315741), although on closer investigation this was certainly causing problems in other storybooks.
