### PR TITLE
chore(recovery-phone): remove legacy redis key fallback

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
@@ -274,63 +274,28 @@ describe('RecoveryPhoneManager', () => {
     ).resolves.toBeDefined();
   });
 
-  it('should read a record written under the legacy key shape', async () => {
+  it('should remove the stored record so the code cannot be used again', async () => {
     const mockPhone = RecoveryPhoneFactory();
     const uid = mockPhone.uid.toString('hex');
     const code = '444444';
-    await redis.set(
-      `${RECOVERY_PHONE_REDIS_PREFIX}:${uid}:${code}`,
-      JSON.stringify({
-        createdAt: Date.now(),
-        phoneNumber: mockPhone.phoneNumber,
-        isSetup: false,
-        lookupData: null,
-      }),
-      'EX',
-      300
+    await recoveryPhoneManager.storeUnconfirmed(
+      uid,
+      code,
+      mockPhone.phoneNumber,
+      false
     );
 
-    const result = await recoveryPhoneManager.getUnconfirmed(uid, code);
-    expect(result?.phoneNumber).toEqual(mockPhone.phoneNumber);
-
-    await expect(recoveryPhoneManager.removeCode(uid, code)).resolves.toBe(
-      true
-    );
+    await expect(recoveryPhoneManager.removeCode(uid)).resolves.toBe(true);
     await expect(
       recoveryPhoneManager.getUnconfirmed(uid, code)
     ).resolves.toBeNull();
   });
 
-  it('should read a legacy record when the new key holds a different code', async () => {
+  it('should return false when there is no stored record to remove', async () => {
     const mockPhone = RecoveryPhoneFactory();
     const uid = mockPhone.uid.toString('hex');
 
-    // A distinct number on the legacy record proves which one came back.
-    const legacyPhoneNumber = '+15005550001';
-
-    // An old pod writes a legacy key while a newer record is still live.
-    await recoveryPhoneManager.storeUnconfirmed(
-      uid,
-      '555555',
-      mockPhone.phoneNumber,
-      false
-    );
-    await redis.set(
-      `${RECOVERY_PHONE_REDIS_PREFIX}:${uid}:666666`,
-      JSON.stringify({
-        createdAt: Date.now(),
-        phoneNumber: legacyPhoneNumber,
-        isSetup: false,
-        lookupData: null,
-      }),
-      'EX',
-      300
-    );
-
-    const result = await recoveryPhoneManager.getUnconfirmed(uid, '666666');
-    expect(result?.phoneNumber).toEqual(legacyPhoneNumber);
-
-    await recoveryPhoneManager.removeCode(uid, '666666');
+    await expect(recoveryPhoneManager.removeCode(uid)).resolves.toBe(false);
   });
 
   it('should return null if no unconfirmed phone number data is found in Redis', async () => {

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
@@ -45,13 +45,6 @@ export const RECOVERY_PHONE_REDIS_PREFIX = 'recovery-phone:sms-attempt';
  */
 const unconfirmedKey = (uid: string) => `${RECOVERY_PHONE_REDIS_PREFIX}:${uid}`;
 
-/**
- * Previous key shape, which held the code in the key name. Kept for the
- * rolling deploy window only.
- */
-const legacyUnconfirmedKey = (uid: string, code: string) =>
-  `${RECOVERY_PHONE_REDIS_PREFIX}:${uid}:${code}`;
-
 @Injectable()
 export class RecoveryPhoneManager {
   constructor(
@@ -160,7 +153,8 @@ export class RecoveryPhoneManager {
   }
 
   /**
-   * Store phone number data and SMS code for a user.
+   * Store phone number data and SMS code for a user. Overwrites any existing
+   * record, so a uid only ever has one code live at a time.
    *
    * @param uid The user's unique identifier
    * @param code The SMS code to associate with this UID
@@ -215,32 +209,17 @@ export class RecoveryPhoneManager {
       }
     }
 
-    // Fall back to the legacy key shape. During a rolling deploy an older pod
-    // can write one, and its scan does not match the new key, so both shapes
-    // can be live at once. Remove this once train 342 is fully rolled out.
-    const legacyData = await this.redisClient.get(
-      legacyUnconfirmedKey(uid, code)
-    );
-    return legacyData ? JSON.parse(legacyData) : null;
+    return null;
   }
 
   /**
-   * Removes a code from redis. Once a code is validated, it's good to proactively remove it from the database
-   * so it cannot be used again.
-   *
-   * This drops the user's live record outright, so only call it after
-   * getUnconfirmed has confirmed the code. The return value means "a record was
-   * removed", not "that code existed".
+   * Removes the user's unconfirmed code record so it cannot be used again.
    *
    * @param uid The user's unique identifier
-   * @param code The SMS code associated with this user
-   * @returns
+   * @returns True if a record was removed
    */
-  async removeCode(uid: string, code: string) {
-    const count = await this.redisClient.del(
-      unconfirmedKey(uid),
-      legacyUnconfirmedKey(uid, code)
-    );
+  async removeCode(uid: string) {
+    const count = await this.redisClient.del(unconfirmedKey(uid));
     return count > 0;
   }
 

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -269,7 +269,7 @@ export class RecoveryPhoneService {
     );
 
     // The code was valid. Remove entry. It cannot be used again.
-    await this.recoveryPhoneManager.removeCode(uid, code);
+    await this.recoveryPhoneManager.removeCode(uid);
 
     // There was a record matching, the uid / code. The confirmation was successful.
     return true;
@@ -299,7 +299,7 @@ export class RecoveryPhoneService {
     }
 
     // The code was valid. Remove entry. It cannot be used again.
-    await this.recoveryPhoneManager.removeCode(uid, code);
+    await this.recoveryPhoneManager.removeCode(uid);
 
     return true;
   }
@@ -359,7 +359,7 @@ export class RecoveryPhoneService {
     );
 
     // after we're done, remove code from redis.
-    await this.recoveryPhoneManager.removeCode(uid, code);
+    await this.recoveryPhoneManager.removeCode(uid);
 
     return true;
   }


### PR DESCRIPTION
## Because

- v1.342.4 re-keyed recovery phone SMS codes on the uid alone, and kept a fallback so a rolling deploy could still read and delete the old `...:{uid}:{code}` keys.
- Train 342 is fully rolled out, and the old keys had the same 5 minute TTL, so none can still exist.
- The fallback costs an extra Redis `GET` on every failed code check, and an extra key in every `DEL`.

## This pull request

- Removes the `legacyUnconfirmedKey` helper from `recovery-phone.manager.ts`.
- Drops the legacy `GET` in `getUnconfirmed` and returns `fa` explicitly when the code does not match.
- Reduces the `DEL` in `removeCode` to the uid-keyed record only.
- Deletes the two legacy fallback tests in `recovery-phone.manager.in.spec.ts`, and adds one test that shows `removeCode` drops the uid-keyed record.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14344

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts`.
- Suggested review order: the manager first, then the deleted tests.
- Risky or complex parts: `getUnconfirmed` keeps the constant-time compare.

## Screenshots (Optional)

## Other information (Optional)

Verified locally: the recovery-phone unit and integration suites pass (103 tests), `tsc --noEmit` on `tsconfig.lib.json` is clean, and `nx lint accounts-recovery-phone` passes. Functional tests were not run.
