### PR TITLE
feat(admin-panel): show up to 100 account history events

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
@@ -514,3 +514,60 @@ it('displays key-stretch-version', async () => {
 
   expect(getByTestId('key-stretch-version')).toBeInTheDocument();
 });
+
+describe('account history', () => {
+  const buildSecurityEvents = (count: number) =>
+    Array.from({ length: count }, (_, index) => ({
+      uid: accountResponse.uid,
+      name: `event-${index}`,
+      createdAt: 1589467100316 + index,
+      ipAddr: '127.0.0.1',
+      additionalInfo: '',
+      verified: true,
+    }));
+
+  it('shows a message when there are no events', () => {
+    const { getByTestId } = render(
+      <Account {...accountResponse} securityEvents={[]} />
+    );
+
+    expect(getByTestId('account-security-events')).toHaveTextContent(
+      "This account doesn't have any account history."
+    );
+  });
+
+  it('shows the first ten events and hides the rest', () => {
+    const { getByText, queryByText } = render(
+      <Account {...accountResponse} securityEvents={buildSecurityEvents(25)} />
+    );
+
+    expect(getByText('event-0')).toBeInTheDocument();
+    expect(getByText('event-9')).toBeInTheDocument();
+    expect(queryByText('event-10')).not.toBeInTheDocument();
+  });
+
+  it('shows the remaining events when "Show more" is clicked', async () => {
+    const user = userEvent.setup();
+    const { getByRole, getByText, queryByRole } = render(
+      <Account {...accountResponse} securityEvents={buildSecurityEvents(25)} />
+    );
+
+    await user.click(getByRole('button', { name: 'Show more' }));
+
+    expect(getByText('event-24')).toBeInTheDocument();
+    expect(
+      queryByRole('button', { name: 'Show more' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides "Show more" when there are ten or fewer events', () => {
+    const { getByText, queryByRole } = render(
+      <Account {...accountResponse} securityEvents={buildSecurityEvents(10)} />
+    );
+
+    expect(getByText('event-9')).toBeInTheDocument();
+    expect(
+      queryByRole('button', { name: 'Show more' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { useState } from 'react';
 import {
   Account as AccountType,
   SecurityEvents as SecurityEventsType,
@@ -26,6 +27,8 @@ import ResultBoolean from '../../ResultBoolean';
 import { HIDE_ROW } from '../../../../constants';
 import { adminApi } from '../../../lib/api';
 import { Carts } from '../Cart';
+
+const INITIAL_SECURITY_EVENT_COUNT = 10;
 
 export type AccountProps = AccountType & {
   onCleared: () => void;
@@ -97,6 +100,7 @@ export const Account = ({
   passkeys,
   accountAuthorizations,
 }: AccountProps) => {
+  const [showAllSecurityEvents, setShowAllSecurityEvents] = useState(false);
   const createdAtDate = getFormattedDate(createdAt);
   const disabledAtDate = getFormattedDate(disabledAt);
   const lockedAtDate = getFormattedDate(lockedAt);
@@ -474,20 +478,36 @@ export const Account = ({
 
         <h3 className="header-lg">Account History</h3>
         {securityEvents && securityEvents.length > 0 ? (
-          <TableXHeaders
-            rowHeaders={['Event', 'Timestamp', 'IP', 'Additional Info']}
-          >
-            {securityEvents.map((securityEvent: SecurityEventsType) => {
-              return (
-                <TableRowXHeader key={securityEvent.uid}>
-                  <>{securityEvent.name}</>
-                  <>{getFormattedDate(securityEvent.createdAt)}</>
-                  <>{securityEvent.ipAddr}</>
-                  <>{securityEvent.additionalInfo}</>
-                </TableRowXHeader>
-              );
-            })}
-          </TableXHeaders>
+          <>
+            <TableXHeaders
+              rowHeaders={['Event', 'Timestamp', 'IP', 'Additional Info']}
+            >
+              {(showAllSecurityEvents
+                ? securityEvents
+                : securityEvents.slice(0, INITIAL_SECURITY_EVENT_COUNT)
+              ).map((securityEvent: SecurityEventsType, index: number) => {
+                return (
+                  // Every event carries the same uid, so pair it with the index.
+                  <TableRowXHeader key={`${securityEvent.uid}-${index}`}>
+                    <>{securityEvent.name}</>
+                    <>{getFormattedDate(securityEvent.createdAt)}</>
+                    <>{securityEvent.ipAddr}</>
+                    <>{securityEvent.additionalInfo}</>
+                  </TableRowXHeader>
+                );
+              })}
+            </TableXHeaders>
+            {!showAllSecurityEvents &&
+              securityEvents.length > INITIAL_SECURITY_EVENT_COUNT && (
+                <button
+                  type="button"
+                  className="bg-grey-10 border-2 border-grey-100 mt-2 px-4 py-2 rounded hover:bg-grey-50 hover:border-grey-10"
+                  onClick={() => setShowAllSecurityEvents(true)}
+                >
+                  Show more
+                </button>
+              )}
+          </>
         ) : (
           <p data-testid="account-security-events" className="result-none">
             This account doesn't have any account history.

--- a/packages/fxa-admin-server/src/rest/account/account.controller.ts
+++ b/packages/fxa-admin-server/src/rest/account/account.controller.ts
@@ -30,7 +30,10 @@ import {
   Email,
   getAccountCustomerByUid,
 } from 'fxa-shared/db/models/auth';
-import { SecurityEventNames } from 'fxa-shared/db/models/auth/security-event';
+import {
+  SecurityEventNames,
+  SECURITY_EVENTS_LIMIT,
+} from 'fxa-shared/db/models/auth/security-event';
 import { AdminPanelFeature } from '@fxa/shared/guards';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
@@ -850,7 +853,7 @@ export class AccountController {
   }
 
   @Features(AdminPanelFeature.AccountSearch)
-  public async securityEvents(account: Account) {
+  public async securityEvents(account: Account, limit = SECURITY_EVENTS_LIMIT) {
     const uidBuffer = uuidTransformer.to(account.uid);
     return await this.db.securityEvents
       .query()
@@ -861,7 +864,7 @@ export class AccountController {
         'securityEventNames.id'
       )
       .where('uid', uidBuffer)
-      .limit(10)
+      .limit(limit)
       .orderBy('createdAt', 'DESC');
   }
 


### PR DESCRIPTION
## Because

- The admin panel's Account History table was capped at 10 events, so support staff investigating an account saw less history than the account holder did.
- FXA-14318 raised the limit to 100 for Settings, but the admin server builds its own Knex query and never calls the shared method, so the panel kept the old cap.

## This pull request

- Adds an optional `limit` argument to `securityEvents()` in `account.controller.ts`, defaulting to the `SECURITY_EVENTS_LIMIT` constant (100) from `fxa-shared`.
- Renders the first 10 rows of Account History and puts the rest behind a "Show more" button, following the Settings `PageRecentActivity` pattern.
- Pairs the row key with the index, because every security event row carries the same uid.
- Adds tests for the cap, the button, and the empty state.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14358

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `account.controller.ts` (`securityEvents`), `Account/index.tsx` (Account History block).
- Suggested review order: server query first, then the component.
- Risky or complex parts: none. The visible cap lives in the component, not the query, so the server change only widens what the panel receives.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Verified locally: `Account/index.test.tsx` 29 of 29 pass, `account.controller.spec.ts` 21 of 21 pass, `nx lint` clean for both packages. No admin-server spec covers `securityEvents`, so the server change has no direct unit test. Functional tests were not run in this session.
