### PR TITLE
chore(shared): remove the legacy IP HMAC lookup from security events

### DIFF
--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -105,26 +105,6 @@ function ipHmac(key: Buffer, uid: Buffer, addr: string) {
 
   return hmac.digest();
 }
-/**
- * This is used during lookups only to match records written before we
- * stopped prefixing ipv4 addresses; FXA-13433.
- *
- * After some amount of time, we will have more recent login records with the new HMAC than
- * the old, and we can remove this legacy HMAC function and the associated tests.
- *
- * Cleanup ticket: https://mozilla-hub.atlassian.net/browse/FXA-13667
- */
-function ipHmacLegacy(key: Buffer, uid: Buffer, addr: string) {
-  addr = sanitizeIp(addr);
-  if (ip.isV4Format(addr)) {
-    addr = '::' + addr;
-  }
-  const hmac = crypto.createHmac('sha256', key);
-  hmac.update(uid);
-  hmac.update(ip.toBuffer(addr));
-
-  return hmac.digest();
-}
 
 export class SecurityEvent extends BaseAuthModel {
   public static tableName = 'securityEvents';
@@ -203,8 +183,7 @@ export class SecurityEvent extends BaseAuthModel {
 
   static async findByUidAndIP(uid: string, ipAddr: string, ipHmacKey: string) {
     const id = uuidTransformer.to(uid);
-    const key = Buffer.from(ipHmacKey);
-    const hmacs = [ipHmac(key, id, ipAddr), ipHmacLegacy(key, id, ipAddr)];
+    const hmac = ipHmac(Buffer.from(ipHmacKey), id, ipAddr);
     return SecurityEvent.query()
       .select(
         'securityEventNames.name as name',
@@ -219,7 +198,7 @@ export class SecurityEvent extends BaseAuthModel {
         'securityEventNames.id'
       )
       .where('securityEvents.uid', id)
-      .whereIn('securityEvents.ipAddrHmac', hmacs)
+      .andWhere('securityEvents.ipAddrHmac', hmac)
       .orderBy('securityEvents.createdAt', 'DESC')
       .limit(20);
   }
@@ -230,8 +209,7 @@ export class SecurityEvent extends BaseAuthModel {
     ipHmacKey: string
   ) {
     const id = uuidTransformer.to(uid);
-    const key = Buffer.from(ipHmacKey);
-    const hmacs = [ipHmac(key, id, ipAddr), ipHmacLegacy(key, id, ipAddr)];
+    const hmac = ipHmac(Buffer.from(ipHmacKey), id, ipAddr);
     return SecurityEvent.query()
       .select(
         'securityEventNames.name as name',
@@ -248,7 +226,7 @@ export class SecurityEvent extends BaseAuthModel {
       .where('securityEvents.uid', id)
       .where('securityEvents.verified', 1)
       .where('securityEvents.nameId', EVENT_NAMES['account.login'])
-      .whereIn('securityEvents.ipAddrHmac', hmacs)
+      .andWhere('securityEvents.ipAddrHmac', hmac)
       .orderBy('securityEvents.createdAt', 'DESC')
       .limit(20);
   }


### PR DESCRIPTION
## Because

- FXA-13433 stopped prefixing IPv4 addresses before the HMAC. To keep the recent IP bypass working while old rows aged out, `findByUidAndIP` and `findByUidAndIPAndVerifiedLogin` matched both the new and the old HMAC with `whereIn`.
- That window has passed. Every recent security event now uses the new format, so the second value in the `IN` list never matches anything.

## This pull request

- Replaces `whereIn` with `andWhere` on `securityEvents.ipAddrHmac` in `findByUidAndIP` and `findByUidAndIPAndVerifiedLogin`.
- Deletes `ipHmacLegacy` and the doc comment above it that named this ticket as the cleanup.
- Inlines the `Buffer.from(ipHmacKey)` local, which only existed so two HMAC calls could share it. `create` already calls `ipHmac` this way.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13667

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-shared/db/models/auth/security-event.ts` is the only file touched.
- Suggested review order: the two query methods first, then the deleted helper.
- Risky or complex parts: these two queries back the recent IP bypass at sign-in. If any pre-FXA-13433 row were still inside the recency window, its owner would get an extra verification prompt rather than a wrongly granted bypass, so the failure mode is safe. `sanitizeIp`, `ipHmac`, the `.limit(20)`, and the callers in `fxa-auth-server/lib/db.ts` are all unchanged. The method signatures do not change, so no caller needs an edit.

## Screenshots (Optional)

## Other information (Optional)

No test changes. Nothing exercised `ipHmacLegacy`, and the only `security-event` unit tests cover `sanitizeIp`, which this leaves alone. Those 13 tests pass.

One style note for reviewers: every other clause in these two queries uses `.where`, and in Knex `.andWhere` is the same method. I used `.andWhere` because the ticket asks for it by name. Say the word if you would rather see `.where` for consistency with the file.

Verification I ran locally:

- `npx nx lint fxa-shared` passes.
- `npx tsc -p packages/fxa-shared/tsconfig.json --noEmit` reports 45 errors. They are all Stripe API mismatches under `libs/payments` and `packages/fxa-shared/payments`, and none are in `db/models/auth`. This is a deletion from a widely consumed package, so the type check matters: it confirms nothing downstream depended on the removed helper.

