### PR TITLE
fix(settings): order l10n bundling before static asset hashing

### DIFF
--- a/packages/fxa-settings/Gruntfile.js
+++ b/packages/fxa-settings/Gruntfile.js
@@ -82,5 +82,40 @@ module.exports = function (grunt) {
   grunt.registerTask('merge-ftl:test', ['concat:ftl-test']);
   grunt.registerTask('watch-ftl', ['watch:ftl']);
 
-  grunt.registerTask('hash-static', ['hash']);
+  // `main.ftl` is the only bundle the client ever requests, and it is written by
+  // `l10n-bundle` rather than shipped by the l10n repo. If hashing runs before that,
+  // the manifest has no `main.ftl` key, AppLocalizationProvider skips the fetch
+  // entirely, and every locale silently falls back to the English JSX defaults.
+  grunt.registerTask('verify-hashed-locales', function () {
+    const mapping = grunt.config('hash.options.mapping');
+    if (!grunt.file.exists(mapping)) {
+      grunt.fail.fatal(`${mapping} was not generated.`);
+    }
+
+    const hashed = grunt.file.readJSON(mapping);
+    const locales = grunt.file.expand(
+      { cwd: 'public/locales', filter: 'isDirectory' },
+      '*'
+    );
+
+    // Otherwise an empty public/locales would pass the check below vacuously.
+    if (!locales.includes('en')) {
+      grunt.fail.fatal(
+        'public/locales has no en directory. Run the l10n-prime and l10n-merge targets first.'
+      );
+    }
+
+    const missing = locales.filter(
+      (locale) => !hashed[`locales/${locale}/main.ftl`]
+    );
+
+    if (missing.length) {
+      grunt.fail.fatal(
+        `${mapping} is missing main.ftl for: ${missing.join(', ')}. ` +
+          'Run the l10n-bundle target before hash-static.'
+      );
+    }
+  });
+
+  grunt.registerTask('hash-static', ['hash', 'verify-hashed-locales']);
 };

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -373,7 +373,8 @@
       "build-static": {
         "cache": true,
         "dependsOn": [
-          "prebuild"
+          "prebuild",
+          "build-l10n"
         ],
         "inputs": [
           "production",


### PR DESCRIPTION
## Because

- Since v1.342.0, production has served English to every locale — the static asset manifest shipped with no `main.ftl` keys, so the settings app fetched no FTL at all.
- The nx upgrade replaced a sequential `build-l10n && build-static` chain with sibling `dependsOn` entries, which carry no ordering guarantee between each other, so grunt `hash-static` could hash `public/locales` before `l10n-bundle` had written into it.

## This pull request

- Adds `build-l10n` to `build-static`'s `dependsOn`, so grunt `hash-static` can no longer run before `l10n-bundle` has written `main.ftl`.
- Fails `hash-static` when the generated manifest is missing `main.ftl` for any locale present on disk.

## Issue that this pull request solves

Closes: FXA-14361

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-settings/package.json` holds the one-line change that actually fixes the outage; `Gruntfile.js` holds the new guard.
- Suggested review order: `package.json` → `Gruntfile.js`.
- Risky or complex parts: nothing in the diff itself. Worth knowing that `public/locales` is gitignored, so nx's hasher cannot see those files as inputs — which is why a stale cache can hide this locally.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Sentry reporting for whole-bundle l10n failures was split out into #21044 (FXA-14362), so this stays a two-file diff. The two PRs are independent and share no files.
- Prod is currently serving English to every locale, so this likely wants a dot release rather than riding the next train.
- History was rewritten to perform that split; the previous head was `efdbd68f37`.
- Verified locally: the nx task graph now orders `build-l10n` ahead of `build-static`; a cold prime → merge → bundle → hash produces `main.ftl` manifest entries for all 88 locales; and the guard fails with a precise message when a locale is missing one.
