### PR TITLE
chore(docs): Add conciseness rules for Claude

### DIFF
--- a/.claude/skills/fxa-jira-bug-description/SKILL.md
+++ b/.claude/skills/fxa-jira-bug-description/SKILL.md
@@ -69,8 +69,8 @@ Where in the code the bug originates. Reference specific file and function if id
 - Regression test added covering the broken path
 - *(add any additional observable outcomes)*
 
-**Key Reference Files:**
-Specific files relevant to investigation or fix. One line each.
+**Key Reference Files:** *(accurate as of drafting; verify before starting, since files get moved and renamed)*
+Specific files relevant to investigation or fix. One line each, no more than 6.
 
 **Out of Scope:** *(omit if not needed)*
 
@@ -103,4 +103,5 @@ Surface the returned `FXA-N` key and the issue URL. That key is this skill's ret
 - Do not speculate on root cause unless there is clear evidence — use Open Questions instead
 - Severity should reflect user impact, not code complexity
 - Always include a regression test in Acceptance Criteria
+- Follow `CLAUDE.md` section 9 on writing style, and make one cut pass before presenting the draft. Steps to Reproduce and Actual Behaviour carry the weight here — trim everything else before trimming those
 - If the bug has security implications (auth bypass, data exposure, token leakage), flag severity as Critical and note it explicitly in Background

--- a/.claude/skills/fxa-jira-feature-description/SKILL.md
+++ b/.claude/skills/fxa-jira-feature-description/SKILL.md
@@ -36,13 +36,13 @@ Incorporate findings directly into the draft — do not list them separately or 
 **Design:** *(Figma link if applicable. Note that all copy, strings, and visual specs should be taken from the latest Figma file — do not reproduce design details here as they may change before implementation. Omit if no design involved.)*
 
 **Background:**
-Why this is needed and what it enables. 2–4 sentences.
+Why this is needed and what it enables. 3 sentences at most.
 
 **Acceptance Criteria:**
-Observable, testable outcomes. Each item verifiable without reading the code. Include criteria for tests, metrics emission, and security events where applicable to this task.
+Observable, testable outcomes. Each item verifiable without reading the code. One line each. Include criteria for tests, metrics emission, and security events where applicable to this task.
 
 **Implementation Steps:**
-Numbered steps with file paths, method names, and structural guidance. Reference the nearest existing pattern for each step. No code snippets — file locations, types, and patterns only.
+Up to 7 numbered steps, one or two lines each. Describe what must be true when the step is done and name the nearest existing pattern to follow — not a keystroke-level plan. Keep file paths out of these steps; they belong in **Key Reference Files**, and code moves between drafting and pickup. No code snippets.
 
 **Tests:**
 What needs to be tested. Unit, integration, and snapshot coverage expectations. Reference the nearest existing test file as a pattern. Omit if covered inline above.
@@ -50,8 +50,8 @@ What needs to be tested. Unit, integration, and snapshot coverage expectations. 
 **Metrics & Security Events:** *(omit if not applicable)*
 Any StatsD metrics or security events (`log.info`, `request.emitMetricsEvent`, `customs` checks) that should be emitted. Reference the nearest equivalent for naming conventions.
 
-**Key Reference Files:**
-Specific files the implementer should read before starting. One line each.
+**Key Reference Files:** *(accurate as of drafting; verify before starting, since files get moved and renamed)*
+Specific files the implementer should read before starting. One line each, no more than 6.
 
 **Out of Scope:** *(omit if not needed)*
 
@@ -80,8 +80,9 @@ Surface the returned `FXA-N` key and the issue URL. That key is this skill's ret
 ## Guidelines
 
 - Do not create, edit, or suggest changes to any source files. Filing a Jira ticket via the MCP (Step 4) is not a source file change.
-- Implementation Steps should give enough detail to start work without follow-up questions — file paths and patterns, not prose
+- Implementation Steps should give enough detail to start work without follow-up questions — patterns to follow and outcomes to hit, not prose and not a file-by-file script
 - Do not include design details (copy, colours, layout, component specifics) — note that the implementer should refer to the latest Figma file
 - Omit redundant or obvious acceptance criteria
+- Follow `CLAUDE.md` section 9 on writing style, and make one cut pass before presenting the draft. A ticket the assignee skims and understands beats a complete one they don't read; when in doubt, drop the section rather than shortening every line in it
 - Include Tests, Metrics & Security Events sections only when relevant to the task type
 - If motivation or scope remain unclear after asking, flag as an Open Question rather than assuming

--- a/.claude/skills/fxa-pr-open/SKILL.md
+++ b/.claude/skills/fxa-pr-open/SKILL.md
@@ -22,12 +22,18 @@ Order of operations: gather state → ask the user up front → align ticket/com
 
 ## Step 1 — Pre-flight
 
