### PR TITLE
fix(errors): return 403 from featureNotEnabled instead of 503

### DIFF
--- a/libs/accounts/errors/src/app-error.ts
+++ b/libs/accounts/errors/src/app-error.ts
@@ -602,7 +602,7 @@ export class AppError extends Error {
     }
     return new AppError(
       {
-        code: 503,
+        code: 403,
         error: 'Feature not enabled',
         errno: ERRNO.FEATURE_NOT_ENABLED,
         message: 'Feature not enabled',

--- a/libs/accounts/errors/src/index.spec.ts
+++ b/libs/accounts/errors/src/index.spec.ts
@@ -213,6 +213,16 @@ describe('AppErrors', () => {
     }
   );
 
+  it('featureNotEnabled', () => {
+    const result = AppError.featureNotEnabled();
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.errno).toEqual(202);
+    expect(result.message).toEqual('Feature not enabled');
+    expect(result.output.statusCode).toEqual(403);
+    expect(result.output.payload.error).toEqual('Feature not enabled');
+    expect(result.output.payload.errno).toEqual(202);
+  });
+
   it('iapInvalidToken', () => {
     const defaultErrorMessage = 'Invalid IAP token';
     let result = AppError.iapInvalidToken();

--- a/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/auth-server-api.ts
@@ -152,7 +152,7 @@ export const AUTH_SERVER_API_DESCRIPTION = {
     | 404         | 198   | Unknown app name                                                              |
     | 400         | 199   | Invalid promotion code                                                        |
     | 503         | 201   | Service unavailable                                                           |
-    | 503         | 202   | Feature not enabled                                                           |
+    | 403         | 202   | Feature not enabled                                                           |
     | 500         | 203   | System unavailable, try again soon                                            |
     | 503         | 204   | This client has been temporarily disabled                                     |
     | 500         | 205   | Could not login with third party account, please try again later              |

--- a/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
@@ -89,7 +89,7 @@ const ACCOUNT_DEVICE_POST = {
             - \`errno: 107\` - Invalid parameter in request body
           `,
         },
-        503: {
+        403: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
             - \`errno: 202\` - Feature not enabled
@@ -159,7 +159,7 @@ const ACCOUNT_DEVICES_NOTIFY_POST = {
             - \`errno: 107\` - Invalid parameter in request body
           `,
         },
-        503: {
+        403: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
             - \`errno: 202\` - Feature not enabled

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.spec.ts
@@ -219,7 +219,7 @@ describe('/account/device', () => {
         throw new Error('should have thrown');
       },
       (err: any) => {
-        expect(err.output.statusCode).toBe(503);
+        expect(err.output.statusCode).toBe(403);
         expect(err.errno).toBe(error.ERRNO.FEATURE_NOT_ENABLED);
       }
     );
@@ -504,7 +504,7 @@ describe('/account/devices/notify', () => {
         throw new Error('should have thrown');
       },
       (err: any) => {
-        expect(err.output.statusCode).toBe(503);
+        expect(err.output.statusCode).toBe(403);
         expect(err.errno).toBe(error.ERRNO.FEATURE_NOT_ENABLED);
       }
     );
@@ -821,7 +821,7 @@ describe('/account/device/commands', () => {
     mockRequest.auth.credentials.refreshTokenId = 'aaabbbccc';
 
     await expect(route.handler(mockRequest)).rejects.toMatchObject({
-      output: { statusCode: 503 },
+      output: { statusCode: 403 },
       errno: error.ERRNO.FEATURE_NOT_ENABLED,
     });
     expect(mockPushbox.retrieve).not.toHaveBeenCalled();
@@ -1310,7 +1310,7 @@ describe('/account/devices/invoke_command', () => {
     mockRequest.auth.credentials.refreshTokenId = 'aaabbbccc';
 
     await expect(route.handler(mockRequest)).rejects.toMatchObject({
-      output: { statusCode: 503 },
+      output: { statusCode: 403 },
       errno: error.ERRNO.FEATURE_NOT_ENABLED,
     });
     expect(mockPushbox.store).not.toHaveBeenCalled();
@@ -1673,7 +1673,7 @@ describe('/account/devices', () => {
     });
 
     await expect(route.handler(mockRequest)).rejects.toMatchObject({
-      output: { statusCode: 503 },
+      output: { statusCode: 403 },
       errno: error.ERRNO.FEATURE_NOT_ENABLED,
     });
   });


### PR DESCRIPTION
## Because

- `AppError.featureNotEnabled()` responded with 503 Service Unavailable. That status tells the client the server is at fault and that a retry may work.
- Neither is true for a disabled feature flag. The server understands the request and refuses it, so 403 is correct.

## This pull request

- Changes the status code in `featureNotEnabled()` to 403 in `app-error.ts`.
- Updates the errno 202 row in the API error table in `auth-server-api.ts`.
- Moves the two errno 202 response blocks in `devices-and-sessions-api.ts` from 503 to 403.
- Updates five stale status assertions in `devices-and-sessions.spec.ts`.
- Adds a unit test in `index.spec.ts` that pins both the 403 status and the 202 errno.

`errno` 202 is unchanged. Clients match on errno, so changing it would break them. None of the ~20 call sites pass an argument or assert on the status, so none needed edits.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14339

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## Other information

`featureNotEnabled()` still sends a `retry-after` header. That was coherent on a 503 and looks out of place on a 403. I left it alone because that is a separate behavior change. It is worth a follow-up ticket.

