### PR TITLE
chore(blender): re-enable investigations and auto-merge

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -4,21 +4,8 @@ repo_name: "Firefox Accounts (mozilla/fxa)"
 node_version: "24.15.0"
 install_command: "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable --inline-builds"
 
-automerge:
-  # Dry-run to stop endless re-approvals: fxa has no required status checks,
-  # so an approved PR goes "clean" immediately and GitHub refuses to arm
-  # auto-merge — BLEnder then re-approves every sweep and approvals pile up as
-  # noise. Re-enable once mozilla/blender#120 (idempotent approval + direct
-  # merge when clean) lands.
-  dry_run: true
-
 investigate:
-  # Disabled: BLEnder's alert remediation is npm-only (npm audit fix +
-  # package-lock.json). fxa is a yarn repo, so remediate always fails, the
-  # alert is never tagged "investigated", and the ~30-min sweep re-investigates
-  # it forever — a runaway cost loop with zero result. Off until BLEnder
-  # supports yarn (see upstream bugs).
-  enabled: false
+  enabled: true
   dismiss_unaffected: true
   max_claude_turns: 100
   max_budget_usd: 6.00


### PR DESCRIPTION
Both temporary BLEnder disables can come off now that the upstream fixes have merged.

- **`investigate.enabled: true`** — BLEnder can now remediate yarn deps ([mozilla/blender#123](https://github.com/mozilla/blender/pull/123)), so the runaway-loop reason for disabling is gone (the loop itself was already fixed by #119).
- **Dropped the `automerge` dry-run block** — idempotent approval + direct-merge-when-clean landed ([mozilla/blender#120](https://github.com/mozilla/blender/pull/120)), so approvals no longer pile up and auto-merge can actually complete. It now inherits the default `dry_run: false`.

Heads up on what to expect after merge:
- The next sweep will investigate the open Dependabot alert backlog (~190) — bounded now (no loop), but a one-time Claude spend.
- Auto-merge will start actually merging safe (patch/minor) Dependabot PRs.
- Out-of-range transitive advisories still won't fully auto-fix until the `resolutions` fallback (mozilla/blender#122) lands — those get flagged, not silently 'fixed'.