### PR TITLE
refactor(deps): replace rimraf with native fs.rmSync

### DIFF
--- a/packages/fxa-auth-server/test/remote/oauth_key_management.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_key_management.in.spec.ts
@@ -7,7 +7,6 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const crypto = require('crypto');
-const rimraf = require('rimraf');
 
 describe('the signing-key management scripts', () => {
   let runScript: (name: string) => Buffer;
@@ -47,7 +46,7 @@ describe('the signing-key management scripts', () => {
   });
 
   afterEach(() => {
-    rimraf.sync(workDir);
+    fs.rmSync(workDir, { recursive: true, force: true });
   });
 
   it('work as intended', () => {

--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.in.spec.ts
@@ -7,7 +7,6 @@ const cp = require('child_process');
 const fs = require('fs');
 const mocks = require('../../test/mocks');
 const path = require('path');
-const rimraf = require('rimraf');
 const crypto = require('crypto');
 
 const ROOT_DIR = '../..';
@@ -77,7 +76,7 @@ describe('#integration - scripts/bulk-mailer', () => {
   let db: any;
 
   beforeAll(async () => {
-    rimraf.sync(OUTPUT_DIRECTORY);
+    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true });
     fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
 
     db = await DB.connect(config);
@@ -100,7 +99,7 @@ describe('#integration - scripts/bulk-mailer', () => {
     ]);
     await db.close();
 
-    rimraf.sync(OUTPUT_DIRECTORY);
+    fs.rmSync(OUTPUT_DIRECTORY, { recursive: true, force: true });
   });
 
   it('fails if --input missing', async () => {

--- a/packages/fxa-geodb/test/maxmind-db-downloader.js
+++ b/packages/fxa-geodb/test/maxmind-db-downloader.js
@@ -9,7 +9,6 @@ var fs = require('fs');
 var MaxmindDbDownloader = require('../lib/maxmind-db-downloader');
 var path = require('path');
 var Promise = require('bluebird');
-var rimraf = require('rimraf');
 var sinon = require('sinon');
 var assert = chai.assert;
 
@@ -28,7 +27,7 @@ describe('maxmind-db-downloader', function () {
     downloadPromiseFunctions = null;
     // cleanup, remove the created directory
     if (fs.statSync(expectedTargetDirPath).isDirectory()) {
-      rimraf.sync(expectedTargetDirPath);
+      fs.rmSync(expectedTargetDirPath, { recursive: true, force: true });
     }
     targetDirPath = '';
     maxmindDbDownloader.stop();

--- a/packages/fxa-profile-server/scripts/run_dev.js
+++ b/packages/fxa-profile-server/scripts/run_dev.js
@@ -8,7 +8,6 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const rimraf = require('rimraf');
 process.env.NODE_ENV = 'development';
 
 var childServer = cp.fork(path.join(__dirname, '..', 'bin', 'server.js'));
@@ -30,5 +29,8 @@ process.on('exit', function () {
   } catch (e) {
     console.log(e); // eslint-disable-line no-console
   }
-  rimraf.sync(path.join(__dirname, '..', 'var', 'public'));
+  fs.rmSync(path.join(__dirname, '..', 'var', 'public'), {
+    recursive: true,
+    force: true,
+  });
 });


### PR DESCRIPTION
## Because

- Node has removed directories recursively since 14.14, so `rimraf` is a dependency for something the standard library already does.
- Part of FXA-13426, dependency reduction and modernization.

## This pull request

- Swaps the five `rimraf.sync` calls for `fs.rmSync(path, { recursive: true, force: true })`.
- Drops the `rimraf` require from `oauth_key_management.in.spec.ts`, `bulk-mailer.in.spec.ts`, `maxmind-db-downloader.js`, and `run_dev.js`. All four files already required `fs`.
- Keeps `force: true` on every call. Without it `fs.rmSync` throws on a missing path where `rimraf.sync` does not, and some of these call sites rely on that.
- Leaves `rimraf` as a devDependency. 12 `package.json` files still run `rimraf dist` in a `clean` script, so dropping the dependency needs a cross-platform answer that this ticket does not cover.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13920

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the four call sites. Check that `force: true` is on each one.
- Suggested review order: `run_dev.js` first, then the three test files.
- Risky or complex parts: none. Every call passes one concrete path, so there is no glob to expand.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

Ran locally, all green:

- `mocha test/maxmind-db-downloader.js` in fxa-geodb: 5 passing, 0 failing.
- `oauth_key_management.in.spec.ts`: 1 passed, 0 failed.
- `bulk-mailer.in.spec.ts`: 7 passed, 0 failed.
- fxa-profile-server jest unit suite: 14 passed, 0 failed.
- `node --check packages/fxa-profile-server/scripts/run_dev.js`, because that script has no test.
- `nx lint` for fxa-auth-server, fxa-geodb, and fxa-profile-server.

Functional tests were not run in this environment. CI covers them.
