### PR TITLE
fix(auth-server): validate credentialId and aaguid formats in passkey responses

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { createMock } from '@golevelup/ts-jest';
+import type { Schema } from 'joi';
 import { StatsD } from 'hot-shots';
 import { AuthLogger as AuthLoggerType } from '../types';
 import {
@@ -5029,5 +5030,46 @@ describe('/account/emails', () => {
       originalEmail: 'signup@example.com',
       primaryEmail: 'signup+1@example.com',
     });
+  });
+});
+
+describe('/account response schema - passkeys', () => {
+  const VALID_PASSKEY = {
+    credentialId: 'A_z-09Aa',
+    name: 'Work laptop',
+    createdAt: 1700000000000,
+    lastUsedAt: null,
+    transports: ['internal'],
+    aaguid: 'adce0002-35bc-c60a-648b-0b25f1f05503',
+    backupEligible: true,
+    backupState: true,
+    prfEnabled: false,
+  };
+
+  let schema: Schema;
+
+  beforeEach(() => {
+    const routes = makeRoutes({});
+    schema = getRoute(routes, '/account', 'GET').options.response.schema;
+  });
+
+  it('accepts a well-formed passkey', () => {
+    const { error } = schema.validate({ passkeys: [VALID_PASSKEY] });
+    expect(error).toBeUndefined();
+  });
+
+  // The shared schema itself is covered in passkeys.spec.ts; this checks wiring.
+  it('rejects an aaguid that is not a hyphenated UUID', () => {
+    const { error } = schema.validate({
+      passkeys: [
+        { ...VALID_PASSKEY, aaguid: 'adce000235bcc60a648b0b25f1f05503' },
+      ],
+    });
+    expect(error?.details).toEqual([
+      expect.objectContaining({
+        context: expect.objectContaining({ key: 'aaguid' }),
+        type: 'string.pattern.base',
+      }),
+    ]);
   });
 });

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -64,6 +64,7 @@ import {
 import { RelyingPartyConfigurationManager } from '@fxa/shared/cms';
 import { OtpUtils } from './utils/otp';
 import { getExistingSecondaryEmailRecord } from './emails';
+import { passkeyResponseSchema } from './passkeys';
 import { Redis } from 'ioredis';
 import { FxaMailer } from '../senders/fxa-mailer';
 import { FxaMailerFormat } from '../senders/fxa-mailer-format';
@@ -3234,22 +3235,7 @@ export const accountRoutes = (
                 })
               )
               .optional(),
-            passkeys: isA
-              .array()
-              .items(
-                isA.object({
-                  credentialId: isA.string().required(),
-                  name: isA.string().required(),
-                  createdAt: isA.number().required(),
-                  lastUsedAt: isA.number().allow(null).required(),
-                  transports: isA.array().items(isA.string()).required(),
-                  aaguid: isA.string().required(),
-                  backupEligible: isA.boolean().required(),
-                  backupState: isA.boolean().required(),
-                  prfEnabled: isA.boolean().required(),
-                })
-              )
-              .optional(),
+            passkeys: isA.array().items(passkeyResponseSchema).optional(),
             subscriptions: isA
               .array()
               .items(

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -11,7 +11,11 @@ import {
   isPasskeyRegistrationEnabled,
   isPasskeyAuthenticationEnabled,
 } from '../passkey-utils';
-import { passkeyRoutes, PasskeyHandler } from './passkeys';
+import {
+  passkeyRoutes,
+  passkeyResponseSchema,
+  PasskeyHandler,
+} from './passkeys';
 import { ConfigType } from '../../config';
 import { FxaMailer } from '../senders/fxa-mailer';
 import { OAuthClientInfoServiceName } from '../senders/oauth_client_info';
@@ -2115,5 +2119,92 @@ describe('passkeys routes', () => {
         ]);
       });
     });
