### PR TITLE
feat(auth-server): return sessionVerificationReason from /session/status

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/session-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/session-api.ts
@@ -89,6 +89,7 @@ const SESSION_STATUS_GET = {
       - \`uid\`: Account id
       - \`details.accountEmailVerified\`: Whether the account's primary email is verified
       - \`details.sessionVerificationMethod\`: The verification method used for the session (e.g., 'email-2fa', 'totp-2fa'), or null if not verified
+      - \`details.sessionVerificationReason\`: What is unverified: 'signup' if the account email is unverified, 'login' if only the session token is unverified. Absent when both are verified.
       - \`details.sessionVerified\`: Whether the session token itself is verified (no pending token verification)
       - \`details.sessionVerificationMeetsMinimumAAL\`: Whether the session's Authentication Assurance Level (AAL) meets or exceeds the account's maximum AAL
       - \`details.verified\`: Deprecated! Use accountEmailVerified and sessionVerified instead.

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -326,6 +326,7 @@ module.exports = function (
             details: isA.object({
               accountEmailVerified: isA.boolean(),
               sessionVerificationMethod: isA.string().allow(null),
+              sessionVerificationReason: isA.string().optional(),
               sessionVerified: isA.boolean(),
               sessionVerificationMeetsMinimumAAL: isA.boolean(),
               verified: isA.boolean(), // Deprecated!
@@ -363,12 +364,22 @@ module.exports = function (
         // Legacy verified flag. Keep for backwards compatibility.
         const verified = accountEmailVerified && sessionVerified;
 
+        // Take the reason from the shared login helper so both endpoints agree
+        // on it. Pass the values above, not the token, so the reason follows the
+        // freshly read account email rather than the token's snapshot of it.
+        const { verificationReason: sessionVerificationReason } =
+          signinUtils.getSessionVerificationStatus({
+            emailVerified: accountEmailVerified,
+            tokenVerified: sessionVerified,
+          });
+
         return {
           state: sessionToken.state,
           uid: sessionToken.uid,
           details: {
             accountEmailVerified,
             sessionVerificationMethod,
+            ...(sessionVerificationReason && { sessionVerificationReason }),
             sessionVerified,
             sessionVerificationMeetsMinimumAAL,
             verified,

--- a/packages/fxa-auth-server/lib/routes/session.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/session.spec.ts
@@ -186,6 +186,7 @@ describe('/session/status', () => {
           accountEmailVerified: false,
           sessionVerificationMeetsMinimumAAL: true,
           sessionVerificationMethod: 'totp-2fa',
+          sessionVerificationReason: 'signup',
           sessionVerified: false,
           verified: false,
         },
@@ -223,6 +224,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: false,
         sessionVerificationMethod: 'email',
+        sessionVerificationReason: 'signup',
         sessionVerified: false,
         verified: false,
         sessionVerificationMeetsMinimumAAL: true,
@@ -259,6 +261,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: false,
         sessionVerificationMethod: 'email',
+        sessionVerificationReason: 'signup',
         sessionVerified: false,
         verified: false,
         sessionVerificationMeetsMinimumAAL: true,
@@ -295,6 +298,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: true,
         sessionVerificationMethod: 'email',
+        sessionVerificationReason: 'login',
         sessionVerified: false,
         verified: false,
         sessionVerificationMeetsMinimumAAL: false,
@@ -371,6 +375,31 @@ describe('/session/status', () => {
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
+  });
+
+  it('omits sessionVerificationReason when the session is verified', async () => {
+    db.account = jest.fn().mockResolvedValue({
+      uid: 'account-123',
+      primaryEmail: {
+        isVerified: true,
+      },
+    });
+    db.totpToken = jest.fn().mockResolvedValue({
+      enabled: false,
+    });
+
+    const request = mocks.mockRequest({
+      credentials: {
+        uid: 'account-123',
+        state: 'verified',
+        tokenVerified: true,
+        verificationMethodValue: 'email',
+        authenticatorAssuranceLevel: 1,
+      },
+    });
+    const resp = await runTest(route, request);
+
+    expect(resp.details).not.toHaveProperty('sessionVerificationReason');
   });
 
   it('has verified AAL 2', async () => {

--- a/packages/fxa-auth-server/test/remote/session_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/session_tests.in.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 
 const Client = require('../client')();
 
@@ -37,7 +40,11 @@ describe.each(testVersions)(
         const email = server.uniqueEmail();
         const password = 'foobar';
         const client = await Client.createAndVerify(
-          server.publicUrl, email, password, server.mailbox, testOptions
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          testOptions
         );
 
         await client.sessionStatus();
@@ -57,7 +64,12 @@ describe.each(testVersions)(
       it('deletes a different custom token', async () => {
         const email = server.uniqueEmail();
         const password = 'foobar';
-        const client = await Client.create(server.publicUrl, email, password, testOptions);
+        const client = await Client.create(
+          server.publicUrl,
+          email,
+          password,
+          testOptions
+        );
 
         const sessionTokenCreate = client.sessionToken;
         const sessions = await client.api.sessions(sessionTokenCreate);
@@ -85,7 +97,12 @@ describe.each(testVersions)(
       it('fails with a bad custom token', async () => {
         const email = server.uniqueEmail();
         const password = 'foobar';
-        const client = await Client.create(server.publicUrl, email, password, testOptions);
+        const client = await Client.create(
+          server.publicUrl,
+          email,
+          password,
+          testOptions
+        );
 
         const sessionTokenCreate = client.sessionToken;
         const c = await client.login();
@@ -107,7 +124,9 @@ describe.each(testVersions)(
           expect(err.code).toBe(401);
           expect(err.errno).toBe(110);
           expect(err.error).toBe('Unauthorized');
-          expect(err.message).toBe('The authentication token could not be found');
+          expect(err.message).toBe(
+            'The authentication token could not be found'
+          );
         }
       });
     });
@@ -117,7 +136,11 @@ describe.each(testVersions)(
         const email = server.uniqueEmail();
         const password = 'foobar';
         const client1 = await Client.createAndVerify(
-          server.publicUrl, email, password, server.mailbox, testOptions
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          testOptions
         );
 
         const client2 = await client1.duplicate();
@@ -150,7 +173,12 @@ describe.each(testVersions)(
       it('creates independent verification state for the new token', async () => {
         const email = server.uniqueEmail();
         const password = 'foobar';
-        const client1 = await Client.create(server.publicUrl, email, password, testOptions);
+        const client1 = await Client.create(
+          server.publicUrl,
+          email,
+          password,
+          testOptions
+        );
         const client2 = await client1.duplicate();
 
         expect(client1.verified).toBeFalsy();
@@ -183,7 +211,10 @@ describe.each(testVersions)(
         const email = server.uniqueEmail();
         const password = 'foobar';
         const client = await Client.createAndVerify(
-          server.publicUrl, email, password, server.mailbox,
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
           { ...testOptions, keys: true }
         );
 
@@ -205,7 +236,11 @@ describe.each(testVersions)(
         const email = server.uniqueEmail();
         const password = 'foobar';
         const client = await Client.createAndVerify(
-          server.publicUrl, email, password, server.mailbox, testOptions
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          testOptions
         );
 
         await client.setupCredentials(email, 'fiibar');
@@ -225,7 +260,12 @@ describe.each(testVersions)(
       it('has sane account-verification behaviour', async () => {
         const email = server.uniqueEmail();
         const password = 'foobar';
-        const client = await Client.create(server.publicUrl, email, password, testOptions);
+        const client = await Client.create(
+          server.publicUrl,
+          email,
+          password,
+          testOptions
+        );
         expect(client.verified).toBeFalsy();
 
         // Clear the verification email, without verifying.
@@ -247,7 +287,10 @@ describe.each(testVersions)(
         const email = server.uniqueEmail();
         const password = 'foobar';
         await Client.createAndVerify(
-          server.publicUrl, email, password, server.mailbox,
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
           { ...testOptions, keys: false }
         );
 
@@ -288,7 +331,10 @@ describe.each(testVersions)(
         const email = server.uniqueEmail();
         const password = 'foobar';
         const client = await Client.createAndVerify(
-          server.publicUrl, email, password, server.mailbox,
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
           { ...testOptions, keys: true }
         );
 
@@ -307,7 +353,11 @@ describe.each(testVersions)(
         const email = server.uniqueEmail();
         const password = 'testx';
         const c = await Client.createAndVerify(
-          server.publicUrl, email, password, server.mailbox, testOptions
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          testOptions
         );
         const uid = c.uid;
         await c.login();
@@ -320,6 +370,7 @@ describe.each(testVersions)(
             accountEmailVerified: true,
             sessionVerificationMeetsMinimumAAL: true,
             sessionVerificationMethod: null,
+            sessionVerificationReason: 'login',
             sessionVerified: false,
             verified: false,
           },


### PR DESCRIPTION
## Because

- `/session/status` says a session is unverified, but not why. The frontend cannot tell a signup confirmation from a login confirmation without a second call.
- The alternative today is `recoveryEmailStatus`, which has side effects and is not a clean status check.

## This pull request

- Adds `details.sessionVerificationReason` to `GET /session/status`. It is `'signup'` when the account email is unverified, and `'login'` when only the session token is unverified.
- Takes the value from the existing `getSessionVerificationStatus` helper in `routes/utils/signin.js`. The login response uses the same helper, so the two endpoints cannot disagree.
- Leaves the key out once both are verified, and declares it as an optional string in the Joi response schema.
- Documents the field in `docs/swagger/session-api.ts`.
- Extends the existing `/session/status` unit tests to cover signup, login, and the verified case, and updates the one remote test that pins the whole `details` object.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12182

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the `/session/status` handler and its response schema in `lib/routes/session.js`.
- Suggested review order: schema, handler, then the specs.
- Risky or complex parts: the name. I picked `sessionVerificationReason` to match the neighbouring `sessionVerificationMethod` and `sessionVerified`. The ticket asks for the bare `verificationReason` that the login response returns. Please confirm which one you want, because this is public API.
- The handler passes `{ emailVerified, tokenVerified }` to the helper rather than the session token. This is deliberate: the reason then follows the account email the handler just read, not the token's snapshot of it. Both files are JS, so nothing type-checks that call.

## Screenshots (Optional)

## Other information (Optional)

- Someone must email `mozilla-accounts-notices` before this reaches production, so RPs know the field exists. Wil raised this on the ticket. It is a release step, not part of this change.
- Server side only. The `SessionStatus` type in `fxa-auth-client` is not extended, so no client can read the field yet. That type already omits the existing `verified` field, so it lags the wire shape either way. Worth a follow-up ticket.
- The deprecated `verified` flag and the AAL fields are unchanged.
- Checked locally with `lib/routes/session.spec.ts` (39 passing) and `nx lint fxa-auth-server`. The remote test needs a running stack, so CI covers it, along with the full auth-server suite.
