### PR TITLE
fix(settings): report unlocalizable errors to Sentry with their message

### DIFF
--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.test.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.test.ts
@@ -17,24 +17,117 @@ const errorWithAnInvalidErrorNumber = {
 } as AuthUiError;
 
 jest.mock('@sentry/browser', () => ({
-  captureMessage: jest.fn(),
+  captureException: jest.fn(),
 }));
 
+const missingErrnoReason =
+  "An error occurred that we attempted to localize and render, but 'errno' is missing.";
+const unknownErrnoReason =
+  'An error occurred that we attempted to localize and render, but this error was not found in auth-errors or oauth-errors. We should either add this error to our list or not display it.';
+
+const capturedException = () => {
+  const [error, context] = (
+    Sentry.captureException as jest.MockedFunction<
+      typeof Sentry.captureException
+    >
+  ).mock.calls[0];
+  return { error: error as Error, context };
+};
+
 describe('getErrorFtlId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('logs an informative error to sentry if passed an error with no errno', () => {
     getErrorFtlId(errorWithNoErrorNumber);
-    const errorMessage = `WARNING: An error occurred that we attempted to localize and render, but 'errno' is missing. error: ${JSON.stringify(
-      errorWithNoErrorNumber
-    )}`;
-    expect(Sentry.captureMessage).toHaveBeenCalledWith(errorMessage);
+    const { error, context } = capturedException();
+    expect(error.message).toEqual("I'm an error with no error number!");
+    expect(context).toEqual({
+      tags: { source: 'getErrorFtlId' },
+      extra: {
+        reason: missingErrnoReason,
+        errno: undefined,
+        code: undefined,
+        retryAfter: undefined,
+      },
+      level: 'warning',
+    });
   });
 
   it('logs to sentry if an error does not match an entry in AuthUiErrors object or OAuth errors array', () => {
     getErrorFtlId(errorWithAnInvalidErrorNumber);
-    const errorMessage = `WARNING: An error occurred that we attempted to localize and render, but this error was not found in auth-errors or oauth-errors. We should either add this error to our list or not display it. error: ${JSON.stringify(
-      errorWithAnInvalidErrorNumber
-    )}`;
-    expect(Sentry.captureMessage).toHaveBeenCalledWith(errorMessage);
+    const { error, context } = capturedException();
+    expect(error.message).toEqual('This is an error with an invalid errno!');
+    expect(context).toEqual({
+      tags: { source: 'getErrorFtlId' },
+      extra: {
+        reason: unknownErrnoReason,
+        errno: notAnExistingErrorNumber,
+        code: undefined,
+        retryAfter: undefined,
+      },
+      level: 'warning',
+    });
+  });
+
+  it('sends the code and retryAfter of an unrecognized error to sentry', () => {
+    getErrorFtlId({
+      errno: notAnExistingErrorNumber,
+      message: 'This is a rate limited error with an invalid errno!',
+      code: 429,
+      retryAfter: 900,
+    });
+    const { context } = capturedException();
+    expect(context).toEqual({
+      tags: { source: 'getErrorFtlId' },
+      extra: {
+        reason: unknownErrnoReason,
+        errno: notAnExistingErrorNumber,
+        code: 429,
+        retryAfter: 900,
+      },
+      level: 'warning',
+    });
+  });
+
+  it('sends a real Error with no errno to sentry with its message and stack intact', () => {
+    const err = new Error('A real Error with no errno');
+    getErrorFtlId(err);
+    const { error } = capturedException();
+    expect(error).toBe(err);
+    expect(error.message).toEqual('A real Error with no errno');
+  });
+
+  it('sends a real Error with an unrecognized errno to sentry with its message and stack intact', () => {
+    const err = Object.assign(new Error('A real Error with an invalid errno'), {
+      errno: notAnExistingErrorNumber,
+    });
+    getErrorFtlId(err);
+    const { error, context } = capturedException();
+    expect(error).toBe(err);
+    expect(error.message).toEqual('A real Error with an invalid errno');
+    expect(context).toEqual({
+      tags: { source: 'getErrorFtlId' },
+      extra: {
+        reason: unknownErrnoReason,
+        errno: notAnExistingErrorNumber,
+        code: undefined,
+        retryAfter: undefined,
+      },
+      level: 'warning',
+    });
+  });
+
+  it('falls back to the reason when the error carries no message', () => {
+    getErrorFtlId({});
+    const { error } = capturedException();
+    expect(error.message).toEqual(missingErrnoReason);
+  });
+
+  it('does not log to sentry for a known errno', () => {
+    getErrorFtlId({ message: 'I am valid', errno: 106 });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('returns an empty string if passed no error number', () => {

--- a/packages/fxa-settings/src/lib/error-utils.ts
+++ b/packages/fxa-settings/src/lib/error-utils.ts
@@ -43,10 +43,7 @@ const handleAuthUiError = (error: {
   return { error: AuthUiErrors.UNEXPECTED_ERROR as HandledError };
 };
 
-export const getHandledError = (error: {
-  errno: number;
-  message: string;
-}) => {
+export const getHandledError = (error: { errno: number; message: string }) => {
   return handleAuthUiError(error);
 };
 
@@ -110,7 +107,7 @@ export const getLocalizedErrorMessage = (
   TODO in FXA-9502: account for potential errno overlap between auth-errors
   and oauth errors. Checking the auth-error array currently happens first.
 **/
-export const getErrorFtlId = (err: { errno?: number; message?: string }) => {
+export const getErrorFtlId = (err: Partial<GenericError>) => {
   if (err.errno) {
     if (err.errno in AuthUiErrorNos) {
       const error = AuthUiErrorNos[err.errno];
@@ -129,14 +126,21 @@ export const getErrorFtlId = (err: { errno?: number; message?: string }) => {
     }
   }
   // If the error isn't found, return an empty string FTL ID and log to Sentry.
-  const logMessage = err.errno
-    ? `WARNING: An error occurred that we attempted to localize and render, but this error was not found in auth-errors or oauth-errors. We should either add this error to our list or not display it. error: ${JSON.stringify(
-        err
-      )}`
-    : `WARNING: An error occurred that we attempted to localize and render, but 'errno' is missing. error: ${JSON.stringify(
-        err
-      )}`;
-  Sentry.captureMessage(logMessage);
+  const reason = err.errno
+    ? 'An error occurred that we attempted to localize and render, but this error was not found in auth-errors or oauth-errors. We should either add this error to our list or not display it.'
+    : "An error occurred that we attempted to localize and render, but 'errno' is missing.";
+  // Capture the error itself: stringifying an Error drops its message and stack.
+  // Keep 'errno' out of the tags: beforeSend in fxa-shared fingerprints a tagged
+  // errno into a single group and downgrades the level to info.
+  const { code, retryAfter } = err;
+  Sentry.captureException(
+    err instanceof Error ? err : new Error(err.message || reason),
+    {
+      tags: { source: 'getErrorFtlId' },
+      extra: { reason, errno: err.errno, code, retryAfter },
+      level: 'warning',
+    }
+  );
   return '';
 };
 


### PR DESCRIPTION
## Because

- `getErrorFtlId` reported unlocalizable errors to Sentry as `JSON.stringify(err)`. An `Error` stringifies to `{}`, because `name`, `message` and `stack` are not own enumerable properties, so every report reads `error: {}`.
- Sentry issue FXA-CONTENT-1HZT collects under 10 of these a day, on `/`, `/settings` and `/settings/emails`, and not one of them names the error.

## This pull request

- Replaces `Sentry.captureMessage` with `Sentry.captureException` in `error-utils.ts`, so a real `Error` reaches Sentry with its message and stack.
- Wraps a non-`Error` input in `new Error(err.message || reason)`, and sends `errno`, `code` and `retryAfter` as extra context.
- Keeps `errno` out of the tags. `beforeSend` in `fxa-shared/sentry/browser.ts` fingerprints a tagged errno into one group and drops the level to `info`.
- Fixes the sibling "not found in auth-errors or oauth-errors" branch the same way. It had the identical bug.
- Updates the two message assertions in `auth-errors.test.ts` and adds cases that pass a real `Error`.

From review round 2:

- Types the `getErrorFtlId` parameter as `Partial<GenericError>`. `code` and `retryAfter` are now part of the declared contract, so the `as GenericError` assertion is gone.
- Adds a test that passes `code: 429` and `retryAfter: 900`, and asserts both reach the Sentry `extra` payload.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13366

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `getErrorFtlId` in `packages/fxa-settings/src/lib/error-utils.ts`.
- Suggested review order: the source change, then the updated assertions in `auth-errors.test.ts`.
- Risky or complex parts: the `level` and `tags` choice depends on `beforeSend` in `fxa-shared/sentry/browser.ts`. A tagged `errno` there would re-group these events and downgrade them to `info`.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

- The return value of `getErrorFtlId` does not change. Both branches still return `''`, and `getLocalizedErrorMessage` is untouched.
- This makes the next occurrence diagnosable. It does not say why the errno-less errors happen. I could not read the production Sentry data.
- Sentry groups by message, so FXA-CONTENT-1HZT stops collecting and a new issue starts. Watch for the replacement issue rather than reading the drop to zero as a fix.
- The new test fails if `code` and `retryAfter` are hardcoded to `undefined`. I hardcoded them and watched it fail, rather than assume it.
- Verified locally: `auth-errors.test.ts` passes, 13 of 13, `npx tsc -p packages/fxa-settings/tsconfig.json --noEmit` reports nothing in the changed files, and `npx nx lint fxa-settings` exits 0. Functional tests were not run.
