### PR TITLE
feat(123done): add step-up auth flow and panel

### DIFF
--- a/packages/123done/README.md
+++ b/packages/123done/README.md
@@ -8,6 +8,33 @@
 1. Visit it in your browser: `http://localhost:8080/`
 1. Hack and reload! (web resources don't require a server restart)
 
+## Step-up authentication
+
+The **Step-Up Auth** button, visible only once you are signed in, re-authorizes the
+existing session with `acr_values=AAL2` and a `max_age`, per
+[RFC 9470](https://www.rfc-editor.org/rfc/rfc9470.html). It sends no `action` and no
+`prompt=login`, so the cached FxA session is reused: you confirm on the signin page with
+no email or password to re-enter, then get a second-factor challenge only if `max_age`
+says the session is stale. Step-up never asks for a password.
+
+`max_age` is the relying party's dial for how per-transaction the elevation is: a tight
+value re-challenges on nearly every action, a loose one creates a sudo window. The input
+next to the button sets it per click, starting from `STEP_UP_MAX_AGE` (default 300
+seconds); clear the box to fall back to that default. A `max_age` on the 123Done page URL
+seeds the box, so it survives a click. Hitting the route directly works too —
+`/api/step_up?max_age=0`, or `?acr_values=` (empty) to make the request freshness-only.
+
+The page shows `acr` and `auth_time` twice: from the `id_token` received at redirect
+time, and from `POST /v1/introspect` against the current access token (via
+`/api/token_claims`). Both should agree. `auth_time` is the value that proves a challenge
+actually happened, since `acr` stays `AAL2` whether or not the session was
+re-authenticated.
+
+To watch a re-challenge, set `max_age` to 0 and click twice. The authorization server
+allows a few seconds of leeway on the comparison (`MAX_AGE_LEEWAY_SECONDS` in
+`fxa-auth-server/lib/oauth/grant.js`), so a click straight after a challenge is satisfied
+silently and one a little later re-challenges.
+
 ### Ansible Deployment
 
 See [fxa-dev 123done](https://github.com/mozilla/fxa-dev/tree/docker/roles/rp) Ansible configuration for details.
@@ -70,6 +97,7 @@ or `heroku config:set`); never commit secret values to the repo.
 - `REDIRECT_URI`, `ISSUER_URI`, `SCOPES`
 - `PKCE_CLIENT_ID`, `PKCE_REDIRECT_URI`
 - `COOKIE_SECRET`, `COOKIE_NAME`
+- `STEP_UP_MAX_AGE` — default `max_age` (seconds) for the step-up flow; optional, defaults to 300
 - `PORT` is provided by Heroku automatically.
 
 Heads up on older apps: some set the client secret as `CLIENT_SECRET` and omit `SCOPES` /

--- a/packages/123done/config.js
+++ b/packages/123done/config.js
@@ -64,6 +64,12 @@ const conf = convict({
     format: Number,
     env: 'PORT',
   },
+  step_up_max_age: {
+    doc: 'Default max_age (seconds) requested by the step-up auth flow',
+    default: 300,
+    format: 'nat',
+    env: 'STEP_UP_MAX_AGE',
+  },
 });
 
 const configTarget = process.env.CONFIG_123DONE || './config.json';

--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -109,7 +109,7 @@ function redirectUrl(params, oauthConfig) {
   return oauthConfig.authorization_endpoint + toQueryString(params);
 }
 
-module.exports = function (app, db) {
+module.exports = function (app, db, checkAuth) {
   // begin a new oauth log in flow
   app.get('/api/login', function (req, res) {
     setupOAuthFlow(req, 'signin', {}, function (err, params, oauthConfig) {
@@ -218,6 +218,32 @@ module.exports = function (app, db) {
     );
   });
 
+  // RFC 9470 step-up: re-authorize an already signed-in session at AAL2 with a
+  // freshness bound. Passes no `action`, so the cached FxA session is reused instead of
+  // going back through email-first, and no `prompt=login`, so step-up never asks for a
+  // password. The user still confirms on the signin page — there is no `prompt=none` —
+  // and is challenged for a second factor only when `max_age` says it is stale. See the
+  // README for how `max_age` behaves and how to drive it.
+  //
+  // Gated on checkAuth, unlike the sign-in routes above: without a session there is
+  // nothing to step up, and an unguarded direct hit would start a cold AAL2 sign-in.
+  app.get('/api/step_up', checkAuth, function (req, res) {
+    setupOAuthFlow(
+      req,
+      null,
+      { acrValues: 'AAL2', max_age: config.step_up_max_age },
+      function (err, params, oauthConfig) {
+        if (err) {
+          // Logged rather than returned: these errors come from fetching the
+          // discovery document, so they carry internal URLs.
+          console.log('step_up', err);
+          return res.status(400).send('could not start the step-up flow');
+        }
+        return res.redirect(redirectUrl(params, oauthConfig));
+      }
+    );
+  });
+
   app.get('/api/prompt_login', function (req, res) {
     setupOAuthFlow(
       req,
@@ -308,6 +334,13 @@ module.exports = function (app, db) {
         req.session.uid = claims.sub;
         req.session.amr = claims.amr;
         req.session.acr = claims.acr;
+        // auth_time is the authentication event in seconds since the epoch. It
+        // advances on every second-factor challenge, so it — not acr — is what
+        // shows whether a step-up actually re-authenticated the user.
+        req.session.auth_time = claims.auth_time;
+        // Stashed on the session because /api/token_claims runs on a later request,
+        // which has no oauthFlows entry left to read the endpoint from.
+        req.session.introspection_endpoint = oauthConfig.introspection_endpoint;
 
         // Fetch additional profile data.
         var profileRes = await fetch(oauthConfig.userinfo_endpoint, {

--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -47,8 +47,9 @@ app.use(function (req, res, next) {
   }
 });
 
-// add oauth endpoints
-oauth(app, db);
+// add oauth endpoints. checkAuth is declared below and hoisted; /api/step_up needs
+// it to enforce the signed-in session it re-authorizes.
+oauth(app, db, checkAuth);
 
 // a function to verify that the current user is authenticated
 function checkAuth(req, res, next) {
@@ -72,8 +73,65 @@ app.get('/api/auth_status', function (req, res) {
       acr: req.session.acr || '0',
       account_aal2: req.session.account_aal2 || false,
       keys_jwe: req.session.keys_jwe || null,
+      // Authentication event from the id_token, in seconds since the epoch.
+      auth_time: req.session.auth_time || null,
+      // Default for the step-up max_age input, so the UI can't drift from config.
+      step_up_max_age: config.get('step_up_max_age'),
     })
   );
+});
+
+// The resource-server half of RFC 9470: introspect our own access token and report
+// the authentication level and event the authorization server sees. This is the
+// check an RP would run before allowing a sensitive action, as opposed to trusting
+// the id_token it received at redirect time.
+//
+// Called once per page load, never polled — /v1/introspect is rate-limited per IP.
+app.get('/api/token_claims', checkAuth, async function (req, res) {
+  const endpoint = req.session.introspection_endpoint;
+  if (!endpoint || !req.session.token) {
+    return res.status(409).json({ error: 'no access token on this session' });
+  }
+
+  let response, text;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: req.session.token }),
+    });
+    text = await response.text();
+  } catch (err) {
+    // Logged rather than returned: the message names the introspection host.
+    console.log('token_claims', err); //eslint-disable-line no-console
+    return res.status(502).json({ error: 'introspection request failed' });
+  }
+
+  // Check the status before parsing. A proxy or the rate-limiter can answer with
+  // HTML, and parsing first would report that as a 502 and lose the real status.
+  if (response.status >= 400) {
+    return res.status(response.status).send(text);
+  }
+
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch (err) {
+    return res
+      .status(502)
+      .json({ error: 'introspection response was not JSON' });
+  }
+
+  res.json({
+    active: body.active,
+    acr: body.acr || null,
+    // Seconds, while iat/exp below are milliseconds. Intentional upstream, for RP
+    // back-compat — see lib/routes/oauth/introspect.js in fxa-auth-server.
+    auth_time: body.auth_time || null,
+    amr: body.amr || null,
+    iat: body.iat || null,
+    exp: body.exp || null,
+  });
 });
 
 // logout clears the current authenticated user

--- a/packages/123done/static/css/main.css
+++ b/packages/123done/static/css/main.css
@@ -90,6 +90,37 @@ button::-moz-focus-inner {
   display: block;
   margin: 20px 0px;
 }
+
+/* Step-up auth is only meaningful for an already-authenticated session. */
+.step-up-data {
+  display: none;
+}
+.logged-in .step-up-data {
+  display: block;
+  padding: 20px;
+}
+.step-up-data .step-up-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+/* Green pill, as #logout and .sign-in-button use, sized for the controls row. */
+.step-up-data .step-up-auth {
+  background: #5fad47;
+  border-radius: 50px;
+  border: none;
+  color: #fff;
+  font-size: 16px;
+  padding: 10px 24px;
+}
+.step-up-data .step-up-claims {
+  display: flex;
+  gap: 48px;
+  font-family: monospace;
+}
+.step-up-data h4 {
+  margin-bottom: 4px;
+}
 .logged-in.is-subscribed #footer-main .subscription-buttons {
   display: none;
 }

--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -208,6 +208,37 @@
       </section>
     </div>
 
+    <!-- Step-up auth (RFC 9470). Lives outside .banner because the banner is the
+         logged-out affordance (.logged-in .banner is display:none); this section is
+         shown only when logged in, via .logged-in .step-up-data. -->
+    <section class="step-up-data">
+      <div class="step-up-controls">
+        <button
+          class="btn btn-large btn-info btn-persona step-up-auth"
+          type="submit"
+        >
+          Step-Up Auth
+        </button>
+        <label for="step-up-max-age">
+          max_age (seconds)
+          <input type="number" id="step-up-max-age" min="0" />
+        </label>
+      </div>
+      <div class="step-up-claims">
+        <div>
+          <h4>From the id_token</h4>
+          <div id="id-token-acr"></div>
+          <div id="id-token-auth-time"></div>
+        </div>
+        <div>
+          <h4>From introspection</h4>
+          <div id="introspect-acr"></div>
+          <div id="introspect-auth-time"></div>
+          <div id="introspect-amr"></div>
+        </div>
+      </div>
+    </section>
+
     <section class="keys-data">
       <div id="keys"></div>
     </section>

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -159,6 +159,42 @@ $(document).ready(function () {
       if (loggedInState.keys_jwe) {
         $('#keys').text(`Scoped key: ${loggedInState.keys_jwe}`);
       }
+
+      renderStepUpClaims(email);
+    }
+
+    // auth_time is seconds since the epoch; show the raw value and a readable one.
+    function formatAuthTime(authTime) {
+      if (!authTime) {
+        return 'auth_time: (none)';
+      }
+      return `auth_time: ${authTime} (${new Date(authTime * 1000).toISOString()})`;
+    }
+
+    // Two views of the same elevation, which should agree: the id_token claims from
+    // redirect time, and what the authorization server reports for the access token.
+    function renderStepUpClaims(email) {
+      $('#id-token-acr, #id-token-auth-time').text('');
+      $('#introspect-acr, #introspect-auth-time, #introspect-amr').text('');
+      if (!email) {
+        return;
+      }
+
+      $('#id-token-acr').text(`acr: ${loggedInState.acr || '(none)'}`);
+      $('#id-token-auth-time').text(formatAuthTime(loggedInState.auth_time));
+
+      // Fetched once per page load; /v1/introspect is rate-limited per IP.
+      $.get('/api/token_claims')
+        .done(function (claims) {
+          $('#introspect-acr').text(`acr: ${claims.acr || '(none)'}`);
+          $('#introspect-auth-time').text(formatAuthTime(claims.auth_time));
+          $('#introspect-amr').text(
+            `amr: ${claims.amr ? claims.amr.join(' ') : '(none)'}`
+          );
+        })
+        .fail(function (xhr) {
+          $('#introspect-acr').text(`introspection failed: ${xhr.status}`);
+        });
     }
 
     function updateListArea(email) {
@@ -283,6 +319,26 @@ $(document).ready(function () {
 
     $('button.prompt-login').click(function (ev) {
       authenticate('prompt_login');
+    });
+
+    // Seeded from `?max_age=` when the page URL carries one, so that override still
+    // reaches /api/step_up — the click handler below sends whatever is in the box.
+    // Otherwise from config, so the box shows the value the route would use anyway.
+    const urlMaxAge = new URLSearchParams(window.location.search).get(
+      'max_age'
+    );
+    $('#step-up-max-age').val(
+      urlMaxAge === null ? loggedInState.step_up_max_age : urlMaxAge
+    );
+
+    $('button.step-up-auth').click(function (ev) {
+      // An empty or non-integer box means "use the route default". Forwarding it raw
+      // would send `max_age=`, which fails authorization-parameter validation and
+      // drops the tester on an error page.
+      const raw = $('#step-up-max-age').val();
+      const maxAge = Number(raw);
+      const valid = raw !== '' && Number.isInteger(maxAge) && maxAge >= 0;
+      authenticate('step_up', valid ? { max_age: maxAge } : {});
     });
 
     // upon click of logout link navigator.id.logout()

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -127,6 +127,59 @@ export class RelierPage extends BaseLayout {
     return this.waitForOauthPage();
   }
 
+  get stepUpAuthButton() {
+    return this.page.locator('button.step-up-auth');
+  }
+
+  /**
+   * Start a step-up flow, forwarding `maxAge` as the `max_age` authorization
+   * parameter. The request carries no `prompt=none`, so the flow stops at the cached
+   * signin page for confirmation; the caller drives that and whatever follows — a
+   * satisfied `max_age` returns to the relier, a stale one adds a second factor.
+   */
+  async clickStepUpAuth(maxAge: number) {
+    await this.page.locator('#step-up-max-age').fill(String(maxAge));
+    await this.stepUpAuthButton.click();
+  }
+
+  /**
+   * The claims 123Done captured from the id_token at redirect time, plus its
+   * configured step-up default. Read over HTTP rather than scraped from the DOM so
+   * assertions are on claim values, not on rendering.
+   */
+  async getAuthStatus(): Promise<{
+    email: string | null;
+    acr: string;
+    amr: string[] | null;
+    auth_time: number | null;
+    account_aal2: boolean;
+    step_up_max_age: number;
+  }> {
+    const response = await this.page.request.get(
+      `${this.target.relierUrl}/api/auth_status`
+    );
+    expect(response.ok()).toBe(true);
+    return response.json();
+  }
+
+  /**
+   * The claims the authorization server reports for 123Done's current access token,
+   * via `POST /v1/introspect`. This is the resource-server view of the elevation, as
+   * opposed to the id_token 123Done was handed at redirect time.
+   */
+  async getTokenClaims(): Promise<{
+    active: boolean;
+    acr: string | null;
+    amr: string[] | null;
+    auth_time: number | null;
+  }> {
+    const response = await this.page.request.get(
+      `${this.target.relierUrl}/api/token_claims`
+    );
+    expect(response.ok()).toBe(true);
+    return response.json();
+  }
+
   async hasAccountAAL2Badge() {
     const text = await this.page.locator('#loggedin span').innerText();
     return text.includes(String.fromCodePoint(0x1f6e1));

--- a/packages/functional-tests/tests/oauth/stepUpAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/stepUpAuth.spec.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, test } from '../../lib/fixtures/standard';
+import { enableTotpOnAccount } from '../../lib/pairing-helpers';
+import { getTotpCode } from '../../lib/totp';
+
+test.describe('severity-2 #smoke', () => {
+  test.describe('OAuth step-up auth', () => {
+    test('satisfies a step-up request from a fresh AAL2 session', async ({
+      target,
+      pages: { page, relier, signin, signinTotpCode },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+      // Assigned to `secret` so account teardown can elevate AAL to delete it.
+      credentials.secret = await enableTotpOnAccount(
+        target.authClient,
+        credentials.sessionToken
+      );
+
+      await relier.goto();
+      await relier.clickEmailFirst();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await expect(page).toHaveURL(/signin_totp_code/);
+      await signinTotpCode.fillOutCodeForm(
+        await getTotpCode(credentials.secret)
+      );
+
+      expect(await relier.isLoggedIn()).toBe(true);
+      const before = await relier.getAuthStatus();
+      expect(before.acr).toBe('AAL2');
+      // Pinned so the equality check below can't pass vacuously on null === null.
+      expect(before.auth_time).toEqual(expect.any(Number));
+
+      await relier.clickStepUpAuth(300);
+
+      // The request carries no prompt=none, so the flow always stops at the cached
+      // signin page to confirm — with no password field, which is the point of
+      // step-up. max_age is well inside the sign-in challenge above, so confirming
+      // returns to the relier without a second factor. Whether a *stale* session gets
+      // re-challenged is grant.js's rule, pinned in its own unit tests.
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
+      await expect(signin.passwordTextbox).toBeHidden();
+      await signin.signInButton.click();
+
+      // isLoggedIn waits for the relier URL, so this also asserts we came back.
+      expect(await relier.isLoggedIn()).toBe(true);
+
+      const after = await relier.getAuthStatus();
+      expect(after.acr).toBe('AAL2');
+      expect(after.auth_time).toBe(before.auth_time);
+
+      // The same elevation, as the authorization server reports it for the access
+      // token — the check a resource server would make before a sensitive action.
+      const introspected = await relier.getTokenClaims();
+      expect(introspected.active).toBe(true);
+      expect(introspected.acr).toBe('AAL2');
+      expect(introspected.auth_time).toBe(after.auth_time);
+      // TOTP, backup codes and SMS all collapse to `otp` in amr.
+      expect(introspected.amr).toContain('otp');
+    });
+  });
+});
+
+// Not in #smoke: this asserts local rendering, and 123Done deploys to stage and
+// production separately from the train.
+test.describe('severity-2', () => {
+  test.describe('OAuth step-up auth', () => {
+    test('hides the step-up button until the user is signed in', async ({
+      pages: { page, relier, signin },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await relier.goto();
+      // 123Done shows the button off body.logged-in, which it only sets once
+      // /api/auth_status resolves — and body.ready marks that point. Without this
+      // gate the hidden assertion would also pass against an unrendered page.
+      await expect(page.locator('body.ready')).toBeAttached();
+      await expect(relier.stepUpAuthButton).toBeHidden();
+
+      await relier.clickEmailFirst();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      expect(await relier.isLoggedIn()).toBe(true);
+      await expect(relier.stepUpAuthButton).toBeVisible();
+
+      // The max_age box is seeded from the server's configured default.
+      const { step_up_max_age } = await relier.getAuthStatus();
+      await expect(page.locator('#step-up-max-age')).toHaveValue(
+        String(step_up_max_age)
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Because

- The server half of step-up auth has landed, but nothing exercised acr_values=AAL2 with max_age end to end
- 123Done's two AAL2 buttons are cold sign-ins, and its only max_age uses pair with prompt=login, which forces a password and bypasses step-up
- 123Done never read auth_time or called introspection, so there was no way to see whether an elevation actually happened

## This pull request

- Adds GET /api/step_up, re-authorizing the cached session at AAL2 with a configurable max_age (STEP_UP_MAX_AGE, default 300)
- Adds GET /api/token_claims, introspecting the access token for the resource-server view of acr, auth_time and amr
- Shows both claim sets side by side in a logged-in-only panel, with a per-request max_age input
- Adds RelierPage helpers and a two-test smoke spec covering button visibility and a TOTP re-challenge advancing auth_time
- Documents the flow and STEP_UP_MAX_AGE in the 123Done README

## Issue that this pull request solves

Closes: #FXA-12862

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
