### PR TITLE
fix(passkeys): accept any browser-reported transport value

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.service.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.ts
@@ -337,7 +337,7 @@ export class PasskeyService {
    */
   private generatePasskeyName(
     aaguid: string,
-    transports: AuthenticatorTransportFuture[],
+    transports: string[],
     existingPasskeys: PasskeyRecord[]
   ): string {
     const baseName = this.getBasePasskeyName(aaguid, transports);
@@ -352,10 +352,7 @@ export class PasskeyService {
    * 2. Transport-based fallback
    * 3. Generic fallback: "Passkey"
    */
-  private getBasePasskeyName(
-    aaguid: string,
-    transports: AuthenticatorTransportFuture[]
-  ): string {
+  private getBasePasskeyName(aaguid: string, transports: string[]): string {
     const allZeros = aaguid === '00000000-0000-0000-0000-000000000000';
 
     if (!allZeros) {

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -134,7 +134,12 @@ export interface VerifiedRegistrationData {
   credentialId: string;
   publicKey: Buffer;
   signCount: number;
-  transports: AuthenticatorTransportFuture[];
+  /**
+   * Browser-reported transports, stored as-is. Not a closed set — the spec
+   * directs RPs to accept and store values they don't recognize:
+   * https://www.w3.org/TR/webauthn-3/#dom-authenticatorattestationresponse-gettransports
+   */
+  transports: string[];
   /** aaguid as a hyphenated-UUID string, forwarded unchanged from SimpleWebAuthn. */
   aaguid: string;
   backupEligible: boolean;

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -228,7 +228,7 @@ interface AuthenticationExtensionsJSON {
 interface PublicKeyCredentialDescriptorJSON {
   id: Base64URLString;
   type: 'public-key';
-  transports?: (AuthenticatorTransport | 'smart-card')[];
+  transports?: string[];
 }
 
 export interface PublicKeyCredentialCreationOptionsJSON {

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -300,6 +300,31 @@ describe('passkeys routes', () => {
       ).rejects.toThrow('Client has sent too many requests');
     });
 
+    it('accepts an unknown transport in excludeCredentials', async () => {
+      mockPasskeyService.generateRegistrationChallenge.mockResolvedValue({
+        ...mockRegistrationOptions,
+        excludeCredentials: [
+          {
+            id: CREDENTIAL_ID_B64,
+            type: 'public-key',
+            transports: ['internal', 'unknown'],
+          },
+        ],
+      });
+
+      const result = await runTest('/passkey/registration/start', {
+        auth: {
+          credentials: { uid: UID, id: SESSION_TOKEN_ID, email: TEST_EMAIL },
+        },
+      });
+
+      await expect(
+        route.options.response.schema.validateAsync(result)
+      ).resolves.toMatchObject({
+        excludeCredentials: [{ transports: ['internal', 'unknown'] }],
+      });
+    });
+
     describe('when the primary email differs from the signup email', () => {
       // A user who changed their primary email: the immutable signup address
       // on accounts.email diverges from the current primary in the emails table.

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -724,22 +724,10 @@ export const passkeyRoutes = (
                 isA.object({
                   id: isA.string().required(),
                   type: isA.string().valid('public-key').required(),
-                  transports: isA
-                    .array()
-                    .items(
-                      isA
-                        .string()
-                        .valid(
-                          'ble',
-                          'cable',
-                          'hybrid',
-                          'internal',
-                          'nfc',
-                          'smart-card',
-                          'usb'
-                        )
-                    )
-                    .optional(),
+                  // Any string: stored transports come from the browser, which
+                  // may report values outside the spec's enum.
+                  // https://www.w3.org/TR/webauthn-3/#enum-transport
+                  transports: isA.array().items(isA.string()).optional(),
                 })
               )
               .optional(),

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.ts
@@ -9,8 +9,9 @@ export type Base64URLString = string;
 export interface PublicKeyCredentialDescriptorJSON {
   id: Base64URLString;
   type: 'public-key';
-  // 'smart-card' is valid per spec but absent from the TS DOM lib's union.
-  transports?: (AuthenticatorTransport | 'smart-card')[];
+  // Not restricted to AuthenticatorTransport — the IDL is sequence<DOMString>:
+  // https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialdescriptor-transports
+  transports?: string[];
 }
 
 /**
@@ -114,7 +115,8 @@ function toNativeDescriptor(
     id: base64urlToBytes(descriptor.id),
     type: descriptor.type,
     ...(descriptor.transports
-      ? { transports: descriptor.transports as AuthenticatorTransport[] }
+      ? // Cast: the DOM lib narrows this to a closed enum.
+        { transports: descriptor.transports as AuthenticatorTransport[] }
       : {}),
   };
 }


### PR DESCRIPTION
## Because

- `POST /passkey/registration/start` returned a 500 when a stored passkey held a transport outside the seven values its response schema allowed. Those users could not add a second passkey. First seen on Firefox Mobile 152 / Android 16.
- WebAuthn treats `transports` as an open list of browser hints. A relying party has to tolerate values it does not recognize.
- The same closed set was declared again in the client types and the passkey lib, so those types disagreed with the wire contract they described.

## This pull request

- Relaxes `excludeCredentials[].transports[]` in the `registration/start` response schema to `array(string())` in `passkeys.ts`. The field stays optional.
- Widens the transport type to `string[]` in `fxa-settings`, `fxa-auth-client`, and the passkey lib's `VerifiedRegistrationData` and passkey-name derivation.
- Leaves the narrow type where SimpleWebAuthn's own input type requires it, casting at that boundary.
- Adds a test in `passkeys.spec.ts` that validates a `registration/start` response holding an unknown transport against the route response schema.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14104

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the `excludeCredentials` schema in `passkeys.ts`, the new test, and `VerifiedRegistrationData` in `webauthn-adapter.ts`.
- Suggested review order: `passkeys.ts`, `passkeys.spec.ts`, then the type changes.
- Risky or complex parts: this reads like weakened validation, so here is why it is not. The three sibling `transports` schemas in the same file, on `registration/finish`, `GET /passkeys`, and `PATCH /passkey/{credentialId}`, are already `array(string())`. `registration/finish` stores whatever the browser reports, then `registration/start` echoes it back through a stricter schema than the one that accepted it. The enum was the outlier. The spec is explicit on both hops: `getTransports()` directs relying parties to accept and store values they do not recognize, and `PublicKeyCredentialDescriptor.transports` is typed `sequence<DOMString>` rather than the enum, so browsers ignore values they do not understand.
- The type widening is compile-time only. `AuthenticatorTransportFuture` is erased at runtime and nothing ever validated against it, which is why the non-standard value reached the database in the first place and why the 500 came from Joi rather than from SimpleWebAuthn. The one runtime consumer, `getBasePasskeyName`, already falls through to "Passkey" for anything it does not match.

## Screenshots (Optional)

## Other information (Optional)

The new test asserts against `route.options.response.schema`, not just the handler return value. The `runTest` helper calls the handler and never validates the response, so a test that only used it would pass before and after this change. On unmodified code the new test fails with the error from the ticket.

Verified locally: `nx test-unit fxa-auth-server` (3751 tests), `nx test-unit accounts-passkey` (184), the `fxa-settings` passkey suites (257), plus `fxa-settings:compile` and `nx build fxa-auth-client` for the type changes. Functional tests were not run.

Two things deliberately left out. Nothing bounds the length or count of `transports` on the write path; if we want a limit it belongs at the write boundary in `libs/accounts/passkey`, not in a response schema. And `hints` is validated against a three-value enum on both start routes, the same closed-enum shape as this bug, but nothing in the tree sets `hints` today so it cannot fire.
