### PR TITLE
fix(functional-tests): register recoveryKey accounts with the tracker

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -69,7 +69,6 @@ test.describe('severity-2 #smoke', () => {
         recoveryKey,
         resetPassword,
         confirmSignupCode,
-        deleteAccount,
       },
       testAccountTracker,
     }) => {
@@ -79,10 +78,7 @@ test.describe('severity-2 #smoke', () => {
         These tests will be removed as part of https://mozilla-hub.atlassian.net/browse/FXA-11426"
       );
 
-      const accountDetails = {
-        email: testAccountTracker.generateEmail(),
-        password: testAccountTracker.generatePassword(),
-      };
+      const accountDetails = testAccountTracker.generateAccountDetails();
       const newPassword = testAccountTracker.generatePassword();
       await page.goto(
         `${target.contentServerUrl}/?force_passwordless=false&forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signupVersion.query}`
@@ -143,9 +139,9 @@ test.describe('severity-2 #smoke', () => {
       );
 
       await resetPassword.fillOutNewPasswordForm(newPassword);
-      accountDetails.password = newPassword;
 
       await expect(page).toHaveURL(/reset_password_with_recovery_key_verified/);
+      accountDetails.password = newPassword;
 
       await resetPassword.continueWithoutDownloadingRecoveryKey();
       await resetPassword.recoveryKeyFinishButton.click();
@@ -171,8 +167,10 @@ test.describe('severity-2 #smoke', () => {
       );
       expect(keys2.kB).toEqual(keys.kB);
 
-      await settings.deleteAccountButton.click();
-      await deleteAccount.deleteAccount(accountDetails.password);
+      // No in-test delete. The account is registered with the tracker, so
+      // teardown destroys it. Deleting it here as well raced that teardown:
+      // accountStatusByEmail still reported the account, then destroyAccount
+      // failed with "Unknown account".
     });
   }
 });

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -25,7 +25,13 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(
+        target,
+        settings,
+        secondaryEmail,
+        newEmail,
+        credentials
+      );
 
       await settings.signOut();
 
@@ -43,9 +49,6 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutPasswordForm(credentials.password);
 
       await expect(settings.primaryEmail.status).toHaveText(newEmail);