-Run these in parallel:
-- `git fetch origin main --quiet` — refresh the base ref so the diff is against current `main` (tolerate failure if offline)
+### Fetch the base first, and wait for it
+
+`git fetch "${FXA_REMOTE:-origin}" main --quiet` — run this alone and let it finish before anything reads the base. `origin` is `mozilla/fxa` on most clones; set `FXA_REMOTE` when `origin` is a personal fork. This is the remote the base branch is read from — not necessarily where the feature branch gets pushed (see Step 5).
+
+Compare against `"${FXA_REMOTE:-origin}"/main`, not local `main`, for the rest of the skill; local `main` is often behind and would silently narrow the diff. If the fetch fails (offline), fall back to local `main` and say so in the 3a summary.
+
+### Then run these in parallel
+
 - `git rev-parse --abbrev-ref HEAD` — current branch name
-- `git log --format=%B main..HEAD` — full commit messages on this branch
-- `git diff main...HEAD --name-only` — changed files
-- `git diff main...HEAD --stat` — files/lines summary
+- `git log --format=%B "${FXA_REMOTE:-origin}"/main..HEAD` — full commit messages on this branch
+- `git diff "${FXA_REMOTE:-origin}"/main...HEAD --name-only` — changed files
+- `git diff "${FXA_REMOTE:-origin}"/main...HEAD --stat` — files/lines summary
 - `git status -sb` — confirm clean tree and check ahead/behind vs upstream
 - `gh pr view --json url,state 2>/dev/null` — confirm no PR exists yet
 
@@ -114,11 +120,17 @@ Title guidance:
 - Otherwise, summarize the cumulative change — do not just use the latest commit subject.
 
 Body drafting guidance:
-- **"Because"** bullets describe motivation/user impact in complete sentences — derive from the Jira ticket and the intake answers, not from the file list. Reference the user need, bug, or requirement, not the code change.
-- **"This pull request"** bullets describe what the code now does in complete sentences — be specific (e.g. "Adds `signinFlow.ts` to handle passkey discovery before falling back to password sign-in"), not vague ("Refactors the sign-in page"). Refer to files with backticks (e.g. `` `packages/fxa-settings/src/pages/Index/index.tsx` ``).
+- **"Because"** bullets describe motivation/user impact — derive from the Jira ticket and the intake answers, not from the file list. Reference the user need, bug, or requirement, not the code change. Up to 3 bullets.
+- **"This pull request"** bullets describe what the code now does. Up to 7 bullets, one line each. Be specific ("Adds `signinFlow.ts` to handle passkey discovery before falling back to password sign-in"), not vague ("Refactors the sign-in page") — but name the behaviour and stop. No trailing rationale clause ("so that…", "without this…", "which avoids…", "the reason being…"); if a decision genuinely needs defending, it goes in "Other information" or a review comment, not appended to every bullet. Fold related edits into one bullet rather than adding bullets. Backtick a path only when the reviewer needs to open that file.
 - **"How to review"** — fill in only when the diff is non-trivial (>~5 files or any risky path). Otherwise leave the three sub-bullets empty.
 - **"Screenshots"** — if the user captured some in Step 3, reference them here (markdown image syntax once attached) or leave the placeholder line for the user to drop attachments into. Leave untouched if no UI changed.
 - **"Other information"** — feature-flag rollout notes, follow-up tickets, deploy ordering caveats, related PRs from intake. Leave placeholder if none.
+
+### Before presenting: one cut pass
+
+Reread the drafted body once and shorten it (see `CLAUDE.md` section 9). Drop any bullet a reviewer would skip. Where a "This pull request" bullet runs to a second sentence, cut it unless it carries something the diff cannot show — a constraint, a caveat, a deliberate omission. Rationale the reviewer can read off the code goes. Cut whole bullets rather than compressing every bullet into a fragment. The finished body should be readable in well under a minute.
+
+Also check accuracy, not just length: every bullet should describe what the diff actually does, and locate the change where it really lives.
 
 ## Step 5 — Confirm and open as draft
 
@@ -127,7 +139,7 @@ Present **both the proposed title and the full draft body** to the user. Ask:
 2. Ready to open the PR? (From Step 1's `git status -sb`: if the branch isn't pushed or is ahead of upstream, the push will run first.)
 
 Only after the user explicitly approves:
