### PR TITLE
test(functional): cover the remaining step-up auth scenarios

### DIFF
--- a/packages/123done/README.md
+++ b/packages/123done/README.md
@@ -35,6 +35,12 @@ allows a few seconds of leeway on the comparison (`MAX_AGE_LEEWAY_SECONDS` in
 `fxa-auth-server/lib/oauth/grant.js`), so a click straight after a challenge is satisfied
 silently and one a little later re-challenges.
 
+Elevation does not survive a token refresh. `POST /api/refresh_token` (no UI, used by the
+functional tests) swaps in a fresh access token, and introspecting it reports no `acr` and
+no `auth_time` — the refresh grant never re-evaluates `acr_values`/`max_age` and the stored
+refresh token holds no authentication event. A relying party has to run step-up again
+rather than assume the elevation carried over.
+
 ### Ansible Deployment
 
 See [fxa-dev 123done](https://github.com/mozilla/fxa-dev/tree/docker/roles/rp) Ansible configuration for details.

--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -327,6 +327,9 @@ module.exports = function (app, db, checkAuth) {
       req.session.keys_jwe = body.keys_jwe;
       var token = (req.session.token = body.access_token);
       var id_token = body.id_token;
+      // Only issued because setupOAuthFlow requests access_type=offline. Kept so
+      // /api/refresh_token can exchange it for a fresh access token.
+      req.session.refresh_token = body.refresh_token;
 
       try {
         // Verify signature and extract claims from id_token
@@ -338,9 +341,6 @@ module.exports = function (app, db, checkAuth) {
         // advances on every second-factor challenge, so it — not acr — is what
         // shows whether a step-up actually re-authenticated the user.
         req.session.auth_time = claims.auth_time;
-        // Stashed on the session because /api/token_claims runs on a later request,
-        // which has no oauthFlows entry left to read the endpoint from.
-        req.session.introspection_endpoint = oauthConfig.introspection_endpoint;
 
         // Fetch additional profile data.
         var profileRes = await fetch(oauthConfig.userinfo_endpoint, {

--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -63,7 +63,22 @@ function checkAuth(req, res, next) {
 // auth status reports who the currently logged in user is on this
 // session
 app.get('/api/auth_status', function (req, res) {
-  console.log(req.session); //eslint-disable-line no-console
+  // Logged field by field rather than spreading the session: this runs on every page
+  // load, and the session carries the access and refresh tokens. A list of what to
+  // print cannot leak a credential added to the session later, the way a list of what
+  // to redact would. Presence is what helps when debugging a flow, not the value.
+  console.log({
+    email: req.session.email,
+    uid: req.session.uid,
+    acr: req.session.acr,
+    amr: req.session.amr,
+    auth_time: req.session.auth_time,
+    account_aal2: req.session.account_aal2,
+    scopes: req.session.scopes,
+    hasToken: !!req.session.token,
+    hasRefreshToken: !!req.session.refresh_token,
+    hasKeysJwe: !!req.session.keys_jwe,
+  }); //eslint-disable-line no-console
 
   res.send(
     JSON.stringify({
@@ -81,6 +96,18 @@ app.get('/api/auth_status', function (req, res) {
   );
 });
 
+// Resolve an endpoint from the issuer's discovery document, keyed off trusted
+// config. Deliberately not read back off the session: the cookie is signed but not
+// encrypted, so a session-supplied URL would be an attacker-influenced target for
+// requests that carry our access token or client_secret. Doing the lookup per call
+// also means sessions minted before this route existed keep working.
+async function discoverEndpoint(name) {
+  const response = await fetch(
+    `${config.get('issuer_uri')}/.well-known/openid-configuration`
+  );
+  return (await response.json())[name];
+}
+
 // The resource-server half of RFC 9470: introspect our own access token and report
 // the authentication level and event the authorization server sees. This is the
 // check an RP would run before allowing a sensitive action, as opposed to trusting
@@ -88,17 +115,19 @@ app.get('/api/auth_status', function (req, res) {
 //
 // Called once per page load, never polled — /v1/introspect is rate-limited per IP.
 app.get('/api/token_claims', checkAuth, async function (req, res) {
-  const endpoint = req.session.introspection_endpoint;
-  if (!endpoint || !req.session.token) {
+  if (!req.session.token) {
     return res.status(409).json({ error: 'no access token on this session' });
   }
 
   let response, text;
   try {
-    response = await fetch(endpoint, {
+    response = await fetch(await discoverEndpoint('introspection_endpoint'), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ token: req.session.token }),
+      body: JSON.stringify({
+        token: req.session.token,
+        token_type_hint: 'access_token',
+      }),
     });
     text = await response.text();
   } catch (err) {
@@ -132,6 +161,46 @@ app.get('/api/token_claims', checkAuth, async function (req, res) {
     iat: body.iat || null,
     exp: body.exp || null,
   });
+});
+
+// Exchange the refresh token for a fresh access token, replacing the one on the
+// session. Test-only, so there is no UI for it: the point it exists to demonstrate
+// is that a refreshed access token carries no `acr` and no `auth_time`, because the
+// refresh grant never re-evaluates acr_values/max_age and the stored refresh token
+// holds no authentication event. An RP must therefore treat a refreshed token as
+// unelevated and run step-up again, rather than assuming elevation persists.
+app.post('/api/refresh_token', checkAuth, async function (req, res) {
+  if (!req.session.refresh_token) {
+    return res.status(409).json({ error: 'no refresh token on this session' });
+  }
+
+  let response, body;
+  try {
+    response = await fetch(await discoverEndpoint('token_endpoint'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        client_id: config.get('client_id'),
+        client_secret: config.get('client_secret'),
+        refresh_token: req.session.refresh_token,
+      }),
+    });
+    body = await response.json();
+  } catch (err) {
+    return res.status(502).json({ error: String(err) });
+  }
+  if (response.status >= 400) {
+    return res.status(response.status).json(body);
+  }
+
+  // Only the access token is replaced. `acr`/`auth_time` on the session describe
+  // the id_token handed over at redirect time and are deliberately left alone, so
+  // /api/token_claims can be compared against them to show the two diverging.
+  req.session.token = body.access_token;
+  req.session.token_type = body.token_type;
+
+  res.json({ token_type: body.token_type, expires_in: body.expires_in });
 });
 
 // logout clears the current authenticated user

--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -136,6 +136,7 @@ export class RelierPage extends BaseLayout {
    * parameter. The request carries no `prompt=none`, so the flow stops at the cached
    * signin page for confirmation; the caller drives that and whatever follows — a
    * satisfied `max_age` returns to the relier, a stale one adds a second factor.
+   * `startStepUp` in tests/oauth/stepUpAuth.spec.ts wraps both cases.
    */
   async clickStepUpAuth(maxAge: number) {
     await this.page.locator('#step-up-max-age').fill(String(maxAge));
@@ -166,6 +167,11 @@ export class RelierPage extends BaseLayout {
    * The claims the authorization server reports for 123Done's current access token,
    * via `POST /v1/introspect`. This is the resource-server view of the elevation, as
    * opposed to the id_token 123Done was handed at redirect time.
+   *
+   * The route also returns `iat`/`exp`, deliberately not surfaced here: they are in
+   * milliseconds while `auth_time` is in seconds, and at second granularity they
+   * cannot tell two tokens issued in the same second apart, so they have no
+   * assertion value. Add them back only with a use.
    */
   async getTokenClaims(): Promise<{
     active: boolean;
@@ -177,6 +183,24 @@ export class RelierPage extends BaseLayout {
       `${this.target.relierUrl}/api/token_claims`
     );
     expect(response.ok()).toBe(true);
+    return response.json();
+  }
+
+  /**
+   * Exchange 123Done's refresh token for a fresh access token. The refresh grant
+   * never re-evaluates `acr_values`/`max_age` and the stored refresh token holds no
+   * authentication event, so the token this installs carries no `acr` and no
+   * `auth_time` — read it back with `getTokenClaims()` to assert that elevation does
+   * not survive a refresh.
+   */
+  async refreshAccessToken() {
+    const response = await this.page.request.post(
+      `${this.target.relierUrl}/api/refresh_token`
+    );
+    // Body in the message: the route answers 409 when the session holds no refresh
+    // token and mirrors the authorization server's status otherwise, so a bare
+    // ok()-is-true assertion would hide which of those happened.
+    expect(response.status(), await response.text()).toBe(200);
     return response.json();
   }
 

--- a/packages/functional-tests/tests/oauth/stepUpAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/stepUpAuth.spec.ts
@@ -2,9 +2,38 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test } from '../../lib/fixtures/standard';
+import { Page, expect, test } from '../../lib/fixtures/standard';
 import { enableTotpOnAccount } from '../../lib/pairing-helpers';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { getTotpCode } from '../../lib/totp';
+import { RelierPage } from '../../pages/relier';
+import { SigninPage } from '../../pages/signin';
+import { SigninTotpCodePage } from '../../pages/signinTotpCode';
+
+// The authorization server allows MAX_AGE_LEEWAY_SECONDS = 5 of grace on the
+// max_age comparison, so a session requested with max_age=0 is satisfied straight
+// after a challenge and goes stale just over 5 seconds later. Nothing larger is
+// reachable inside a test, which is why every re-challenge here uses 0.
+const MAX_AGE_STALE_MS = 7000;
+
+// Far outside that window, so a session that authenticated seconds ago satisfies
+// the request outright. This is the "sudo window" end of the max_age dial.
+const MAX_AGE_SUDO_WINDOW_SECONDS = 300;
+
+// Bounds for a plausible just-issued auth_time, in seconds. Generous on the past
+// side so a slow CI run cannot fail on timing alone, tight on the future side
+// because that is where a milliseconds-for-seconds regression would land.
+const AUTH_TIME_MAX_AGE_S = 600;
+const AUTH_TIME_SKEW_S = 60;
+
+/** An account whose TOTP secret is known, so codes can be generated for it. */
+type TotpAccount = Credentials & { secret: string };
+
+type AuthStatus = Awaited<ReturnType<RelierPage['getAuthStatus']>>;
+
+/** An elevation snapshot whose `auth_time` is known to be present and sane. */
+type Elevation = AuthStatus & { auth_time: number };
 
 test.describe('severity-2 #smoke', () => {
   test.describe('OAuth step-up auth', () => {
@@ -13,29 +42,18 @@ test.describe('severity-2 #smoke', () => {
       pages: { page, relier, signin, signinTotpCode },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
-      // Assigned to `secret` so account teardown can elevate AAL to delete it.
-      credentials.secret = await enableTotpOnAccount(
-        target.authClient,
-        credentials.sessionToken
-      );
+      const credentials = await signUpWithTotp(target, testAccountTracker);
+      await signInToRelierWithTotp({
+        credentials,
+        page,
+        relier,
+        signin,
+        signinTotpCode,
+      });
 
-      await relier.goto();
-      await relier.clickEmailFirst();
-      await signin.fillOutEmailFirstForm(credentials.email);
-      await signin.fillOutPasswordForm(credentials.password);
-      await expect(page).toHaveURL(/signin_totp_code/);
-      await signinTotpCode.fillOutCodeForm(
-        await getTotpCode(credentials.secret)
-      );
+      const before = await captureElevation(relier);
 
-      expect(await relier.isLoggedIn()).toBe(true);
-      const before = await relier.getAuthStatus();
-      expect(before.acr).toBe('AAL2');
-      // Pinned so the equality check below can't pass vacuously on null === null.
-      expect(before.auth_time).toEqual(expect.any(Number));
-
-      await relier.clickStepUpAuth(300);
+      await relier.clickStepUpAuth(MAX_AGE_SUDO_WINDOW_SECONDS);
 
       // The request carries no prompt=none, so the flow always stops at the cached
       // signin page to confirm — with no password field, which is the point of
@@ -51,10 +69,9 @@ test.describe('severity-2 #smoke', () => {
 
       const after = await relier.getAuthStatus();
       expect(after.acr).toBe('AAL2');
+      // Unchanged, because no challenge happened — same authentication event.
       expect(after.auth_time).toBe(before.auth_time);
 
-      // The same elevation, as the authorization server reports it for the access
-      // token — the check a resource server would make before a sensitive action.
       const introspected = await relier.getTokenClaims();
       expect(introspected.active).toBe(true);
       expect(introspected.acr).toBe('AAL2');
@@ -97,3 +114,413 @@ test.describe('severity-2', () => {
     });
   });
 });
+
+// severity-2 puts these on stage but not production, which runs severity-1 only.
+// They fail on stage until 123Done is redeployed there — it ships to stage and
+// production separately from the train — and that window is accepted rather than
+// carried as a gate someone has to remember to remove.
+test.describe('severity-2', () => {
+  test.describe('OAuth step-up auth re-challenges', () => {
+    test('re-challenges a stale AAL2 session for TOTP and advances auth_time', async ({
+      target,
+      pages: { page, relier, signin, signinTotpCode },
+      testAccountTracker,
+    }) => {
+      const credentials = await signUpWithTotp(target, testAccountTracker);
+      await signInToRelierWithTotp({
+        credentials,
+        page,
+        relier,
+        signin,
+        signinTotpCode,
+      });
+
+      const before = await captureElevation(relier);
+      await goStale(page);
+
+      await startStepUp({ maxAge: 0, page, relier, signin });
+
+      // A step-up on an already-verified session currently reaches the TOTP page
+      // via a bounce through /inline_totp_setup, so wait on the destination rather
+      // than asserting the immediate URL.
+      await page.waitForURL(/signin_totp_code/);
+      await signinTotpCode.fillOutCodeForm(
+        await getTotpCode(credentials.secret)
+      );
+
+      expect(await relier.isLoggedIn()).toBe(true);
+      await expectElevationAdvanced(relier, before);
+    });
+
+    test('accepts a backup authentication code as the second factor', async ({
+      target,
+      pages: { page, relier, signin, signinRecoveryCode, signinTotpCode },
+      testAccountTracker,
+    }) => {
+      const { credentials, recoveryCodes } = await signUpWithTotpAndBackupCodes(
+        target,
+        testAccountTracker
+      );
+      await signInToRelierWithTotp({
+        credentials,
+        page,
+        relier,
+        signin,
+        signinTotpCode,
+      });
+
+      const before = await captureElevation(relier);
+      await goStale(page);
+
+      await startStepUp({ maxAge: 0, page, relier, signin });
+      await page.waitForURL(/signin_totp_code/);
+      await signinTotpCode.clickTroubleEnteringCode();
+      // No recovery phone on this account, so the choice screen is skipped.
+      await page.waitForURL(/signin_recovery_code/);
+      await signinRecoveryCode.fillOutCodeForm(recoveryCodes[0]);
+
+      expect(await relier.isLoggedIn()).toBe(true);
+      // `recovery-code` maps to the same `otp` amr value as `totp-2fa`, so amr
+      // cannot show which method was used — auth_time advancing is the only signal
+      // that this one satisfied the challenge.
+      await expectElevationAdvanced(relier, before);
+    });
+
+    test('drops elevation from a refreshed access token', async ({
+      target,
+      pages: { page, relier, signin, signinTotpCode },
+      testAccountTracker,
+    }) => {
+      const credentials = await signUpWithTotp(target, testAccountTracker);
+      await signInToRelierWithTotp({
+        credentials,
+        page,
+        relier,
+        signin,
+        signinTotpCode,
+      });
+
+      const elevated = await relier.getTokenClaims();
+      expect(elevated.active).toBe(true);
+      expect(elevated.acr).toBe('AAL2');
+      expect(typeof elevated.auth_time).toBe('number');
+
+      await relier.refreshAccessToken();
+
+      // The refresh grant never re-evaluates acr_values/max_age, and the stored
+      // refresh token carries no authentication event, so the new access token has
+      // no assurance level to report. A resource server has to run step-up again
+      // rather than treat a refreshed token as still elevated.
+      // `active: true` is load-bearing: it proves the authorization server knows
+      // this token and considers it live, so the two null claims below describe a
+      // real unelevated token rather than a failed introspection. Introspection's
+      // iat/exp cannot be used to tell the two tokens apart — they are second
+      // granular, so a refresh inside the same second reports identical values.
+      const refreshed = await relier.getTokenClaims();
+      expect(refreshed.active).toBe(true);
+      expect(refreshed.acr).toBe(null);
+      expect(refreshed.auth_time).toBe(null);
+    });
+
+    test('enrols a second factor inline when the account has none', async ({
+      target,
+      pages: { page, inlineTotpSetup, relier, signin, totp },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await relier.goto();
+      await relier.clickEmailFirst();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      expect(await relier.isLoggedIn()).toBe(true);
+      expect((await relier.getAuthStatus()).acr).toBe('AAL1');
+
+      await startStepUp({ maxAge: 0, page, relier, signin });
+
+      // There is no AAL2 method to challenge, so errno 170 routes to enrolment.
+      const { available: recoveryPhoneAvailable } =
+        await target.authClient.recoveryPhoneAvailable(
+          credentials.sessionToken
+        );
+      // Sets credentials.secret, which account teardown needs to elevate and delete.
+      await totp.completeInlineSetupWithBackupCodes(
+        inlineTotpSetup,
+        credentials,
+        recoveryPhoneAvailable
+      );
+
+      expect(await relier.isLoggedIn()).toBe(true);
+      const after = await relier.getAuthStatus();
+      expect(after.acr).toBe('AAL2');
+      expect(typeof after.auth_time).toBe('number');
+    });
+  });
+});
+
+// Local only, and not for the same reason as the block above: two 7 second sleeps
+// plus three TOTP entries put this near the 60 second test ceiling, so remote
+// latency would make it flake rather than fail honestly.
+test.describe('OAuth step-up auth repeat challenges (local only)', () => {
+  test('re-challenges each successive sensitive action under a tight max_age', async ({
+    target,
+    pages: { page, relier, signin, signinTotpCode },
+    testAccountTracker,
+  }) => {
+    const credentials = await signUpWithTotp(target, testAccountTracker);
+    await signInToRelierWithTotp({
+      credentials,
+      page,
+      relier,
+      signin,
+      signinTotpCode,
+    });
+
+    const first = await captureElevation(relier);
+    await goStale(page);
+
+    await startStepUp({ maxAge: 0, page, relier, signin });
+    await page.waitForURL(/signin_totp_code/);
+    await signinTotpCode.fillOutCodeForm(await getTotpCode(credentials.secret));
+    expect(await relier.isLoggedIn()).toBe(true);
+    const second = await expectElevationAdvanced(relier, first);
+
+    await goStale(page);
+
+    // The elevation granted moments ago has itself gone stale, so a second
+    // sensitive action is challenged afresh rather than reusing it.
+    await startStepUp({ maxAge: 0, page, relier, signin });
+    await page.waitForURL(/signin_totp_code/);
+    await signinTotpCode.fillOutCodeForm(await getTotpCode(credentials.secret));
+    expect(await relier.isLoggedIn()).toBe(true);
+    await expectElevationAdvanced(relier, second);
+  });
+});
+
+// Local only — see "Routing SMS tests in CI" in the README. SmsClient.getCode()
+// rejects a severity-labelled test that reads an SMS code without a #phone tag,
+// so this describe deliberately carries no severity label.
+test.describe('OAuth step-up auth with recovery phone (local only)', () => {
+  test.beforeAll(({ target }) => {
+    target.smsClient.guardTestPhoneNumber();
+  });
+
+  test('accepts a recovery phone code as the second factor', async ({
+    target,
+    pages: {
+      page,
+      recoveryPhone,
+      relier,
+      settings,
+      signin,
+      signinRecoveryChoice,
+      signinRecoveryPhone,
+      signinTotpCode,
+    },
+    testAccountTracker,
+  }) => {
+    const { credentials } = await signUpWithTotpAndBackupCodes(
+      target,
+      testAccountTracker
+    );
+    await signInToRelierWithTotp({
+      credentials,
+      page,
+      relier,
+      signin,
+      signinTotpCode,
+    });
+
+    // Recovery phone has no API shortcut, so enrol it through Settings on the
+    // session we already have. The MFA guard still applies: it is a separate
+    // emailed-code check on account changes, independent of the session's AAL.
+    await settings.goto();
+    await settings.totp.addRecoveryPhoneButton.click();
+    await settings.confirmMfaGuard(credentials.email);
+    await recoveryPhone.submitPhoneNumber();
+    await expect(recoveryPhone.confirmHeader).toBeVisible();
+    await recoveryPhone.submitCode(
+      await target.smsClient.getCode({ ...credentials })
+    );
+    await expect(settings.alertBar).toHaveText('Recovery phone added');
+
+    await relier.goto();
+    const before = await captureElevation(relier);
+    await goStale(page);
+
+    await startStepUp({ maxAge: 0, page, relier, signin });
+    await page.waitForURL(/signin_totp_code/);
+    await signinTotpCode.clickTroubleEnteringCode();
+    // Both a phone and backup codes are set up, so the choice screen renders.
+    await page.waitForURL(/signin_recovery_choice/);
+    await signinRecoveryChoice.clickChoosePhone();
+    await signinRecoveryChoice.clickContinue();
+    await page.waitForURL(/signin_recovery_phone/);
+    await signinRecoveryPhone.enterCode(
+      await target.smsClient.getCode({ ...credentials })
+    );
+    await signinRecoveryPhone.clickConfirm();
+
+    expect(await relier.isLoggedIn()).toBe(true);
+    await expectElevationAdvanced(relier, before);
+  });
+});
+
+/**
+ * Sign up an account with TOTP enabled over the API rather than the Settings UI.
+ * `credentials.secret` is set so account teardown can elevate to AAL2 and delete it.
+ */
+async function signUpWithTotp(
+  target: BaseTarget,
+  testAccountTracker: TestAccountTracker
+): Promise<TotpAccount> {
+  const credentials = await testAccountTracker.signUp();
+  credentials.secret = await enableTotpOnAccount(
+    target.authClient,
+    credentials.sessionToken
+  );
+  // Narrowed rather than copied: the tracker holds this same object, and helpers
+  // like completeInlineSetupWithBackupCodes mutate it, so a copy could drift.
+  return credentials as TotpAccount;
+}
+
+/**
+ * As `signUpWithTotp`, plus a set of backup authentication codes. Codes can only be
+ * generated once TOTP is enabled (FXA-14058), and the endpoint needs a verified
+ * session at the account's required assurance level — both true only in this order.
+ */
+async function signUpWithTotpAndBackupCodes(
+  target: BaseTarget,
+  testAccountTracker: TestAccountTracker
+): Promise<{ credentials: TotpAccount; recoveryCodes: string[] }> {
+  const credentials = await signUpWithTotp(target, testAccountTracker);
+  const { recoveryCodes } = await target.authClient.replaceRecoveryCodes(
+    credentials.sessionToken
+  );
+  return { credentials, recoveryCodes };
+}
+
+/**
+ * Start a step-up from a signed-in RP session and confirm the cached-signin screen.
+ *
+ * Step-up deliberately sends no `action`, so FxA reuses the signed-in session and
+ * asks the user to confirm it. Nothing happens until that button is clicked — no
+ * second-factor challenge, and no grant — which is why every scenario goes through
+ * here rather than calling clickStepUpAuth directly.
+ *
+ * The confirmation screen is also where a password would be demanded if `max_age`
+ * were folded back into `wantsLogin()`, so asserting its absence here guards that
+ * regression for every scenario at no extra cost.
+ *
+ * `expectChallenge: false` is for a session that already satisfies the request: the
+ * grant is issued immediately and the user never leaves the RP, so this waits on the
+ * redirect_uri response. Waiting on the relier URL instead would match the page we
+ * are already on and resolve before the round trip had started.
+ */
+async function startStepUp({
+  expectChallenge = true,
+  maxAge,
+  page,
+  relier,
+  signin,
+}: {
+  expectChallenge?: boolean;
+  maxAge: number;
+  page: Page;
+  relier: RelierPage;
+  signin: SigninPage;
+}): Promise<void> {
+  await relier.clickStepUpAuth(maxAge);
+  await expect(signin.cachedSigninSubmitButton).toBeVisible();
+  await expect(signin.passwordTextbox).toBeHidden();
+
+  if (expectChallenge) {
+    await signin.cachedSigninSubmitButton.click();
+    return;
+  }
+  await Promise.all([
+    page.waitForResponse(/\/api\/oauth/),
+    signin.cachedSigninSubmitButton.click(),
+  ]);
+}
+
+/** Reach the RP signed in and session-AAL2, by way of a TOTP challenge. */
+async function signInToRelierWithTotp({
+  credentials,
+  page,
+  relier,
+  signin,
+  signinTotpCode,
+}: {
+  credentials: TotpAccount;
+  page: Page;
+  relier: RelierPage;
+  signin: SigninPage;
+  signinTotpCode: SigninTotpCodePage;
+}): Promise<void> {
+  await relier.goto();
+  await relier.clickEmailFirst();
+  await signin.fillOutEmailFirstForm(credentials.email);
+  await signin.fillOutPasswordForm(credentials.password);
+  await page.waitForURL(/signin_totp_code/);
+  await signinTotpCode.fillOutCodeForm(await getTotpCode(credentials.secret));
+
+  expect(await relier.isLoggedIn()).toBe(true);
+}
+
+/**
+ * Snapshot the RP's current AAL2 elevation, with `auth_time` narrowed to a number so
+ * comparisons against it cannot pass vacuously against null.
+ *
+ * The bounds are the assertion that matters. `auth_time` is seconds since the epoch
+ * while introspection reports `iat`/`exp` in milliseconds, and that asymmetry is
+ * exactly the regression to guard: a millisecond value would land tens of thousands
+ * of years in the future and sail past any typeof or non-null check.
+ */
+async function captureElevation(relier: RelierPage): Promise<Elevation> {
+  const status = await relier.getAuthStatus();
+  expect(status.acr).toBe('AAL2');
+
+  if (typeof status.auth_time !== 'number') {
+    throw new Error(`expected a numeric auth_time, got ${status.auth_time}`);
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  expect(status.auth_time).toBeGreaterThan(nowSeconds - AUTH_TIME_MAX_AGE_S);
+  expect(status.auth_time).toBeLessThanOrEqual(nowSeconds + AUTH_TIME_SKEW_S);
+
+  return { ...status, auth_time: status.auth_time };
+}
+
+/**
+ * Assert a fresh AAL2 elevation relative to `before`, from both the id_token the RP
+ * was handed and the authorization server's own view of the access token — the
+ * check a resource server would make before a sensitive action.
+ */
+async function expectElevationAdvanced(
+  relier: RelierPage,
+  before: Elevation
+): Promise<Elevation> {
+  const after = await captureElevation(relier);
+  expect(after.auth_time).toBeGreaterThan(before.auth_time);
+
+  const introspected = await relier.getTokenClaims();
+  expect(introspected.active).toBe(true);
+  expect(introspected.acr).toBe('AAL2');
+  expect(introspected.auth_time).toBe(after.auth_time);
+  // Every second factor maps to `otp`, so this cannot identify which one ran — it
+  // guards against the claim going missing entirely.
+  expect(introspected.amr).toContain('otp');
+
+  return after;
+}
+
+/**
+ * Let the session age past the leeway-adjusted `max_age=0` window. A real
+ * wall-clock wait: freshness is evaluated server-side against the session's
+ * authentication event, so there is no clock to fake from here and no observable
+ * state to poll for — the session goes stale silently.
+ */
+async function goStale(page: Page): Promise<void> {
+  // eslint-disable-next-line playwright/no-wait-for-timeout
+  await page.waitForTimeout(MAX_AGE_STALE_MS);
+}

--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -266,6 +266,75 @@ test.describe('severity-1 #smoke', () => {
       expect(await relier.isLoggedIn()).toBe(true);
     });
 
+    // Step-up counterpart to the test above: same divert, reached by an RP
+    // re-authorizing an already signed-in session rather than by a fresh sign-in.
+    // The rest of the step-up suite lives in tests/oauth/stepUpAuth.spec.ts; this
+    // one is here for the passkey helpers.
+    test('diverts a passkey user without TOTP to inline TOTP setup on RP step-up', async ({
+      target,
+      pages: {
+        page,
+        inlineTotpSetup,
+        relier,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        totp,
+      },
+      testAccountTracker,
+    }) => {
+      test.skip(
+        target.name !== 'local',
+        'requires the local 123done /api/step_up toggle'
+      );
+
+      // Sign in to the RP with the passkey, so the session is already session-AAL2
+      // (AMR {pwd, webauthn}) while the account itself has no TOTP.
+      const credentials = await setUpAccountWithPasskey({
+        target,
+        page,
+        settings,
+        settingsPasskeyAdd,
+        signin,
+        testAccountTracker,
+      });
+      await settings.signOut();
+
+      await relier.goto();
+      await relier.clickEmailFirst();
+      await settingsPasskeyAdd.passkeyAuth.assertion(async () => {
+        await signin.passkeySigninButton.click();
+        await page.waitForURL((url) => url.href.startsWith(target.relierUrl));
+      });
+      expect(await relier.isLoggedIn()).toBe(true);
+
+      await relier.clickStepUpAuth(0);
+      // Step-up reuses the signed-in session, so FxA asks the user to confirm it
+      // before re-authorizing anything.
+      await expect(signin.cachedSigninSubmitButton).toBeVisible();
+      await signin.cachedSigninSubmitButton.click();
+
+      // Current behaviour, not desired behaviour. A passkey assertion is itself
+      // AAL2, but the divert in Signin/utils.ts keys on `accountHasTotp === false`
+      // and does not count a passkey, so these users are made to enrol a TOTP app
+      // they do not need. FXA-12861 specified fixing this and shipped without it;
+      // when that is fixed, this becomes an assertion that no divert happens.
+      await page.waitForURL(/inline_totp_setup/);
+
+      // Enrolling does satisfy the step-up and return to the RP, so the divert is
+      // a detour rather than a dead end.
+      const { available: recoveryPhoneAvailable } =
+        await target.authClient.recoveryPhoneAvailable(credentials.sessionToken);
+      await totp.completeInlineSetupWithBackupCodes(
+        inlineTotpSetup,
+        credentials,
+        recoveryPhoneAvailable
+      );
+
+      expect(await relier.isLoggedIn()).toBe(true);
+      expect((await relier.getAuthStatus()).acr).toBe('AAL2');
+    });
+
     test('AMO-style profile AAL2: passkey-only user is diverted to TOTP setup before the RP grant', async ({
       target,
       pages: {


### PR DESCRIPTION
## Because

- Step-up authentication had only a single smoke test, leaving the rest of the epic's scenarios unverified.
- Step-up is satisfied by any AAL2 method, and `amr` collapses them all to `otp`, so only an end-to-end check can show that a given factor re-authenticated.

## This pull request

- Adds stale-session re-challenge, backup-code, recovery-phone, inline-enrolment, repeat-challenge and token-refresh scenarios, plus the passkey divert case, keying per-method checks off `auth_time`.
- Adds a `startStepUp` helper that confirms the cached-signin page every scenario stops on, and asserts no password is demanded there.
- Adds `POST /api/refresh_token` to 123done, showing that a refreshed access token reports no `acr` or `auth_time`.
- Resolves 123done's oauth endpoints from the issuer's discovery document, so no outbound request target comes from the signed-but-unencrypted session cookie.
- Logs `/api/auth_status` sessions field by field, so the access and refresh tokens no longer reach the logs on every page load.

## Issue that this pull request solves

Closes: #FXA-12863

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/functional-tests/tests/oauth/stepUpAuth.spec.ts`, and the two 123done routes in `packages/123done/server.js`.
- Risky or complex parts: the `max_age` scenarios depend on `MAX_AGE_LEEWAY_SECONDS = 5` in `fxa-auth-server/lib/oauth/grant.js`, so they use a real wall-clock wait. `grant.js`'s own unit tests pin the freshness rule deterministically; these cover the RP round trip.

## Other information (Optional)

**Expect stage to fail until 123done is redeployed there.** Four scenarios are labelled `severity-2`, so they run on stage — but they drive `/api/step_up` and `/api/refresh_token`, and 123done ships to stage and production via Heroku separately from the train. This was chosen deliberately over carrying a target gate that someone has to remember to remove; FXA-12862 is on main now, so the deploy needs a ref containing this PR. Production runs `severity-1` only, so it is unaffected.

Two cases stay local on purpose, for reasons unrelated to that deploy:

- `re-challenges each successive sensitive action` — two 7s waits plus three TOTP entries put it near the 60s ceiling, so remote latency would make it flake.
- `accepts a recovery phone code` — `SmsClient.assertSmsTestIsIsolated` rejects a severity-labelled test that reads an SMS code without `#phone`.

