### PR TITLE
fix(profile-server): stop nextAvatar 500 and read-time avatar deletion

### DIFF
--- a/packages/fxa-profile-server/lib/db/memory.js
+++ b/packages/fxa-profile-server/lib/db/memory.js
@@ -87,6 +87,19 @@ MemoryStore.prototype = {
     return P.resolve();
   },
 
+  // The selection goes too, the way the mysql `avatar_selected` foreign key
+  // cascades.
+  deleteUserAvatars: function deleteUserAvatars(uid) {
+    var userId = uid.toString('hex');
+    Object.keys(this.avatars).forEach((id) => {
+      if (this.avatars[id].userId.toString('hex') === userId) {
+        delete this.avatars[id];
+      }
+    });
+    delete this.selected[userId];
+    return P.resolve();
+  },
+
   addProvider: function addProvider(name) {
     this.providers[name] = name;
     return P.resolve(name);

--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -28,30 +28,43 @@ function nextAvatar(result) {
     result.avatar &&
     (result.avatarDefault || result.avatar.startsWith(monogramUrl))
   ) {
-    const displayName = result.displayName;
-    let avatarUrl = result.avatar;
-    if (displayName && ALPHANUMERIC.test(displayName)) {
-      avatarUrl = `${monogramUrl}/v1/avatar/${displayName[0]}`;
-    } else if (ALPHANUMERIC.test(result.email)) {
-      avatarUrl = `${monogramUrl}/v1/avatar/${result.email[0]}`;
-    } else {
-      avatarUrl = avatarShared.DEFAULT_AVATAR.avatar;
+    // `ALPHANUMERIC.test(undefined)` matches the coerced string `'undefined'`,
+    // so check the type first.
+    const initial = [result.displayName, result.email].find(
+      (value) => typeof value === 'string' && ALPHANUMERIC.test(value)
+    );
+    if (initial) {
+      return `${monogramUrl}/v1/avatar/${initial[0]}`;
     }
-    return avatarUrl;
+    // A missing email means scope hid it, so no initial is knowable yet. Keep
+    // the stored avatar: `changeAvatar` deletes every row for the uid when it
+    // sees the generic default.
+    return typeof result.email === 'string'
+      ? avatarShared.DEFAULT_AVATAR.avatar
+      : result.avatar;
   }
   return result.avatar;
 }
 
-async function changeAvatar(avatarUrl, uid) {
+// Whether monograms should be persisted at all is under review in FXA-14383:
+// `/v1/avatar` cannot compute one, so this row is the only way a monogram
+// reaches a `profile:avatar`-only client.
+async function changeAvatar(avatarUrl, uid, selectedAvatar) {
   if (avatarUrl === avatarShared.DEFAULT_AVATAR.avatar) {
     await db.deleteUserAvatars(uid);
-  } else {
-    await db.addAvatar(
-      crypto.randomBytes(16).toString('hex'),
-      uid,
-      avatarUrl,
-      'fxa'
-    );
+    return;
+  }
+  await db.addAvatar(
+    crypto.randomBytes(16).toString('hex'),
+    uid,
+    avatarUrl,
+    'fxa'
+  );
+  // `addAvatar` inserts and re-points the selection, orphaning the monogram row
+  // it supersedes. A monogram has no uploaded image, so the row is the whole
+  // cleanup; the URL check keeps an uploaded avatar out of this branch.
+  if (selectedAvatar && selectedAvatar.url.startsWith(monogramUrl)) {
+    await db.deleteAvatar(selectedAvatar.id);
   }
 }
 
@@ -131,7 +144,7 @@ module.exports = {
       // Check if the db needs to be updated or just the profileCache
       const selectedAvatar = await db.getSelectedAvatar(creds.user);
       if (!selectedAvatar || selectedAvatar.url !== newAvatar) {
-        await changeAvatar(newAvatar, creds.user);
+        await changeAvatar(newAvatar, creds.user, selectedAvatar);
       }
     }
     // Check to see if the oauth-server is reporting a newer `profileChangedAt`

--- a/packages/fxa-profile-server/test/api.in.spec.ts
+++ b/packages/fxa-profile-server/test/api.in.spec.ts
@@ -15,6 +15,7 @@ const testServer = require('./lib/server');
 const Static = require('./lib/static');
 const img = require('../lib/img');
 const mockFactory = require('./lib/mock');
+const avatarShared = require('../lib/routes/avatar/_shared');
 
 function randomHex(bytes: number): string {
   return crypto.randomBytes(bytes).toString('hex');
@@ -445,6 +446,123 @@ describe('#integration - api', () => {
       expect(res.result.email).toBe('user@example.domain');
       expect(res.result.sub).toBe(USERID);
       expect(Object.keys(res.result)).toHaveLength(2);
+      assertSecurityHeaders(res);
+    });
+
+    const MONOGRAM = `${PUBLIC_URL}/v1/avatar/u`;
+
+    describe('token that cannot read the email', () => {
+      it('should return the default avatar when no avatar is stored', async () => {
+        const scopedUser = uid();
+        mock.token({
+          user: scopedUser,
+          scope: ['profile:avatar'],
+        });
+        const res = await Server.api.get({
+          url: '/profile',
+          headers: {
+            authorization: 'Bearer ' + tok,
+          },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.result.avatar).toBe(avatarShared.DEFAULT_AVATAR.avatar);
+        expect(res.result.avatarDefault).toBe(true);
+        expect(Object.keys(res.result)).toHaveLength(2);
+        assertSecurityHeaders(res);
+      });
+
+      it('should keep the stored avatar', async () => {
+        const scopedUser = uid();
+        await db.addAvatar(avatarId(), scopedUser, MONOGRAM, 'fxa');
+        mock.token({
+          user: scopedUser,
+          scope: ['profile:avatar'],
+        });
+        const res = await Server.api.get({
+          url: '/profile',
+          headers: {
+            authorization: 'Bearer ' + tok,
+          },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.result.avatar).toBe(MONOGRAM);
+        const selected = await db.getSelectedAvatar(scopedUser);
+        expect(selected.url).toBe(MONOGRAM);
+        assertSecurityHeaders(res);
+      });
+
+      it('should keep the stored avatar for a non-ASCII display name', async () => {
+        const scopedUser = uid();
+        await db.addAvatar(avatarId(), scopedUser, MONOGRAM, 'fxa');
+        await db.setDisplayName(scopedUser, 'Álvaro');
+        mock.token({
+          user: scopedUser,
+          scope: ['profile:display_name', 'profile:avatar'],
+        });
+        const res = await Server.api.get({
+          url: '/profile',
+          headers: {
+            authorization: 'Bearer ' + tok,
+          },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.result.displayName).toBe('Álvaro');
+        expect(res.result.avatar).toBe(MONOGRAM);
+        const selected = await db.getSelectedAvatar(scopedUser);
+        expect(selected.url).toBe(MONOGRAM);
+        assertSecurityHeaders(res);
+      });
+    });
+
+    it('should delete the stored avatar when the email starts with a non-alphanumeric character', async () => {
+      const plainUser = uid();
+      const otherUser = uid();
+      await db.addAvatar(avatarId(), plainUser, MONOGRAM, 'fxa');
+      await db.addAvatar(avatarId(), otherUser, MONOGRAM, 'fxa');
+      mock.token({
+        user: plainUser,
+        scope: ['profile'],
+      });
+      mock.email('_user@example.com');
+      mock.email('_user@example.com'); // a second time for the refetch
+      const res = await Server.api.get({
+        url: '/profile',
+        headers: {
+          authorization: 'Bearer ' + tok,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.result.avatar).toBe(avatarShared.DEFAULT_AVATAR.avatar);
+      expect(res.result.avatarDefault).toBe(true);
+      expect(await db.getSelectedAvatar(plainUser)).toBeUndefined();
+      const otherSelected = await db.getSelectedAvatar(otherUser);
+      expect(otherSelected.url).toBe(MONOGRAM);
+      assertSecurityHeaders(res);
+    });
+
+    it('should delete the monogram row it supersedes when the initial changes', async () => {
+      const monogramUser = 'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1';
+      const staleAvatarId = 'b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2';
+      const staleMonogram = `${PUBLIC_URL}/v1/avatar/a`;
+      const freshMonogram = `${PUBLIC_URL}/v1/avatar/b`;
+      await db.addAvatar(staleAvatarId, monogramUser, staleMonogram, 'fxa');
+      mock.token({
+        user: monogramUser,
+        scope: ['profile'],
+      });
+      mock.email('bob@example.com');
+      mock.email('bob@example.com'); // a second time for the refetch
+      const res = await Server.api.get({
+        url: '/profile',
+        headers: {
+          authorization: 'Bearer ' + tok,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.result.avatar).toBe(freshMonogram);
+      const selected = await db.getSelectedAvatar(monogramUser);
+      expect(selected.url).toBe(freshMonogram);
+      expect(await db.getAvatar(staleAvatarId)).toBeUndefined();
       assertSecurityHeaders(res);
     });
   });


### PR DESCRIPTION
## Because

- `/v1/profile` returned a 500 for a token that can read `avatar` but not `email`. `ALPHANUMERIC.test(result.email)` matches when the field is absent, because the regex coerces `undefined` to the string `"undefined"` and `"u"` is alphanumeric. `result.email[0]` then threw.
- Once that stopped throwing, the generic-default fallback turned a read into a write: `changeAvatar` calls `db.deleteUserAvatars(uid)` whenever it sees the default URL, so a GET of `/v1/profile` deleted the user's avatar rows.
- `addAvatar` inserts and re-points `avatar_selected` without cleaning up, so every monogram write orphaned the row it superseded — a fresh row each time the computed initial changed.
- `deleteUserAvatars` was implemented only on the mysql driver, so that branch threw `TypeError` in local dev and tests instead of deleting, and had never been exercised.

## This pull request

- `nextAvatar` now type-checks before testing a field, so an absent field cannot produce a bogus initial.
- When the email is absent it returns the stored avatar rather than the generic default, so the read stays a read. The gate is on `email` specifically: an account always has one, so its absence always means scope hid it, whereas a missing `displayName` is ambiguous. `ALPHANUMERIC` is ASCII-only, so a name like "Álvaro" plus an unreadable email would otherwise land back on the default and the delete.
- A readable field whose first character is non-alphanumeric still yields the generic default, unchanged from `57d004be94`.
- `changeAvatar` deletes the monogram row a new monogram supersedes, so the table stops accumulating. The URL check keeps uploaded avatars out of that branch, and a monogram has no uploaded image, so the row is the whole cleanup.
- Adds `deleteUserAvatars` to the memory driver, mirroring the mysql `avatar_selected` cascade, plus coverage.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14359

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Start with `nextAvatar` in `lib/routes/profile.js`; the rest follows from it.
- Risky or complex parts: the `typeof result.email === 'string'` ternary is the "absent vs present-but-unusable" distinction. Absent means scope hid it, so no initial is knowable and the stored avatar must be left alone.
- `nx test-integration fxa-profile-server` passes `api.in.spec.ts` locally. `events.in.spec.ts` fails on this machine with `Connection is closed.` from ioredis — it needs `yarn start infrastructure`, and it is untouched here.

## Screenshots (Optional)

## Other information (Optional)

- Monogram persistence and the `avatarDefault: false` reporting are left to FXA-14383. The accumulation half of ticket item 4 is fixed here; what remains is a decision, because the persisted row is load-bearing: `/v1/avatar` is scoped to `profile:avatar` alone and reads `getSelectedAvatar` only, so it cannot compute a monogram, and this handler returns the DB value rather than the computed one — it writes, drops the cache, and re-reads. Dropping persistence with no read-time replacement would remove monograms from both endpoints.
- An earlier version of this note cited the GraphQL `selectedAvatar` resolver as a blocker. That resolver went away with `fxa-graphql-api` in `01e268cf9b`; only a dead helper in `fxa-shared/db/models/profile` remains. The real relier-facing surface is `/v1/profile` and `/v1/avatar`.
- Ticket item 5 — `ALPHANUMERIC` is ASCII-only, so non-ASCII names never get a monogram — is still an open decision on FXA-14359.
- The ticket suggests checking Sentry for real `/v1/profile` 500s. Not done here; this stands as correctness hygiene either way.
