### PR TITLE
fix(admin-panel): update RP post-create steps for the fxa-legacy event broker

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.test.tsx
@@ -147,9 +147,8 @@ it('creates a new relying party via UI', async () => {
   await screen.findByText(
     'To finalize this new RP, a couple more steps are needed'
   );
-  await screen.findByText(
-    'gcloud pubsub topics create rpQueue-new-id --message-retention-duration=2678400s'
-  );
+  await screen.findByText('eventbroker_endpoint_subscription_config');
+  await screen.findByText('fxa-legacy/tf/stage/locals.tf');
   await screen.findByText('client_secret: SECRET123');
   fireEvent.click(screen.getByText('Got it!'));
 

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -249,7 +249,7 @@ const CreateRelyingParty = ({ onExit }: { onExit: () => void }) => {
             </a>{' '}
             (webservices-infra). One entry provisions the topic, the push
             subscription, and the Firestore webhook document.
-            <pre className="p-2">{`"${rpId}" = {
+            <pre className="p-2">{`"${rpId}" = { # pragma: allowlist secret
   endpoint        = "<webhook url>",
   resource_server = <bool>,
 },`}</pre>

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -17,7 +17,11 @@ import { AdminPanelFeature } from '@fxa/shared/guards';
 import { Guard } from '../Guard';
 import { useGuardContext } from '../../hooks/GuardContext';
 import { useUserContext } from '../../hooks/UserContext';
-import { getFormattedDate, getWafTfPath } from '../../lib/utils';
+import {
+  getEventBrokerTfPath,
+  getFormattedDate,
+  getWafTfPath,
+} from '../../lib/utils';
 import { TableRowYHeader, TableYHeaders } from '../TableYHeaders';
 import { adminApi } from '../../lib/api';
 
@@ -194,21 +198,8 @@ const CreateRelyingParty = ({ onExit }: { onExit: () => void }) => {
   const [rpId, setRpId] = useState<string>('');
   const [rpSecret, setRpSecret] = useState<string>('');
 
-  // Note, these are v1 projects. We need to migrate queues over to V2.
-  const gcpTerminalLink =
-    window.location.host === 'fxa-admin-panel.prod.mozaws.net'
-      ? `https://console.cloud.google.com/welcome?cloudshell=true&project=moz-fx-fxa-prod-375e`
-      : `https://console.cloud.google.com/welcome?cloudshell=true&project=moz-fx-fxa-nonprod-375e`;
-
-  const oauthClientConfig =
-    window.location.host === 'fxa-admin-panel.prod.mozaws.net'
-      ? `https://github.com/mozilla/webservices-infra/blob/main/fxa/k8s/fxa/values-prod.yaml`
-      : `https://github.com/mozilla/webservices-infra/blob/main/fxa/k8s/fxa/values-stage.yaml`;
-
-  const eventBrokerTfConfig =
-    window.location.host === 'fxa-admin-panel.prod.mozaws.net'
-      ? `https://github.com/mozilla-services/cloudops-infra/blob/master/projects/fxa/tf/prod/envs/prod/resources/eventbroker.tf`
-      : `https://github.com/mozilla-services/cloudops-infra/blob/master/projects/fxa/tf/nonprod/envs/stage/resources/eventbroker.tf`;
+  const eventBrokerTfPath = getEventBrokerTfPath();
+  const eventBrokerTfUrl = `https://github.com/mozilla/webservices-infra/blob/main/${eventBrokerTfPath}`;
 
   const resetState = () => {
     setStatus('');
@@ -246,49 +237,29 @@ const CreateRelyingParty = ({ onExit }: { onExit: () => void }) => {
             To finalize this new RP, a couple more steps are needed
           </h3>
           <p className="mb-2">
-            <b>Step 1:</b> Create a pubsub queue. In order to do this click{' '}
+            <b>Step 1:</b> Add the client id to the{' '}
+            <code>eventbroker_endpoint_subscription_config</code> map in{' '}
             <a
-              href={gcpTerminalLink}
+              href={eventBrokerTfUrl}
               target="_blank"
+              rel="noreferrer"
               className="underline text-blue-700"
             >
-              here
+              {eventBrokerTfPath}
             </a>{' '}
-            to open a gcp terminal, and issue the following command:
-            <pre className="p-2">
-              gcloud pubsub topics create rpQueue-{rpId}{' '}
-              --message-retention-duration=2678400s
-            </pre>
+            (webservices-infra). One entry provisions the topic, the push
+            subscription, and the Firestore webhook document.
+            <pre className="p-2">{`"${rpId}" = {
+  endpoint        = "<webhook url>",
+  resource_server = <bool>,
+},`}</pre>
+            Both attributes are optional. <code>resource_server</code> defaults
+            to <code>false</code>. Omit <code>endpoint</code> entirely for a
+            topic with no webhook.
           </p>
 
           <p className="mb-2">
-            <b>Step 2:</b> Next, update this{' '}
-            <a
-              href={eventBrokerTfConfig}
-              target="_blank"
-              className="underline text-blue-700"
-            >
-              file
-            </a>{' '}
-            accordingly. This registers the webhook used for message delivery.
-          </p>
-
-          <p className="mb-2">
-            <b>Step 3:</b> Next, update the OAUTH_CLIENT_IDS mappings{' '}
-            <a
-              href={oauthClientConfig}
-              target="_blank"
-              className="underline text-blue-700"
-            >
-              here
-            </a>
-            . This is used to map client-ids to a known name for legacy
-            amplitude events. This is considered optional, and may be RP
-            dependant.
-          </p>
-
-          <p className="mb-2">
-            <b>Step 4:</b> Provide the following secret in secure manner to the
+            <b>Step 2:</b> Provide the following secret in secure manner to the
             relying party. This secret cannot be displayed again! If it is lost
             or compromised, the RP's secret must be rotated.
             <br />

--- a/packages/fxa-admin-panel/src/lib/utils.spec.ts
+++ b/packages/fxa-admin-panel/src/lib/utils.spec.ts
@@ -2,7 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getFormattedDuration } from './utils';
+import { getEventBrokerTfPath, getFormattedDuration } from './utils';
+
+const setHost = (host: string) => {
+  Object.defineProperty(window, 'location', {
+    value: { host },
+    writable: true,
+  });
+};
 
 describe('utils', () => {
   describe('formatDuration', () => {
@@ -22,6 +29,35 @@ describe('utils', () => {
       expect(getFormattedDuration(25 * 60 * 60 + 59 * 60 + 59)).toBe(
         '25h 59m 59s'
       );
+    });
+  });
+
+  describe('getEventBrokerTfPath', () => {
+    const originalLocation = window.location;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+      });
+    });
+
+    it.each([
+      {
+        host: 'fxa-admin-panel.prod.mozaws.net',
+        expected: 'fxa-legacy/tf/prod/locals.tf',
+      },
+      {
+        host: 'fxa-admin-panel.prod.mozgcp.net',
+        expected: 'fxa-legacy/tf/prod/locals.tf',
+      },
+      {
+        host: 'fxa-admin-panel.stage.mozaws.net',
+        expected: 'fxa-legacy/tf/stage/locals.tf',
+      },
+    ])('should return $expected on $host', ({ host, expected }) => {
+      setHost(host);
+      expect(getEventBrokerTfPath()).toBe(expected);
     });
   });
 });

--- a/packages/fxa-admin-panel/src/lib/utils.ts
+++ b/packages/fxa-admin-panel/src/lib/utils.ts
@@ -22,3 +22,8 @@ export const getWafTfPath = () =>
   window.location.host.startsWith('fxa-admin-panel.prod.')
     ? 'fxa/tf/prod/waf.tf'
     : 'fxa/tf/stage/waf.tf';
+
+export const getEventBrokerTfPath = () =>
+  window.location.host.startsWith('fxa-admin-panel.prod.')
+    ? 'fxa-legacy/tf/prod/locals.tf'
+    : 'fxa-legacy/tf/stage/locals.tf';


### PR DESCRIPTION
## Because

- The event broker moved from GCPv1 (cloudops-infra) into MozCloud as the `fxa-legacy` tenant. Nobody updated the post-create steps on the admin panel.
- Step 1 told the operator to run `gcloud pubsub topics create` by hand. That fails with a permission error now, and Terraform creates the topic anyway.
- Step 2 linked a dead cloudops-infra file. Step 3 pointed at the `OAUTH_CLIENT_IDS` map for legacy Amplitude events, which is deprecated.
- All three env-conditional URLs matched the prod host with `===`, so any prod host other than `fxa-admin-panel.prod.mozaws.net` silently got the nonprod links.

## This pull request

- Drops the manual `gcloud pubsub topics create` step and the `OAUTH_CLIENT_IDS` step from `PageRelyingParties/index.tsx`.
- Points the IaC step at `eventbroker_endpoint_subscription_config` in `webservices-infra` `fxa-legacy/tf/{stage,prod}/locals.tf`, and shows the entry shape. One entry gets you the topic, the push subscription, and the Firestore webhook document.
- Renumbers the client secret handoff. The panel now shows two steps instead of four.
- Adds `getEventBrokerTfPath()` next to `getWafTfPath()` in `lib/utils.ts`, using the same `startsWith` host check. That is the part that fixes the prod fall-through.
- Covers two prod hosts and one stage host for the new helper in `utils.spec.ts`, so the tests fail if the exact host match ever comes back. Drops the `index.test.tsx` assertion for the gcloud command that no longer exists.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14345

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the post-create block in `PageRelyingParties/index.tsx`, and the new helper in `lib/utils.ts`.
- Suggested review order: `lib/utils.ts`, then the component, then the two test files.
- Risky or complex parts: nothing tricky in the code. The risk is the copy. Please check the `locals.tf` path and the entry shape against what `fxa-legacy` actually expects. A wrong path sends operators to the wrong repo.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The panel wording follows the "Register Your Webhook" section of the public RP tutorial instead of new phrasing.

Both attributes in the map entry are optional. `resource_server` defaults to `false`, and you leave `endpoint` out for a topic with no webhook.

One caveat on local test results: six tests in `PageRelyingParties/index.test.tsx` fail in my sandbox both before and after this change. The local `react-router` is v6 and `RelyingPartyRow` imports `NavLink` from it, which v6 does not export. That is an environment problem on my side, not something this PR touches. CI runs the full suite.
