### PR TITLE
chore(content-server): replace deprecated node-uuid with uuid

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/flow.js
+++ b/packages/fxa-content-server/app/scripts/models/flow.js
@@ -20,7 +20,7 @@ import ResumeTokenMixin from './mixins/resume-token';
 import UrlMixin from './mixins/url';
 import vat from '../lib/vat';
 import Url from '../lib/url';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 var Model = Backbone.Model.extend({
   initialize(options) {
@@ -64,7 +64,7 @@ var Model = Backbone.Model.extend({
       } else if (urlParams.deviceId) {
         this.set('deviceId', urlParams.deviceId);
       } else {
-        this.set('deviceId', uuid.v4().replace(/-/g, ''));
+        this.set('deviceId', uuidv4().replace(/-/g, ''));
       }
     }
   },

--- a/packages/fxa-content-server/app/scripts/models/unique-user-id.js
+++ b/packages/fxa-content-server/app/scripts/models/unique-user-id.js
@@ -22,7 +22,7 @@ import Cocktail from 'cocktail';
 import ResumeTokenMixin from './mixins/resume-token';
 import UrlMixin from './mixins/url';
 import Storage from '../lib/storage';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 var Model = Backbone.Model.extend({
   initialize(options) {
@@ -53,7 +53,7 @@ var Model = Backbone.Model.extend({
         // uniqueUserId is the new name.
         uniqueUserId = storage.get('uniqueUserId');
       } else {
-        uniqueUserId = uuid.v4();
+        uniqueUserId = uuidv4();
       }
     }
 

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/base.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/base.js
@@ -5,7 +5,7 @@
 import _ from 'underscore';
 import { assert } from 'chai';
 import BaseExperiment from 'lib/experiments/grouping-rules/base';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 describe('lib/experiments/grouping-rules/base', () => {
   let experiment;
@@ -216,7 +216,7 @@ describe('lib/experiments/grouping-rules/base', () => {
         for (let i = 0; i < ITERATIONS; ++i) {
           const choice = experiment.choose({
             experimentChooser,
-            uuid: uuid.v4(),
+            uuid: uuidv4(),
           });
 
           counts[choice]++;

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -98,7 +98,6 @@
     "morgan": "^1.11.0",
     "mozlog": "^3.0.2",
     "mustache": "4.2.0",
-    "node-uuid": "1.4.8",
     "node-vat": "0.0.9",
     "normalize.css": "8.0.1",
     "on-headers": "1.1.0",
@@ -113,6 +112,7 @@
     "time-grunt": "2.0.0",
     "ua-parser-js": "1.0.35",
     "underscore": "^1.13.8",
+    "uuid": "^11.1.1",
     "verror": "1.10.1",
     "webpack": "^5.104.1"
   },

--- a/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
@@ -19,7 +19,7 @@ const remoteAddress =
 const geolocate = require('fxa-shared/express/geo-locate').geolocate(geodb)(
   remoteAddress
 )(logger);
-const uuid = require('node-uuid');
+const { v4: uuidv4 } = require('uuid');
 const validation = require('../validation');
 
 const {
@@ -120,7 +120,7 @@ module.exports = function (config, glean) {
     // Amplitude-specific device id, like the client-side equivalent
     // created in app/scripts/lib/app-start.js. Transient for now,
     // but will become persistent in due course.
-    const deviceId = (metricsData.deviceId = uuid.v4().replace(/-/g, ''));
+    const deviceId = (metricsData.deviceId = uuidv4().replace(/-/g, ''));
 
     if (metricsData.event_type === 'engage') {
       if (metricsData.service in SERVICES) {

--- a/packages/fxa-content-server/server/lib/routes/get-update-firefox.js
+++ b/packages/fxa-content-server/server/lib/routes/get-update-firefox.js
@@ -9,7 +9,7 @@ const amplitude = require('../amplitude');
 const flowMetrics = require('../flow-metrics');
 const { logFlowEvent } = require('../flow-event');
 const Url = require('url');
-const uuid = require('node-uuid');
+const { v4: uuidv4 } = require('uuid');
 const validation = require('../validation');
 const {
   overrideJoiMessages,
@@ -73,7 +73,7 @@ module.exports = function (config) {
       // Amplitude-specific device id, like the client-side equivalent
       // created in app/scripts/lib/app-start.js. Transient for now,
       // but will become persistent in due course.
-      metricsData.deviceId = uuid.v4().replace(/-/g, '');
+      metricsData.deviceId = uuidv4().replace(/-/g, '');
 
       amplitude(beginEvent, req, metricsData);
       logFlowEvent(beginEvent, metricsData, req);

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -79,7 +79,6 @@ const webpackConfig = {
         'jquery-ui-touch-punch-amd/jquery.ui.touch-punch'
       ),
       'ua-parser-js': require.resolve('ua-parser-js/src/ua-parser'),
-      uuid: require.resolve('node-uuid/uuid'),
       vat: require.resolve('node-vat/vat'),
       'fxa-auth-client/browser': require.resolve('fxa-auth-client/browser'),
       '@fxa/vendored/common-password-list': path.resolve(

--- a/yarn.lock
+++ b/yarn.lock
@@ -33520,7 +33520,6 @@ __metadata:
     morgan: "npm:^1.11.0"
     mozlog: "npm:^3.0.2"
     mustache: "npm:4.2.0"
-    node-uuid: "npm:1.4.8"
     node-vat: "npm:0.0.9"
     normalize.css: "npm:8.0.1"
     on-headers: "npm:1.1.0"
@@ -33549,6 +33548,7 @@ __metadata:
     underscore: "npm:^1.13.8"
     upng-js: "npm:2.1.0"
     url-loader: "npm:4.1.1"
+    uuid: "npm:^11.1.1"
     verror: "npm:1.10.1"
     webpack: "npm:^5.104.1"
     webpack-dev-middleware: "npm:^7.4.0"
@@ -43864,15 +43864,6 @@ __metadata:
     uap-ref-impl: "npm:0.2.0"
     yamlparser: "npm:0.0.2"
   checksum: 10c0/9f786ea10b12c72f8217cd0099d0a16a2b41a4110c43b68e87b8891040777cd27a553dfe52076edf44f1d5faca6be9322bf39f6b9442181fcb41563ac8fc49a0
-  languageName: node
-  linkType: hard
-
-"node-uuid@npm:1.4.8":
-  version: 1.4.8
-  resolution: "node-uuid@npm:1.4.8"
-  bin:
-    uuid: ./bin/uuid
-  checksum: 10c0/c87d0806292d40a7aaffa457c062407c176edbfef974dde32c34cb1db1cb6a686c141c8a34ed49a4602365e92dcf6dd2d3ce476d275e679f1ac746aebd3600c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- `node-uuid` is deprecated. Its own README tells you to use `uuid` instead.
- `fxa-content-server` was the last package pinning it, at `1.4.8`.

## This pull request

- Replaces `node-uuid` with `uuid` at `^11.1.1`. That is the version the root already resolves, so yarn does not pull a second copy.
- Drops the `uuid: require.resolve('node-uuid/uuid')` alias from `webpack.config.js`. That alias is why browser code importing `'uuid'` got `node-uuid`.
- Switches all five call sites to a named import. `uuid` v11 has no default export, so `uuid.v4()` on a default import throws at runtime.
- Names the binding `uuidv4`, which is the name `server/lib/glean/server_events.js` already uses.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-4894

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the five call sites in the table below.
- Suggested review order: `package.json` and `webpack.config.js` first, then the call sites.
- Risky or complex parts: the import shape. Changing the import but not the call lints clean and throws at runtime, so the two must be read together.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

**Read the five call sites by eye. No automated test covers them.** `fxa-content-server` has no `test` script and no nx test target, so neither a local run nor CI executes these files. Lint is the only automated check that reads them, and it passes (`nx lint fxa-content-server`, exit 0).

| File | Import | Call |
|---|---|---|
| `server/lib/routes/get-metrics-flow.js` | `:22` | `:123` |
| `server/lib/routes/get-update-firefox.js` | `:12` | `:76` |
| `app/scripts/models/flow.js` | `:23` | `:67` |
| `app/scripts/models/unique-user-id.js` | `:25` | `:56` |
| `app/tests/spec/lib/experiments/grouping-rules/base.js` | `:8` | `:219` |

The generated values keep their shape. The three `deviceId` sites keep `.replace(/-/g, '')`, so they stay 32-char hex. `unique-user-id.js` has no `.replace` and still returns a dashed v4, so the persisted identifier does not change.

`uuid` 11.1.1 still ships CommonJS. Its `exports` map routes `node.require` to `dist/cjs/index.js`, so the two `require('uuid')` server files are fine.