-
-      // Update which email to use for account cleanup
-      credentials.email = newEmail;
     });
 
     test('change primary email, password and login', async ({
@@ -63,7 +66,13 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(
+        target,
+        settings,
+        secondaryEmail,
+        newEmail,
+        credentials
+      );
 
       await setNewPassword(
         settings,
@@ -71,10 +80,9 @@ test.describe('severity-1 #smoke', () => {
         initialPassword,
         newPassword,
         target,
-        newEmail
+        newEmail,
+        credentials
       );
-
-      credentials.password = newPassword;
 
       await settings.signOut();
 
@@ -89,10 +97,6 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutPasswordForm(newPassword);
 
       await expect(settings.primaryEmail.status).toHaveText(newEmail);
-
-      // Update credentials to use for account cleanup
-      credentials.email = newEmail;
-      credentials.password = newPassword;
     });
 
     test('change primary email, change password, login, change email and login', async ({
@@ -111,7 +115,13 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, secondEmail);
+      await changePrimaryEmail(
+        target,
+        settings,
+        secondaryEmail,
+        secondEmail,
+        credentials
+      );
 
       await setNewPassword(
         settings,
@@ -119,10 +129,9 @@ test.describe('severity-1 #smoke', () => {
         initialPassword,
         newPassword,
         target,
-        secondEmail
+        secondEmail,
+        credentials
       );
-
-      credentials.password = newPassword;
 
       await settings.signOut();
 
@@ -137,9 +146,15 @@ test.describe('severity-1 #smoke', () => {
       // After sign-out + sign-in, the JWT cache is cleared, so the MFA modal appears.
       await settings.secondaryEmail.makePrimaryButton.click();
       await settings.confirmMfaGuard(secondEmail);
+
+      // The primary email is back to the initial one, so cleanup needs it
+      // again. Set it before the assertion, not after.
+      credentials.email = initialEmail;
+
       await expect(settings.alertBar).toHaveText(
         new RegExp(`${initialEmail}.*is now your primary email`)
       );
+
       await settings.signOut();
 
       // Login with primary email and new password
@@ -147,9 +162,6 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutPasswordForm(newPassword);
 
       await expect(settings.settingsHeading).toBeVisible();
-
-      // Update which password to use for account cleanup
-      credentials.password = newPassword;
     });
 
     test('can change primary email, delete account', async ({
@@ -174,7 +186,13 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(
+        target,
+        settings,
+        secondaryEmail,
+        newEmail,
+        credentials
+      );
       await expect(settings.primaryEmail.status).toHaveText(newEmail);
 
       // Click delete account
@@ -189,6 +207,10 @@ test.describe('severity-1 #smoke', () => {
       await signup.goto();
       await signup.fillOutEmailForm(newEmail);
       await signup.fillOutSignupForm(newPassword);
+
+      // The new account exists from here on, so cleanup needs its password
+      credentials.password = newPassword;
+
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(newEmail);
       await confirmSignupCode.fillOutCodeForm(code);
@@ -197,10 +219,6 @@ test.describe('severity-1 #smoke', () => {
         'Account confirmed successfully'
       );
       await expect(settings.primaryEmail.status).toHaveText(newEmail);
-
-      // Update credentials to use for account cleanup
-      credentials.email = newEmail;
-      credentials.password = newPassword;
     });
 
     test('removing secondary emails', async ({
@@ -277,13 +295,19 @@ async function changePrimaryEmail(
   target: BaseTarget,
   settings: SettingsPage,
   secondaryEmail: SecondaryEmailPage,
-  email: string
+  email: string,
+  credentials: Credentials
 ): Promise<void> {
   await settings.secondaryEmail.addButton.click();
   await secondaryEmail.fillOutEmail(email);
   const code: string = await target.emailClient.getVerifySecondaryCode(email);
   await secondaryEmail.fillOutVerificationCode(code);
   await settings.secondaryEmail.makePrimaryButton.click();
+
+  // Re-point cleanup before the assertions below. The server has already
+  // promoted this address, so a failing assertion would otherwise leave the
+  // tracker on an address that is now a secondary.
+  credentials.email = email;
 
   await expect(settings.settingsHeading).toBeVisible();
   await expect(settings.alertBar).toHaveText(
@@ -297,7 +321,8 @@ async function setNewPassword(
   oldPassword: string,
   newPassword: string,
   target: BaseTarget,
-  email: string
+  email: string,
+  credentials: Credentials
 ): Promise<void> {
   await settings.password.changeButton.click();
 
@@ -308,6 +333,10 @@ async function setNewPassword(
 
   await changePassword.fillOutChangePassword(oldPassword, newPassword);
 
-  await expect(settings.settingsHeading).toBeVisible();
+  // Re-point cleanup only after the alert confirms the change. A rejected
+  // change must not leave the tracker on a password the account never had.
   await expect(settings.alertBar).toHaveText('Password updated');
+  credentials.password = newPassword;
+
+  await expect(settings.settingsHeading).toBeVisible();
 }


### PR DESCRIPTION
## Because

- `recoveryKey.spec.ts` built its account object by hand, so the tracker never held the account and teardown could not destroy it.
- The spec's own UI delete raced teardown: `accountStatusByEmail` still reported the account, then `destroyAccount` failed with "Unknown account".
- Both specs re-pointed tracked credentials before the assertion proving the server accepted the change, so a rejected request left teardown using credentials the account never had.

## This pull request

- Registers the recoveryKey account with `generateAccountDetails()`.
- Drops the in-test UI delete and its `deleteAccount` fixture, leaving teardown as the only deletion path.
- Threads `credentials` into `changePrimaryEmail` and `setNewPassword` so each re-point sits beside the change it tracks.
- Re-points passwords only after the assertion confirming the server accepted the change.
- Re-points emails immediately after promotion, which the server has already applied by that point.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14285

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the reset block in `recoveryKey.spec.ts`, and `changePrimaryEmail` / `setNewPassword` in `changeEmail.spec.ts`.
- Suggested review order: `recoveryKey.spec.ts`, then `changeEmail.spec.ts`.
- Risky or complex parts: `setNewPassword` swaps the alert and heading assertions so the alert gates the re-point. The heading check stays last, so a late UI failure still cleans up.

## Screenshots (Optional)

None. This change is test-only.

## Other information (Optional)

- The email re-points still land before their confirming assertion, unlike the password ones. The server has already applied the promotion at that point, so the ordering is safe.
- Local checks: `npx nx lint functional-tests` reports 0 errors. `npx tsc -p packages/functional-tests/tsconfig.json --noEmit` adds no new errors; the 3 it reports are pre-existing in `lib/`. The Playwright suite needs a live stack, so CI is the check.
