### PR TITLE
fix(settings): reject a whitespace-only new password

### DIFF
--- a/packages/fxa-settings/src/components/FormPassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.test.tsx
@@ -47,6 +47,26 @@ describe('with current password field', () => {
     await inputNewPassword('testotest0');
     expect(screen.getByTestId('save-password-button')).toBeDisabled();
   });
+
+  it('rejects a new password of spaces only', async () => {
+    const spacesOnly = ' '.repeat(8);
+    renderWithLocalizationProvider(<Subject />);
+    await inputCurrentPassword('quuz');
+    await inputNewPassword(spacesOnly);
+    await inputVerifyPassword(spacesOnly);
+    expect(screen.getByTestId('change-password-length')).toContainElement(
+      screen.getByTestId('icon-invalid')
+    );
+    expect(screen.getByTestId('save-password-button')).toBeDisabled();
+  });
+
+  it('accepts a new password padded with spaces', async () => {
+    renderWithLocalizationProvider(<Subject />);
+    await inputCurrentPassword('quuz');
+    await inputNewPassword('    testo1    ');
+    await inputVerifyPassword('    testo1    ');
+    expect(screen.getByTestId('save-password-button')).toBeEnabled();
+  });
 });
 
 describe('without current password field', () => {

--- a/packages/fxa-settings/src/components/FormPassword/index.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.tsx
@@ -197,7 +197,9 @@ export const FormPassword = ({
             registration={register('newPassword', {
               required: true,
               validate: {
-                length: (value: string) => value.length > 7,
+                // Whitespace-only passwords reuse the 8-character row.
+                length: (value: string) =>
+                  value.length > 7 && value.trim() !== '',
                 notEmail: (value: string) => {
                   return !passwordValidator.isSameAsEmail(value.toLowerCase());
                 },


### PR DESCRIPTION
## Because

- The change-password form checked the length of the new password only, so eight spaces passed.
- A user who saved a space-only password could not sign in again. The sign-in form rejects it.

## This pull request

- Adds a trim check to the `length` validator in `FormPassword`. It is the predicate `FormPasswordWithInlineCriteria` already uses.
- Adds two tests: a space-only password is rejected, and a space-padded password with real content still works.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9473

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the `length` validator in `FormPassword/index.tsx`.
- Suggested review order: the component, then the two tests.
- Risky or complex parts: keep the predicate as `value.length > 7 && value.trim() !== ''`. The shorter `value.trim().length > 7` also rejects a valid padded password such as `"  abc123  "`, which locks out users whose password has padding.

## Screenshots (Optional)

None. The failure shows on the existing "At least 8 characters" row, so there is no new copy and no layout change.

## Other information (Optional)

- `PageCreatePassword` had the same bug. It and `PageChangePassword` both render `FormPassword`, so this one change fixes both pages.
- The auth server still accepts a whitespace-only password. That is a server-side decision and is out of scope here.
- Ran locally: the `FormPassword`, `PageChangePassword`, and `PageCreatePassword` specs, 40 tests pass. Lint passes for `fxa-settings`.
