### PR TITLE
fix(auth-server): run bulk-mailer test scripts without a shell

### DIFF
--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.in.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.in.spec.ts
@@ -11,7 +11,7 @@ const crypto = require('crypto');
 
 const ROOT_DIR = '../..';
 const cwd = path.resolve(__dirname, ROOT_DIR);
-const execAsync = promisify(cp.exec);
+const execFileAsync = promisify(cp.execFile);
 
 const log = mocks.mockLog();
 const config = require('../../config').default.getProperties();
@@ -64,6 +64,8 @@ const DB = createDB(config, log, Token, UnblockCode);
 
 const execOptions = {
   cwd,
+  // Script output is captured through a pipe now, so the 1 MB default is too small.
+  maxBuffer: 10 * 1024 * 1024,
   env: {
     ...process.env,
     NODE_ENV: 'dev',
@@ -71,6 +73,21 @@ const execOptions = {
     AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
   },
 };
+
+// execFile takes an argument array, so no path goes through a shell.
+function runScript(args: string[]) {
+  return execFileAsync(
+    'node',
+    [
+      '-r',
+      'ts-node/register/transpile-only',
+      '-r',
+      'tsconfig-paths/register',
+      ...args,
+    ],
+    execOptions
+  );
+}
 
 describe('#integration - scripts/bulk-mailer', () => {
   let db: any;
@@ -86,10 +103,14 @@ describe('#integration - scripts/bulk-mailer', () => {
       db.createAccount(account2Mock),
     ]);
 
-    await execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/dump-users --emails ${account1Mock.email},${account2Mock.email} > ${USER_DUMP_PATH}`,
-      execOptions
-    );
+    const { stdout } = await runScript([
+      'scripts/dump-users',
+      '--emails',
+      `${account1Mock.email},${account2Mock.email}`,
+    ]);
+    // Fail here, not in a later test, if the dump did not arrive whole.
+    JSON.parse(stdout);
+    fs.writeFileSync(USER_DUMP_PATH, stdout);
   });
 
   afterAll(async () => {
@@ -104,10 +125,7 @@ describe('#integration - scripts/bulk-mailer', () => {
 
   it('fails if --input missing', async () => {
     try {
-      await execAsync(
-        'node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/bulk-mailer --method sendVerifyEmail',
-        execOptions
-      );
+      await runScript(['scripts/bulk-mailer', '--method', 'sendVerifyEmail']);
       throw new Error('script should have failed');
     } catch (err: any) {
       expect(err.message).toContain('Command failed');
@@ -116,10 +134,13 @@ describe('#integration - scripts/bulk-mailer', () => {
 
   it('fails if --input file missing', async () => {
     try {
-      await execAsync(
-        'node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/bulk-mailer --input does_not_exist --method sendVerifyEmail',
-        execOptions
-      );
+      await runScript([
+        'scripts/bulk-mailer',
+        '--input',
+        'does_not_exist',
+        '--method',
+        'sendVerifyEmail',
+      ]);
       throw new Error('script should have failed');
     } catch (err: any) {
       expect(err.message).toContain('Command failed');
@@ -128,10 +149,7 @@ describe('#integration - scripts/bulk-mailer', () => {
 
   it('fails if --method missing', async () => {
     try {
-      await execAsync(
-        'node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/bulk-mailer --input ${USER_DUMP_PATH}',
-        execOptions
-      );
+      await runScript(['scripts/bulk-mailer', '--input', USER_DUMP_PATH]);
       throw new Error('script should have failed');
     } catch (err: any) {
       expect(err.message).toContain('Command failed');
@@ -140,10 +158,13 @@ describe('#integration - scripts/bulk-mailer', () => {
 
   it('fails if --method is invalid', async () => {
     try {
-      await execAsync(
-        'node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method doesNotExist',
-        execOptions
-      );
+      await runScript([
+        'scripts/bulk-mailer',
+        '--input',
+        USER_DUMP_PATH,
+        '--method',
+        'doesNotExist',
+      ]);
       throw new Error('script should have failed');
     } catch (err: any) {
       expect(err.message).toContain('Command failed');
@@ -151,10 +172,15 @@ describe('#integration - scripts/bulk-mailer', () => {
   });
 
   it('succeeds with valid input file and method, writing files to disk', async () => {
-    await execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendPasswordChangedEmail --write ${OUTPUT_DIRECTORY}`,
-      execOptions
-    );
+    await runScript([
+      'scripts/bulk-mailer',
+      '--input',
+      USER_DUMP_PATH,
+      '--method',
+      'sendPasswordChangedEmail',
+      '--write',
+      OUTPUT_DIRECTORY,
+    ]);
 
     expect(
       fs.existsSync(
@@ -202,10 +228,13 @@ describe('#integration - scripts/bulk-mailer', () => {
   });
 
   it('succeeds with valid input file and method, writing emails to stdout', async () => {
-    const output = await execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendPasswordChangedEmail`,
-      execOptions
-    );
+    const output = await runScript([
+      'scripts/bulk-mailer',
+      '--input',
+      USER_DUMP_PATH,
+      '--method',
+      'sendPasswordChangedEmail',
+    ]);
     const result = output.stdout.toString();
 
     expect(result).toContain(account1Mock.uid);
@@ -219,9 +248,13 @@ describe('#integration - scripts/bulk-mailer', () => {
   });
 
   it('succeeds with valid input file and method, sends', async () => {
-    await execAsync(
-      `node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendVerifyEmail --send`,
-      execOptions
-    );
+    await runScript([
+      'scripts/bulk-mailer',
+      '--input',
+      USER_DUMP_PATH,
+      '--method',
+      'sendVerifyEmail',
+      '--send',
+    ]);
   });
 });


### PR DESCRIPTION
## Because

- CodeQL flagged four `execAsync` calls in `bulk-mailer.in.spec.ts`. Each one builds a shell command from a `__dirname`-derived path.
- A path with characters the shell treats specially can change what the command does.

## This pull request

- Replaces `promisify(cp.exec)` with `promisify(cp.execFile)` and adds a `runScript(args)` helper. The script and its options go through as an argument array, so no value reaches a shell.
- Captures the `dump-users` output from stdout and writes `user_dump.json` with `fs`. `execFile` has no shell, so the old `>` redirect is gone. The dump is parsed before it is written, so a short read fails in `beforeAll` instead of confusing a later test.
- Raises `maxBuffer` to 10 MB, because script output now comes back through a pipe instead of going straight to disk.
- Passes the real `USER_DUMP_PATH` in the two `--method` tests. They used single quotes, so the script got the literal text `${USER_DUMP_PATH}` as its input path. Both still fail for the reason their names give.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13670

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/test/scripts/bulk-mailer.in.spec.ts`.
- Suggested review order: the `runScript` helper, then `beforeAll`, then the six call sites.
- Risky or complex parts: the `beforeAll` dump. It is the only site that lost a shell redirect. Check that `user_dump.json` still lands before the tests that read it.

## Screenshots (Optional)

None. There is no user interface change.

## Other information (Optional)

- I did not run this spec. It creates real accounts, so it needs MySQL and Redis. CI covers it: the `scripts` Jest project matches `test/scripts/**/*.in.spec.ts`, and CircleCI runs the `test-scripts` target.
- The type-check is clean for the changed file, and `npx nx lint fxa-auth-server` exits 0.
- The `fxa-auth-server` unit suite reports 3758 passed and 13 failed. The same 13 fail on a pristine tree, in `lib/routes/account.spec.ts` and `config/index.spec.ts`. The unit Jest project ignores `*.in.spec.ts`, so it never loads the changed file.
- Every assertion in the spec is unchanged. No test was added, removed, or re-enabled.
