### PR TITLE
feat(auth-server): tag account.login events with the login method

### DIFF
--- a/packages/fxa-auth-server/lib/account-events.ts
+++ b/packages/fxa-auth-server/lib/account-events.ts
@@ -26,6 +26,12 @@ type EmailEvent = BaseEvent & {
   template: string;
 };
 
+export type SecurityEventLoginMethod =
+  | 'password'
+  | 'passwordless.otp'
+  | 'passwordless.thirdParty'
+  | 'passkey';
+
 interface SecurityEventAdditionalInfo {
   userAgent?: string;
   location?: {
@@ -39,6 +45,9 @@ interface SecurityEventAdditionalInfo {
   };
   client_id?: string;
   service?: string;
+  // How the user authenticated. Rows written before this field existed have no
+  // method; read those as unknown, not as a password login.
+  method?: SecurityEventLoginMethod;
   waf?: {
     clientJa4?: string;
     clientJa3?: string;
@@ -138,7 +147,7 @@ export class AccountEventsManager {
 
       await this.usersDbRef?.doc(uid).collection('events').add(emailEvent);
       this.statsd.increment('accountEvents.recordEmailEvent.write', {
-        template: message.template
+        template: message.template,
       });
     } catch (err) {
       // Failing to write to events shouldn't break anything

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
@@ -48,8 +48,13 @@ jest.mock('fxa-shared/db/models/auth', () => ({
   },
 }));
 
+jest.mock('./utils/security-event', () => ({
+  recordSecurityEvent: jest.fn(),
+}));
+
 const mocks = require('../../test/mocks');
 const { getRoute } = require('../../test/routes_helpers');
+const { recordSecurityEvent } = require('./utils/security-event');
 const { AppError: error } = require('@fxa/accounts/errors');
 
 // Install a typed mock FxaMailer in the Container before loading linked-accounts
@@ -241,6 +246,31 @@ describe('/linked_account', () => {
         expect(mockDB.createSessionToken).toHaveBeenCalledTimes(1);
         expect(result.uid).toBe(UID);
         expect(result.sessionToken).toBeTruthy();
+      });
+
+      it('records an account.login security event tagged as third party', async () => {
+        // The stored proc derives `verified` from the token id, so the new
+        // session token id has to reach the event. Without it a TOTP-gated
+        // sign-in is recorded as a verified login.
+        const SESSION_TOKEN_ID = 'sessiontokenid';
+        mockDB.createSessionToken = jest.fn(() =>
+          Promise.resolve({
+            id: SESSION_TOKEN_ID,
+            uid: UID,
+            data: 'sessiontoken123',
+          })
+        );
+
+        await runTest(route, mockRequest);
+
+        expect(recordSecurityEvent).toHaveBeenCalledWith(
+          'account.login',
+          expect.objectContaining({
+            account: { uid: UID },
+            tokenId: SESSION_TOKEN_ID,
+            method: 'passwordless.thirdParty',
+          })
+        );
       });
 
       it('does not create a new account when the domain is blocklisted', async () => {

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -22,6 +22,7 @@ import {
   notifyAttachedServicesForAccountSession,
 } from './utils/account';
 import { normalizeEmail } from 'fxa-shared/email/helpers';
+import { recordSecurityEvent } from './utils/security-event';
 import {
   getGooglePublicKey,
   getApplePublicKey,
@@ -629,6 +630,14 @@ export class LinkedAccountHandler {
     };
 
     const sessionToken = await this.db.createSessionToken(sessionTokenOptions);
+
+    await recordSecurityEvent('account.login', {
+      db: this.db,
+      request,
+      account: { uid: accountRecord.uid },
+      tokenId: sessionToken.id,
+      method: 'passwordless.thirdParty',
+    });
 
     // Mirror the SNS notifications that AccountHandler.createAccount
     // fires. Placed after createSessionToken so db.sessions already

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -1628,7 +1628,10 @@ describe('passkeys routes', () => {
 
         expect(recordSecurityEvent).toHaveBeenCalledWith(
           'account.login',
-          expect.objectContaining({ account: { uid: UID } })
+          expect.objectContaining({
+            account: { uid: UID },
+            method: 'passkey',
+          })
         );
       });
 

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -594,6 +594,7 @@ export class PasskeyHandler {
           db: this.db,
           request,
           account: { uid: account.uid },
+          method: 'passkey',
         });
       }
     } catch (err) {

--- a/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
@@ -1300,10 +1300,10 @@ describe('passwordless security events', () => {
     route = getRoute(routes, '/account/passwordless/confirm_code', 'POST');
 
     return runTest(route, mockRequest, () => {
-      // Should record three events: account.create (so the generic
+      // Should record four events: account.create (so the generic
       // account-creation metric fires for OTP signups too), then
-      // registration_complete and otp_verified.
-      expect(mockRecordSecurityEvent).toHaveBeenCalledTimes(3);
+      // registration_complete, otp_verified and account.login.
+      expect(mockRecordSecurityEvent).toHaveBeenCalledTimes(4);
       expect(mockRecordSecurityEvent).toHaveBeenNthCalledWith(
         1,
         'account.create',
@@ -1318,6 +1318,61 @@ describe('passwordless security events', () => {
         3,
         'account.passwordless_login_otp_verified',
         expect.objectContaining({ account: { uid } })
+      );
+      expect(mockRecordSecurityEvent).toHaveBeenNthCalledWith(
+        4,
+        'account.login',
+        expect.objectContaining({
+          account: { uid },
+          method: 'passwordless.otp',
+        })
+      );
+    });
+  });
+
+  it('should pass the new session token id on the account.login event', () => {
+    // The stored proc derives `verified` from the token id, so the new session
+    // token id has to reach the event. Without it a TOTP-gated sign-in is
+    // recorded as a verified login.
+    const SESSION_TOKEN_ID = 'sessiontokenid';
+    mockDB.createSessionToken = jest.fn(() =>
+      Promise.resolve({
+        id: SESSION_TOKEN_ID,
+        data: 'sessiontoken123',
+        emailVerified: true,
+        tokenVerified: false,
+        lastAuthAt: () => 1234567890,
+      })
+    );
+
+    mockRequest.payload.code = '123456';
+
+    routes = makeRoutes({
+      log: mockLog,
+      db: mockDB,
+      customs: mockCustoms,
+      recordSecurityEvent: mockRecordSecurityEvent,
+      config: {
+        passwordlessOtp: {
+          enabled: true,
+          ttl: 300,
+          digits: 6,
+          allowedClientServices: {
+            'test-client-id': { allowedServices: ['*'] },
+          },
+        },
+      },
+    });
+    route = getRoute(routes, '/account/passwordless/confirm_code', 'POST');
+
+    return runTest(route, mockRequest, () => {
+      expect(mockRecordSecurityEvent).toHaveBeenCalledWith(
+        'account.login',
+        expect.objectContaining({
+          account: { uid },
+          tokenId: SESSION_TOKEN_ID,
+          method: 'passwordless.otp',
+        })
       );
     });
   });
@@ -1362,6 +1417,7 @@ describe('passwordless security events', () => {
       expect(recordedEvents).not.toContain('account.create');
       expect(recordedEvents).toEqual([
         'account.passwordless_login_otp_verified',
+        'account.login',
       ]);
     });
   });

--- a/packages/fxa-auth-server/lib/routes/passwordless.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.ts
@@ -213,9 +213,7 @@ class PasswordlessHandler {
     await this.customs.check(
       request,
       email,
-      isNewAccount
-        ? PASSWORDLESS_SEND_OTP_SIGNUP
-        : PASSWORDLESS_SEND_OTP_SIGNIN
+      isNewAccount ? PASSWORDLESS_SEND_OTP_SIGNUP : PASSWORDLESS_SEND_OTP_SIGNIN
     );
   }
 
@@ -346,6 +344,14 @@ class PasswordlessHandler {
       db: this.db,
       request,
       account: { uid: account.uid },
+    });
+
+    await recordSecurityEvent('account.login', {
+      db: this.db,
+      request,
+      account: { uid: account.uid },
+      tokenId: sessionToken.id,
+      method: 'passwordless.otp',
     });
 
     // Mirror the SNS notifications that AccountHandler.createAccount

--- a/packages/fxa-auth-server/lib/routes/utils/security-event.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/security-event.spec.ts
@@ -364,4 +364,21 @@ describe('recordSecurityEvent', () => {
       sigsciTags: 'TRAVERSAL',
     });
   });
+
+  it('includes the method in additionalInfo when given', async () => {
+    await recordSecurityEvent('account.login', {
+      ...makeOpts(),
+      method: 'passkey',
+    });
+
+    const [, message] = mockMgrRecordSecurityEvent.mock.calls[0];
+    expect(message.additionalInfo.method).toBe('passkey');
+  });
+
+  it('omits the method from additionalInfo when not given', async () => {
+    await recordSecurityEvent('account.login', makeOpts());
+
+    const [, message] = mockMgrRecordSecurityEvent.mock.calls[0];
+    expect(message.additionalInfo).not.toHaveProperty('method');
+  });
 });

