### PR TITLE
fix(settings): point app download buttons at Bitly link

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
@@ -16,11 +16,11 @@ describe('Connect another device Promo', () => {
     await screen.findByText('Find Firefox in the Google Play and App Store.');
     expect(screen.getByTestId('play-store-link')).toHaveAttribute(
       'href',
-      'https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox'
+      'https://mzl.la/setting-appdownload'
     );
     expect(screen.getByTestId('app-store-link')).toHaveAttribute(
       'href',
-      'https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926'
+      'https://mzl.la/setting-appdownload'
     );
   });
 });

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
@@ -9,6 +9,9 @@ import { SettingsContext } from '../../../models/contexts/SettingsContext';
 import GleanMetrics from '../../../lib/glean';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
+// Bitly smart link. It detects the platform and redirects to the correct store.
+const APP_DOWNLOAD_LINK = 'https://mzl.la/setting-appdownload';
+
 export function ConnectAnotherDevicePromo() {
   const { navigatorLanguages } = useContext(SettingsContext);
   const GooglePlayBadge = getStoreImageByLanguages(
@@ -39,7 +42,7 @@ export function ConnectAnotherDevicePromo() {
         <LinkExternal
           className="self-center rounded focus-visible-default outline-offset-2"
           data-testid="play-store-link"
-          href="https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox"
+          href={APP_DOWNLOAD_LINK}
           onClick={() => GleanMetrics.accountPref.googlePlaySubmit()}
         >
           {GooglePlayBadge}
@@ -47,7 +50,7 @@ export function ConnectAnotherDevicePromo() {
         <LinkExternal
           className="self-center m-2 rounded focus-visible-default outline-offset-2"
           data-testid="app-store-link"
-          href="https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926"
+          href={APP_DOWNLOAD_LINK}
           onClick={() => GleanMetrics.accountPref.appleSubmit()}
         >
           {AppStoreBadge}


### PR DESCRIPTION
## Because

- The Adjust link behind the app download buttons on the settings page stopped recording data correctly in March, so the D2M acquisition numbers are estimates.

## This pull request

- Points both store badges in `ConnectAnotherDevicePromo` at `https://mzl.la/setting-appdownload`.
- Updates the two `href` assertions in the component test.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14114

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have manually reviewed all AI generated code.

## Other information

- The ticket gives one link, and the page has two buttons. The Google Play badge and the App Store badge now use the same URL, so the per-platform redirect depends on Bitly. Tell me in review if you want a separate link for each platform.
- The slug comes from the ticket. I cannot check from the repo where it resolves, so please confirm it reaches both stores before merge.
- `constants.ts` still holds `DOWNLOAD_LINK_TEMPLATE_ANDROID`, `DOWNLOAD_LINK_TEMPLATE_IOS`, and `DOWNLOAD_LINK_PAIRING_APP` with Adjust URLs. Nothing in `fxa-settings` reads them. I left them alone. They look worth a separate cleanup.