+  });
+
+  describe('passkeyResponseSchema', () => {
+    const VALID_PASSKEY = {
+      credentialId: 'A_z-09Aa',
+      name: 'Work laptop',
+      createdAt: 1700000000000,
+      lastUsedAt: null,
+      transports: ['internal'],
+      aaguid: 'adce0002-35bc-c60a-648b-0b25f1f05503',
+      backupEligible: true,
+      backupState: true,
+      prfEnabled: false,
+    };
+    const BAD_AAGUID_PASSKEY = {
+      ...VALID_PASSKEY,
+      aaguid: 'adce000235bcc60a648b0b25f1f05503',
+    };
+
+    function getResponseSchema(method: string, path: string): Schema {
+      const all = passkeyRoutes(
+        customs,
+        db,
+        config,
+        statsd,
+        glean,
+        log,
+        mailer
+      );
+      const route = all.find(
+        (r: any) => r.path === path && r.method === method
+      );
+      const schema = (route?.options as { response?: { schema?: Schema } })
+        ?.response?.schema;
+      if (!schema) {
+        throw new Error(`No response schema on route: ${method} ${path}`);
+      }
+      return schema;
+    }
+
+    it('accepts a well-formed passkey', () => {
+      const { error } = passkeyResponseSchema.validate(VALID_PASSKEY);
+      expect(error).toBeUndefined();
+    });
+
+    it('rejects a non-base64url credentialId', () => {
+      const { error } = passkeyResponseSchema.validate({
+        ...VALID_PASSKEY,
+        credentialId: 'has/slash',
+      });
+      expect(error?.details).toEqual([
+        expect.objectContaining({
+          context: expect.objectContaining({ key: 'credentialId' }),
+          type: 'string.pattern.base',
+        }),
+      ]);
+    });
+
+    it('rejects an aaguid that is not a hyphenated UUID', () => {
+      const { error } = passkeyResponseSchema.validate(BAD_AAGUID_PASSKEY);
+      expect(error?.details).toEqual([
+        expect.objectContaining({
+          context: expect.objectContaining({ key: 'aaguid' }),
+          type: 'string.pattern.base',
+        }),
+      ]);
+    });
+
+    // `GET /passkeys` returns an array, the other two a single object.
+    const routeCases: Array<[string, string, unknown]> = [
+      ['POST', '/passkey/registration/finish', BAD_AAGUID_PASSKEY],
+      ['GET', '/passkeys', [BAD_AAGUID_PASSKEY]],
+      ['PATCH', '/passkey/{credentialId}', BAD_AAGUID_PASSKEY],
+    ];
+
+    it.each(routeCases)(
+      '%s %s validates its response against the schema',
+      (method, path, response) => {
+        const { error } = getResponseSchema(method, path).validate(response);
+        expect(error?.details[0]).toEqual(
+          expect.objectContaining({
+            context: expect.objectContaining({ key: 'aaguid' }),
+            type: 'string.pattern.base',
+          })
+        );
+      }
+    );
   });
 });

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -38,6 +38,24 @@ const base64urlString = (maxLen: number) =>
 const base64urlCredentialId = () => base64urlString(1364);
 const base64urlChallenge = () => base64urlString(64);
 
