### PR TITLE
feat(l10n): report whole-bundle l10n load failures to Sentry

### DIFF
--- a/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
@@ -14,6 +14,11 @@ import { Localized } from '@fluent/react';
 import fetchMock from 'fetch-mock';
 import AppLocalizationProvider from './AppLocalizationProvider';
 
+// `it` negotiates to exactly ['it', 'en'], which keeps the set of requested
+// bundle paths small enough to assert on precisely.
+const HASHED_BASE_DIR = '/hashed';
+const HASHED_LOCALES = ['it'];
+
 describe('<AppLocalizationProvider/>', () => {
   const locales = ['en-GB', 'en-CA', 'es-ES'];
   const bundles = ['greetings', 'farewells'];
@@ -26,21 +31,46 @@ describe('<AppLocalizationProvider/>', () => {
   }
 
   beforeAll(() => {
+    // Keys must match the path `fetchMessages` builds, which has no leading
+    // slash. `farewells` is absent for every locale but en-CA, so those
+    // lookups miss and Fluent falls back.
     fetchMock.get(
       '/static-asset-manifest.json',
-      `
-      {
-        "/locales/en-CA/greetings.ftl": "/locales/en-CA/greetings.ftl",
-        "/locales/en-CA/farewells.ftl": "/locales/en-CA/farewells.ftl",
-        "/locales/es-ES/greetings.ftl": "/locales/es-ES/greetings.ftl",
-        "/locales/en-GB/greetings.ftl": "/locales/en-GB/greetings.ftl",
-      }
-      `
+      JSON.stringify({
+        'locales/en-CA/greetings.ftl': 'locales/en-CA/greetings.ftl',
+        'locales/en-CA/farewells.ftl': 'locales/en-CA/farewells.ftl',
+        'locales/es-ES/greetings.ftl': 'locales/es-ES/greetings.ftl',
+        'locales/en-GB/greetings.ftl': 'locales/en-GB/greetings.ftl',
+      })
     );
     fetchMock.get('/locales/en-CA/greetings.ftl', 'hello = Hello\n');
     fetchMock.get('/locales/en-CA/farewells.ftl', 'goodbye = Goodbye\n');
     fetchMock.get('/locales/es-ES/greetings.ftl', 'hello = Hola\n');
     fetchMock.get('/locales/en-GB/greetings.ftl', 'hello = Hello { $amount }');
+
+    // A separate manifest, served under its own baseDir so it does not
+    // collide with the default manifest fixture above. `farewells` is
+    // deliberately absent from it, and `notfound` maps to a path that 404s.
+    fetchMock.get(
+      `${HASHED_BASE_DIR}/static-asset-manifest.json`,
+      JSON.stringify({
+        'locales/it/greetings.ftl': 'locales/it/greetings.1a2b3c.ftl',
+        'locales/en/greetings.ftl': 'locales/en/greetings.4d5e6f.ftl',
+        'locales/it/notfound.ftl': 'locales/it/notfound.7a8b9c.ftl',
+        'locales/en/notfound.ftl': 'locales/en/notfound.7a8b9c.ftl',
+      })
+    );
+    fetchMock.get(
+      `${HASHED_BASE_DIR}/locales/it/greetings.1a2b3c.ftl`,
+      'hello = Ciao\n'
+    );
+    fetchMock.get(
+      `${HASHED_BASE_DIR}/locales/en/greetings.4d5e6f.ftl`,
+      'hello = Hello\n'
+    );
+    fetchMock.get(`${HASHED_BASE_DIR}/locales/it/notfound.7a8b9c.ftl`, 404);
+    fetchMock.get(`${HASHED_BASE_DIR}/locales/en/notfound.7a8b9c.ftl`, 404);
+
     fetchMock.get('*', { throws: new Error() });
   });
 
@@ -168,5 +198,106 @@ describe('<AppLocalizationProvider/>', () => {
     await waitUntilTranslated();
 
     expect(getByTestId('result')).toHaveTextContent('Hello ⁨$US123.00⁩');
+  });
+
+  describe('reportBundleError', () => {
+    function renderWithManifest(
+      bundlesToLoad: Array<string>,
+      reportBundleError: jest.Mock,
+      baseDir = HASHED_BASE_DIR
+    ) {
+      return render(
+        <AppLocalizationProvider
+          baseDir={baseDir}
+          bundles={bundlesToLoad}
+          userLocales={HASHED_LOCALES}
+          reportBundleError={reportBundleError}
+        >
+          <main data-testid="result">
+            <Localized id="hello">
+              <div>untranslated</div>
+            </Localized>
+          </main>
+        </AppLocalizationProvider>
+      );
+    }
+
+    it('resolves the hashed path from the manifest and reports nothing', async () => {
+      const reportBundleError = jest.fn();
+      const { getByTestId } = renderWithManifest(
+        ['greetings'],
+        reportBundleError
+      );
+      await waitUntilTranslated();
+
+      expect(getByTestId('result')).toHaveTextContent('Ciao');
+      expect(reportBundleError).not.toHaveBeenCalled();
+    });
+
+    it('reports a bundle with no entry in the manifest, once per locale', async () => {
+      const reportBundleError = jest.fn();
+      const { getByTestId } = renderWithManifest(
+        ['farewells'],
+        reportBundleError
+      );
+      await waitUntilTranslated();
+
+      expect(
+        reportBundleError.mock.calls.map(([error, locale]) => [
+          error.message,
+          locale,
+        ])
+      ).toEqual([
+        [
+          'No static asset mapping for l10n bundle: locales/it/farewells.ftl',
+          'it',
+        ],
+        [
+          'No static asset mapping for l10n bundle: locales/en/farewells.ftl',
+          'en',
+        ],
+      ]);
+      expect(getByTestId('result')).toHaveTextContent('untranslated');
+    });
+
+    it('reports a bundle whose hashed path does not resolve, once per locale', async () => {
+      const reportBundleError = jest.fn();
+      renderWithManifest(['notfound'], reportBundleError);
+      await waitUntilTranslated();
+
+      expect(
+        reportBundleError.mock.calls.map(([error, locale]) => [
+          error.message,
+          locale,
+        ])
+      ).toEqual([
+        [
+          `Fetching l10n bundle returned 404: ${HASHED_BASE_DIR}/locales/it/notfound.7a8b9c.ftl`,
+          'it',
+        ],
+        [
+          `Fetching l10n bundle returned 404: ${HASHED_BASE_DIR}/locales/en/notfound.7a8b9c.ftl`,
+          'en',
+        ],
+      ]);
+    });
+
+    it('reports an unreachable manifest', async () => {
+      const reportBundleError = jest.fn();
+      renderWithManifest(['greetings'], reportBundleError, '/no-manifest');
+      await waitUntilTranslated();
+
+      // A manifest failure is not scoped to one locale, so it carries none.
+      expect(reportBundleError.mock.calls[0]).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Fetching l10n static asset manifest failed: /no-manifest/static-asset-manifest.json'
+          ),
+        }),
+      ]);
+      // Without mappings the unhashed paths are requested and fail too, so a
+      // manifest outage costs one report plus one per negotiated locale.
+      expect(reportBundleError).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/packages/fxa-react/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.tsx
@@ -7,45 +7,75 @@ import { LocalizationProvider, ReactLocalization } from '@fluent/react';
 import React, { Component } from 'react';
 import { EN_GB_LOCALES, parseAcceptLanguage } from '@fxa/shared/l10n';
 
+type ReportError = (error: Error) => void;
+
+// A bundle failure belongs to the locale whose file could not be loaded. A
+// manifest failure breaks every locale at once, so it carries none.
+type ReportBundleError = (error: Error, locale?: string) => void;
+
+function describeCause(err: unknown) {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /**
  * Gets l10n messages from server
  * @param baseDir The root location where locales folders are held
  * @param locale The target language
  * @param bundle The target bundle (ie main)
  * @param mappings A set of mappings for static resources.
+ * @param reportBundleError Receives whole-bundle load failures for this locale.
  * @returns
  */
 async function fetchMessages(
   baseDir: string,
   locale: string,
   bundle: string,
-  mappings?: Record<string, string>
+  mappings?: Record<string, string>,
+  reportBundleError?: ReportBundleError
 ) {
+  // Build the path to l10n file
+  const path = `locales/${locale}/${bundle}.ftl`;
+
+  // If mappings were provided see if there is one for the path. This
+  // will be a location where the file path contains a hash in the file
+  // name
+  const mappedPath = mappings ? mappings[path] : path;
+
+  // If we don't have mapped path, there are no l10n resources for this language.
+  if (!mappedPath) {
+    reportBundleError?.(
+      new Error(`No static asset mapping for l10n bundle: ${path}`),
+      locale
+    );
+    return '';
+  }
+
+  // Fetch the file and return the messages
+  const resolvedPath = `${baseDir}/${mappedPath}`;
   try {
-    // Build the path to l10n file
-    let path = `locales/${locale}/${bundle}.ftl`;
+    const response = await fetch(resolvedPath);
 
-    // If mappings were proivided see if there is one for the path. This
-    // will be a location where the file path contains a hash in the file
-    // name
-    if (mappings) {
-      path = mappings[path];
-    }
-
-    // If we don't have mapped path, there are no l10n resources for this language.
-    if (!path) {
+    // A non-OK body is not FTL, and handing it to Fluent yields an empty bundle.
+    if (!response.ok) {
+      reportBundleError?.(
+        new Error(
+          `Fetching l10n bundle returned ${response.status}: ${resolvedPath}`
+        ),
+        locale
+      );
       return '';
     }
 
-    // Fetch the file and return the messages
-    const resolvedPath = `${baseDir}/${path}`;
-    const response = await fetch(resolvedPath);
-    const messages = await response.text();
-
-    return messages;
+    return await response.text();
   } catch (e) {
     // We couldn't fetch any strings; just return nothing and fluent will fall
     // back to the default locale if needed.
+    reportBundleError?.(
+      new Error(
+        `Fetching l10n bundle failed: ${resolvedPath} (${describeCause(e)})`
+      ),
+      locale
+    );
     return '';
   }
 }
@@ -54,21 +84,36 @@ function fetchAllMessages(
   baseDir: string,
   locale: string,
   bundles: Array<string>,
-  mappings?: Record<string, string>
+  mappings?: Record<string, string>,
+  reportBundleError?: ReportBundleError
 ) {
   return Promise.all(
-    bundles.map((bndl) => fetchMessages(baseDir, locale, bndl, mappings))
+    bundles.map((bndl) =>
+      fetchMessages(baseDir, locale, bndl, mappings, reportBundleError)
+    )
   );
 }
 
-async function fetchL10nHashedMappings(mappingUrl: string) {
+async function fetchL10nHashedMappings(
+  mappingUrl: string,
+  reportBundleError?: ReportBundleError
+) {
   try {
     // These mappigns are currently generated with grunt. See grunt task hash-static
     // in fxa-settings for an example of how the mappings are generated.
     const mappingsResponse = await fetch(mappingUrl);
-    const json = await mappingsResponse.json();
-    return json;
+    if (!mappingsResponse.ok) {
+      throw new Error(`Received status ${mappingsResponse.status}`);
+    }
+    return await mappingsResponse.json();
   } catch (err) {
+    reportBundleError?.(
+      new Error(
+        `Fetching l10n static asset manifest failed: ${mappingUrl} (${describeCause(
+          err
+        )})`
+      )
+    );
     return undefined;
   }
 }
@@ -76,17 +121,25 @@ async function fetchL10nHashedMappings(mappingUrl: string) {
 async function createFluentBundleGenerator(
   baseDir: string,
   currentLocales: Array<string>,
-  bundles: Array<string>
+  bundles: Array<string>,
+  reportBundleError?: ReportBundleError
 ) {
   const mappings = await fetchL10nHashedMappings(
-    `${baseDir}/static-asset-manifest.json`
+    `${baseDir}/static-asset-manifest.json`,
+    reportBundleError
   );
   const fetched = await Promise.all(
     currentLocales
       .filter((l) => !EN_GB_LOCALES.includes(l))
       .map(async (locale) => {
         return {
-          [locale]: await fetchAllMessages(baseDir, locale, bundles, mappings),
+          [locale]: await fetchAllMessages(
+            baseDir,
+            locale,
+            bundles,
+            mappings,
+            reportBundleError
+          ),
         };
       })
   );
@@ -127,7 +180,11 @@ type Props = {
   children: any;
   // pass messages directly in, used in testing
   messages?: { [key: string]: string[] };
-  reportError?: (error: Error) => void;
+  // Per-string Fluent errors, e.g. an id missing from the bundle. Defaults to
+  // @fluent/react's console reporter.
+  reportError?: ReportError;
+  // Failures to load a bundle at all, where no string in it can resolve.
+  reportBundleError?: ReportBundleError;
 };
 
 export default class AppLocalizationProvider extends Component<Props, State> {
@@ -137,6 +194,7 @@ export default class AppLocalizationProvider extends Component<Props, State> {
     bundles: ['main'],
     children: React.createElement('div'),
     reportError: undefined,
+    reportBundleError: undefined,
   };
 
   constructor(props: Props) {
@@ -170,7 +228,8 @@ export default class AppLocalizationProvider extends Component<Props, State> {
     const bundleGenerator = await createFluentBundleGenerator(
       baseDir,
       currentLocales,
-      bundles
+      bundles,
+      this.props.reportBundleError
     );
     this.setState({
       l10n: new ReactLocalization(

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -36,6 +36,7 @@ import { MozServices } from '../../lib/types';
 import mockUseFxAStatus from '../../lib/hooks/useFxAStatus/mocks';
 import { useFxAStatus } from '../../lib/hooks';
 import sentryMetrics from 'fxa-shared/sentry/browser';
+import { flushL10nErrorReports } from '../../lib/l10n-error-reporter';
 import { OAuthError, OAUTH_ERRORS } from '../../lib/oauth';
 
 jest.mock('../../lib/hooks/useFxAStatus', () => ({
@@ -50,6 +51,11 @@ jest.mock('fxa-shared/sentry/browser', () => ({
     disable: jest.fn(),
     captureException: jest.fn(),
   },
+}));
+
+jest.mock('../../lib/l10n-error-reporter', () => ({
+  __esModule: true,
+  flushL10nErrorReports: jest.fn(),
 }));
 
 jest.mock('../../models/contexts/SettingsContext', () => ({
@@ -292,6 +298,97 @@ describe('glean', () => {
         integration: mockIntegration,
       }
     );
+  });
+});
+
+describe('sentry', () => {
+  const mockIntegration = {
+    isSync: jest.fn(),
+    isDesktopSync: jest.fn(),
+    isFirefoxClientServiceRelay: jest.fn(),
+    getServiceName: jest.fn(),
+    getClientId: jest.fn(),
+    getCmsInfo: jest.fn(),
+    getLegalTerms: jest.fn(),
+    data: {},
+  };
+
+  const mockOptedOutAccountResult = {
+    account: {
+      ...mockMetricsQueryAccountResult.account,
+      metricsEnabled: false,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFxAStatus as jest.Mock).mockReturnValue(mockUseFxAStatus());
+    (useIntegration as jest.Mock).mockReturnValue(mockIntegration);
+    (currentAccount as jest.Mock).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    (useFxAStatus as jest.Mock).mockReset();
+    (useIntegration as jest.Mock).mockReset();
+    (useInitialMetricsQueryState as jest.Mock).mockReset();
+    (useLocalSignedInQueryState as jest.Mock).mockReset();
+    (currentAccount as jest.Mock).mockReset();
+  });
+
+  async function renderApp() {
+    await act(async () => {
+      renderWithLocalizationProvider(
+        <MemoryRouter>
+          <AppContext.Provider
+            value={{ ...mockAppContext(), ...createAppContext() }}
+          >
+            <App flowQueryParams={updatedFlowQueryParams} />
+          </AppContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  }
+
+  it('flushes the buffered l10n reports for an account with metrics enabled', async () => {
+    (useInitialMetricsQueryState as jest.Mock).mockReturnValue({
+      data: mockMetricsQueryAccountResult,
+      loading: false,
+    });
+    (useLocalSignedInQueryState as jest.Mock).mockReturnValue({
+      data: { isSignedIn: true },
+    });
+
+    await renderApp();
+
+    expect(flushL10nErrorReports).toHaveBeenCalled();
+  });
+
+  it('flushes the buffered l10n reports when signed out, before the metrics query resolves', async () => {
+    (useInitialMetricsQueryState as jest.Mock).mockReturnValue({
+      loading: true,
+    });
+    (useLocalSignedInQueryState as jest.Mock).mockReturnValue({
+      data: { isSignedIn: false },
+    });
+
+    await renderApp();
+
+    expect(flushL10nErrorReports).toHaveBeenCalled();
+  });
+
+  it('does not flush the buffered l10n reports for an account opted out of metrics', async () => {
+    (useInitialMetricsQueryState as jest.Mock).mockReturnValue({
+      data: mockOptedOutAccountResult,
+      loading: false,
+    });
+    (useLocalSignedInQueryState as jest.Mock).mockReturnValue({
+      data: { isSignedIn: true },
+    });
+
+    await renderApp();
+
+    expect(sentryMetrics.disable).toHaveBeenCalled();
+    expect(flushL10nErrorReports).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -41,6 +41,7 @@ import {
 import { AccountStateProvider } from '../../models/contexts/AccountStateContext';
 
 import sentryMetrics from 'fxa-shared/sentry/browser';
+import { flushL10nErrorReports } from '../../lib/l10n-error-reporter';
 // Components
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { ScrollToTop } from '../Settings/ScrollToTop';
@@ -415,6 +416,9 @@ export const App = ({ flowQueryParams }: { flowQueryParams: QueryParams }) => {
   useEffect(() => {
     if (metricsEnabled || isSignedIn === false) {
       sentryMetrics.enable();
+      // l10n bundles are fetched before this component can mount, so any
+      // failure there is buffered until Sentry will accept it.
+      flushL10nErrorReports();
     } else {
       sentryMetrics.disable();
     }

--- a/packages/fxa-settings/src/contexts/DynamicLocalizationContext.tsx
+++ b/packages/fxa-settings/src/contexts/DynamicLocalizationContext.tsx
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import {
   isRTLLocale,
@@ -11,7 +17,7 @@ import {
   getCurrentLocale,
   validateLocale,
   detectBrowserDefaultLocale,
-  DEFAULT_LOCALE
+  DEFAULT_LOCALE,
 } from '../lib/locales';
 
 interface DynamicLocalizationContextType {
@@ -21,15 +27,20 @@ interface DynamicLocalizationContextType {
   isLoading: boolean;
 }
 
-const DynamicLocalizationContext = createContext<DynamicLocalizationContextType | null>(null);
+const DynamicLocalizationContext =
+  createContext<DynamicLocalizationContextType | null>(null);
 
 export const DynamicLocalizationProvider: React.FC<{
   children: React.ReactNode;
   baseDir: string;
   bundles?: string[];
-}> = ({ children, baseDir, bundles = ['main'] }) => {
+  reportBundleError?: (error: Error) => void;
+}> = ({ children, baseDir, bundles = ['main'], reportBundleError }) => {
   const [currentLocale, setCurrentLocale] = useState(() => getCurrentLocale());
-  const [userLocales, setUserLocales] = useState<readonly string[]>(() => [getCurrentLocale(), DEFAULT_LOCALE]);
+  const [userLocales, setUserLocales] = useState<readonly string[]>(() => [
+    getCurrentLocale(),
+    DEFAULT_LOCALE,
+  ]);
   const [isLoading, setIsLoading] = useState(false);
   const [key, setKey] = useState(0); // Force re-render of AppLocalizationProvider
 
@@ -40,7 +51,7 @@ export const DynamicLocalizationProvider: React.FC<{
       if (newLocale !== currentLocale) {
         setCurrentLocale(newLocale);
         setUserLocales([newLocale, DEFAULT_LOCALE]);
-        setKey(prev => prev + 1);
+        setKey((prev) => prev + 1);
       }
     };
 
@@ -50,40 +61,42 @@ export const DynamicLocalizationProvider: React.FC<{
     };
   }, [currentLocale]);
 
-  const switchLanguage = useCallback(async (locale: string) => {
-    // Validate against supported languages
-    if (!validateLocale(locale)) {
-      console.warn(`Locale ${locale} is not supported`);
-      return;
-    }
+  const switchLanguage = useCallback(
+    async (locale: string) => {
+      // Validate against supported languages
+      if (!validateLocale(locale)) {
+        console.warn(`Locale ${locale} is not supported`);
+        return;
+      }
 
-    if (locale === currentLocale) {
-      return; // No change needed
-    }
+      if (locale === currentLocale) {
+        return; // No change needed
+      }
 
-    setIsLoading(true);
+      setIsLoading(true);
 
-    try {
-      // 1. Save preference to localStorage
-      saveLocalePreference(locale);
+      try {
+        // 1. Save preference to localStorage
+        saveLocalePreference(locale);
 
-      // 2. Update document attributes
-      document.documentElement.lang = locale;
-      document.documentElement.dir = isRTLLocale(locale) ? 'rtl' : 'ltr';
+        // 2. Update document attributes
+        document.documentElement.lang = locale;
+        document.documentElement.dir = isRTLLocale(locale) ? 'rtl' : 'ltr';
 
-      // 3. Update state
-      setCurrentLocale(locale);
-      setUserLocales([locale, DEFAULT_LOCALE]);
+        // 3. Update state
+        setCurrentLocale(locale);
+        setUserLocales([locale, DEFAULT_LOCALE]);
 
-      // 4. Force AppLocalizationProvider to re-mount and reload bundles
-      setKey(prev => prev + 1);
-
-    } catch (error) {
-      // Language switch failed, we can't really do anything about it so ignore it
-    } finally {
-      setIsLoading(false);
-    }
-  }, [currentLocale]);
+        // 4. Force AppLocalizationProvider to re-mount and reload bundles
+        setKey((prev) => prev + 1);
+      } catch (error) {
+        // Language switch failed, we can't really do anything about it so ignore it
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [currentLocale]
+  );
 
   const clearLanguagePreference = useCallback(async () => {
     setIsLoading(true);
@@ -97,15 +110,16 @@ export const DynamicLocalizationProvider: React.FC<{
 
       // 3. Update document attributes
       document.documentElement.lang = browserDefaultLocale;
-      document.documentElement.dir = isRTLLocale(browserDefaultLocale) ? 'rtl' : 'ltr';
+      document.documentElement.dir = isRTLLocale(browserDefaultLocale)
+        ? 'rtl'
+        : 'ltr';
 
       // 4. Update state
       setCurrentLocale(browserDefaultLocale);
       setUserLocales([browserDefaultLocale, DEFAULT_LOCALE]);
 
       // 5. Force AppLocalizationProvider to re-mount and reload bundles
-      setKey(prev => prev + 1);
-
+      setKey((prev) => prev + 1);
     } catch (error) {
       // Clear failed, ignore it
     } finally {
@@ -114,17 +128,20 @@ export const DynamicLocalizationProvider: React.FC<{
   }, []);
 
   return (
-    <DynamicLocalizationContext.Provider value={{
-      currentLocale,
-      switchLanguage,
-      clearLanguagePreference,
-      isLoading
-    }}>
+    <DynamicLocalizationContext.Provider
+      value={{
+        currentLocale,
+        switchLanguage,
+        clearLanguagePreference,
+        isLoading,
+      }}
+    >
       <AppLocalizationProvider
         key={key} // This forces re-mount when language changes
         baseDir={baseDir}
         userLocales={userLocales}
         bundles={bundles}
+        reportBundleError={reportBundleError}
       >
         {children}
       </AppLocalizationProvider>
@@ -140,7 +157,7 @@ export const useDynamicLocalization = () => {
       currentLocale: DEFAULT_LOCALE,
       switchLanguage: async () => {},
       clearLanguagePreference: async () => {},
-      isLoading: false
+      isLoading: false,
     };
   }
   return context;

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -20,6 +20,7 @@ import { restorePairingAttribution } from './lib/pairing-attribution';
 import CookiesDisabled from './pages/CookiesDisabled';
 import { BrowserRouter } from 'react-router';
 import { DynamicLocalizationProvider } from './contexts/DynamicLocalizationContext';
+import { reportL10nError } from './lib/l10n-error-reporter';
 
 export interface FlowQueryParams {
   broker?: string;
@@ -105,7 +106,10 @@ try {
   root.render(
     <StrictMode>
       <BrowserRouter>
-        <DynamicLocalizationProvider baseDir={config.l10n.baseUrl}>
+        <DynamicLocalizationProvider
+          baseDir={config.l10n.baseUrl}
+          reportBundleError={reportL10nError}
+        >
           <AppErrorBoundary>
             <AppContext.Provider value={appContext}>
               <NimbusProvider>

--- a/packages/fxa-settings/src/lib/l10n-error-reporter.test.ts
+++ b/packages/fxa-settings/src/lib/l10n-error-reporter.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/browser';
+import {
+  MAX_L10N_ERROR_REPORTS,
+  flushL10nErrorReports,
+  reportL10nError,
+  resetL10nErrorReporter,
+} from './l10n-error-reporter';
+
+jest.mock('@sentry/browser', () => ({
+  captureException: jest.fn(),
+}));
+
+const mockCaptureException = Sentry.captureException as jest.MockedFunction<
+  typeof Sentry.captureException
+>;
+
+describe('reportL10nError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetL10nErrorReporter();
+  });
+
+  describe('before metrics are enabled', () => {
+    it('does not send to Sentry, which would discard the event', () => {
+      reportL10nError(
+        new Error('No static asset mapping for l10n bundle'),
+        'fr'
+      );
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('sends the buffered reports once flushed', () => {
+      const first = new Error(
+        'No static asset mapping for locales/fr/main.ftl'
+      );
+      const second = new Error('Fetching l10n static asset manifest failed');
+
+      reportL10nError(first, 'fr');
+      reportL10nError(second);
+      flushL10nErrorReports();
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(2);
+      expect(mockCaptureException).toHaveBeenCalledWith(first, {
+        tags: { area: 'l10n' },
+        extra: { locale: 'fr' },
+      });
+    });
+  });
+
+  describe('after metrics are enabled', () => {
+    beforeEach(() => {
+      flushL10nErrorReports();
+    });
+
+    it('reports the error to Sentry tagged as l10n with the failing locale', () => {
+      const error = new Error('No static asset mapping for l10n bundle');
+
+      reportL10nError(error, 'fr');
+
+      expect(mockCaptureException).toHaveBeenCalledWith(error, {
+        tags: { area: 'l10n' },
+        extra: { locale: 'fr' },
+      });
+    });
+
+    it('attaches no locale when the failure is not locale specific', () => {
+      const error = new Error('Fetching l10n static asset manifest failed');
+
+      reportL10nError(error);
+
+      expect(mockCaptureException).toHaveBeenCalledWith(error, {
+        tags: { area: 'l10n' },
+        extra: undefined,
+      });
+    });
+
+    it('reports a repeated message only once', () => {
+      const message =
+        'No static asset mapping for l10n bundle: locales/fr/main.ftl';
+      reportL10nError(new Error(message), 'fr');
+      reportL10nError(new Error(message), 'fr');
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    });
+
+    it(`stops reporting after ${MAX_L10N_ERROR_REPORTS} distinct messages`, () => {
+      for (let i = 0; i < MAX_L10N_ERROR_REPORTS + 5; i++) {
+        reportL10nError(
+          new Error(`No static asset mapping for bundle ${i}`),
+          'fr'
+        );
+      }
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(
+        MAX_L10N_ERROR_REPORTS
+      );
+    });
+  });
+});

--- a/packages/fxa-settings/src/lib/l10n-error-reporter.ts
+++ b/packages/fxa-settings/src/lib/l10n-error-reporter.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/browser';
+
+/**
+ * Sentry starts disabled and is only enabled once we know the user has not
+ * opted out of metrics, which happens inside `App`. `App` cannot mount until
+ * AppLocalizationProvider has resolved its bundles, so every bundle failure is
+ * reported before Sentry will accept anything. Reports are therefore buffered
+ * and flushed by `flushL10nErrorReports` once metrics are enabled — if the user
+ * has opted out, the buffer is simply never flushed.
+ */
+export const MAX_L10N_ERROR_REPORTS = 10;
+
+type L10nErrorReport = {
+  error: Error;
+  locale?: string;
+};
+
+const reportedMessages = new Set<string>();
+let pendingReports: Array<L10nErrorReport> = [];
+let metricsEnabled = false;
+
+function captureReport({ error, locale }: L10nErrorReport) {
+  Sentry.captureException(error, {
+    tags: { area: 'l10n' },
+    extra: locale ? { locale } : undefined,
+  });
+}
+
+/**
+ * Reports a failure to load a localization bundle. Individual missing string ids
+ * are deliberately left to Fluent's console reporter — the signal worth alerting
+ * on is "no strings resolved at all".
+ *
+ * One report is possible per locale per bundle, and switching languages remounts
+ * the provider and refetches, so reports are deduped by message and capped for
+ * the life of the page. A widespread manifest failure still means a handful of
+ * events per session; tune the volume Sentry-side rather than here, so the first
+ * report of a new failure is never the one that gets dropped.
+ *
+ * `locale` is the locale whose bundle failed, and is absent when the failure is
+ * the manifest itself. It cannot be read off the document, whose lang attribute
+ * is seeded from `navigator.languages` and left untouched when another tab
+ * changes the stored language preference.
+ */
+export function reportL10nError(error: Error, locale?: string) {
+  if (
+    reportedMessages.has(error.message) ||
+    reportedMessages.size >= MAX_L10N_ERROR_REPORTS
+  ) {
+    return;
+  }
+  reportedMessages.add(error.message);
+
+  const report = { error, locale };
+
+  if (metricsEnabled) {
+    captureReport(report);
+  } else {
+    pendingReports.push(report);
+  }
+}
+
+/**
+ * Called once metrics are known to be enabled. Sends anything reported during
+ * app startup and lets later reports through immediately.
+ */
+export function flushL10nErrorReports() {
+  metricsEnabled = true;
+  const queued = pendingReports;
+  pendingReports = [];
+  queued.forEach(captureReport);
+}
+
+// Exported for tests; the cap, dedup set and buffer are page-lifetime state.
+export function resetL10nErrorReporter() {
+  reportedMessages.clear();
+  pendingReports = [];
+  metricsEnabled = false;
+}


### PR DESCRIPTION
## Because

- FXA-14361 highlighted a a bug that served English to every locale in production
- The client emits no telemetry when an l10n bundle fails to load, so a whole-bundle outage is indistinguishable from a working page unless someone reads the copy.

## This pull request

- Adds a `reportBundleError` prop to `AppLocalizationProvider`, fired when a bundle has no manifest entry, returns a non-OK status, or the manifest itself cannot be loaded.
- Sends those failures to Sentry tagged `area: 'l10n'` with the failing locale, deduped by message and capped at 10 per page load.
- Buffers reports until `sentryMetrics.enable()` runs, flushing from the same effect in `App` that enables it.
- Returns an empty bundle rather than a non-OK response body, which Fluent would otherwise parse as junk.
- Leaves individual missing string ids with Fluent's console reporter.
- Fixes the test manifest fixture, which was invalid JSON with leading-slash keys that never matched the path the provider computes.

## Issue that this pull request solves

Closes: FXA-14362

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the buffer/flush in `l10n-error-reporter.ts`, and the three report sites in `AppLocalizationProvider.tsx`.
- Suggested review order: `AppLocalizationProvider.tsx` → `l10n-error-reporter.ts` → `App/index.tsx` → `index.tsx`.
- Risky or complex parts: the reporter holds page-lifetime module state (dedup set, buffer, enabled flag). `DynamicLocalizationContext.tsx` is a two-line change plus a whole-file reformat from the pre-commit prettier hook.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Split out of #21043 so the outage fix there stays a two-file diff. The two are independent and share no files.
- Sampling was deliberately left out. Bundle-level reporting plus dedup is expected to produce 1–3 events per affected session, so volume is better tuned in Sentry than by risking the first report of a new failure.
- Buffering is load-bearing, not defensive: `beforeSend` drops events while Sentry is disabled, and `AppLocalizationProvider` resolves bundles before `App` can mount, so without it the feature would report nothing.
- The fixture fix was verified by pointing a mapping value at a path `fetch-mock` does not serve — the existing tests passed either way beforehand, so a green suite did not prove the mapping was being consulted.
