### PR TITLE
chore(deps): replace babel-eslint with @babel/eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",
+    "@babel/eslint-parser": "^7.27.5",
     "@babel/plugin-transform-typescript": "^7.27.1",
     "@babel/preset-env": "^7.27.1",
     "@babel/preset-react": "^7.27.1",
@@ -246,7 +247,6 @@
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^7.1.1",
     "autoprefixer": "^10.4.14",
-    "babel-eslint": "^10.1.0",
     "babel-jest": "30.0.5",
     "copyfiles": "^2.4.1",
     "eslint": "^8.57.1",

--- a/packages/fxa-content-server/.eslintrc
+++ b/packages/fxa-content-server/.eslintrc
@@ -1,8 +1,9 @@
 {
   "extends": ["plugin:fxa/client", "plugin:fxa/recommended"],
   "plugins": ["fxa"],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
+    "requireConfigFile": false,
     "ecmaVersion": "2020",
     "sourceType": "module"
   },

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -117,6 +117,7 @@
   },
   "devDependencies": {
     "@babel/cli": "7.23.0",
+    "@babel/eslint-parser": "^7.27.5",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@types/backbone": "^1.4.19",
@@ -124,7 +125,6 @@
     "@types/sinon-chai": "3.2.5",
     "@types/sinon-express-mock": "1.3.9",
     "audit-filter": "^0.5.0",
-    "babel-eslint": "^10.1.0",
     "babel-plugin-dynamic-import-webpack": "1.1.0",
     "chai": "^4.5.0",
     "copy-webpack-plugin": "12.0.2",

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -64,7 +64,6 @@
     "@types/react-helmet": "^6.1.6",
     "@types/rimraf": "3.0.0",
     "@types/sinon": "^10",
-    "babel-eslint": "^10.1.0",
     "babel-loader": "^9.1.3",
     "babel-preset-react-app": "^10.0.1",
     "camelcase": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,6 +2844,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/eslint-parser@npm:^7.27.5":
+  version: 7.29.7
+  resolution: "@babel/eslint-parser@npm:7.29.7"
+  dependencies:
+    "@nicolo-ribaudo/eslint-scope-5-internals": "npm:5.1.1-v1"
+    eslint-visitor-keys: "npm:^2.1.0"
+    semver: "npm:^6.3.1"
+  peerDependencies:
+    "@babel/core": ^7.11.0
+    eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
+  checksum: 10c0/c24dcd941b0a149b197a9e9c3297a01d621775ac71cdf2e1134b1097c1691b46ce969355e1be3676d83b88f62c43ed33cf3a499da21ea11a5eb07339ce64ac20
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.18.13, @babel/generator@npm:^7.26.10, @babel/generator@npm:^7.27.5, @babel/generator@npm:^7.7.2":
   version: 7.27.5
   resolution: "@babel/generator@npm:7.27.5"
@@ -3207,7 +3221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.26.10, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.5, @babel/parser@npm:^7.27.7, @babel/parser@npm:^7.7.0":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.26.10, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.5, @babel/parser@npm:^7.27.7":
   version: 7.27.7
   resolution: "@babel/parser@npm:7.27.7"
   dependencies:
@@ -4523,7 +4537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.16.0, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.26.10, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.27.7, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.7.2":
+"@babel/traverse@npm:^7.16.0, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.26.10, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.27.7, @babel/traverse@npm:^7.7.2":
   version: 7.27.7
   resolution: "@babel/traverse@npm:7.27.7"
   dependencies:
@@ -4579,7 +4593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.6, @babel/types@npm:^7.18.13, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.26.10, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.27.6, @babel/types@npm:^7.27.7, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.0":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.6, @babel/types@npm:^7.18.13, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.26.10, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.27.6, @babel/types@npm:^7.27.7, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.27.7
   resolution: "@babel/types@npm:7.27.7"
   dependencies:
@@ -24362,22 +24376,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-eslint@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "babel-eslint@npm:10.1.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.0.0"
-    "@babel/parser": "npm:^7.7.0"
-    "@babel/traverse": "npm:^7.7.0"
-    "@babel/types": "npm:^7.7.0"
-    eslint-visitor-keys: "npm:^1.0.0"
-    resolve: "npm:^1.12.0"
-  peerDependencies:
-    eslint: ">= 4.12.1"
-  checksum: 10c0/a1596111871ce3615410a2ffb87ab8383b35a8c8e1942b47130cb12bca2578c8eb9d8e56c3c84f44d7abe716684f6794f2e6c1e5b4e6d09f171ae51670be44b9
-  languageName: node
-  linkType: hard
-
 "babel-jest@npm:30.0.5":
   version: 30.0.5
   resolution: "babel-jest@npm:30.0.5"
@@ -30919,7 +30917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^1.0.0, eslint-visitor-keys@npm:^1.1.0, eslint-visitor-keys@npm:^1.3.0":
+"eslint-visitor-keys@npm:^1.1.0, eslint-visitor-keys@npm:^1.3.0":
   version: 1.3.0
   resolution: "eslint-visitor-keys@npm:1.3.0"
   checksum: 10c0/10c91fdbbe36810dd4308e57f9a8bc7177188b2a70247e54e3af1fa05ebc66414ae6fd4ce3c6c6821591f43a556e9037bc6b071122e099b5f8b7d2f76df553e3
@@ -33415,6 +33413,7 @@ __metadata:
   resolution: "fxa-content-server@workspace:packages/fxa-content-server"
   dependencies:
     "@babel/cli": "npm:7.23.0"
+    "@babel/eslint-parser": "npm:^7.27.5"
     "@babel/plugin-proposal-class-properties": "npm:^7.18.6"
     "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
     "@types/backbone": "npm:^1.4.19"
@@ -33422,7 +33421,6 @@ __metadata:
     "@types/sinon-chai": "npm:3.2.5"
     "@types/sinon-express-mock": "npm:1.3.9"
     audit-filter: "npm:^0.5.0"
-    babel-eslint: "npm:^10.1.0"
     babel-loader: "npm:^9.1.3"
     babel-plugin-dynamic-import-webpack: "npm:1.1.0"
     backbone: "npm:^1.6.0"
@@ -33735,7 +33733,6 @@ __metadata:
     "@types/rimraf": "npm:3.0.0"
     "@types/sinon": "npm:^10"
     async-wait-until: "npm:^2.0.12"
-    babel-eslint: "npm:^10.1.0"
     babel-loader: "npm:^9.1.3"
     babel-preset-react-app: "npm:^10.0.1"
     camelcase: "npm:^6.3.0"
@@ -33948,6 +33945,7 @@ __metadata:
     "@aws-sdk/client-sns": "npm:^3.973.0"
     "@aws-sdk/client-sqs": "npm:^3.973.0"
     "@babel/core": "npm:^7.29.6"
+    "@babel/eslint-parser": "npm:^7.27.5"
     "@babel/plugin-transform-typescript": "npm:^7.27.1"
     "@babel/preset-env": "npm:^7.27.1"
     "@babel/preset-react": "npm:^7.27.1"
@@ -34060,7 +34058,6 @@ __metadata:
     "@typescript-eslint/parser": "npm:^7.1.1"
     app-store-server-api: "npm:^0.16.0"
     autoprefixer: "npm:^10.4.14"
-    babel-eslint: "npm:^10.1.0"
     babel-jest: "npm:30.0.5"
     base64url: "npm:^3.0.1"
     bn.js: "npm:^5.2.3"
@@ -49732,7 +49729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.11.1, resolve@npm:^1.12.0, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.10, resolve@npm:^1.22.2, resolve@npm:^1.22.4, resolve@npm:^1.22.8, resolve@npm:^1.9.0":
+"resolve@npm:^1.1.7, resolve@npm:^1.11.1, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.10, resolve@npm:^1.22.2, resolve@npm:^1.22.4, resolve@npm:^1.22.8, resolve@npm:^1.9.0":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -49771,7 +49768,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.12.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.9.0#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.9.0#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:


### PR DESCRIPTION
## Because

- `babel-eslint` is deprecated. Upstream renamed it to `@babel/eslint-parser` and no longer ships updates for the old name.
- Three manifests still declared it, and `fxa-content-server` still used it as its ESLint parser.

## This pull request

- Points the `fxa-content-server` ESLint parser at `@babel/eslint-parser`.
- Sets `requireConfigFile: false` in `parserOptions`. This package has no `babel.config.js` and no `.babelrc`, and the new parser refuses to run without the flag.
- Swaps the devDependency in the root manifest and in `fxa-content-server`.
- Drops the declaration from `fxa-react`. It has no parser config, so it needs no parser package.
- Updates the affected `yarn.lock` entries.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-4896

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-content-server/.eslintrc`
- Suggested review order: `.eslintrc`, then the three manifests, then `yarn.lock`
- Risky or complex parts: `requireConfigFile: false`. Drop that flag and every file fails to parse.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

The package lint script runs `eslint app server --cache`. This change touches no source file, so a cached run can report success without re-parsing anything. I verified it with the cache removed:

```
cd packages/fxa-content-server && rm -f .eslintcache && npx eslint app server
```

Exit 0 with no output, both before and after the change.

`ecmaVersion` and `sourceType` are unchanged. No lint rule was disabled, no path was added to `ignorePatterns`, and no Babel config was added.

`fxa-content-server` has no test script. `fxa-react` unit tests pass (100 passed, 0 failed). `nx lint` passes for both packages.
