### PR TITLE
refactor(auth-server): remove the canSend feature flag from the mailer

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -704,12 +704,6 @@ const convictConf = convict({
       default: true,
       env: 'SMTP_METRICS_ENABLED',
     },
-    fxaMailerDisableSend: {
-      doc: 'Array of templates that should not be supported by fxa mailer. Used to fallback to previous email sending if in a pinch.',
-      format: Array,
-      default: [''],
-      env: 'SMTP_FXA_MAILER_DISABLE_SEND',
-    },
   },
   maxEventLoopDelay: {
     doc: 'Max event-loop delay before which incoming requests are rejected',

--- a/packages/fxa-auth-server/lib/inactive-accounts/index.ts
+++ b/packages/fxa-auth-server/lib/inactive-accounts/index.ts
@@ -296,29 +296,21 @@ export class InactiveAccountsManager {
       inactiveDeletionEta: now + emailTypeSpecificVals.timeToDeletion,
     };
 
-    if (this.fxaMailer.canSend(emailTypeSpecificVals.emailTemplate)) {
-      await this.fxaMailer[emailTypeSpecificVals.emailSender]({
-        ...FxaMailerFormat.account(account),
-        ...(await FxaMailerFormat.metricsContext(requestForGlean)),
-        ...FxaMailerFormat.localTime(requestForGlean),
-        ...FxaMailerFormat.location(requestForGlean),
-        ...FxaMailerFormat.device(requestForGlean),
-        ...FxaMailerFormat.sync(false),
-        // use the formatter to convert inactiveDeletionEta to localized strings
-        deletionDate: FxaMailerFormat.localTime(
-          requestForGlean,
-          message.inactiveDeletionEta
-        ).date,
-        // override acceptLanguage to ensure email is localized as best we can
-        acceptLanguage: account.locale,
-      });
-    } else {
-      await this.mailer[emailTypeSpecificVals.emailSender](
-        account.emails,
-        account,
-        message
-      );
-    }
+    await this.fxaMailer[emailTypeSpecificVals.emailSender]({
+      ...FxaMailerFormat.account(account),
+      ...(await FxaMailerFormat.metricsContext(requestForGlean)),
+      ...FxaMailerFormat.localTime(requestForGlean),
+      ...FxaMailerFormat.location(requestForGlean),
+      ...FxaMailerFormat.device(requestForGlean),
+      ...FxaMailerFormat.sync(false),
+      // use the formatter to convert inactiveDeletionEta to localized strings
+      deletionDate: FxaMailerFormat.localTime(
+        requestForGlean,
+        message.inactiveDeletionEta
+      ).date,
+      // override acceptLanguage to ensure email is localized as best we can
+      acceptLanguage: account.locale,
+    });
 
     this.statsd.increment(
       `account.inactive.${emailTypeSpecificVals.attempt}-email.sent`

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1909,19 +1909,20 @@ export class AccountHandler {
         // for mobile users, due to the web view automatically closing after a
         // successful login. The `isFirefoxMobileClient` option matches the
         // client-side check against `integration.isFirefoxMobileClient()`.
+        // No `return` here: the caller discards the value, and returning from
+        // only some branches trips TS7030 now that the untyped old-mailer
+        // fallback, which widened the return type to `any`, is gone.
         if (hasTotpToken || isFirefoxMobileClient) {
-          return await this.fxaMailer.sendPasswordResetWithRecoveryKeyPromptEmail(
-            {
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-            }
-          );
+          await this.fxaMailer.sendPasswordResetWithRecoveryKeyPromptEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+          });
         } else {
-          return await this.fxaMailer.sendPasswordResetAccountRecoveryEmail({
+          await this.fxaMailer.sendPasswordResetAccountRecoveryEmail({
             ...FxaMailerFormat.account(account),
             ...(await FxaMailerFormat.metricsContext(request)),
             ...FxaMailerFormat.localTime(request),

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -344,20 +344,11 @@ export class AccountHandler {
     tokenVerificationId: any;
     verificationMethod: string;
   }) {
-    const {
-      request,
-      account,
-      sessionToken,
-      tokenVerificationId,
-      verificationMethod,
-    } = options;
-    const { deviceId, flowId, flowBeginTime, productId, planId } =
-      await request.app.metricsContext;
-    const locale = request.app.acceptLanguage;
+    const { request, account, tokenVerificationId, verificationMethod } =
+      options;
+    const { flowId, flowBeginTime } = await request.app.metricsContext;
     const form = request.payload as any;
     const query = request.query;
-    const ip = request.app.clientAddress;
-    const style = form.style;
 
     if (account.emailVerified) {
       return;
@@ -368,24 +359,6 @@ export class AccountHandler {
         case 'email-otp': {
           const secret = account.emailCode;
           const code = this.otpUtils.generateOtpCode(secret, this.otpOptions);
-          const emailContext = {
-            acceptLanguage: locale,
-            code,
-            deviceId,
-            flowId,
-            flowBeginTime,
-            productId,
-            planId,
-            ip,
-            location: request.app.geo.location,
-            timeZone: request.app.geo.timeZone,
-            uaBrowser: sessionToken.uaBrowser,
-            uaBrowserVersion: sessionToken.uaBrowserVersion,
-            uaOS: sessionToken.uaOS,
-            uaOSVersion: sessionToken.uaOSVersion,
-            uaDeviceType: sessionToken.uaDeviceType,
-            uid: sessionToken.uid,
-          };
 
           const rpCmsConfig = await fetchRpCmsData(
             request,
@@ -394,99 +367,46 @@ export class AccountHandler {
           );
 
           if (!rpCmsConfig || !rpCmsConfig.VerifyShortCodeEmail) {
-            if (this.fxaMailer.canSend('verifyShortCode')) {
-              await this.fxaMailer.sendVerifyShortCodeEmail({
-                ...FxaMailerFormat.account(account),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.location(request),
-                ...FxaMailerFormat.device(request),
-                ...FxaMailerFormat.sync(form.service || query.service || false),
-                code,
-              });
-            } else {
-              await this.mailer.sendVerifyShortCodeEmail(
-                [],
-                account,
-                emailContext
-              );
-            }
+            await this.fxaMailer.sendVerifyShortCodeEmail({
+              ...FxaMailerFormat.account(account),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.location(request),
+              ...FxaMailerFormat.device(request),
+              ...FxaMailerFormat.sync(form.service || query.service || false),
+              code,
+            });
           } else {
-            const metricsContext = await request.app.metricsContext;
-            const rpEmailContext = {
-              ...emailContext,
-              target: 'strapi',
-              cmsRpClientId: rpCmsConfig.clientId,
-              cmsRpFromName: rpCmsConfig.shared?.emailFromName,
-              entrypoint: metricsContext.entrypoint,
-              logoUrl: rpCmsConfig?.shared?.emailLogoUrl,
-              logoAltText: rpCmsConfig?.shared?.emailLogoAltText,
-              logoWidth: rpCmsConfig?.shared?.emailLogoWidth,
-              ...rpCmsConfig.VerifyShortCodeEmail,
-            };
-            if (this.fxaMailer.canSend('verifyShortCode')) {
-              await this.fxaMailer.sendVerifyShortCodeEmail({
-                ...FxaMailerFormat.account(account),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.location(request),
-                ...FxaMailerFormat.device(request),
-                ...FxaMailerFormat.sync(form.service || query.service || false),
-                ...FxaMailerFormat.cmsLogo(rpCmsConfig.shared),
-                ...FxaMailerFormat.cmsEmailSubject(
-                  rpCmsConfig.VerifyShortCodeEmail
-                ),
-                ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
-                code,
-              });
-            } else {
-              await this.mailer.sendVerifyShortCodeEmail(
-                [],
-                account,
-                rpEmailContext
-              );
-            }
+            await this.fxaMailer.sendVerifyShortCodeEmail({
+              ...FxaMailerFormat.account(account),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.location(request),
+              ...FxaMailerFormat.device(request),
+              ...FxaMailerFormat.sync(form.service || query.service || false),
+              ...FxaMailerFormat.cmsLogo(rpCmsConfig.shared),
+              ...FxaMailerFormat.cmsEmailSubject(
+                rpCmsConfig.VerifyShortCodeEmail
+              ),
+              ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
+              code,
+            });
           }
           break;
         }
         default: {
-          if (this.fxaMailer.canSend('verify')) {
-            await this.fxaMailer.sendVerifyEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.sync(form.service || query.service),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              code: account.emailCode,
-              resume: form.resume,
-              redirectTo: form.redirectTo,
-              service: form.service || query.service,
-            });
-          } else {
-            await this.mailer.sendVerifyEmail([], account, {
-              code: account.emailCode,
-              service: form.service || query.service,
-              redirectTo: form.redirectTo,
-              resume: form.resume,
-              acceptLanguage: locale,
-              deviceId,
-              flowId,
-              flowBeginTime,
-              productId,
-              planId,
-              ip,
-              location: request.app.geo.location,
-              timeZone: request.app.geo.timeZone,
-              style,
-              uaBrowser: sessionToken.uaBrowser,
-              uaBrowserVersion: sessionToken.uaBrowserVersion,
-              uaOS: sessionToken.uaOS,
-              uaOSVersion: sessionToken.uaOSVersion,
-              uaDeviceType: sessionToken.uaDeviceType,
-              uid: sessionToken.uid,
-            });
-          }
+          await this.fxaMailer.sendVerifyEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.sync(form.service || query.service),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            code: account.emailCode,
+            resume: form.resume,
+            redirectTo: form.redirectTo,
+            service: form.service || query.service,
+          });
         }
       }
 
@@ -1350,12 +1270,8 @@ export class AccountHandler {
       // successful verification — sending it here too would result in a duplicate.
       if (accountRecord.primaryEmail.isVerified) {
         if (sessionToken.tokenVerified) {
-          const geoData = request.app.geo;
           const service =
             (request.payload as any).service || request.query.service;
-          const ip = request.app.clientAddress;
-          const { deviceId, flowId, flowBeginTime, entrypoint } =
-            await request.app.metricsContext;
 
           const rpCmsConfig = await fetchRpCmsData(
             request,
@@ -1364,81 +1280,38 @@ export class AccountHandler {
           );
 
           try {
-            const emailContext = {
-              acceptLanguage: request.app.acceptLanguage,
-              deviceId,
-              flowId,
-              flowBeginTime,
-              ip,
-              location: geoData.location,
-              service,
-              timeZone: geoData.timeZone,
-              uaBrowser: request.app.ua.browser,
-              uaBrowserVersion: request.app.ua.browserVersion,
-              uaOS: request.app.ua.os,
-              uaOSVersion: request.app.ua.osVersion,
-              uaDeviceType: request.app.ua.deviceType,
-              uid: sessionToken.uid,
-            };
             if (!rpCmsConfig || !rpCmsConfig.NewDeviceLoginEmail) {
-              if (this.fxaMailer.canSend('newDeviceLogin')) {
-                const clientInfo =
-                  await this.oauthClientInfoService.fetch(service);
-                await this.fxaMailer.sendNewDeviceLoginEmail({
-                  ...FxaMailerFormat.account(accountRecord),
-                  ...FxaMailerFormat.device(request),
-                  ...FxaMailerFormat.localTime(request),
-                  ...FxaMailerFormat.location(request),
-                  ...(await FxaMailerFormat.metricsContext(request)),
-                  ...FxaMailerFormat.sync(service),
-                  clientName: clientInfo.name,
-                  showBannerWarning: false,
-                });
-              } else {
-                await this.mailer.sendNewDeviceLoginEmail(
-                  accountRecord.emails,
-                  accountRecord,
-                  emailContext
-                );
-              }
+              const clientInfo =
+                await this.oauthClientInfoService.fetch(service);
+              await this.fxaMailer.sendNewDeviceLoginEmail({
+                ...FxaMailerFormat.account(accountRecord),
+                ...FxaMailerFormat.device(request),
+                ...FxaMailerFormat.localTime(request),
+                ...FxaMailerFormat.location(request),
+                ...(await FxaMailerFormat.metricsContext(request)),
+                ...FxaMailerFormat.sync(service),
+                clientName: clientInfo.name,
+                showBannerWarning: false,
+              });
             } else {
-              if (this.fxaMailer.canSend('newDeviceLogin')) {
-                const clientInfo =
-                  await this.oauthClientInfoService.fetch(service);
-                await this.fxaMailer.sendNewDeviceLoginEmail({
-                  ...FxaMailerFormat.account(accountRecord),
-                  ...FxaMailerFormat.device(request),
-                  ...FxaMailerFormat.localTime(request),
-                  ...FxaMailerFormat.location(request),
-                  ...(await FxaMailerFormat.metricsContext(request)),
-                  ...FxaMailerFormat.sync(service),
-                  ...FxaMailerFormat.cmsLogo(rpCmsConfig.shared),
-                  ...FxaMailerFormat.cmsEmailSubject(
-                    rpCmsConfig.NewDeviceLoginEmail
-                  ),
-                  ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
-                  clientName: clientInfo.name,
-                  showBannerWarning: false,
-                  target: 'strapi',
-                });
-              } else {
-                const rpEmailContext = {
-                  ...emailContext,
-                  target: 'strapi',
-                  cmsRpClientId: rpCmsConfig.clientId,
-                  cmsRpFromName: rpCmsConfig.shared?.emailFromName,
-                  entrypoint,
-                  logoUrl: rpCmsConfig?.shared?.emailLogoUrl,
-                  logoAltText: rpCmsConfig?.shared?.emailLogoAltText,
-                  logoWidth: rpCmsConfig?.shared?.emailLogoWidth,
-                  ...rpCmsConfig.NewDeviceLoginEmail,
-                };
-                await this.mailer.sendNewDeviceLoginEmail(
-                  accountRecord.emails,
-                  accountRecord,
-                  rpEmailContext
-                );
-              }
+              const clientInfo =
+                await this.oauthClientInfoService.fetch(service);
+              await this.fxaMailer.sendNewDeviceLoginEmail({
+                ...FxaMailerFormat.account(accountRecord),
+                ...FxaMailerFormat.device(request),
+                ...FxaMailerFormat.localTime(request),
+                ...FxaMailerFormat.location(request),
+                ...(await FxaMailerFormat.metricsContext(request)),
+                ...FxaMailerFormat.sync(service),
+                ...FxaMailerFormat.cmsLogo(rpCmsConfig.shared),
+                ...FxaMailerFormat.cmsEmailSubject(
+                  rpCmsConfig.NewDeviceLoginEmail
+                ),
+                ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
+                clientName: clientInfo.name,
+                showBannerWarning: false,
+                target: 'strapi',
+              });
             }
           } catch (err) {
             // If we couldn't email them, no big deal. Log
@@ -2032,62 +1905,31 @@ export class AccountHandler {
       if (recoveryKeyId) {
         await this.db.deleteRecoveryKey(account.uid);
 
-        const geoData = request.app.geo;
-        const ip = request.app.clientAddress;
-        const emailOptions = {
-          acceptLanguage: request.app.acceptLanguage,
-          ip: ip,
-          location: geoData.location,
-          timeZone: geoData.timeZone,
-          uaBrowser: request.app.ua.browser,
-          uaBrowserVersion: request.app.ua.browserVersion,
-          uaOS: request.app.ua.os,
-          uaOSVersion: request.app.ua.osVersion,
-          uaDeviceType: request.app.ua.deviceType,
-          uid: account.uid,
-        };
-
         // a new key won't be autogenerated for users with 2FA enabled or currently,
         // for mobile users, due to the web view automatically closing after a
         // successful login. The `isFirefoxMobileClient` option matches the
         // client-side check against `integration.isFirefoxMobileClient()`.
         if (hasTotpToken || isFirefoxMobileClient) {
-          if (this.fxaMailer.canSend('passwordResetWithRecoveryKeyPrompt')) {
-            return await this.fxaMailer.sendPasswordResetWithRecoveryKeyPromptEmail(
-              {
-                ...FxaMailerFormat.account(account),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.location(request),
-                ...FxaMailerFormat.device(request),
-                ...FxaMailerFormat.sync(false),
-              }
-            );
-          } else {
-            return await this.mailer.sendPasswordResetWithRecoveryKeyPromptEmail(
-              account.emails,
-              account,
-              emailOptions
-            );
-          }
-        } else {
-          if (this.fxaMailer.canSend('passwordResetAccountRecovery')) {
-            return await this.fxaMailer.sendPasswordResetAccountRecoveryEmail({
+          return await this.fxaMailer.sendPasswordResetWithRecoveryKeyPromptEmail(
+            {
               ...FxaMailerFormat.account(account),
               ...(await FxaMailerFormat.metricsContext(request)),
               ...FxaMailerFormat.localTime(request),
               ...FxaMailerFormat.location(request),
               ...FxaMailerFormat.device(request),
               ...FxaMailerFormat.sync(false),
-              productName: 'Firefox',
-            });
-          } else {
-            return await this.mailer.sendPasswordResetAccountRecoveryEmail(
-              account.emails,
-              account,
-              emailOptions
-            );
-          }
+            }
+          );
+        } else {
+          return await this.fxaMailer.sendPasswordResetAccountRecoveryEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+            productName: 'Firefox',
+          });
         }
       }
     };

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -237,47 +237,17 @@ module.exports = (
         throw error.emailExists();
       }
 
-      const geoData = request.app.geo;
       try {
-        if (fxaMailer.canSend('verifySecondaryCode')) {
-          await fxaMailer.sendVerifySecondaryCodeEmail({
-            ...FxaMailerFormat.account(account),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(false),
-            code: otpUtils.generateOtpCode(secret, otpOptions),
-            email,
-          });
-        } else {
-          await mailer.sendVerifySecondaryCodeEmail(
-            [
-              {
-                email,
-                normalizedEmail,
-                isVerified: false,
-                isPrimary: false,
-                uid,
-              },
-            ],
-            sessionToken,
-            {
-              code: otpUtils.generateOtpCode(secret, otpOptions),
-              deviceId: sessionToken.deviceId,
-              acceptLanguage: request.app.acceptLanguage,
-              email,
-              primaryEmail,
-              location: geoData.location,
-              timeZone: geoData.timeZone,
-              uaBrowser: sessionToken.uaBrowser,
-              uaBrowserVersion: sessionToken.uaBrowserVersion,
-              uaOS: sessionToken.uaOS,
-              uaOSVersion: sessionToken.uaOSVersion,
-              uid,
-            }
-          );
-        }
+        await fxaMailer.sendVerifySecondaryCodeEmail({
+          ...FxaMailerFormat.account(account),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(false),
+          code: otpUtils.generateOtpCode(secret, otpOptions),
+          email,
+        });
       } catch (err) {
         log.error('secondary_email.sendVerifySecondaryCodeEmail.error', {
           err: err,
@@ -530,20 +500,12 @@ module.exports = (
       }
 
       try {
-        if (fxaMailer.canSend('postVerifySecondary')) {
-          await fxaMailer.sendPostVerifySecondaryEmail({
-            ...FxaMailerFormat.account(account),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.sync(false),
-            secondaryEmail: email,
-          });
-        } else {
-          await mailer.sendPostVerifySecondaryEmail([], account, {
-            acceptLanguage: request.app.acceptLanguage,
-            secondaryEmail: email,
-            uid,
-          });
-        }
+        await fxaMailer.sendPostVerifySecondaryEmail({
+          ...FxaMailerFormat.account(account),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.sync(false),
+          secondaryEmail: email,
+        });
       } catch (e) {
         log.error('secondary_email.sendPostVerifySecondaryEmail.error', {
           uid,
@@ -779,14 +741,10 @@ module.exports = (
         const sessionToken = request.auth.credentials;
         const service = request.payload.service || request.query.service;
         const type = request.payload.type || request.query.type;
-        const ip = request.app.clientAddress;
-        const geoData = request.app.geo;
-        const style = request.payload.style;
 
         // This endpoint can resend multiple types of codes, set these values once it
         // is known what is being verified.
         let code;
-        let emails = [];
 
         // Return immediately if this session or token is already verified. Only exception
         // is if the email param has been specified, which means that this is
@@ -810,92 +768,53 @@ module.exports = (
           return {};
         }
 
-        const { flowId, flowBeginTime } = await request.app.metricsContext;
         const account = await db.account(sessionToken.uid);
 
-        const mailerOpts = {
-          code,
-          deviceId: sessionToken.deviceId,
-          flowId,
-          flowBeginTime,
-          service,
-          ip,
-          location: geoData.location,
-          timeZone: geoData.timeZone,
-          timestamp: Date.now(),
-          redirectTo: request.payload.redirectTo,
-          resume: request.payload.resume,
-          acceptLanguage: request.app.acceptLanguage,
-          uaBrowser: sessionToken.uaBrowser,
-          uaBrowserVersion: sessionToken.uaBrowserVersion,
-          uaOS: sessionToken.uaOS,
-          uaOSVersion: sessionToken.uaOSVersion,
-          uaDeviceType: sessionToken.uaDeviceType,
-          uid: sessionToken.uid,
-          style,
-        };
-
         if (type && type === 'upgradeSession') {
-          if (fxaMailer.canSend('verifyPrimary')) {
-            await fxaMailer.sendVerifyPrimaryEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(service),
-              code,
-              service,
-              redirectTo: request.payload.redirectTo,
-              resume: request.payload.resume,
-            });
-          } else {
-            await mailer.sendVerifyPrimaryEmail(
-              emails,
-              sessionToken,
-              mailerOpts
-            );
-          }
+          await fxaMailer.sendVerifyPrimaryEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(service),
+            code,
+            service,
+            redirectTo: request.payload.redirectTo,
+            resume: request.payload.resume,
+          });
           await request.emitMetricsEvent(
             `email.verification_email_primary.resent`
           );
         } else if (!sessionToken.emailVerified) {
-          if (fxaMailer.canSend('verify')) {
-            await fxaMailer.sendVerifyEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.sync(service),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              code,
-              service,
-              redirectTo: request.payload.redirectTo,
-              resume: request.payload.resume,
-            });
-          } else {
-            await mailer.sendVerifyEmail(emails, sessionToken, mailerOpts);
-          }
+          await fxaMailer.sendVerifyEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.sync(service),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            code,
+            service,
+            redirectTo: request.payload.redirectTo,
+            resume: request.payload.resume,
+          });
           await request.emitMetricsEvent(`email.verification.resent`);
         } else {
-          if (fxaMailer.canSend('verifyLogin')) {
-            const clientInfo = await oauthClientInfoService.fetch(service);
-            await fxaMailer.sendVerifyLoginEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(service),
-              code,
-              service,
-              clientName: clientInfo.name,
-              redirectTo: request.payload.redirectTo,
-              resume: request.payload.resume,
-            });
-          } else {
-            await mailer.sendVerifyLoginEmail(emails, sessionToken, mailerOpts);
-          }
+          const clientInfo = await oauthClientInfoService.fetch(service);
+          await fxaMailer.sendVerifyLoginEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(service),
+            code,
+            service,
+            clientName: clientInfo.name,
+            redirectTo: request.payload.redirectTo,
+            resume: request.payload.resume,
+          });
           await request.emitMetricsEvent(`email.confirmation.resent`);
         }
 
@@ -917,11 +836,9 @@ module.exports = (
               throw error.cannotResendEmailCodeToUnownedEmail();
             }
 
-            emails = [foundEmail];
             code = foundEmail.emailCode;
             return !foundEmail.isVerified;
           } else if (!sessionToken.tokenVerified) {
-            emails = emailData;
             code = sessionToken.tokenVerificationId;
 
             // Check to see if this account has a verified TOTP token. If so, then it should
@@ -1209,29 +1126,15 @@ module.exports = (
         }
 
         // Notify any verified email address associated with the account of the deletion.
-        const emails = account.emails.filter((item) => {
-          if (!emailsMatch(item.normalizedEmail, email)) {
-            return item;
-          }
+        const accountData = FxaMailerFormat.account(account);
+        accountData.cc = accountData.cc.filter((e) => e !== email);
+        await fxaMailer.sendPostRemoveSecondaryEmail({
+          ...accountData,
+          ...FxaMailerFormat.localTime(request),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.sync(false),
+          secondaryEmail: email,
         });
-
-        if (fxaMailer.canSend('postRemoveSecondary')) {
-          const accountData = FxaMailerFormat.account(account);
-          accountData.cc = accountData.cc.filter((e) => e !== email);
-          await fxaMailer.sendPostRemoveSecondaryEmail({
-            ...accountData,
-            ...FxaMailerFormat.localTime(request),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.sync(false),
-            secondaryEmail: email,
-          });
-        } else {
-          await mailer.sendPostRemoveSecondaryEmail(emails, account, {
-            deviceId: sessionToken.deviceId,
-            secondaryEmail: email,
-            uid,
-          });
-        }
 
         return {};
       },
@@ -1323,20 +1226,13 @@ module.exports = (
           }
 
           const account = await db.account(uid);
-          if (fxaMailer.canSend('postVerifySecondary')) {
-            await fxaMailer.sendPostChangePrimaryEmail({
-              ...FxaMailerFormat.account(account),
-              ...FxaMailerFormat.sync(false),
-              ...FxaMailerFormat.localTime(request),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              email: FxaMailerFormat.account(account).to,
-            });
-          } else {
-            await mailer.sendPostChangePrimaryEmail(account.emails, account, {
-              acceptLanguage: request.app.acceptLanguage,
-              uid,
-            });
-          }
+          await fxaMailer.sendPostChangePrimaryEmail({
+            ...FxaMailerFormat.account(account),
+            ...FxaMailerFormat.sync(false),
+            ...FxaMailerFormat.localTime(request),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            email: FxaMailerFormat.account(account).to,
+          });
 
           await recordSecurityEvent('account.primary_secondary_swapped', {
             db,
@@ -1482,57 +1378,17 @@ module.exports = (
         // Generate a new OTP code using the secret and resend the email.
         const code = otpUtils.generateOtpCode(secret, otpOptions);
 
-        const {
-          deviceId,
-          uaBrowser,
-          uaBrowserVersion,
-          uaOS,
-          uaOSVersion,
-          uaDeviceType,
-        } = sessionToken;
-
-        const geoData = request.app.geo;
         try {
-          if (fxaMailer.canSend('verifySecondaryCode')) {
-            await fxaMailer.sendVerifySecondaryCodeEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-              code,
-              email,
-            });
-          } else {
-            await mailer.sendVerifySecondaryCodeEmail(
-              [
-                {
-                  email,
-                  normalizedEmail,
-                  isVerified: false,
-                  isPrimary: false,
-                  uid,
-                },
-              ],
-              sessionToken,
-              {
-                code,
-                deviceId,
-                acceptLanguage: request.app.acceptLanguage,
-                email,
-                primaryEmail: sessionToken.email,
-                location: geoData.location,
-                timeZone: geoData.timeZone,
-                uaBrowser,
-                uaBrowserVersion,
-                uaOS,
-                uaOSVersion,
-                uaDeviceType,
-                uid,
-              }
-            );
-          }
+          await fxaMailer.sendVerifySecondaryCodeEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+            code,
+            email,
+          });
         } catch (err) {
           log.error('secondary_email.resendVerifySecondaryCodeEmail.error', {
             err: err,

--- a/packages/fxa-auth-server/lib/routes/ip-profiling.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/ip-profiling.spec.ts
@@ -186,9 +186,7 @@ describe('IP Profiling', () => {
       ],
     });
     jest.clearAllMocks();
-    mockFxaMailerInstance = installMockFxaMailer({
-      canSend: jest.fn().mockResolvedValue(true),
-    });
+    mockFxaMailerInstance = installMockFxaMailer();
     mocks.mockOAuthClientInfo();
     mockDBInstance = mocks.mockDB({
       email: TEST_EMAIL,

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
@@ -83,8 +83,6 @@ const makeRoutes = function (options: any = {}, requireMocks?: any) {
   }
 
   // Reset FxaMailer mocks
-  mockFxaMailer.canSend.mockClear();
-  mockFxaMailer.canSend.mockReturnValue(true);
   mockFxaMailer.sendPostAddLinkedAccountEmail.mockClear();
   mockFxaMailer.sendPostAddLinkedAccountEmail.mockResolvedValue(undefined);
 

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -439,42 +439,15 @@ export class LinkedAccountHandler {
           await this.updateProfileDisplayName(accountRecord.uid, name);
         }
 
-        const geoData = request.app.geo;
-        const ip = request.app.clientAddress;
-
-        if (this.fxaMailer.canSend('postAddLinkedAccount')) {
-          await this.fxaMailer.sendPostAddLinkedAccountEmail({
-            ...FxaMailerFormat.account(accountRecord),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(service),
-            providerName: PROVIDER_NAME[provider],
-          });
-        } else {
-          const emailOptions = {
-            acceptLanguage: request.app.acceptLanguage,
-            deviceId,
-            flowId,
-            flowBeginTime,
-            ip,
-            location: geoData.location,
-            providerName: PROVIDER_NAME[provider],
-            timeZone: geoData.timeZone,
-            uaBrowser: request.app.ua.browser,
-            uaBrowserVersion: request.app.ua.browserVersion,
-            uaOS: request.app.ua.os,
-            uaOSVersion: request.app.ua.osVersion,
-            uaDeviceType: request.app.ua.deviceType,
-            uid: accountRecord.uid,
-          };
-          await this.mailer.sendPostAddLinkedAccountEmail(
-            accountRecord.emails,
-            accountRecord,
-            emailOptions
-          );
-        }
+        await this.fxaMailer.sendPostAddLinkedAccountEmail({
+          ...FxaMailerFormat.account(accountRecord),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(service),
+          providerName: PROVIDER_NAME[provider],
+        });
         request.setMetricsFlowCompleteSignal('account.login', 'login');
         switch (provider) {
           case 'google':

--- a/packages/fxa-auth-server/lib/routes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/mfa.ts
@@ -90,28 +90,16 @@ class MfaHandler {
       // is valid for 30s.
       // For specifics see: https://www.npmjs.com/package/otplib
       const expirationTime = (options.step * options.window) / 60;
-      if (this.fxaMailer.canSend('verifyAccountChange')) {
-        await this.fxaMailer.sendVerifyAccountChangeEmail({
-          ...FxaMailerFormat.account(account),
-          ...(await FxaMailerFormat.metricsContext(request)),
-          ...FxaMailerFormat.localTime(request),
-          ...FxaMailerFormat.location(request),
-          ...FxaMailerFormat.device(request),
-          ...FxaMailerFormat.sync(false),
-          code,
-          expirationTime,
-        });
-      } else {
-        await this.mailer.sendVerifyAccountChangeEmail(
-          account.emails,
-          account,
-          {
-            code,
-            uid,
-            expirationTime,
-          }
-        );
-      }
+      await this.fxaMailer.sendVerifyAccountChangeEmail({
+        ...FxaMailerFormat.account(account),
+        ...(await FxaMailerFormat.metricsContext(request)),
+        ...FxaMailerFormat.localTime(request),
+        ...FxaMailerFormat.location(request),
+        ...FxaMailerFormat.device(request),
+        ...FxaMailerFormat.sync(false),
+        code,
+        expirationTime,
+      });
 
       success = true;
     } catch (error) {

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -190,7 +190,6 @@ describe('passkeys routes', () => {
     };
 
     mockFxaMailer = {
-      canSend: jest.fn().mockReturnValue(true),
       sendPostAddPasskeyEmail: jest.fn().mockResolvedValue(undefined),
       sendPostRemovePasskeyEmail: jest.fn().mockResolvedValue(undefined),
       sendNewDeviceLoginEmail: jest.fn().mockResolvedValue(undefined),
@@ -532,7 +531,6 @@ describe('passkeys routes', () => {
         payload,
       });
 
-      expect(mockFxaMailer.canSend).toHaveBeenCalledWith('postAddPasskey');
       expect(mockFxaMailer.sendPostAddPasskeyEmail).toHaveBeenCalledTimes(1);
       expect(mockFxaMailer.sendPostAddPasskeyEmail).toHaveBeenCalledWith(
         expect.objectContaining({ showSyncPasswordNote: true })
@@ -564,23 +562,6 @@ describe('passkeys routes', () => {
       expect(mockFxaMailer.sendPostAddPasskeyEmail).toHaveBeenCalledWith(
         expect.objectContaining({ showSyncPasswordNote: false })
       );
-    });
-
-    it('skips email when canSend returns false', async () => {
-      mockFxaMailer.canSend.mockReturnValue(false);
-
-      await runTest('/passkey/registration/finish', {
-        auth: {
-          credentials: {
-            uid: UID,
-            id: SESSION_TOKEN_ID,
-            email: TEST_EMAIL,
-          },
-        },
-        payload,
-      });
-
-      expect(mockFxaMailer.sendPostAddPasskeyEmail).not.toHaveBeenCalled();
     });
 
     it('swallows email send errors and still returns passkey data', async () => {
@@ -866,32 +847,10 @@ describe('passkeys routes', () => {
         'DELETE'
       );
 
-      expect(mockFxaMailer.canSend).toHaveBeenCalledWith('postRemovePasskey');
       expect(mockFxaMailer.sendPostRemovePasskeyEmail).toHaveBeenCalledTimes(1);
       expect(mockFxaMailer.sendPostRemovePasskeyEmail).toHaveBeenCalledWith(
         expect.objectContaining({ to: TEST_EMAIL })
       );
-    });
-
-    it('skips email when canSend returns false', async () => {
-      mockFxaMailer.canSend.mockReturnValue(false);
-
-      await runTest(
-        '/passkey/{credentialId}',
-        {
-          auth: {
-            credentials: {
-              uid: UID,
-              id: SESSION_TOKEN_ID,
-              email: TEST_EMAIL,
-            },
-          },
-          params: { credentialId: CREDENTIAL_ID_B64 },
-        },
-        'DELETE'
-      );
-
-      expect(mockFxaMailer.sendPostRemovePasskeyEmail).not.toHaveBeenCalled();
     });
 
     it('swallows email send errors and still returns empty object', async () => {
@@ -1521,24 +1480,6 @@ describe('passkeys routes', () => {
         expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
         expect(mockFxaMailer.sendNewDeviceLoginEmail).toHaveBeenCalledWith(
           expect.objectContaining({ clientName: 'Mozilla' })
-        );
-      });
-
-      it('falls back to the legacy mailer when fxaMailer cannot send newDeviceLogin', async () => {
-        mockFxaMailer.canSend.mockReturnValue(false);
-
-        await runTest('/passkey/authentication/finish', {
-          auth: { credentials: {} },
-          app: { ua: {} },
-          payload,
-        });
-
-        expect(mockFxaMailer.sendNewDeviceLoginEmail).not.toHaveBeenCalled();
-        expect(mailer.sendNewDeviceLoginEmail).toHaveBeenCalledTimes(1);
-        expect(mailer.sendNewDeviceLoginEmail).toHaveBeenCalledWith(
-          [{ email: TEST_EMAIL, isPrimary: true, isVerified: true }],
-          expect.objectContaining({ uid: UID }),
-          expect.objectContaining({ uid: UID })
         );
       });
 

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -191,17 +191,15 @@ export class PasskeyHandler {
       this.glean.passkey.createComplete(request);
 
       try {
-        if (this.fxaMailer.canSend('postAddPasskey')) {
-          await this.fxaMailer.sendPostAddPasskeyEmail({
-            ...FxaMailerFormat.account({ ...account, uid }),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(false),
-            showSyncPasswordNote: account.verifierSetAt > 0,
-          });
-        }
+        await this.fxaMailer.sendPostAddPasskeyEmail({
+          ...FxaMailerFormat.account({ ...account, uid }),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(false),
+          showSyncPasswordNote: account.verifierSetAt > 0,
+        });
       } catch (err) {
         this.log.error('passkeys.registrationFinish.sendEmail', { err });
         reportSentryError(err, request);
@@ -318,16 +316,14 @@ export class PasskeyHandler {
     this.glean.passkey.deleteSuccess(request);
 
     try {
-      if (this.fxaMailer.canSend('postRemovePasskey')) {
-        await this.fxaMailer.sendPostRemovePasskeyEmail({
-          ...FxaMailerFormat.account({ ...account, uid }),
-          ...(await FxaMailerFormat.metricsContext(request)),
-          ...FxaMailerFormat.localTime(request),
-          ...FxaMailerFormat.location(request),
-          ...FxaMailerFormat.device(request),
-          ...FxaMailerFormat.sync(false),
-        });
-      }
+      await this.fxaMailer.sendPostRemovePasskeyEmail({
+        ...FxaMailerFormat.account({ ...account, uid }),
+        ...(await FxaMailerFormat.metricsContext(request)),
+        ...FxaMailerFormat.localTime(request),
+        ...FxaMailerFormat.location(request),
+        ...FxaMailerFormat.device(request),
+        ...FxaMailerFormat.sync(false),
+      });
     } catch (err) {
       this.log.error('passkeys.deletePasskey.sendEmail', { err });
       reportSentryError(err, request);
@@ -508,35 +504,17 @@ export class PasskeyHandler {
     // yet, so service framing would be premature.
     const emailService = keysRequired ? undefined : service;
     try {
-      const geoData = request.app.geo;
-      if (this.fxaMailer.canSend('newDeviceLogin')) {
-        const clientInfo =
-          await this.oauthClientInfoService.fetch(emailService);
-        await this.fxaMailer.sendNewDeviceLoginEmail({
-          ...FxaMailerFormat.account(account),
-          ...FxaMailerFormat.device(request),
-          ...FxaMailerFormat.localTime(request),
-          ...FxaMailerFormat.location(request),
-          ...(await FxaMailerFormat.metricsContext(request)),
-          ...FxaMailerFormat.sync(false),
-          clientName: clientInfo.name,
-          showBannerWarning: false,
-        });
-      } else {
-        await this.mailer.sendNewDeviceLoginEmail(account.emails, account, {
-          acceptLanguage: request.app.acceptLanguage,
-          ip: request.app.clientAddress,
-          location: geoData.location,
-          service: emailService,
-          timeZone: geoData.timeZone,
-          uaBrowser: request.app.ua.browser,
-          uaBrowserVersion: request.app.ua.browserVersion,
-          uaOS: request.app.ua.os,
-          uaOSVersion: request.app.ua.osVersion,
-          uaDeviceType: request.app.ua.deviceType,
-          uid: account.uid,
-        });
-      }
+      const clientInfo = await this.oauthClientInfoService.fetch(emailService);
+      await this.fxaMailer.sendNewDeviceLoginEmail({
+        ...FxaMailerFormat.account(account),
+        ...FxaMailerFormat.device(request),
+        ...FxaMailerFormat.localTime(request),
+        ...FxaMailerFormat.location(request),
+        ...(await FxaMailerFormat.metricsContext(request)),
+        ...FxaMailerFormat.sync(false),
+        clientName: clientInfo.name,
+        showBannerWarning: false,
+      });
     } catch (err) {
       this.log.trace(
         'passkeys.authenticationFinish.sendNewDeviceLoginEmail.error',

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -256,7 +256,6 @@ module.exports = function (
           sessionToken?: string;
         };
         const wantsKeys = requestHelper.wantsKeys(request);
-        const ip = request.app.clientAddress;
 
         const hasTotp = await checkTotpToken();
 
@@ -455,40 +454,16 @@ module.exports = function (
             generation: account.verifierSetAt,
           });
           await oauth.removePublicAndCanGrantTokens(passwordChangeToken.uid);
-          const emails = await db.accountEmails(passwordChangeToken.uid);
-          const geoData = request.app.geo;
-          const {
-            browser: uaBrowser,
-            browserVersion: uaBrowserVersion,
-            os: uaOS,
-            osVersion: uaOSVersion,
-            deviceType: uaDeviceType,
-          } = request.app.ua;
 
           try {
-            if (fxaMailer.canSend('passwordChanged')) {
-              await fxaMailer.sendPasswordChangedEmail({
-                ...FxaMailerFormat.account(account),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.location(request),
-                ...FxaMailerFormat.device(request),
-                ...FxaMailerFormat.sync(false),
-              });
-            } else {
-              await mailer.sendPasswordChangedEmail(emails, account, {
-                acceptLanguage: request.app.acceptLanguage,
-                ip,
-                location: geoData.location,
-                timeZone: geoData.timeZone,
-                uaBrowser,
-                uaBrowserVersion,
-                uaOS,
-                uaOSVersion,
-                uaDeviceType,
-                uid: passwordChangeToken.uid,
-              });
-            }
+            await fxaMailer.sendPasswordChangedEmail({
+              ...FxaMailerFormat.account(account),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.location(request),
+              ...FxaMailerFormat.device(request),
+              ...FxaMailerFormat.sync(false),
+            });
           } catch (error) {
             // If we couldn't email them, no big deal. Log
             // and pretend everything worked.
@@ -685,7 +660,6 @@ module.exports = function (
         }
 
         const wantsKeys = requestHelper.wantsKeys(request);
-        const ip = request.app.clientAddress;
 
         const hasTotp = await otpUtils.hasTotpToken({ uid });
 
@@ -858,40 +832,16 @@ module.exports = function (
             generation: account.verifierSetAt,
           });
           await oauth.removePublicAndCanGrantTokens(uid);
-          const emails = await db.accountEmails(uid);
-          const geoData = request.app.geo;
-          const {
-            browser: uaBrowser,
-            browserVersion: uaBrowserVersion,
-            os: uaOS,
-            osVersion: uaOSVersion,
-            deviceType: uaDeviceType,
-          } = request.app.ua;
 
           try {
-            if (fxaMailer.canSend('passwordChanged')) {
-              await fxaMailer.sendPasswordChangedEmail({
-                ...FxaMailerFormat.account(account),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.location(request),
-                ...FxaMailerFormat.device(request),
-                ...FxaMailerFormat.sync(false),
-              });
-            } else {
-              await mailer.sendPasswordChangedEmail(emails, account, {
-                acceptLanguage: request.app.acceptLanguage,
-                ip,
-                location: geoData.location,
-                timeZone: geoData.timeZone,
-                uaBrowser,
-                uaBrowserVersion,
-                uaOS,
-                uaOSVersion,
-                uaDeviceType,
-                uid: uid,
-              });
-            }
+            await fxaMailer.sendPasswordChangedEmail({
+              ...FxaMailerFormat.account(account),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.location(request),
+              ...FxaMailerFormat.device(request),
+              ...FxaMailerFormat.sync(false),
+            });
           } catch (error) {
             // If we couldn't email them, no big deal. Log
             // and pretend everything worked.
@@ -1067,48 +1017,17 @@ module.exports = function (
         request.setMetricsFlowCompleteSignal(flowCompleteSignal);
 
         const code = await otpManager.create(account.uid);
-        const ip = request.app.clientAddress;
         const service = payload.service || request.query.service;
-        const { deviceId, flowId, flowBeginTime } =
-          await request.app.metricsContext;
-        const geoData = request.app.geo;
-        const {
-          browser: uaBrowser,
-          browserVersion: uaBrowserVersion,
-          os: uaOS,
-          osVersion: uaOSVersion,
-          deviceType: uaDeviceType,
-        } = request.app.ua;
 
-        if (fxaMailer.canSend('passwordForgotOtp')) {
-          await fxaMailer.sendPasswordForgotOtpEmail({
-            ...FxaMailerFormat.account(account),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.sync(service),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.localTime(request),
-            code,
-          });
-        } else {
-          await mailer.sendPasswordForgotOtpEmail(account.emails, account, {
-            code,
-            service,
-            acceptLanguage: request.app.acceptLanguage,
-            deviceId,
-            flowId,
-            flowBeginTime,
-            ip,
-            location: geoData.location,
-            timeZone: geoData.timeZone,
-            uaBrowser,
-            uaBrowserVersion,
-            uaOS,
-            uaOSVersion,
-            uaDeviceType,
-            uid: account.uid,
-          });
-        }
+        await fxaMailer.sendPasswordForgotOtpEmail({
+          ...FxaMailerFormat.account(account),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.sync(service),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.localTime(request),
+          code,
+        });
 
         glean.resetPassword.otpEmailSent(request);
 
@@ -1334,22 +1253,14 @@ module.exports = function (
               emailOptions
             );
           } else {
-            if (fxaMailer.canSend('passwordReset')) {
-              await fxaMailer.sendPasswordResetEmail({
-                ...FxaMailerFormat.account(account),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.location(request),
-                ...FxaMailerFormat.device(request),
-                ...FxaMailerFormat.sync(false),
-              });
-            } else {
-              await mailer.sendPasswordResetEmail(
-                emails,
-                passwordForgotToken,
-                emailOptions
-              );
-            }
+            await fxaMailer.sendPasswordResetEmail({
+              ...FxaMailerFormat.account(account),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.location(request),
+              ...FxaMailerFormat.device(request),
+              ...FxaMailerFormat.sync(false),
+            });
           }
         }
 

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -66,29 +66,14 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
         });
 
         const account = await db.account(uid);
-        const { acceptLanguage, clientAddress: geo, ua } = request.app;
 
-        if (fxaMailer.canSend('postNewRecoveryCodes')) {
-          await fxaMailer.sendPostNewRecoveryCodesEmail({
-            ...FxaMailerFormat.account(account),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.sync(false),
-            ...FxaMailerFormat.localTime(request),
-          });
-        } else {
-          await mailer.sendPostNewRecoveryCodesEmail(account.emails, account, {
-            acceptLanguage,
-            location: geo.location,
-            timeZone: geo.timeZone,
-            uaBrowser: ua.browser,
-            uaBrowserVersion: ua.browserVersion,
-            uaOS: ua.os,
-            uaOSVersion: ua.osVersion,
-            uaDeviceType: ua.deviceType,
-            uid,
-          });
-        }
+        await fxaMailer.sendPostNewRecoveryCodesEmail({
+          ...FxaMailerFormat.account(account),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.sync(false),
+          ...FxaMailerFormat.localTime(request),
+        });
 
         log.info('account.recoveryCode.replaced', { uid });
         await request.emitMetricsEvent('recoveryCode.replaced', { uid });
@@ -213,29 +198,14 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
         glean.twoFactorAuth.replaceCodeComplete(request, { uid });
 
         const account = await db.account(uid);
-        const { acceptLanguage, clientAddress: geo, ua } = request.app;
 
-        if (fxaMailer.canSend('postNewRecoveryCodes')) {
-          await fxaMailer.sendPostNewRecoveryCodesEmail({
-            ...FxaMailerFormat.account(account),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.sync(false),
-            ...FxaMailerFormat.localTime(request),
-          });
-        } else {
-          await mailer.sendPostNewRecoveryCodesEmail(account.emails, account, {
-            acceptLanguage,
-            location: geo.location,
-            timeZone: geo.timeZone,
-            uaBrowser: ua.browser,
-            uaBrowserVersion: ua.browserVersion,
-            uaOS: ua.os,
-            uaOSVersion: ua.osVersion,
-            uaDeviceType: ua.deviceType,
-            uid,
-          });
-        }
+        await fxaMailer.sendPostNewRecoveryCodesEmail({
+          ...FxaMailerFormat.account(account),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.sync(false),
+          ...FxaMailerFormat.localTime(request),
+        });
 
         await recordSecurityEvent('account.recovery_codes_created', {
           db,
@@ -363,61 +333,33 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
         await db.verifyTokensWithMethod(tokenId, 'recovery-code');
 
         const account = await db.account(uid);
-        const { acceptLanguage, clientAddress: ip, geo, ua } = request.app;
 
         const mailerPromises = [];
 
-        if (fxaMailer.canSend('postSigninRecoveryCode')) {
-          mailerPromises.push(
-            fxaMailer.sendPostSigninRecoveryCodeEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-            })
-          );
-        } else {
-          mailerPromises.push(
-            mailer.sendPostSigninRecoveryCodeEmail(account.emails, account, {
-              acceptLanguage,
-              ip,
-              location: geo.location,
-              timeZone: geo.timeZone,
-              uaBrowser: ua.browser,
-              uaBrowserVersion: ua.browserVersion,
-              uaOS: ua.os,
-              uaOSVersion: ua.osVersion,
-              uaDeviceType: ua.deviceType,
-              uid,
-            })
-          );
-        }
+        mailerPromises.push(
+          fxaMailer.sendPostSigninRecoveryCodeEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+          })
+        );
 
         if (remaining <= codeConfig.notifyLowCount) {
           log.info('account.recoveryCode.notifyLowCount', { uid, remaining });
 
-          if (fxaMailer.canSend('lowRecoveryCodes')) {
-            mailerPromises.push(
-              fxaMailer.sendLowRecoveryCodesEmail({
-                ...FxaMailerFormat.account(account),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.device(request),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.sync(false),
-                numberRemaining: remaining,
-              })
-            );
-          } else {
-            mailerPromises.push(
-              mailer.sendLowRecoveryCodesEmail(account.emails, account, {
-                acceptLanguage,
-                numberRemaining: remaining,
-                uid,
-              })
-            );
-          }
+          mailerPromises.push(
+            fxaMailer.sendLowRecoveryCodesEmail({
+              ...FxaMailerFormat.account(account),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.device(request),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.sync(false),
+              numberRemaining: remaining,
+            })
+          );
         }
 
         await Promise.allSettled(mailerPromises);

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -77,66 +77,26 @@ module.exports = (
         async function sendKeyCreationEmail() {
           const account = await db.account(uid);
 
-          if (fxaMailer.canSend('postAddAccountRecovery')) {
-            await fxaMailer.sendPostAddAccountRecoveryEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-            });
-          } else {
-            const { acceptLanguage, clientAddress: geo, ua } = request.app;
-            const emailOptions = {
-              acceptLanguage,
-              location: geo.location,
-              timeZone: geo.timeZone,
-              uaBrowser: ua.browser,
-              uaBrowserVersion: ua.browserVersion,
-              uaOS: ua.os,
-              uaOSVersion: ua.osVersion,
-              uaDeviceType: ua.deviceType,
-              uid,
-            };
-            await mailer.sendPostAddAccountRecoveryEmail(
-              account.emails,
-              account,
-              emailOptions
-            );
-          }
+          await fxaMailer.sendPostAddAccountRecoveryEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+          });
         }
 
         async function sendKeyChangeEmail() {
           const account = await db.account(uid);
-          if (fxaMailer.canSend('postChangeAccountRecovery')) {
-            await fxaMailer.sendPostChangeAccountRecoveryEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-            });
-          } else {
-            const { acceptLanguage, clientAddress: geo, ua } = request.app;
-            const emailOptions = {
-              acceptLanguage,
-              location: geo.location,
-              timeZone: geo.timeZone,
-              uaBrowser: ua.browser,
-              uaBrowserVersion: ua.browserVersion,
-              uaOS: ua.os,
-              uaOSVersion: ua.osVersion,
-              uaDeviceType: ua.deviceType,
-              uid,
-            };
-            await mailer.sendPostChangeAccountRecoveryEmail(
-              account.emails,
-              account,
-              emailOptions
-            );
-          }
+          await fxaMailer.sendPostChangeAccountRecoveryEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+          });
         }
 
         async function postKeyCreation() {
@@ -442,34 +402,14 @@ module.exports = (
 
         const account = await db.account(uid);
 
-        if (fxaMailer.canSend('postRemoveAccountRecovery')) {
-          await fxaMailer.sendPostRemoveAccountRecoveryEmail({
-            ...FxaMailerFormat.account(account),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(false),
-          });
-        } else {
-          const { acceptLanguage, clientAddress: geo, ua } = request.app;
-          const emailOptions = {
-            acceptLanguage,
-            location: geo.location,
-            timeZone: geo.timeZone,
-            uaBrowser: ua.browser,
-            uaBrowserVersion: ua.browserVersion,
-            uaOS: ua.os,
-            uaOSVersion: ua.osVersion,
-            uaDeviceType: ua.deviceType,
-            uid,
-          };
-          await mailer.sendPostRemoveAccountRecoveryEmail(
-            account.emails,
-            account,
-            emailOptions
-          );
-        }
+        await fxaMailer.sendPostRemoveAccountRecoveryEmail({
+          ...FxaMailerFormat.account(account),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(false),
+        });
 
         return {};
       },

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -440,7 +440,6 @@ class RecoveryPhoneHandler {
       await this.glean.login.recoveryPhoneSuccess(request);
 
       const account = await this.db.account(uid);
-      const { acceptLanguage, geo, ua } = request.app;
 
       this.statsd.increment(
         'account.recoveryPhone.phoneSignin.success',
@@ -456,31 +455,14 @@ class RecoveryPhoneHandler {
       });
 
       try {
-        if (this.fxaMailer.canSend('postSigninRecoveryPhone')) {
-          await this.fxaMailer.sendPostSigninRecoveryPhoneEmail({
-            ...FxaMailerFormat.account(account),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(false),
-          });
-        } else {
-          await this.mailer.sendPostSigninRecoveryPhoneEmail(
-            account.emails,
-            account,
-            {
-              acceptLanguage,
-              timeZone: geo.timeZone,
-              uaBrowser: ua.browser,
-              uaBrowserVersion: ua.browserVersion,
-              uaOS: ua.os,
-              uaOSVersion: ua.osVersion,
-              uaDeviceType: ua.deviceType,
-              uid,
-            }
-          );
-        }
+        await this.fxaMailer.sendPostSigninRecoveryPhoneEmail({
+          ...FxaMailerFormat.account(account),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(false),
+        });
       } catch (error) {
         // log email send error but don't throw
         // user should be allowed to proceed
@@ -547,7 +529,6 @@ class RecoveryPhoneHandler {
       await this.glean.twoStepAuthPhoneCode.complete(request);
 
       const account = await this.db.account(uid);
-      const { acceptLanguage, geo, ua } = request.app;
 
       this.statsd.increment(
         'account.recoveryPhone.phoneAdded.success',
@@ -566,39 +547,18 @@ class RecoveryPhoneHandler {
       // when 2fa setup is complete
       if (hasTotpToken) {
         try {
-          if (this.fxaMailer.canSend('postAddRecoveryPhone')) {
-            await this.fxaMailer.sendPostAddRecoveryPhoneEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-              maskedLastFourPhoneNumber: `••••••${this.recoveryPhoneService.stripPhoneNumber(
-                phoneNumber || '',
-                4
-              )}`,
-            });
-          } else {
-            await this.mailer.sendPostAddRecoveryPhoneEmail(
-              account.emails,
-              account,
-              {
-                acceptLanguage,
-                maskedLastFourPhoneNumber: `••••••${this.recoveryPhoneService.stripPhoneNumber(
-                  phoneNumber || '',
-                  4
-                )}`,
-                timeZone: geo.timeZone,
-                uaBrowser: ua.browser,
-                uaBrowserVersion: ua.browserVersion,
-                uaOS: ua.os,
-                uaOSVersion: ua.osVersion,
-                uaDeviceType: ua.deviceType,
-                uid,
-              }
-            );
-          }
+          await this.fxaMailer.sendPostAddRecoveryPhoneEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+            maskedLastFourPhoneNumber: `••••••${this.recoveryPhoneService.stripPhoneNumber(
+              phoneNumber || '',
+              4
+            )}`,
+          });
         } catch (error) {
           // log email send error but don't throw
           // user should be allowed to proceed
@@ -709,35 +669,17 @@ class RecoveryPhoneHandler {
       request,
     });
 
-    const { acceptLanguage, geo, ua } = request.app;
     const account = await this.db.account(uid);
 
     try {
-      if (this.fxaMailer.canSend('postChangeRecoveryPhone')) {
-        await this.fxaMailer.sendPostChangeRecoveryPhoneEmail({
-          ...FxaMailerFormat.account(account),
-          ...(await FxaMailerFormat.metricsContext(request)),
-          ...FxaMailerFormat.localTime(request),
-          ...FxaMailerFormat.location(request),
-          ...FxaMailerFormat.device(request),
-          ...FxaMailerFormat.sync(false),
-        });
-      } else {
-        await this.mailer.sendPostChangeRecoveryPhoneEmail(
-          account.emails,
-          account,
-          {
-            acceptLanguage,
-            timeZone: geo.timeZone,
-            uaBrowser: ua.browser,
-            uaBrowserVersion: ua.browserVersion,
-            uaOS: ua.os,
-            uaOSVersion: ua.osVersion,
-            uaDeviceType: ua.deviceType,
-            uid,
-          }
-        );
-      }
+      await this.fxaMailer.sendPostChangeRecoveryPhoneEmail({
+        ...FxaMailerFormat.account(account),
+        ...(await FxaMailerFormat.metricsContext(request)),
+        ...FxaMailerFormat.localTime(request),
+        ...FxaMailerFormat.location(request),
+        ...FxaMailerFormat.device(request),
+        ...FxaMailerFormat.sync(false),
+      });
     } catch (error) {
       // log error, but don't throw
       // user should be allowed to proceed if email or security event fails
@@ -810,34 +752,16 @@ class RecoveryPhoneHandler {
       );
 
       const account = await this.db.account(uid);
-      const { acceptLanguage, geo, ua } = request.app;
 
       try {
-        if (this.fxaMailer.canSend('passwordResetRecoveryPhone')) {
-          await this.fxaMailer.sendPasswordResetRecoveryPhoneEmail({
-            ...FxaMailerFormat.account(account),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(false),
-          });
-        } else {
-          await this.mailer.sendPasswordResetRecoveryPhoneEmail(
-            account.emails,
-            account,
-            {
-              acceptLanguage,
-              timeZone: geo.timeZone,
-              uaBrowser: ua.browser,
-              uaBrowserVersion: ua.browserVersion,
-              uaOS: ua.os,
-              uaOSVersion: ua.osVersion,
-              uaDeviceType: ua.deviceType,
-              uid,
-            }
-          );
-        }
+        await this.fxaMailer.sendPasswordResetRecoveryPhoneEmail({
+          ...FxaMailerFormat.account(account),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(false),
+        });
       } catch (error) {
         this.log.error(
           'account.recoveryPhone.phonePasswordResetNotification.error',
@@ -886,7 +810,6 @@ class RecoveryPhoneHandler {
       await this.glean.twoStepAuthPhoneRemove.success(request);
 
       const account = await this.db.account(uid);
-      const { acceptLanguage, geo, ua } = request.app;
 
       try {
         await recordSecurityEvent('account.recovery_phone_removed', {
@@ -895,31 +818,14 @@ class RecoveryPhoneHandler {
           account,
         });
 
-        if (this.fxaMailer.canSend('postRemoveRecoveryPhone')) {
-          await this.fxaMailer.sendPostRemoveRecoveryPhoneEmail({
-            ...FxaMailerFormat.account(account),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(false),
-          });
-        } else {
-          await this.mailer.sendPostRemoveRecoveryPhoneEmail(
-            account.emails,
-            account,
-            {
-              acceptLanguage,
-              timeZone: geo.timeZone,
-              uaBrowser: ua.browser,
-              uaBrowserVersion: ua.browserVersion,
-              uaOS: ua.os,
-              uaOSVersion: ua.osVersion,
-              uaDeviceType: ua.deviceType,
-              uid,
-            }
-          );
-        }
+        await this.fxaMailer.sendPostRemoveRecoveryPhoneEmail({
+          ...FxaMailerFormat.account(account),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(false),
+        });
       } catch (error) {
         // log email send error but don't throw
         // user should be allowed to proceed

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -551,42 +551,20 @@ module.exports = function (
             );
 
           // Send new device login notification email after successful verification
-          const geoData = request.app.geo;
           const service = options.service || request.query.service;
 
           try {
-            if (fxaMailer.canSend('newDeviceLogin')) {
-              const clientInfo = await oauthClientInfoService.fetch(service);
-              await fxaMailer.sendNewDeviceLoginEmail({
-                ...FxaMailerFormat.account(account),
-                ...FxaMailerFormat.device(request),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.location(request),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.sync(service),
-                clientName: clientInfo.name,
-                showBannerWarning: false,
-              });
-            } else {
-              const emailOptions = {
-                acceptLanguage: request.app.acceptLanguage,
-                ip: request.app.clientAddress, // TODO: Double check this... It doesn't seem to be used?
-                location: geoData.location,
-                service,
-                timeZone: geoData.timeZone,
-                uaBrowser: sessionToken.uaBrowser,
-                uaBrowserVersion: sessionToken.uaBrowserVersion,
-                uaOS: sessionToken.uaOS,
-                uaOSVersion: sessionToken.uaOSVersion,
-                uaDeviceType: sessionToken.uaDeviceType,
-                uid,
-              };
-              await mailer.sendNewDeviceLoginEmail(
-                account.emails,
-                account,
-                emailOptions
-              );
-            }
+            const clientInfo = await oauthClientInfoService.fetch(service);
+            await fxaMailer.sendNewDeviceLoginEmail({
+              ...FxaMailerFormat.account(account),
+              ...FxaMailerFormat.device(request),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.location(request),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.sync(service),
+              clientName: clientInfo.name,
+              showBannerWarning: false,
+            });
           } catch (err) {
             log.trace('Session.verify_code.sendNewDeviceLoginEmail.error', {
               error: err,
@@ -660,71 +638,45 @@ module.exports = function (
         if (account.primaryEmail.isVerified) {
           // Unverified emails mean that the user is attempting to resend the code from signup page,
           // therefore they get sent a different email template with the code.
-          if (fxaMailer.canSend('verifyLoginCode')) {
-            // This will just short-circuit to Mozilla, but leaving for future proofing.
-            const clientInfo = await oauthClientInfoService.fetch(undefined);
-            const cmsConfig = await getOptionalCmsEmailConfig(options, {
-              request,
-              cmsManager,
-              log,
-              emailTemplate: 'VerifyLoginCodeEmail',
-            });
-            await fxaMailer.sendVerifyLoginCodeEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-              ...FxaMailerFormat.cmsLogo(cmsConfig),
-              ...FxaMailerFormat.cmsEmailSubject(cmsConfig),
-              code,
-              service: clientInfo.name,
-              serviceName: clientInfo.name,
-            });
-          } else {
-            await mailer.sendVerifyLoginCodeEmail(
-              account.emails,
-              account,
-              await getOptionalCmsEmailConfig(options, {
-                request,
-                cmsManager,
-                log,
-                emailTemplate: 'VerifyLoginCodeEmail',
-              })
-            );
-          }
+          // This will just short-circuit to Mozilla, but leaving for future proofing.
+          const clientInfo = await oauthClientInfoService.fetch(undefined);
+          const cmsConfig = await getOptionalCmsEmailConfig(options, {
+            request,
+            cmsManager,
+            log,
+            emailTemplate: 'VerifyLoginCodeEmail',
+          });
+          await fxaMailer.sendVerifyLoginCodeEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+            ...FxaMailerFormat.cmsLogo(cmsConfig),
+            ...FxaMailerFormat.cmsEmailSubject(cmsConfig),
+            code,
+            service: clientInfo.name,
+            serviceName: clientInfo.name,
+          });
         } else {
-          if (fxaMailer.canSend('verifyShortCode')) {
-            const cmsConfig = await getOptionalCmsEmailConfig(options, {
-              request,
-              cmsManager,
-              log,
-              emailTemplate: 'VerifyShortCodeEmail',
-            });
-            await fxaMailer.sendVerifyShortCodeEmail({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-              ...FxaMailerFormat.cmsLogo(cmsConfig),
-              ...FxaMailerFormat.cmsEmailSubject(cmsConfig),
-              code,
-            });
-          } else {
-            await mailer.sendVerifyShortCodeEmail(
-              [],
-              account,
-              await getOptionalCmsEmailConfig(options, {
-                request,
-                cmsManager,
-                log,
-                emailTemplate: 'VerifyShortCodeEmail',
-              })
-            );
-          }
+          const cmsConfig = await getOptionalCmsEmailConfig(options, {
+            request,
+            cmsManager,
+            log,
+            emailTemplate: 'VerifyShortCodeEmail',
+          });
+          await fxaMailer.sendVerifyShortCodeEmail({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+            ...FxaMailerFormat.cmsLogo(cmsConfig),
+            ...FxaMailerFormat.cmsEmailSubject(cmsConfig),
+            code,
+          });
         }
 
         return {};

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -232,40 +232,17 @@ module.exports = (
 
     async function sendEmailNotification() {
       const account = await db.account(uid);
-      const geoData = request.app.geo;
-      const ip = request.app.clientAddress;
       const service = request.payload.service || request.query.service;
 
       try {
-        if (fxaMailer.canSend('postChangeTwoStepAuthentication')) {
-          await fxaMailer.sendPostChangeTwoStepAuthenticationEmail({
-            ...FxaMailerFormat.account(account),
-            ...FxaMailerFormat.metricsContext(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(service),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.localTime(request),
-          });
-        } else {
-          const emailOptions = {
-            acceptLanguage: request.app.acceptLanguage,
-            ip: ip,
-            location: geoData.location,
-            service: service,
-            timeZone: geoData.timeZone,
-            uaBrowser: request.app.ua.browser,
-            uaBrowserVersion: request.app.ua.browserVersion,
-            uaOS: request.app.ua.os,
-            uaOSVersion: request.app.ua.osVersion,
-            uaDeviceType: request.app.ua.deviceType,
-            uid: uid,
-          };
-          await mailer.sendPostChangeTwoStepAuthenticationEmail(
-            account.emails,
-            account,
-            emailOptions
-          );
-        }
+        await fxaMailer.sendPostChangeTwoStepAuthenticationEmail({
+          ...FxaMailerFormat.account(account),
+          ...FxaMailerFormat.metricsContext(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(service),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.localTime(request),
+        });
       } catch (error) {
         log.error('mailer.sendPostChangeTwoStepAuthenticationEmail', {
           error,
@@ -301,34 +278,14 @@ module.exports = (
       const account = await db.account(uid);
 
       try {
-        if (fxaMailer.canSend('postRemoveTwoStepAuthentication')) {
-          await fxaMailer.sendPostRemoveTwoStepAuthenticationEmail({
-            ...FxaMailerFormat.account(account),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.device(request),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.sync(service),
-          });
-        } else {
-          const geoData = request.app.geo;
-          const emailOptions = {
-            acceptLanguage: request.app.acceptLanguage,
-            location: geoData.location,
-            timeZone: geoData.timeZone,
-            uaBrowser: request.app.ua.browser,
-            uaBrowserVersion: request.app.ua.browserVersion,
-            uaOS: request.app.ua.os,
-            uaOSVersion: request.app.ua.osVersion,
-            uaDeviceType: request.app.ua.deviceType,
-            uid,
-          };
-          await mailer.sendPostRemoveTwoStepAuthenticationEmail(
-            account.emails,
-            account,
-            emailOptions
-          );
-        }
+        await fxaMailer.sendPostRemoveTwoStepAuthenticationEmail({
+          ...FxaMailerFormat.account(account),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.device(request),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.sync(service),
+        });
       } catch (err) {
         // If email fails, log the error without aborting the operation.
         log.error('mailer.sendPostRemoveTwoStepAuthenticationEmail', {
@@ -745,8 +702,6 @@ module.exports = (
 
         async function sendEmailNotification() {
           const account = await db.account(uid);
-          const geoData = request.app.geo;
-          const ip = request.app.clientAddress;
           const service = request.payload?.service || request.query?.service;
 
           // include recovery method context if available
@@ -759,41 +714,16 @@ module.exports = (
           const recoveryMethod = maskedPhoneNumber ? 'phone' : 'codes';
 
           try {
-            if (fxaMailer.canSend('postAddTwoStepAuthentication')) {
-              await fxaMailer.sendPostAddTwoStepAuthenticationEmail({
-                ...FxaMailerFormat.account(account),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.device(request),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.sync(service),
-                ...FxaMailerFormat.location(request),
-                recoveryMethod,
-                maskedPhoneNumber,
-              });
-            } else {
-              const emailOptions = {
-                acceptLanguage: request.app.acceptLanguage,
-                ip,
-                location: geoData.location,
-                service,
-                timeZone: geoData.timeZone,
-                uaBrowser: request.app.ua.browser,
-                uaBrowserVersion: request.app.ua.browserVersion,
-                uaOS: request.app.ua.os,
-                uaOSVersion: request.app.ua.osVersion,
-                uaDeviceType: request.app.ua.deviceType,
-                uid,
-              };
-              await mailer.sendPostAddTwoStepAuthenticationEmail(
-                account.emails,
-                account,
-                {
-                  ...emailOptions,
-                  recoveryMethod,
-                  maskedPhoneNumber,
-                }
-              );
-            }
+            await fxaMailer.sendPostAddTwoStepAuthenticationEmail({
+              ...FxaMailerFormat.account(account),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.device(request),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.sync(service),
+              ...FxaMailerFormat.location(request),
+              recoveryMethod,
+              maskedPhoneNumber,
+            });
           } catch (error) {
             log.error('mailer.sendPostAddTwoStepAuthenticationEmail', {
               error,
@@ -1009,63 +939,35 @@ module.exports = (
         );
 
         const account = await db.account(uid);
-        const { acceptLanguage, clientAddress: ip, geo, ua } = request.app;
 
         const { remaining } = await db.consumeRecoveryCode(uid, code);
 
         const mailerPromises = [];
 
-        if (fxaMailer.canSend('postConsumeRecoveryCode')) {
-          mailerPromises.push(
-            fxaMailer.sendPostConsumeRecoveryCodeEmail({
-              ...FxaMailerFormat.account(account),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.device(request),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.sync(service),
-            })
-          );
-        } else {
-          mailerPromises.push(
-            mailer.sendPostConsumeRecoveryCodeEmail(account.emails, account, {
-              acceptLanguage,
-              ip,
-              location: geo.location,
-              timeZone: geo.timeZone,
-              uaBrowser: ua.browser,
-              uaBrowserVersion: ua.browserVersion,
-              uaOS: ua.os,
-              uaOSVersion: ua.osVersion,
-              uaDeviceType: ua.deviceType,
-              uid,
-            })
-          );
-        }
+        mailerPromises.push(
+          fxaMailer.sendPostConsumeRecoveryCodeEmail({
+            ...FxaMailerFormat.account(account),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.device(request),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.sync(service),
+          })
+        );
 
         if (remaining <= codeConfig.notifyLowCount) {
           log.info('account.recoveryCode.notifyLowCount', { uid, remaining });
 
-          if (fxaMailer.canSend('lowRecoveryCodes')) {
-            mailerPromises.push(
-              fxaMailer.sendLowRecoveryCodesEmail({
-                ...FxaMailerFormat.account(account),
-                ...FxaMailerFormat.localTime(request),
-                ...FxaMailerFormat.device(request),
-                ...(await FxaMailerFormat.metricsContext(request)),
-                ...FxaMailerFormat.sync(service),
-                numberRemaining: remaining,
-              })
-            );
-          } else {
-            mailerPromises.push(
-              mailer.sendLowRecoveryCodesEmail(account.emails, account, {
-                acceptLanguage,
-                numberRemaining: remaining,
-                uid,
-              })
-            );
-          }
+          mailerPromises.push(
+            fxaMailer.sendLowRecoveryCodesEmail({
+              ...FxaMailerFormat.account(account),
+              ...FxaMailerFormat.localTime(request),
+              ...FxaMailerFormat.device(request),
+              ...(await FxaMailerFormat.metricsContext(request)),
+              ...FxaMailerFormat.sync(service),
+              numberRemaining: remaining,
+            })
+          );
         }
 
         await Promise.all(mailerPromises);
@@ -1200,42 +1102,19 @@ module.exports = (
         async function sendEmailNotification() {
           if (!isValidCode) return;
           const account = await db.account(sessionToken.uid);
-          const geoData = request.app.geo;
-          const ip = request.app.clientAddress;
           const service = request.payload.service || request.query.service;
-          const emailOptions = {
-            acceptLanguage: request.app.acceptLanguage,
-            ip: ip,
-            location: geoData.location,
-            service: service,
-            timeZone: geoData.timeZone,
-            uaBrowser: request.app.ua.browser,
-            uaBrowserVersion: request.app.ua.browserVersion,
-            uaOS: request.app.ua.os,
-            uaOSVersion: request.app.ua.osVersion,
-            uaDeviceType: request.app.ua.deviceType,
-            uid: sessionToken.uid,
-          };
 
-          if (fxaMailer.canSend('newDeviceLogin')) {
-            const clientInfo = await oauthClientInfoService.fetch(service);
-            return await fxaMailer.sendNewDeviceLoginEmail({
-              ...FxaMailerFormat.account(account),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.sync(service),
-              clientName: clientInfo.name,
-              showBannerWarning: false,
-            });
-          } else {
-            return mailer.sendNewDeviceLoginEmail(
-              account.emails,
-              account,
-              emailOptions
-            );
-          }
+          const clientInfo = await oauthClientInfoService.fetch(service);
+          return await fxaMailer.sendNewDeviceLoginEmail({
+            ...FxaMailerFormat.account(account),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.sync(service),
+            clientName: clientInfo.name,
+            showBannerWarning: false,
+          });
         }
       },
     },

--- a/packages/fxa-auth-server/lib/routes/unblock-codes.js
+++ b/packages/fxa-auth-server/lib/routes/unblock-codes.js
@@ -41,49 +41,22 @@ module.exports = (log, db, mailer, config, customs) => {
 
         request.validateMetricsContext();
 
-        const { flowId, flowBeginTime } = await request.app.metricsContext;
-
         await customs.check(request, email, 'sendUnblockCode');
 
         const emailRecord = await db.accountRecord(email);
         const { uid } = emailRecord;
 
         const unblockCode = await db.createUnblockCode(uid);
-        const emails = await db.accountEmails(uid);
 
-        const {
-          browser: uaBrowser,
-          browserVersion: uaBrowserVersion,
-          os: uaOS,
-          osVersion: uaOSVersion,
-          deviceType: uaDeviceType,
-        } = request.app.ua;
-        if (fxaMailer.canSend('unblockCode')) {
-          await fxaMailer.sendUnblockCodeEmail({
-            ...FxaMailerFormat.account(emailRecord),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.sync(false),
-            unblockCode,
-          });
-        } else {
-          await mailer.sendUnblockCodeEmail(emails, emailRecord, {
-            acceptLanguage: request.app.acceptLanguage,
-            unblockCode,
-            flowId,
-            flowBeginTime,
-            location: request.app.geo.location,
-            timeZone: request.app.geo.timeZone,
-            uaBrowser,
-            uaBrowserVersion,
-            uaOS,
-            uaOSVersion,
-            uaDeviceType,
-            uid,
-          });
-        }
+        await fxaMailer.sendUnblockCodeEmail({
+          ...FxaMailerFormat.account(emailRecord),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.sync(false),
+          unblockCode,
+        });
 
         await request.emitMetricsEvent('account.login.sentUnblockCode');
 

--- a/packages/fxa-auth-server/lib/routes/unblock-codes.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/unblock-codes.spec.ts
@@ -61,8 +61,7 @@ describe('/account/login/send_unblock_code', () => {
       },
     },
   });
-  // Mock the modern FxaMailer (the legacy `mailer` else-branch is not exercised:
-  // canSend defaults to true, so makeRoutes leaves `mailer` as the default stub).
+  // Mock the modern FxaMailer; `makeRoutes` leaves `mailer` as the default stub.
   const mockFxaMailer = installMockFxaMailer();
   const mockDb = mocks.mockDB({
     uid: uid,

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.js
@@ -104,34 +104,17 @@ module.exports = {
       const isNewAccount = Date.now() - account.createdAt < MAX_NEW_ACCOUNT_AGE;
 
       if (!isNewAccount) {
-        const geoData = request.app.geo;
-        const emailOptions = {
-          acceptLanguage: request.app.acceptLanguage,
-          location: geoData.location,
-          service: clientId,
-          timeZone: geoData.timeZone,
-          uid: credentials.uid,
-        };
-
-        if (fxaMailer.canSend('newDeviceLogin')) {
-          const clientInfo = await oauthClientInfoService.fetch(clientId);
-          await fxaMailer.sendNewDeviceLoginEmail({
-            ...FxaMailerFormat.account(account),
-            ...FxaMailerFormat.device(request),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.location(request),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.sync(clientId),
-            clientName: clientInfo.name,
-            showBannerWarning: false,
-          });
-        } else {
-          await mailer.sendNewDeviceLoginEmail(
-            account.emails,
-            account,
-            emailOptions
-          );
-        }
+        const clientInfo = await oauthClientInfoService.fetch(clientId);
+        await fxaMailer.sendNewDeviceLoginEmail({
+          ...FxaMailerFormat.account(account),
+          ...FxaMailerFormat.device(request),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.location(request),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.sync(clientId),
+          clientName: clientInfo.name,
+          showBannerWarning: false,
+        });
       }
     }
   },

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -322,9 +322,6 @@ module.exports = (
 
       let sessions;
 
-      const { deviceId, flowId, flowBeginTime } =
-        await request.app.metricsContext;
-
       const mustVerifySession = !sessionToken.tokenVerified;
 
       // The final event to complete the login flow depends on the details
@@ -445,38 +442,18 @@ module.exports = (
           sessionToken.tokenVerificationId ||
           accountRecord.primaryEmail.emailCode;
         try {
-          if (fxaMailer.canSend('verify')) {
-            await fxaMailer.sendVerifyEmail({
-              ...FxaMailerFormat.account(accountRecord),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.sync(service),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              code: emailCode,
-              resume,
-              redirectTo,
-              service,
-            });
-          } else {
-            await mailer.sendVerifyEmail([], accountRecord, {
-              code: emailCode,
-              service,
-              redirectTo,
-              resume,
-              acceptLanguage: request.app.acceptLanguage,
-              deviceId,
-              flowId,
-              flowBeginTime,
-              timeZone: request.app.geo.timeZone,
-              uaBrowser: request.app.ua.browser,
-              uaBrowserVersion: request.app.ua.browserVersion,
-              uaOS: request.app.ua.os,
-              uaOSVersion: request.app.ua.osVersion,
-              uaDeviceType: request.app.ua.deviceType,
-              uid: sessionToken.uid,
-            });
-          }
+          await fxaMailer.sendVerifyEmail({
+            ...FxaMailerFormat.account(accountRecord),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.sync(service),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            code: emailCode,
+            resume,
+            redirectTo,
+            service,
+          });
           await request.emitMetricsEvent('email.verification.sent');
         } catch (err) {
           log.error('mailer.verification.error', {
@@ -533,48 +510,22 @@ module.exports = (
           tokenVerificationId: sessionToken.tokenVerificationId,
         });
 
-        const geoData = request.app.geo;
         try {
-          if (fxaMailer.canSend('verifyLogin')) {
-            const clientInfo = await oauthClientInfoService.fetch(service);
-            await fxaMailer.sendVerifyLoginEmail({
-              ...FxaMailerFormat.account(accountRecord),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(service),
-              code: sessionToken.tokenVerificationId,
-              clientName: clientInfo.name,
-              redirectTo: redirectTo,
-              service: service,
-              resume: resume,
-              uid: sessionToken.uid,
-            });
-          } else {
-            await mailer.sendVerifyLoginEmail(
-              accountRecord.emails,
-              accountRecord,
-              {
-                acceptLanguage: request.app.acceptLanguage,
-                code: sessionToken.tokenVerificationId,
-                deviceId,
-                flowId,
-                flowBeginTime,
-                redirectTo: redirectTo,
-                resume: resume,
-                service: service,
-                location: geoData.location,
-                timeZone: geoData.timeZone,
-                uaBrowser: request.app.ua.browser,
-                uaBrowserVersion: request.app.ua.browserVersion,
-                uaOS: request.app.ua.os,
-                uaOSVersion: request.app.ua.osVersion,
-                uaDeviceType: request.app.ua.deviceType,
-                uid: sessionToken.uid,
-              }
-            );
-          }
+          const clientInfo = await oauthClientInfoService.fetch(service);
+          await fxaMailer.sendVerifyLoginEmail({
+            ...FxaMailerFormat.account(accountRecord),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(service),
+            code: sessionToken.tokenVerificationId,
+            clientName: clientInfo.name,
+            redirectTo: redirectTo,
+            service: service,
+            resume: resume,
+            uid: sessionToken.uid,
+          });
           await request.emitMetricsEvent('email.confirmation.sent');
         } catch (err) {
           log.error('mailer.confirmation.error', {
@@ -594,70 +545,24 @@ module.exports = (
         const rpCmsConfig = await fetchRpCmsData(request, cmsManager, log);
 
         try {
-          if (fxaMailer.canSend('verifyLoginCode')) {
-            const clientInfo = await oauthClientInfoService.fetch(service);
-            await fxaMailer.sendVerifyLoginCodeEmail({
-              ...FxaMailerFormat.account(accountRecord),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(service),
-              ...FxaMailerFormat.cmsLogo(rpCmsConfig?.shared),
-              ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
-              ...FxaMailerFormat.cmsEmailSubject(
-                rpCmsConfig?.VerifyLoginCodeEmail
-              ),
-              code,
-              redirectTo,
-              resume,
-              serviceName: clientInfo.name,
-            });
-          } else {
-            const { timeZone } = request.app.geo;
-            const emailContext = {
-              acceptLanguage: request.app.acceptLanguage,
-              code,
-              deviceId,
-              flowId,
-              flowBeginTime,
-              redirectTo,
-              resume,
-              service,
-              timeZone,
-              uaBrowser: request.app.ua.browser,
-              uaBrowserVersion: request.app.ua.browserVersion,
-              uaOS: request.app.ua.os,
-              uaOSVersion: request.app.ua.osVersion,
-              uaDeviceType: request.app.ua.deviceType,
-              uid: sessionToken.uid,
-            };
-
-            if (!rpCmsConfig || !rpCmsConfig.VerifyLoginCodeEmail) {
-              await mailer.sendVerifyLoginCodeEmail(
-                accountRecord.emails,
-                accountRecord,
-                emailContext
-              );
-            } else {
-              const metricsContext = await request.app.metricsContext;
-              await mailer.sendVerifyLoginCodeEmail(
-                accountRecord.emails,
-                accountRecord,
-                {
-                  ...emailContext,
-                  target: 'strapi',
-                  cmsRpClientId: rpCmsConfig.clientId,
-                  cmsRpFromName: rpCmsConfig.shared?.emailFromName,
-                  entrypoint: metricsContext.entrypoint,
-                  logoUrl: rpCmsConfig?.shared?.emailLogoUrl,
-                  logoAltText: rpCmsConfig?.shared?.emailLogoAltText,
-                  logoWidth: rpCmsConfig?.shared?.emailLogoWidth,
-                  ...rpCmsConfig.VerifyLoginCodeEmail,
-                }
-              );
-            }
-          }
+          const clientInfo = await oauthClientInfoService.fetch(service);
+          await fxaMailer.sendVerifyLoginCodeEmail({
+            ...FxaMailerFormat.account(accountRecord),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(service),
+            ...FxaMailerFormat.cmsLogo(rpCmsConfig?.shared),
+            ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
+            ...FxaMailerFormat.cmsEmailSubject(
+              rpCmsConfig?.VerifyLoginCodeEmail
+            ),
+            code,
+            redirectTo,
+            resume,
+            serviceName: clientInfo.name,
+          });
 
           await request.emitMetricsEvent('email.tokencode.sent');
           await glean.login.verifyCodeEmailSent(request, {

--- a/packages/fxa-auth-server/lib/routes/utils/signup.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signup.js
@@ -22,7 +22,7 @@ module.exports = (log, db, mailer, push, verificationReminders, glean) => {
      */
     verifyAccount: async (request, account, options) => {
       const { uid } = account;
-      const { newsletters, service, reminder, style, scopes } = options;
+      const { newsletters, service, reminder, scopes } = options;
       await db.verifyEmail(account, account.primaryEmail.emailCode);
 
       const geoData = request.app.geo;
@@ -87,29 +87,15 @@ module.exports = (log, db, mailer, push, verificationReminders, glean) => {
         (scopeSet.intersects(NOTIFICATION_SCOPES) && !service)
       ) {
         const onMobileDevice = request.app.ua.deviceType === 'mobile';
-        const mailOptions = {
-          acceptLanguage: request.app.acceptLanguage,
-          service: 'sync',
-          uid,
-          onMobileDevice,
-        };
 
-        if (style) {
-          mailOptions.style = style;
-        }
-
-        if (fxaMailer.canSend('postVerify')) {
-          return await fxaMailer.sendPostVerifyEmail({
-            ...FxaMailerFormat.account(account),
-            ...(await FxaMailerFormat.metricsContext(request)),
-            ...FxaMailerFormat.localTime(request),
-            ...FxaMailerFormat.sync(service),
-            productName: 'Firefox',
-            onDesktopOrTabletDevice: !onMobileDevice,
-          });
-        } else {
-          return mailer.sendPostVerifyEmail([], account, mailOptions);
-        }
+        return await fxaMailer.sendPostVerifyEmail({
+          ...FxaMailerFormat.account(account),
+          ...(await FxaMailerFormat.metricsContext(request)),
+          ...FxaMailerFormat.localTime(request),
+          ...FxaMailerFormat.sync(service),
+          productName: 'Firefox',
+          onDesktopOrTabletDevice: !onMobileDevice,
+        });
       }
 
       return {};

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
@@ -62,7 +62,6 @@ describe('lib/senders/fxa-mailer', () => {
 
     mockConfig = {
       sender: 'Firefox Accounts <accounts@firefox.com>',
-      fxaMailerDisableSend: [],
     };
 
     fxaMailer = new FxaMailer(
@@ -176,37 +175,6 @@ describe('lib/senders/fxa-mailer', () => {
         const sendArgs = mockEmailSender.send.mock.calls[0][0];
         expect(sendArgs.from).toBe('Mozilla Monitor <noreply@firefox.com>');
       });
-    });
-  });
-
-  describe('canSend', () => {
-    it('should return true when template is not in disable list', () => {
-      expect(fxaMailer.canSend('newDeviceLogin')).toBe(true);
-    });
-
-    it('should return false when template is in disable list', () => {
-      mockConfig.fxaMailerDisableSend = ['newDeviceLogin'];
-      fxaMailer = new FxaMailer(
-        mockEmailSender as any,
-        mockLinkBuilder as any,
-        mockConfig,
-        mockBindings,
-        mockAccountEventsManager as any
-      );
-      expect(fxaMailer.canSend('newDeviceLogin')).toBe(false);
-    });
-
-    it('should return true for different template when one is disabled', () => {
-      mockConfig.fxaMailerDisableSend = ['verifyLogin'];
-      fxaMailer = new FxaMailer(
-        mockEmailSender as any,
-        mockLinkBuilder as any,
-        mockConfig,
-        mockBindings,
-        mockAccountEventsManager as any
-      );
-      expect(fxaMailer.canSend('verifyLogin')).toBe(false);
-      expect(fxaMailer.canSend('newDeviceLogin')).toBe(true);
     });
   });
 

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -125,19 +125,6 @@ export class FxaMailer extends FxaEmailRenderer {
     super(bindings);
   }
 
-  /**
-   * Feature flag esque method that signals if the template is supported by the new mailer. Used to easily
-   * fall back to old email code if necessary.
-   * @param templateName The name of the template to check on.
-   * @returns True if the email can be sent, and false if the template is included in the SMTP_FXA_MAILER_DISABLE_SEND list.
-   */
-  canSend(templateName: string) {
-    if (this.mailerConfig.fxaMailerDisableSend.includes(templateName)) {
-      return false;
-    }
-    return true;
-  }
-
   async sendRecoveryEmail(
     opts: EmailSenderOpts &
       OmitCommonLinks<TemplateData> &

--- a/packages/fxa-auth-server/scripts/recorded-future/check-and-reset.ts
+++ b/packages/fxa-auth-server/scripts/recorded-future/check-and-reset.ts
@@ -37,8 +37,6 @@ import { createDB } from '../../lib/db';
 import oauthDb from '../../lib/oauth/db';
 import * as butil from '../../lib/crypto/butil';
 import PasswordFn from '../../lib/crypto/password';
-import bouncesFn from '../../lib/bounces';
-import sendersFn from '../../lib/senders';
 import TokenFn from '../../lib/tokens';
 import { emitStatsdMetrics } from '../lib/metrics';
 import { collect, parseBooleanArg } from '../lib/args';
@@ -310,10 +308,6 @@ async function resetAccounts(
   resetWithEmails: boolean
 ) {
   const authDb = await getAuthDb();
-  const bounces = bouncesFn(config, authDb);
-  const senders = await sendersFn(log, config, bounces, statsd);
-  // the dynamically named `send\w+Email` functions are not in the type of senders.email
-  const mailer: any = senders.email;
   const accountEventManager = new AccountEventsManager();
 
   // setup for fxa-mailer, since this runs outside of the key_server context we
@@ -351,41 +345,37 @@ async function resetAccounts(
         }
       );
       await oauthDb.removeTokensAndCodes(acct.uid);
-      if (fxaMailer.canSend('passwordChangeRequired')) {
-        // the new fxa-mailer is more type script, so we create a 'fake'
-        // request to satisfy the type checking
-        const request = {
-          app: {
-            ua: {},
-            metricsContext: Promise.resolve({
-              flowBeginTime: 1234567890,
-              flowId: 'fxa-internal-flow-id',
-            }),
-            geo: {
-              timeZone: '',
-              location: {
-                city: '',
-                state: '',
-                stateCode: '',
-                country: '',
-                countryCode: '',
-                postalCode: '',
-              },
+      // the new fxa-mailer is more type script, so we create a 'fake'
+      // request to satisfy the type checking
+      const request = {
+        app: {
+          ua: {},
+          metricsContext: Promise.resolve({
+            flowBeginTime: 1234567890,
+            flowId: 'fxa-internal-flow-id',
+          }),
+          geo: {
+            timeZone: '',
+            location: {
+              city: '',
+              state: '',
+              stateCode: '',
+              country: '',
+              countryCode: '',
+              postalCode: '',
             },
-            acceptLanguage: acct.locale || 'en', // should be set, but fallback if not
           },
-        };
-        await fxaMailer.sendPasswordChangeRequiredEmail({
-          ...FxaMailerFormat.account(acct as unknown as any), // this _should_ be safe
-          ...(await FxaMailerFormat.metricsContext(request)),
-          ...FxaMailerFormat.localTime(request),
-          ...FxaMailerFormat.location(request),
-          ...FxaMailerFormat.device(request),
-          ...FxaMailerFormat.sync(false),
-        });
-      } else {
-        await mailer.sendPasswordChangeRequiredEmail(acct.emails, acct);
-      }
+          acceptLanguage: acct.locale || 'en', // should be set, but fallback if not
+        },
+      };
+      await fxaMailer.sendPasswordChangeRequiredEmail({
+        ...FxaMailerFormat.account(acct as unknown as any), // this _should_ be safe
+        ...(await FxaMailerFormat.metricsContext(request)),
+        ...FxaMailerFormat.localTime(request),
+        ...FxaMailerFormat.location(request),
+        ...FxaMailerFormat.device(request),
+        ...FxaMailerFormat.sync(false),
+      });
       await accountEventManager.recordSecurityEvent(authDb, {
         uid: acct.uid,
         name: 'account.must_reset',

--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -157,36 +157,22 @@ async function run() {
           }
 
           const account = await db.account(uid);
-          // NOTE: If we need to disable these for any reason, the `method` names will
-          // be the old mailer style `verificationReminderFirstEmail`, not just the template
-          // name `verificationReminderFirst`.
-          if (fxaMailer.canSend(method)) {
-            // because of how verification-reminders keys are defined, we need to additionally
-            // prepend 'send' and capitalize the first letter to match the full method name in fxa-mailer
-            const fxaMailerMethod = `send${method[0].toUpperCase()}${method.substring(1)}`;
-            await fxaMailer[fxaMailerMethod]({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync(false),
-              email: account.email,
-              code: account.emailCode,
-              flowBeginTime,
-              flowId,
-              uid,
-            });
-          } else {
-            await mailer[method]({
-              acceptLanguage: account.locale,
-              code: account.emailCode,
-              email: account.email,
-              flowBeginTime,
-              flowId,
-              uid,
-            });
-          }
+          // because of how verification-reminders keys are defined, we need to additionally
+          // prepend 'send' and capitalize the first letter to match the full method name in fxa-mailer
+          const fxaMailerMethod = `send${method[0].toUpperCase()}${method.substring(1)}`;
+          await fxaMailer[fxaMailerMethod]({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync(false),
+            email: account.email,
+            code: account.emailCode,
+            flowBeginTime,
+            flowId,
+            uid,
+          });
           // eslint-disable-next-line require-atomic-updates
           sent[uid] = true;
         } catch (err) {
@@ -360,27 +346,16 @@ async function run() {
           }
 
           const account = await db.account(uid);
-          if (fxaMailer.canSend(method)) {
-            const fxaMailerMethod = `send${method[0].toUpperCase()}${method.substring(1)}`;
-            await fxaMailer[fxaMailerMethod]({
-              ...FxaMailerFormat.account(account),
-              ...(await FxaMailerFormat.metricsContext(request)),
-              ...FxaMailerFormat.localTime(request),
-              ...FxaMailerFormat.location(request),
-              ...FxaMailerFormat.device(request),
-              ...FxaMailerFormat.sync('sync'),
-              productName: 'Firefox',
-            });
-          } else {
-            await mailer[method]({
-              acceptLanguage: account.locale,
-              code: account.emailCode,
-              email: account.email,
-              flowBeginTime,
-              flowId,
-              uid,
-            });
-          }
+          const fxaMailerMethod = `send${method[0].toUpperCase()}${method.substring(1)}`;
+          await fxaMailer[fxaMailerMethod]({
+            ...FxaMailerFormat.account(account),
+            ...(await FxaMailerFormat.metricsContext(request)),
+            ...FxaMailerFormat.localTime(request),
+            ...FxaMailerFormat.location(request),
+            ...FxaMailerFormat.device(request),
+            ...FxaMailerFormat.sync('sync'),
+            productName: 'Firefox',
+          });
           // eslint-disable-next-line require-atomic-updates
           sent[uid] = true;
         } catch (err) {

--- a/packages/fxa-auth-server/test/fixtures/fxa-mailer.ts
+++ b/packages/fxa-auth-server/test/fixtures/fxa-mailer.ts
@@ -21,9 +21,6 @@ import { FxaMailer } from '../../lib/senders/fxa-mailer';
  * with {@link uninstallMockFxaMailer} in `afterEach`** — TypeDI state is not
  * reset by Jest's `clearMocks`, so an un-removed mock leaks into later specs.
  *
- * `canSend` defaults to `true` so the modern FxaMailer code path is exercised;
- * override it (or any method) via the argument or `.mockReturnValue(...)`.
- *
  * Prefer mocking `FxaMailer` over the legacy `mailer`. Tests that only exercise
  * the FxaMailer path can pass a throwaway stub for the legacy `mailer` argument
  * rather than mocking its untyped surface.
@@ -38,10 +35,7 @@ import { FxaMailer } from '../../lib/senders/fxa-mailer';
 export function installMockFxaMailer(
   overrides?: PartialFuncReturn<FxaMailer>
 ): DeepMocked<FxaMailer> {
-  const mailer = createMock<FxaMailer>({
-    canSend: () => true,
-    ...overrides,
-  });
+  const mailer = createMock<FxaMailer>({ ...overrides });
   Container.set(FxaMailer, mailer);
   return mailer;
 }


### PR DESCRIPTION
## Because

- `canSend` was a migration flag for `libs/email-sender`. Every email goes through the new mailer now, and a rollback is off the table, so the flag and the old-mailer branches behind it are dead weight.
- Each guarded call site kept an `else` branch that sent through the old mailer. That branch became unreachable, so it goes with the flag.

## This pull request

- Removes the `canSend` method from `FxaMailer` in `lib/senders/fxa-mailer.ts`.
- Removes the `smtp.fxaMailerDisableSend` config block and its `SMTP_FXA_MAILER_DISABLE_SEND` env entry from `config/index.ts`.
- Unwraps 54 guarded call sites across the route handlers, `lib/inactive-accounts/index.ts`, `scripts/verification-reminders.js`, and `scripts/recorded-future/check-and-reset.ts`. The new mailer send stays; the old-mailer `else` branch goes.
- Drops the locals, imports, and assignments that only fed the removed branches.
- Removes the `canSend` tests and mocks, including the tests that only asserted the disabled or old-mailer path, in `fxa-mailer.spec.ts`, `passkeys.spec.ts`, and `test/fixtures/fxa-mailer.ts`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13034

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/senders/fxa-mailer.ts` and `config/index.ts` hold the actual removal. The rest is call-site unwrapping.
- Suggested review order: mailer, then config, then the routes, then the two scripts, then the specs.
- Risky or complex parts: the diff must not lose a send. Every changed file keeps the same count of `fxaMailer.send*` calls as `main`. `unblock-codes.js` also loses a `db.accountEmails(uid)` call, and `check-and-reset.ts` loses its `bouncesFn`/`sendersFn` setup, because nothing but the old mailer used them.

## Screenshots (Optional)

## Other information (Optional)

Operators should know that emails `SMTP_FXA_MAILER_DISABLE_SEND` could suppress can no longer be turned off by config. The escape hatch is gone, which is what the ticket asks for.

AC 4 asks for the config value to go from the auth server and the admin server. `fxa-admin-server` has no occurrence of `fxaMailerDisableSend` or `SMTP_FXA_MAILER_DISABLE_SEND`, so there is nothing to remove there.

Two follow-ups I did not do here:

- 13 route modules no longer use the legacy `mailer` argument they are constructed with. Dropping that parameter means touching module signatures, call sites, and tests, which is wider than this ticket allows.
- `totp.js` line 238 spreads `FxaMailerFormat.metricsContext(request)` without `await`, so the metrics fields never reach `sendPostChangeTwoStepAuthenticationEmail`. It predates this change and sits in the branch I kept. Every other call site awaits it.

Local verification:

- `npx nx lint fxa-auth-server` passes.
- The Jest unit suite reports 3731 passed and 13 failed. All 13 failures reproduce on an unmodified tree. `account.spec.ts` hits `util.isError is not a function` under Node 24, and `config/index.spec.ts` trips on a local `snsTopicEndpoint` setting. Neither is related to this change.
- `git grep "canSend"` returns only `canSendToIOS` in `lib/push.js`, which has nothing to do with the mailer.