-1. Push the branch if not yet pushed, or if local is ahead of upstream (use upstream tracking on first push).
+1. Push the branch if not yet pushed, or if local is ahead of its tracking branch. Use the branch's configured upstream when it has one; otherwise `"${FXA_REMOTE:-origin}"`, setting tracking on that first push. The push target is not always the base remote from Step 1 — a contributor with write access only to their fork pushes there and opens the PR across forks.
 2. Open the PR as a draft against `main` with the approved title and body.
 3. Print the PR URL.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,22 @@ Follow the commit message format defined in [CONTRIBUTING.md — Git Commit Guid
 
 Key points: `type(scope): subject` format; imperative present tense subject; `Because:` / `This commit:` body sections; `Fixes #N` footer for issues.
 
+**Never add a `Co-Authored-By: Claude ...` trailer** to any commit message.
+
+Length budget — these are read at `git blame` speed, so keep them scannable:
+
+- Subject ≤72 chars.
+- `Because:` — up to 3 bullets. Motivation only.
+- `This commit:` — up to 5 bullets, one line each. What changed; the why belongs in `Because:`.
+- If the change genuinely won't fit in 5 bullets, say the commit is too big rather than adding more bullets.
+
+See section 9 for phrasing.
+
 ## 7) Available Skills
 
 Suggest these proactively when the task matches — do not wait to be asked.
+
+Invoke the skill even when the ask arrives mid-task. "File a ticket for this" in the middle of implementation work should still run `/fxa-jira-feature-description` or `/fxa-jira-bug-description` — a freehand description written inline is how tickets end up unreadable.
 
 | Skill                           | Use when                                                                                    |
 | ------------------------------- | ------------------------------------------------------------------------------------------- |
@@ -110,6 +123,16 @@ Suggest these proactively when the task matches — do not wait to be asked.
 **Shift-left is a golden goal.** Prefer testing business logic at the lowest layer that exercises it. FXA has three layers, cheapest to costliest: unit (`nx test-unit`), integration (`nx test-integration`), functional/E2E (Playwright in `packages/functional-tests`). Route handlers and React components should be thin shells; their tests cover wiring (auth, request/response shape, error propagation, rendering), not business branches. When a route or component has more than ~3 tests differing only in input shape, that's the signal to extract the rule into a pure function or hook and unit-test it directly. Shifting left is not required for every change — but always strive for it, and flag the opportunities to improve.
 
 Skills: `/fxa-test-draft` (draft tests for changes), `/fxa-test-repair` (audit a test file), `/fxa-test-independence` (verify isolation).
+
+## 9) Conciseness & Writing Style
+
+**Be concise.** Applies to commit messages, PR bodies, Jira tickets, and code comments. Length is earned by the reader needing it, not by how much you know.
+
+- **Cut items before compressing sentences.** The first way to shorten is to drop a point that didn't need making, or fold two related ones together. Tightening a point that does need making is fine. What's not fine is keeping every point and squeezing each into a semicolon-spliced fragment — whatever survives should read like prose a person wrote.
+- **One claim per bullet.** State what changed. Add the reason when it isn't inferable and lives nowhere else, not by default on every bullet.
+- **Meta-commentary needs to save the reader work.** Noting what's out of scope, or why an obvious-looking alternative was rejected, earns its place when a reviewer would otherwise ask. It doesn't when it's just narrating the boundaries of the diff.
+- **Ticket refs in code: only where the history is the answer.** Default to putting the why in the comment. An `FXA-12345` pointer is right when the code reads as complex, confusing, or non-standard and the explanation is bigger than a comment can hold — a workaround, an external constraint, a large fix where the ticket discussion is the real context. Not in test names or `describe` blocks. Leave existing refs alone.
+- **File paths earn their place.** Name a file when the reader needs to open it. In Jira, paths belong in the reference section, not woven through the prose.
 
 ## BLEnder
 


### PR DESCRIPTION
## Because

- Claude-authored commit messages, PR bodies, and Jira tickets have grown long enough that reviewers skip them, and verbose commit bodies make `git blame` harder to scan
- Nothing in `CLAUDE.md` or the skills capped length, and `/fxa-pr-open` explicitly asked for complete sentences
- `/fxa-pr-open` fetched `origin main` for its base ref, which is a personal fork on clones that keep `mozilla/fxa` on another remote

## This pull request

- Adds `CLAUDE.md` section 9, conciseness and writing style rules covering commit messages, PR bodies, Jira tickets, and code comments
- Adds commit message length budgets and a no-`Co-Authored-By` rule to section 6
- Caps PR body bullets at 7 in `/fxa-pr-open`, bans trailing rationale clauses, and adds a cut pass before the draft is presented
- Caps Jira background and implementation steps, and moves file paths into Key Reference Files with a note that they go stale
- Requires the Jira skills to be invoked even mid-task
- Resolves the `/fxa-pr-open` base remote from `FXA_REMOTE`, defaulting to `origin`

## Issue that this pull request solves

Closes: N/A

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

No ticket — AI tooling config with no product or runtime impact. No pre-merge review run for the same reason; the diff is four markdown files. Came out of the Slack thread on Claude verbosity.
