### PR TITLE
chore(deps): remove the fast-text-encoding polyfill

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -398,12 +398,6 @@ export default class AuthClient {
   }
 
   static async create(authServerUri: string, options?: AuthClientOptions) {
-    if (typeof TextEncoder === 'undefined') {
-      await import(
-        // @ts-ignore
-        /* webpackChunkName: "fast-text-encoding" */ 'fast-text-encoding'
-      );
-    }
     await crypto.checkWebCrypto();
     return new AuthClient(authServerUri, options);
   }

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -51,13 +51,11 @@
   "author": "",
   "license": "MPL-2.0",
   "devDependencies": {
-    "@types/fast-text-encoding": "^1",
     "@types/mocha": "^10",
     "@types/node": "^22.13.5",
     "@types/prettier": "^2",
     "eslint": "^8.38.0",
     "eslint-config-react-app": "^7.0.1",
-    "fast-text-encoding": "^1.0.4",
     "mocha": "^10.4.0",
     "prettier": "^3.5.3",
     "typescript": "5.5.3"

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -55,7 +55,6 @@
     "duration-js": "4.0.0",
     "expose-loader": "5.0.0",
     "express": "^4.21.2",
-    "fast-text-encoding": "^1.0.4",
     "fxa-auth-client": "workspace:*",
     "fxa-auth-server": "workspace:*",
     "fxa-geodb": "workspace:*",

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -62,7 +62,6 @@ const webpackConfig = {
       cocktail: require.resolve('./app/scripts/lib/cocktail'),
       draggable: require.resolve('jquery-ui/ui/widgets/draggable'),
       duration: require.resolve('duration-js/duration'),
-      'fast-text-encoding': require.resolve('fast-text-encoding'),
       fxaCryptoDeriver: path.resolve(
         __dirname,
         '../../dist/libs/vendored/crypto-relier/src/index.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -20529,13 +20529,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/fast-text-encoding@npm:^1":
-  version: 1.0.3
-  resolution: "@types/fast-text-encoding@npm:1.0.3"
-  checksum: 10c0/9ec0ca8f2461202ac3321160b0e7b8d07a4728b1b3197fa68c672d792cb7cdfff08924f81b3564d21db9bcb9c90e47680f7ff7b73195192776baecc17293c9c2
-  languageName: node
-  linkType: hard
-
 "@types/file-loader@npm:^5.0.0":
   version: 5.0.4
   resolution: "@types/file-loader@npm:5.0.4"
@@ -32254,13 +32247,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-text-encoding@npm:^1.0.4":
-  version: 1.0.6
-  resolution: "fast-text-encoding@npm:1.0.6"
-  checksum: 10c0/e1d0381bda229c92c7906f63308f3b9caca8c78b732768b1ee16f560089ed21bc159bbe1434138ccd3815931ec8d4785bdade1ad1c45accfdf27ac6606ac67d2
-  languageName: node
-  linkType: hard
-
 "fast-uri@npm:^3.0.1":
   version: 3.1.5
   resolution: "fast-uri@npm:3.1.5"
@@ -33646,13 +33632,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fxa-auth-client@workspace:packages/fxa-auth-client"
   dependencies:
-    "@types/fast-text-encoding": "npm:^1"
     "@types/mocha": "npm:^10"
     "@types/node": "npm:^22.13.5"
     "@types/prettier": "npm:^2"
     eslint: "npm:^8.38.0"
     eslint-config-react-app: "npm:^7.0.1"
-    fast-text-encoding: "npm:^1.0.4"
     mocha: "npm:^10.4.0"
     prettier: "npm:^3.5.3"
     typescript: "npm:5.5.3"
@@ -33816,7 +33800,6 @@ __metadata:
     eslint: "npm:^7.32.0"
     expose-loader: "npm:5.0.0"
     express: "npm:^4.21.2"
-    fast-text-encoding: "npm:^1.0.4"
     firefox-profile: "npm:4.7.0"
     fxa-auth-client: "workspace:*"
     fxa-auth-server: "workspace:*"


### PR DESCRIPTION
## Because

- `TextEncoder` and `TextDecoder` are globals in every Node and browser target FxA supports, so the `fast-text-encoding` polyfill never loads.
- The import only ran for its side effect. Nothing in the repo imports a name from it.

## This pull request

- Removes the `typeof TextEncoder === 'undefined'` guard and its dynamic import from `AuthClient.create` in `client.ts`.
- Removes the `fast-text-encoding` resolve alias from `webpack.config.js`.
- Drops `fast-text-encoding` and `@types/fast-text-encoding` from the `fxa-auth-client` and `fxa-content-server` manifests, and updates `yarn.lock` to match.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13921

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `AuthClient.create` in `packages/fxa-auth-client/lib/client.ts`.
- Suggested review order: `client.ts`, then the webpack alias, then the two manifests and the lockfile.
- Risky or complex parts: the published-package note below. The premise that `TextEncoder` exists in all supported targets is the reviewer's to confirm.

## Screenshots (Optional)

## Other information (Optional)

`packages/fxa-auth-client` publishes to npm, so third parties consume it. Today, on an environment with no global `TextEncoder`, `AuthClient.create()` recovers by loading the polyfill. After this change it does not, and such a consumer fails later inside `checkWebCrypto` or during key derivation. Nothing replaces the guard, since the ticket asks for removal rather than a substitute. No exported signature moves, so this is not an API change.

Verified locally: `nx lint fxa-auth-client` and `nx lint fxa-content-server` pass, `tsc -p packages/fxa-auth-client/tsconfig.json --noEmit` is clean, and the `fxa-auth-client` unit suite passes (47 tests). No tests were added or changed. Functional tests were not run.