--- a/packages/fxa-auth-server/lib/routes/utils/security-event.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/security-event.ts
@@ -3,10 +3,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { SecurityEventNames } from 'fxa-shared/db/models/auth/security-event';
-import { AccountEventsManager } from '../../account-events';
+import {
+  AccountEventsManager,
+  SecurityEventLoginMethod,
+} from '../../account-events';
 import { Container } from 'typedi';
 
-export async function recordSecurityEvent(name: SecurityEventNames, opts: any) {
+type RecordSecurityEventOpts = {
+  method?: SecurityEventLoginMethod;
+  // Routes that create a session while unauthenticated must pass the new
+  // session token id. Without it the stored proc cannot find the pending
+  // tokenVerificationId and marks the row verified.
+  tokenId?: string;
+  [key: string]: any;
+};
+
+export async function recordSecurityEvent(
+  name: SecurityEventNames,
+  opts: RecordSecurityEventOpts
+) {
   const mgr = Container.get(AccountEventsManager);
   if (mgr == null || typeof mgr.recordSecurityEvent !== 'function') {
     return;
@@ -28,12 +43,13 @@ export async function recordSecurityEvent(name: SecurityEventNames, opts: any) {
     name,
     uid: opts?.account?.uid || opts?.request?.auth?.credentials?.uid,
     ipAddr: opts?.request?.app?.clientAddress,
-    tokenId: opts?.request?.auth?.credentials?.id,
+    tokenId: opts?.tokenId ?? opts?.request?.auth?.credentials?.id,
     additionalInfo: {
       userAgent: opts?.request.headers['user-agent'],
       location: opts?.request.app.geo.location,
       ...(clientId && { client_id: clientId }),
       ...(service && { service }),
+      ...(opts?.method && { method: opts.method }),
       waf: Object.values(waf).some(Boolean) ? waf : undefined,
     },
   });

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -682,6 +682,7 @@ module.exports = (
             location: request.app.geo.location,
             ...(clientId && { client_id: clientId }),
             ...(service && { service }),
+            method: 'password',
           },
         });
       }

