### PR TITLE
fix(rate-limit): match ignoreEmails against the non-normalized email

### DIFF
--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -190,6 +190,101 @@ describe('rate-limit', () => {
     expect(statsd.increment).toHaveBeenCalledWith('rate_limit.ignore.email');
   });
 
+  it('matches ignored emails against the non-normalized email when given', () => {
+    rateLimit = new RateLimit(
+      {
+        rules: {},
+        ignoreEmails: ['^.*\\+srl\\d{0,4}@mozilla\\.com$'],
+      },
+      redis,
+      statsd
+    );
+
+    // Callers strip the +suffix from opts.email, so only the raw email can match.
+    expect(
+      rateLimit.skip(
+        'test',
+        { email: 'user@mozilla.com' },
+        'user+srl1@mozilla.com'
+      )
+    ).toBeTruthy();
+    expect(
+      rateLimit.skip(
+        'test',
+        { email: 'user@mozilla.com' },
+        'user+other@mozilla.com'
+      )
+    ).toBeFalsy();
+    expect(rateLimit.skip('test', { email: 'user@mozilla.com' })).toBeFalsy();
+  });
+
+  it('matches ignored emails against a mixed-case non-normalized email', () => {
+    rateLimit = new RateLimit(
+      {
+        rules: {},
+        ignoreEmails: ['^.*\\+srl\\d{0,4}@mozilla\\.com$'],
+      },
+      redis,
+      statsd
+    );
+
+    // The raw email keeps the case, opts.email loses the +suffix. Only the
+    // lowercased raw email has both.
+    expect(
+      rateLimit.skip(
+        'test',
+        { email: 'user@mozilla.com' },
+        'User+srl1@Mozilla.com'
+      )
+    ).toBeTruthy();
+    expect(
+      rateLimit.skip(
+        'test',
+        { email: 'user@mozilla.com' },
+        'User+other@Mozilla.com'
+      )
+    ).toBeFalsy();
+  });
+
+  it('still matches ignored emails against the normalized email', () => {
+    rateLimit = new RateLimit(
+      {
+        rules: {},
+        ignoreEmails: ['^qa@mozilla\\.com$'],
+      },
+      redis,
+      statsd
+    );
+
+    // Normalization lowercases and trims, so only opts.email can match here.
+    expect(
+      rateLimit.skip('test', { email: 'qa@mozilla.com' }, ' QA@Mozilla.com ')
+    ).toBeTruthy();
+  });
+
+  it('keeps the normalized email on the BQ row when a raw email is given', () => {
+    const bqWriter = { write: jest.fn() };
+    rateLimit = new RateLimit(
+      {
+        rules: {},
+        ignoreEmails: ['^.*\\+srl\\d{0,4}@mozilla\\.com$'],
+      },
+      redis,
+      statsd,
+      bqWriter
+    );
+
+    rateLimit.skip(
+      'test',
+      { email: 'user@mozilla.com' },
+      'user+srl1@mozilla.com'
+    );
+
+    expect(bqWriter.write).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'user@mozilla.com', wasSkipped: true })
+    );
+  });
+
   it('can ignore certain ips', () => {
     rateLimit = new RateLimit(
       {

--- a/libs/accounts/rate-limit/src/lib/rate-limit.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.ts
@@ -109,16 +109,25 @@ export class RateLimit {
    * certain users.
    * @param action - The action being checked. Required so BQ events include context.
    * @param opts - The current properties being checked.
+   * @param nonNormalizedEmail - The email as the user supplied it. Matched against
+   *        ignoreEmails in addition to opts.email.
    * @returns True if the check should be skipped.
    */
-  skip(action: string, opts: BlockOnOpts) {
+  skip(action: string, opts: BlockOnOpts, nonNormalizedEmail?: string) {
     const ignoredIp =
       opts.ip != null && this.config.ignoreIPs?.some((x) => opts.ip === x);
     const ignoredUid =
       opts.uid != null && this.config.ignoreUIDs?.some((x) => opts.uid === x);
-    const ignoredEmail =
-      opts.email != null &&
-      this.config.ignoreEmails?.some((x) => opts.email?.match(x));
+    // Match every form: the raw email keeps the +suffix, the normalized one keeps
+    // the trim and lowercase, and the lowercased raw email keeps both.
+    const emails = [
+      nonNormalizedEmail,
+      nonNormalizedEmail?.trim().toLocaleLowerCase(),
+      opts.email,
+    ].filter((x): x is string => x != null);
+    const ignoredEmail = this.config.ignoreEmails?.some((x) =>
+      emails.some((email) => email.match(x))
+    );
     const skipped = ignoredIp || ignoredUid || ignoredEmail;
 
     if (ignoredIp) this.statsd?.increment('rate_limit.ignore.ip');

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -115,7 +115,7 @@ class CustomsClient {
 
   async check(request, email, action) {
     const opts = toOpts(request?.app?.clientAddress, email, undefined);
-    const checked = await this.checkV2(request, 'check', action, opts);
+    const checked = await this.checkV2(request, 'check', action, opts, email);
     if (checked) {
       return;
     }
@@ -146,7 +146,8 @@ class CustomsClient {
       request,
       'checkAuthenticated',
       action,
-      opts
+      opts,
+      email
     );
     if (checked) {
       return;
@@ -291,7 +292,7 @@ class CustomsClient {
    * customs action being checked. If there is, we will call into this code instead of calling
    * the legacy customs service.
    */
-  async checkV2(request, type, action, opts) {
+  async checkV2(request, type, action, opts, nonNormalizedEmail) {
     // Short circuit if rate limit wasn't provided.
     if (this.rateLimit == null) {
       return false;
@@ -309,8 +310,9 @@ class CustomsClient {
     }
 
     // The config can specify that certain ips, emails, or uids should be excluded
-    // from rate limit checks.
-    const skip = this.rateLimit.skip(action, opts);
+    // from rate limit checks. Pass the raw email so an ignoreEmails pattern can
+    // match a +suffix that opts.email no longer carries.
+    const skip = this.rateLimit.skip(action, opts, nonNormalizedEmail);
     if (skip) {
       this.statsd.increment(`${serviceName}.check.v2.skip`, [
         opts.ip_email ? 'ip_email' : '',

--- a/packages/fxa-auth-server/lib/customs.spec.ts
+++ b/packages/fxa-auth-server/lib/customs.spec.ts
@@ -356,12 +356,26 @@ describe('Customs', () => {
 
       await customs.check(request, email, 'accountStatusCheck');
 
-      expect(mockRateLimit.skip).toHaveBeenCalledWith('accountStatusCheck', {
-        ip,
-        email,
-        ip_email,
-      });
+      expect(mockRateLimit.skip).toHaveBeenCalledWith(
+        'accountStatusCheck',
+        { ip, email, ip_email },
+        email
+      );
       expect(mockRateLimit.check).toHaveBeenCalledTimes(0);
+    });
+
+    it('passes the non-normalized email to skip', async () => {
+      mockRateLimit.check = jest.fn(async () => Promise.resolve(null));
+
+      const emailWithAlias = 'user+srl1@mozilla.com';
+
+      await customs.check(request, emailWithAlias, 'accountStatusCheck');
+
+      expect(mockRateLimit.skip).toHaveBeenCalledWith(
+        'accountStatusCheck',
+        expect.objectContaining({ email: 'user@mozilla.com' }),
+        emailWithAlias
+      );
     });
 
     it('normalizes emails with plus aliases for configured domains', async () => {


### PR DESCRIPTION
## Because

- A stage bypass pattern like `^.*\+srl\d{0,4}@mozilla\.com$` never matched, so rate limits could not be skipped for those test accounts.
- `customs.js` normalizes the email before it reaches the rate-limit library. Normalization strips the `+suffix` that the pattern needs.

## This pull request

- Adds an optional `nonNormalizedEmail` parameter to `RateLimit.skip()`. It matches `config.ignoreEmails` against the raw email and the normalized one.
- Adds the lowercased raw email as a third match candidate. Normalization lowercases before it strips the `+suffix`, so a mixed-case input like `User+srl1@Mozilla.com` matched neither of the first two forms.
- Passes the raw email through `CustomsClient.checkV2()` from `check()` and `checkAuthenticated()`.
- Keeps `RateLimit.check()` on the normalized email, so a `+suffix` address cannot evade rate limits.
- Keeps the normalized email on the BigQuery row that a skipped check writes.
- Adds specs for the `+suffix` match and for the normalized fallback.

## Issue that this pull request solves

Closes: FXA-13194

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `skip()` in `libs/accounts/rate-limit/src/lib/rate-limit.ts`, and the `checkV2()` call site in `packages/fxa-auth-server/lib/customs.js`.
- Suggested review order: `rate-limit.ts`, then `customs.js`, then the two spec files.
- Risky or complex parts: `skip()` matches on the raw email and the normalized one. A match on the raw email only would drop the trim and the lowercase that an existing pattern can depend on. Read the deployment note below.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Warning: audit the deployed `ignoreEmails` values before you merge this.

The bypass is config-gated, not code-gated. `config.ignoreEmails` is a per-environment list of regexes. This fix makes those patterns match the raw address as well as the normalized one. Any pattern already in a production config becomes more permissive, because it then also matches `user+anything@...`. The owner of the prod config must make that call.

`BlockOn` and `BlockOnOpts` do not change. A raw email is not a new blocking dimension, so it stays out of the mapped type.
