### PR TITLE
fix(auth): point email app download buttons at the Bitly link

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -489,14 +489,12 @@ const convictConf = convict({
     androidUrl: {
       doc: 'url to Android product page',
       format: String,
-      default:
-        'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=android&creative=button&utm_source=email',
+      default: 'https://mzl.la/email-appdownload',
     },
     iosUrl: {
       doc: 'url to IOS product page',
       format: String,
-      default:
-        'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=ios&creative=button&fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8&utm_source=email',
+      default: 'https://mzl.la/email-appdownload',
     },
     mozillaSupportUrl: {
       doc: 'url to general Mozilla support page',


### PR DESCRIPTION
## Because

- The Adjust tracker behind the app store badges in FxA emails stopped recording in March, so download clicks from email are no longer attributed.
- The reporter asked for every email that shows those badges, not the welcome email alone.

## This pull request

- Sets the `androidUrl` and `iosUrl` defaults in `packages/fxa-auth-server/config/index.ts` to `https://mzl.la/email-appdownload`.
- Both values feed the shared `appBadges` partial, so four templates pick up the new link with no template edits: `postVerify`, `passwordResetAccountRecovery`, `cadReminderFirst`, `cadReminderSecond`.
- Leaves `downloadSubscription` alone. It falls back to `appStoreLink` and `playStoreLink` from per-product subscription metadata, which are store links for a subscribed app rather than the generic Firefox badges.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14115

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/config/index.ts`, the `smtp.androidUrl` and `smtp.iosUrl` defaults.
- Risky or complex parts: neither key has an `env:` entry. Please confirm stage and prod config does not pin these values, or the change will not take effect there.

## Screenshots (Optional)

Not applicable, no user interface change.

## Other information (Optional)

- Attribution trade-off: the old URLs carried `campaign=fxa-conf-email` plus `adgroup=android` or `adgroup=ios`, so clicks split by platform and by campaign. One Bitly link for both badges reports a single total with no split. The reporter chose the single link.
- `fxa-admin-server` keeps its own `androidUrl` and `iosUrl` defaults on the old Adjust URLs. Its templates do not render `appBadges`, so nothing there is user-visible. Left out of scope.

