### PR TITLE
fix(tsconfig): stop functional-tests build config overriding base paths

### DIFF
--- a/packages/functional-tests/tsconfig.build.json
+++ b/packages/functional-tests/tsconfig.build.json
@@ -1,8 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist"],
-  "compilerOptions": {
-    "paths": {
-    }
-  }
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/fxa-auth-server/.storybook/tsconfig.storybook.json
+++ b/packages/fxa-auth-server/.storybook/tsconfig.storybook.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"],
   "compilerOptions": {
+    // Storybook resolves paths against baseUrl ./dist (see main.js), so this alias must point at the compiled index.js.
     "paths": {
       "@fxa/shared/l10n": ["libs/shared/l10n/src/index.js"]
     }


### PR DESCRIPTION
## Because

- TypeScript replaces `paths`, it does not merge it. A project config that declares its own `paths` drops every alias in `tsconfig.base.json`.
- `packages/functional-tests/tsconfig.build.json` declared an empty `paths: {}`. That wiped the base alias table for the project.

## This pull request

- Removes the empty `paths` override from `packages/functional-tests/tsconfig.build.json`, so the project inherits the base aliases.
- Records why the `@fxa/shared/l10n` override in `packages/fxa-auth-server/.storybook/tsconfig.storybook.json` must stay.

## Issue that this pull request solves

Closes: FXA-12499

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the two tsconfig files in the diff.
- Suggested review order: `packages/functional-tests/tsconfig.build.json` first, then the comment in `packages/fxa-auth-server/.storybook/tsconfig.storybook.json`.
- Risky or complex parts: none of the four configs feed a service at boot. The two that jest reads are untouched.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Four configs in the repo declare their own `paths`. Every other project config inherits from the base already. Here is the decision for each one.

- `packages/functional-tests/tsconfig.build.json`, **redundant**, removed. The `paths` block was empty. It deleted the base aliases and gave nothing back. A type-check of the old config reported `Cannot find module '@fxa/shared/metrics/glean'`. That error is gone, and no new error appears.
- `packages/fxa-admin-server/tsconfig.build.json`, **necessary**, left as is. The 38 aliases look like a subset of the base. But `jest.config.js` and `jest-e2e.config.js` `require()` this file and pass `compilerOptions.paths` to `pathsToModuleNameMapper`. The targets drop the `.ts` extension on purpose, so jest resolves the compiled output under `modulePaths: ['<rootDir>/../dist/']`.
- `packages/fxa-event-broker/tsconfig.build.json`, **necessary**, left as is, for the same reason. I tried the removal. `npx jest --listTests` then failed with `TypeError: Cannot read properties of undefined (reading 'paths')`, because `compilerOptions` no longer exists.
- `packages/fxa-auth-server/.storybook/tsconfig.storybook.json`, **necessary**, kept, with a comment. `.storybook/main.js` gives `TsconfigPathsPlugin` a `baseUrl` of `./dist`. The alias must name the compiled `index.js`. The base names `src/index.ts`, which does not exist under `dist`.

The two necessary build configs get their reason here, not inline. Node parses `.json` with `JSON.parse`, which rejects comments. A comment in either file crashes the jest suite that requires it. The storybook config takes a comment safely, because its only reader, `tsconfig-paths`, parses with json5.

`tsconfig.base.json` is unchanged. No `.ts` or `.tsx` file is touched.

Note that nothing references `packages/functional-tests/tsconfig.build.json`. No nx target, npm script, CI step, or Dockerfile names it. Its `compile` script runs `tsc --noEmit` against `tsconfig.json`. The fix is correct, but it is inert today. Deletion of the file is separate cleanup.

The second half of the ticket, the ecosystem docs update, is not done here. Those docs live in `mozilla/ecosystem-platform`, and the link in the ticket is unresolved.

Verification: `tsc --noEmit` against all four configs, before and after, compared line by line. `npx nx lint functional-tests` and `npx nx lint fxa-auth-server` both pass. The `fxa-auth-server` jest unit project reports 3758 passed and 13 failed. Those same 13 fail on the unmodified files, because Node 24 dropped `util.isError`, which the `intel` logger calls. Functional tests were not run.
