### PR TITLE
chore(customs): replace deep-equal with util.isDeepStrictEqual

### DIFF
--- a/packages/fxa-customs-server/lib/settings/limits.js
+++ b/packages/fxa-customs-server/lib/settings/limits.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const deepEqual = require('deep-equal');
+const { isDeepStrictEqual } = require('util');
 const { initialCapital } = require('../utils');
 
 module.exports = (config, Settings, log) => {
@@ -87,7 +87,7 @@ module.exports = (config, Settings, log) => {
             message: 'types do not match',
           });
           settings[key] = current;
-        } else if (!deepEqual(current, future)) {
+        } else if (!isDeepStrictEqual(current, future)) {
           log.info({
             op: 'limits.validate.changed',
             key,

--- a/packages/fxa-customs-server/lib/settings/requestChecks.js
+++ b/packages/fxa-customs-server/lib/settings/requestChecks.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const deepEqual = require('deep-equal');
+const { isDeepStrictEqual } = require('util');
 const { initialCapital } = require('../utils');
 
 module.exports = (config, Settings, log) => {
@@ -56,7 +56,7 @@ module.exports = (config, Settings, log) => {
             message: 'types do not match',
           });
           settings[key] = current;
-        } else if (!deepEqual(current, future)) {
+        } else if (!isDeepStrictEqual(current, future)) {
           log.info({
             op: 'requestChecks.validate.changed',
             key,

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -37,7 +37,6 @@
     "convict-format-with-moment": "^6.2.0",
     "convict-format-with-validator": "^6.2.0",
     "dedent": "^1.5.1",
-    "deep-equal": "2.2.0",
     "hapi-swagger": "^17.3.0",
     "hot-shots": "^10.2.1",
     "ip": "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29116,31 +29116,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-equal@npm:2.2.0":
-  version: 2.2.0
-  resolution: "deep-equal@npm:2.2.0"
-  dependencies:
-    call-bind: "npm:^1.0.2"
-    es-get-iterator: "npm:^1.1.2"
-    get-intrinsic: "npm:^1.1.3"
-    is-arguments: "npm:^1.1.1"
-    is-array-buffer: "npm:^3.0.1"
-    is-date-object: "npm:^1.0.5"
-    is-regex: "npm:^1.1.4"
-    is-shared-array-buffer: "npm:^1.0.2"
-    isarray: "npm:^2.0.5"
-    object-is: "npm:^1.1.5"
-    object-keys: "npm:^1.1.1"
-    object.assign: "npm:^4.1.4"
-    regexp.prototype.flags: "npm:^1.4.3"
-    side-channel: "npm:^1.0.4"
-    which-boxed-primitive: "npm:^1.0.2"
-    which-collection: "npm:^1.0.1"
-    which-typed-array: "npm:^1.1.9"
-  checksum: 10c0/31de99f3c1b516ef67ba82cbe54fdc1691cdd93ab8ede561eee94f7f8baff6594ddc0860c48707f6cd12e4efd5421e3450e20c40ca71906a9d0abe9017944cd3
-  languageName: node
-  linkType: hard
-
 "deep-equal@npm:^2.0.5":
   version: 2.2.3
   resolution: "deep-equal@npm:2.2.3"
@@ -30418,7 +30393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-get-iterator@npm:^1.1.2, es-get-iterator@npm:^1.1.3":
+"es-get-iterator@npm:^1.1.3":
   version: 1.1.3
   resolution: "es-get-iterator@npm:1.1.3"
   dependencies:
@@ -33926,7 +33901,6 @@ __metadata:
     convict-format-with-moment: "npm:^6.2.0"
     convict-format-with-validator: "npm:^6.2.0"
     dedent: "npm:^1.5.1"
-    deep-equal: "npm:2.2.0"
     eslint: "npm:^7.32.0"
     fxa-shared: "workspace:*"
     grunt: "npm:^1.6.1"
@@ -37357,7 +37331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-array-buffer@npm:^3.0.1, is-array-buffer@npm:^3.0.2, is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
+"is-array-buffer@npm:^3.0.2, is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
   version: 3.0.5
   resolution: "is-array-buffer@npm:3.0.5"
   dependencies:
@@ -49863,7 +49837,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.4.3, regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
+"regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
   dependencies:
@@ -57572,7 +57546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.13, which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19, which-typed-array@npm:^1.1.2, which-typed-array@npm:^1.1.9":
+"which-typed-array@npm:^1.1.13, which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19, which-typed-array@npm:^1.1.2":
   version: 1.1.19
   resolution: "which-typed-array@npm:1.1.19"
   dependencies:


### PR DESCRIPTION
## Because

- `deep-equal` is a third-party package that does what Node's `util.isDeepStrictEqual` already does.
- The customs server is the only package that pins it, so replacing the two call sites drops the dependency.

## This pull request

- Replaces `deep-equal` with `util.isDeepStrictEqual` in `limits.js` and `requestChecks.js`.
- Removes `deep-equal` from `packages/fxa-customs-server/package.json` and updates `yarn.lock`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13931

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/settings/limits.js` and `lib/settings/requestChecks.js`, four changed lines between them.
- Suggested review order: the two settings files, then `package.json` and `yarn.lock`.
- Risky or complex parts: the strict vs loose comparison. See Other information.

## Screenshots (Optional)

## Other information (Optional)

`deep-equal` compares loosely by default and `isDeepStrictEqual` is strict, so the case to worry about is `1` vs `'1'`. Two things make the swap safe:

- Both calls sit in the `else if` of a `typeof current !== typeof future` guard. A top-level `1` vs `'1'` takes the first branch and never reaches the comparison.
- The `else if` body only calls `log.info`. Nothing is assigned, returned, or thrown, so where strict and loose disagree the effect is one log line.

One caveat worth stating: for objects and arrays, `typeof` is `'object'` on both sides, so a nested `1` vs `'1'` does reach the comparison and could log differently. Still only a log line.

Verification: `test/local/settings_tests.js` covers both call sites and passes locally, 30 assertions. `npx nx lint fxa-customs-server` is clean. No tests needed changing, which is why that box is unchecked.