--- a/packages/fxa-auth-server/lib/routes/utils/signin.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.spec.ts
@@ -836,6 +836,7 @@ describe('sendSigninNotifications', () => {
             state: 'California',
             stateCode: 'CA',
           },
+          method: 'password',
         },
       });
     });


### PR DESCRIPTION
## Because

- `account.login` is a catch-all. A password sign-in and a passkey sign-in write the same row, so security history cannot tell them apart.
- Passwordless OTP writes only `account.passwordless_login_otp_verified`, and third party auth writes no security event at all. Those two sign-ins are invisible in security history today.

## This pull request

- Adds `method` to `SecurityEventAdditionalInfo` in `account-events.ts`, as the union `password | passwordless.otp | passwordless.thirdParty | passkey`.
- Passes `method` through the shared `recordSecurityEvent` helper in `routes/utils/security-event.ts`.
- Sets the method on the password flow (`routes/utils/signin.js`, which builds its own `additionalInfo`) and on the passkey flow (`routes/passkeys.ts`).
- Writes an `account.login` event for passwordless OTP (`routes/passwordless.ts`) and for third party auth (`routes/linked-accounts.ts`). Neither wrote one before.
- Adds a co-located spec per flow, and two for the helper.

`additionalInfo` is already a JSON column, so this needs no new event name, no `securityEventNames` row, and no migration. The passwordless OTP `account.login` is in addition to `account.passwordless_login_otp_verified`, not a replacement. Nothing mutates or deletes an existing row.

## Issue that this pull request solves

Closes: FXA-14325

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: there are two write paths that do not share code. `routes/utils/security-event.ts` is the shared helper, used by passkeys and passwordless. `routes/utils/signin.js` calls `accountEventsManager.recordSecurityEvent` directly with its own `additionalInfo` literal, so the helper change does nothing for it.
- Suggested review order: `account-events.ts`, then `routes/utils/security-event.ts`, then the four call sites.
- Risky or complex parts:
  - `sendSigninNotifications` is shared by `/account/login` and `/session/reauth`. Both are password authentication, so `password` is correct for both.
  - Nothing is backfilled. Existing rows have no `method`. A consumer must read a missing `method` as unknown, never as `password`. There is deliberately no default in the type and none at read time.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

This is item 2 from the ticket only. Item 1, keeping the unverified to verified transition instead of overwriting the row, needs its own ticket. It is riskier: it touches the logic that skips login confirmation emails.

Out of scope on purpose: the Amplitude `emitMetricsEvent('account.login')` calls are a different pipeline and are unchanged. Rendering `method` in the admin panel or in Settings is not part of this change.

Verified locally: the `fxa-auth-server` Jest unit suite and `nx lint fxa-auth-server`. Functional tests were not run.
