### PR TITLE
fix(profile-server): disable cookie parsing to avoid spurious 400s

### DIFF
--- a/packages/fxa-profile-server/lib/server/_static.js
+++ b/packages/fxa-profile-server/lib/server/_static.js
@@ -35,6 +35,11 @@ exports.create = async function () {
         // which is more forgiving of missing Origin header.
         origin: config.corsOrigin[0] === '*' ? 'ignore' : config.corsOrigin[0],
       },
+      // These routes are loaded by `<img>`, so cookies ride along. See the
+      // `state` note in server/web.js.
+      state: {
+        parse: false,
+      },
     },
   });
   server.validator(Joi);

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -78,6 +78,14 @@ exports.create = async function createServer() {
         noOpen: false,
         noSniff: true,
       },
+      // This is a bearer-token API and reads no cookies, but browsers still
+      // attach any `.firefox.com`-scoped cookie to same-site requests such as
+      // the monogram avatar `<img>`. Hapi parses cookies in `onPreAuth` and
+      // rejects RFC 6265 violations with a 400 before routing, so a single
+      // third-party cookie holding unencoded JSON takes down every route.
+      state: {
+        parse: false,
+      },
       validate: {
         options: {
           stripUnknown: true,

--- a/packages/fxa-profile-server/test/server.in.spec.ts
+++ b/packages/fxa-profile-server/test/server.in.spec.ts
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { assertSecurityHeaders } from './lib/util';
+import config from '../lib/config';
 const Server = require('./lib/server');
+const Static = require('./lib/static');
 const packageJson = require('../package.json');
 
 describe('#integration - server', () => {
@@ -57,6 +59,36 @@ describe('#integration - server', () => {
   describe('/__lbheartbeat__', () => {
     it('should succeed', async () => {
       const res = await Server.get('/__lbheartbeat__');
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe('cookie handling', () => {
+    // Raw unencoded JSON, matching the consent-manager cookie set on
+    // `.firefox.com`. The `"` and `,` violate RFC 6265, which Hapi rejects with
+    // a 400 in `onPreAuth` unless cookie parsing is off.
+    const MOCK_MALFORMED_COOKIE =
+      'tcm={"purposes":{"Analytics":true},"confirmed":true}';
+
+    it('serves the monogram avatar when the request carries a malformed cookie', async () => {
+      const res = await Server.api.get({
+        url: '/avatar/l',
+        headers: { cookie: MOCK_MALFORMED_COOKIE },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toBe('image/svg+xml; charset=UTF-8');
+      expect(res.result).toContain('>L</text>');
+    });
+
+    // The static image server is a separate Hapi instance, so it needs its own
+    // coverage — otherwise half the fix can regress without failing a test.
+    it('serves a default avatar image when the request carries a malformed cookie', async () => {
+      const res = await Static.get({
+        url: `/a/${config.get('img.defaultAvatarId')}`,
+        headers: { cookie: MOCK_MALFORMED_COOKIE },
+      });
+
       expect(res.statusCode).toBe(200);
     });
   });


### PR DESCRIPTION
Because:

- Hapi parses cookies in `onPreAuth` and rejects RFC 6265 violations with a 400 before routing, so one malformed cookie breaks every route.
- A consent-manager cookie on `.firefox.com` holds unencoded JSON, and browsers attach it to same-site requests like the monogram avatar `<img>`, so default avatars fail to render.
- `nextAvatar` treats a missing email as alphanumeric, so a token scoped to `profile:avatar` alone throws on `email[0]`.

This commit:

- Disables cookie parsing on the web and static image servers.
- Makes the monogram initial lookup type-safe.
- Adds regression tests for both paths.

Closes FXA-14356

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Check out the ticket since this is hard to repro locally.