+// Mirrors `AAGUID_RE` in libs/accounts/passkey, which rejects the same
+// values at the DB boundary.
+const AAGUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Shape of a passkey as returned by the passkey and `/account` routes. */
+export const passkeyResponseSchema = isA.object({
+  credentialId: base64urlCredentialId().required(),
+  name: isA.string().required(),
+  createdAt: isA.number().required(),
+  lastUsedAt: isA.number().allow(null).required(),
+  transports: isA.array().items(isA.string()).required(),
+  aaguid: isA.string().regex(AAGUID_PATTERN).required(),
+  backupEligible: isA.boolean().required(),
+  backupState: isA.boolean().required(),
+  prfEnabled: isA.boolean().required(),
+});
+
 /** Subset of the Customs service used by passkey routes. */
 interface Customs {
   /**
@@ -844,17 +862,7 @@ export const passkeyRoutes = (
           }),
         },
         response: {
-          schema: isA.object({
-            credentialId: isA.string().required(),
-            name: isA.string().required(),
-            createdAt: isA.number().required(),
-            lastUsedAt: isA.number().allow(null).required(),
-            transports: isA.array().items(isA.string()).required(),
-            aaguid: isA.string().required(),
-            backupEligible: isA.boolean().required(),
-            backupState: isA.boolean().required(),
-            prfEnabled: isA.boolean().required(),
-          }),
+          schema: passkeyResponseSchema,
         },
       },
       handler: async function (request: AuthRequest) {
@@ -874,19 +882,7 @@ export const passkeyRoutes = (
           payload: false,
         },
         response: {
-          schema: isA.array().items(
-            isA.object({
-              credentialId: isA.string().required(),
-              name: isA.string().required(),
-              createdAt: isA.number().required(),
-              lastUsedAt: isA.number().allow(null).required(),
-              transports: isA.array().items(isA.string()).required(),
-              aaguid: isA.string().required(),
-              backupEligible: isA.boolean().required(),
-              backupState: isA.boolean().required(),
-              prfEnabled: isA.boolean().required(),
-            })
-          ),
+          schema: isA.array().items(passkeyResponseSchema),
         },
       },
       handler: function (request: AuthRequest) {
@@ -1022,17 +1018,7 @@ export const passkeyRoutes = (
           }),
         },
         response: {
-          schema: isA.object({
-            credentialId: isA.string().required(),
-            name: isA.string().required(),
-            createdAt: isA.number().required(),
-            lastUsedAt: isA.number().allow(null).required(),
-            transports: isA.array().items(isA.string()).required(),
-            aaguid: isA.string().required(),
-            backupEligible: isA.boolean().required(),
-            backupState: isA.boolean().required(),
-            prfEnabled: isA.boolean().required(),
-          }),
+          schema: passkeyResponseSchema,
         },
       },
       handler: function (request: AuthRequest) {


### PR DESCRIPTION
## Because

- The passkey response schemas typed `credentialId` and `aaguid` as plain strings, so the route schemas said nothing about the wire format.
- The same 9-field passkey object appeared in four response schemas. Four copies drift.

## This pull request

- Adds one `passkeyResponseSchema` in `routes/passkeys.ts`. It checks `credentialId` against the base64url alphabet and `aaguid` against a hyphenated UUID.
- Points all four sites at it: the responses for `POST /passkey/registration/finish`, `GET /passkeys`, `PATCH /passkey/{credentialId}`, and the passkey list inside `GET /account`.
- Adds tests for the schema, plus one per route to check each one uses it.

Request-side validation already called `base64urlCredentialId()` and is untouched. So is the repository-layer check, which stays as a second line of defense. Nothing about the wire format changes.

One thing to flag: the aaguid regex is a copy of `AAGUID_RE` in `libs/accounts/passkey`, which is module-private. `BASE64URL_PATTERN` already duplicates `BASE64URL_RE` the same way. Exporting both from the lib and using one definition is a reasonable follow-up, but it turns this into a cross-package change, so I left it alone.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13623

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `passkeys.ts`, mainly `passkeyResponseSchema` and `AAGUID_PATTERN`.
- Suggested review order: `passkeys.ts`, then `account.ts`, then the two spec files.
- Risky or complex parts: a stricter response schema means a bad stored row now fails the response, not just one field. On `GET /account` that is the whole settings page load. I do not think it can happen: `aaguid` comes out of a `BINARY(16)` column through `bufferToAaguid`, and `credentialId` comes from `toString('base64url')`. Both always match. Worth a second opinion.

## Screenshots (Optional)

None. No user interface change.

## Other information (Optional)

Ran locally, in `packages/fxa-auth-server`:

- `npx jest lib/routes/passkeys.spec.ts lib/routes/account.spec.ts`, 247 tests pass.
- `npx nx lint fxa-auth-server` passes.

I did not run the functional tests. The local sandbox stack has open issues, so CI covers them.
