### PR TITLE
fix(cms):  request 100 entries when extracting CMS l10n strings

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/cms/localization.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/cms/localization.spec.ts
@@ -553,14 +553,20 @@ describe('CMSLocalization', () => {
 
       const originalFetch = global.fetch;
       global.fetch = jest.fn().mockImplementation((url: string) => {
-        if (url === 'http://localhost:1337/api/relying-parties?populate=*') {
+        if (
+          url ===
+          'http://localhost:1337/api/relying-parties?populate=*&pagination[pageSize]=100'
+        ) {
           return Promise.resolve({
             ok: true,
             status: 200,
             json: () => Promise.resolve({ data: relyingPartyEntries }),
           });
         }
-        if (url === 'http://localhost:1337/api/legal-notices?populate=*') {
+        if (
+          url ===
+          'http://localhost:1337/api/legal-notices?populate=*&pagination[pageSize]=100'
+        ) {
           return Promise.resolve({
             ok: true,
             status: 200,
@@ -574,7 +580,7 @@ describe('CMSLocalization', () => {
         const result = await localization.fetchAllStrapiEntries();
 
         expect(global.fetch as any).toHaveBeenCalledWith(
-          'http://localhost:1337/api/relying-parties?populate=*',
+          'http://localhost:1337/api/relying-parties?populate=*&pagination[pageSize]=100',
           {
             headers: {
               Authorization: 'Bearer test-api-key',
@@ -584,7 +590,7 @@ describe('CMSLocalization', () => {
         );
 
         expect(global.fetch as any).toHaveBeenCalledWith(
-          'http://localhost:1337/api/legal-notices?populate=*',
+          'http://localhost:1337/api/legal-notices?populate=*&pagination[pageSize]=100',
           {
             headers: {
               Authorization: 'Bearer test-api-key',
@@ -613,14 +619,20 @@ describe('CMSLocalization', () => {
 
       const originalFetch = global.fetch;
       global.fetch = jest.fn().mockImplementation((url: string) => {
-        if (url === 'http://localhost:1337/api/relying-parties?populate=*') {
+        if (
+          url ===
+          'http://localhost:1337/api/relying-parties?populate=*&pagination[pageSize]=100'
+        ) {
           return Promise.resolve({
             ok: true,
             status: 200,
             json: () => Promise.resolve({ data: relyingPartyEntries }),
           });
         }
-        if (url === 'http://localhost:1337/api/legal-notices?populate=*') {
+        if (
+          url ===
+          'http://localhost:1337/api/legal-notices?populate=*&pagination[pageSize]=100'
+        ) {
           return Promise.resolve({
             ok: false,
             status: 500,
@@ -667,14 +679,20 @@ describe('CMSLocalization', () => {
 
       const originalFetch = global.fetch;
       global.fetch = jest.fn().mockImplementation((url: string) => {
-        if (url === 'http://localhost:1337/api/relying-parties?populate=*') {
+        if (
+          url ===
+          'http://localhost:1337/api/relying-parties?populate=*&pagination[pageSize]=100'
+        ) {
           return Promise.resolve({
             ok: true,
             status: 200,
             json: () => Promise.resolve({ data: relyingPartyEntries }),
           });
         }
-        if (url === 'http://localhost:1337/api/legal-notices?populate=*') {
+        if (
+          url ===
+          'http://localhost:1337/api/legal-notices?populate=*&pagination[pageSize]=100'
+        ) {
           return Promise.resolve({
             ok: true,
             status: 200,

--- a/packages/fxa-auth-server/lib/routes/utils/cms/localization.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/cms/localization.ts
@@ -646,8 +646,11 @@ export class CMSLocalization {
 
       for (const collection of collectionTypes) {
         try {
+          // Without an explicit pageSize, Strapi applies its rest.defaultLimit
+          // of 25 and drops the remaining entries without an error. 100 is
+          // rest.maxLimit, so this is the most a single request can return.
           const response = await fetch(
-            `${strapiBaseUrl}/api/${collection}?populate=*`,
+            `${strapiBaseUrl}/api/${collection}?populate=*&pagination[pageSize]=100`,
             { headers }
           );
 


### PR DESCRIPTION
## Because

- Smart Window is not fully localized in French. Some of its strings, including "Sign in to use Smart Window", do not exist in `fxa-cms-l10n` at all, so they were never available to translate.
- The l10n extractor requested `/api/relying-parties` with no `pageSize`, so Strapi applied its `rest.defaultLimit` of 25, returned 25 of the 30 entries, and reported success. Nothing read the `total` it also returned, so six weeks of missing strings produced no error anywhere.

## This pull request

- Adds `pagination[pageSize]=100` to each collection request in `fetchAllStrapiEntries` in `localization.ts`. 100 is Strapi's `rest.maxLimit`, so it is the most a single request can return.
- Updates the URL assertions in `localization.spec.ts`, which are what pin the parameter against a future refactor.
- Leaves the `default` single type unpaginated, since single types return one object.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14367

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**Verified against production Strapi** with a read-only token:

| | fetched | pagination | smartwindow |
|---|---|---|---|
| before | 25 | `pageCount: 2, total: 30` | absent |
| after | 30 | `pageCount: 1, total: 30` | id 379, `l10nId: l10n-11` |