### PR TITLE
chore(content-server): replace mkdirp with native fs.mkdirSync

### DIFF
--- a/packages/fxa-content-server/grunttasks/l10n-create-json.js
+++ b/packages/fxa-content-server/grunttasks/l10n-create-json.js
@@ -4,7 +4,6 @@
 
 // grunt task convert translated .po files to .json
 
-var mkdirp = require('mkdirp');
 var fs = require('fs');
 var path = require('path');
 
@@ -18,7 +17,7 @@ module.exports = function (grunt) {
     'Create localized string bundles for the client.',
     function () {
       if (!fs.existsSync(jsonOutputPath)) {
-        mkdirp.sync(jsonOutputPath);
+        fs.mkdirSync(jsonOutputPath, { recursive: true });
       }
 
       grunt.task.run(['copy:strings', 'po2json']);

--- a/packages/fxa-content-server/grunttasks/l10n-extract.js
+++ b/packages/fxa-content-server/grunttasks/l10n-extract.js
@@ -7,7 +7,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var mkdirp = require('mkdirp');
 var extract = require('jsxgettext-recursive-next');
 var execSync = require('child_process').execSync;
 
@@ -31,7 +30,7 @@ module.exports = function (grunt) {
       var done = this.async();
 
       if (!fs.existsSync(messagesOutputPath)) {
-        mkdirp.sync(messagesOutputPath);
+        fs.mkdirSync(messagesOutputPath, { recursive: true });
       }
       // jsxgettext does not support ES2015, only ES5. Run babel to convert
       // then run the extractor on the ES5 files.

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -94,7 +94,6 @@
     "jsxgettext-recursive-next": "1.1.0",
     "legal-docs": "https://github.com/mozilla/legal-docs.git#68a02d3a95f22fb10db68893bb54e49bc0604f69",
     "load-grunt-tasks": "^5.1.0",
-    "mkdirp": "3.0.1",
     "mocha": "^10.4.0",
     "morgan": "^1.11.0",
     "mozlog": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33867,7 +33867,6 @@ __metadata:
     legal-docs: "https://github.com/mozilla/legal-docs.git#68a02d3a95f22fb10db68893bb54e49bc0604f69"
     load-grunt-tasks: "npm:^5.1.0"
     mini-css-extract-plugin: "npm:^2.9.2"
-    mkdirp: "npm:3.0.1"
     mocha: "npm:^10.4.0"
     morgan: "npm:^1.11.0"
     mozlog: "npm:^3.0.2"
@@ -43342,15 +43341,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:3.0.1, mkdirp@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
-  languageName: node
-  linkType: hard
-
 "mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.3, mkdirp@npm:~0.5.1":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
@@ -43368,6 +43358,15 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "mkdirp@npm:3.0.1"
+  bin:
+    mkdirp: dist/cjs/src/bin.js
+  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- `mkdirp` predates Node 10. Native `fs` does recursive mkdir, so the dependency adds nothing.
- Part of the dependency reduction work under FXA-13426.

## This pull request

- Replaces both `mkdirp.sync(...)` calls in the l10n grunt tasks with `fs.mkdirSync(path, { recursive: true })`. The two files are `grunttasks/l10n-create-json.js` and `grunttasks/l10n-extract.js`.
- Removes the `mkdirp` require from both files. Each one already required `fs` on the line above.
- Drops `mkdirp` from `packages/fxa-content-server/package.json` and updates `yarn.lock`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13919

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the two grunt tasks in `packages/fxa-content-server/grunttasks/`.
- Suggested review order: `l10n-create-json.js`, then `l10n-extract.js`, then the `package.json` and `yarn.lock` removal.
- Risky or complex parts: none. `mkdirp.sync` returned the full path. `fs.mkdirSync` returns the first directory it created, or `undefined`. Neither call site reads the result, so the difference does not matter. The `if (!fs.existsSync(...))` guards are now redundant, but I left them. Removing them is outside this ticket.

## Screenshots (Optional)

## Other information (Optional)

- `fxa-content-server` has no `test-unit` target, and these are grunt tasks with no unit tests. I ran the `l10n-create-json` task body against a stub grunt and confirmed it creates the output directory. I also ran `node --check` on both files.
- `npx nx lint fxa-content-server` exits 0.
- The `yarn.lock` diff only touches `mkdirp`. The workspace dependency line goes away, and the `mkdirp@npm:3.0.1` selector merges into the existing `mkdirp@npm:^3.0.0` entry, which a transitive dependency still needs.
- `packages/fxa-geodb/test/maxmind-db-downloader.js` mentions mkdirp in a comment. It never imported the package, so I left it alone.
