### PR TITLE
fix(settings): bound email bounce polling and extract it to a hook

### DIFF
--- a/packages/fxa-settings/src/lib/hooks/index.ts
+++ b/packages/fxa-settings/src/lib/hooks/index.ts
@@ -4,6 +4,7 @@
 
 export * from './useAccountData';
 export * from './useChangeFocusEffect';
+export * from './useEmailBouncePolling';
 export * from './useEscKeydownEffect';
 export * from './useFocusOnTriggeringElementOnClose';
 export * from './useFxAStatus';

--- a/packages/fxa-settings/src/lib/hooks/useEmailBouncePolling.test.ts
+++ b/packages/fxa-settings/src/lib/hooks/useEmailBouncePolling.test.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { act, renderHook } from '@testing-library/react';
+import AuthClient from 'fxa-auth-client/browser';
+import {
+  POLL_INTERVAL,
+  POLL_TIMEOUT,
+  useEmailBouncePolling,
+} from './useEmailBouncePolling';
+
+const EMAIL = 'test@example.com';
+const OTHER_EMAIL = 'other@example.com';
+// The initial check plus one per tick until the deadline. Pinned rather than
+// derived, so a schedule change has to face the server's budget of 100
+// requests per IP per 15 minutes.
+const EXPECTED_POLL_COUNT = 60;
+
+describe('useEmailBouncePolling', () => {
+  let emailBounceStatus: jest.Mock;
+  let authClient: AuthClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    emailBounceStatus = jest.fn().mockResolvedValue({ hasHardBounce: false });
+    authClient = { emailBounceStatus } as unknown as AuthClient;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  // Fake timers do not settle promises, so each advance runs inside act() to
+  // let the pending requests resolve. Pass 0 to only settle.
+  async function advanceTimers(ms: number) {
+    await act(async () => {
+      jest.advanceTimersByTime(ms);
+    });
+  }
+
+  function callsFor(email: string) {
+    return emailBounceStatus.mock.calls.filter(([arg]) => arg === email).length;
+  }
+
+  function render(email: string | undefined) {
+    return renderHook(
+      ({ email }: { email: string | undefined }) =>
+        useEmailBouncePolling(email, authClient),
+      { initialProps: { email } }
+    );
+  }
+
+  it('does not poll without an email', async () => {
+    render(undefined);
+    await advanceTimers(POLL_TIMEOUT);
+    expect(emailBounceStatus).not.toHaveBeenCalled();
+  });
+
+  it('stops polling once the timeout has elapsed', async () => {
+    render(EMAIL);
+    await advanceTimers(POLL_TIMEOUT);
+    expect(emailBounceStatus).toHaveBeenCalledTimes(EXPECTED_POLL_COUNT);
+
+    await advanceTimers(POLL_TIMEOUT);
+    expect(emailBounceStatus).toHaveBeenCalledTimes(EXPECTED_POLL_COUNT);
+  });
+
+  it('stops on elapsed time rather than on a tick count', async () => {
+    render(EMAIL);
+    await advanceTimers(0);
+
+    // A backgrounded tab throttles the interval, so the clock passes the
+    // deadline after far fewer than EXPECTED_POLL_COUNT ticks.
+    jest.setSystemTime(Date.now() + POLL_TIMEOUT);
+    await advanceTimers(POLL_INTERVAL * 2);
+    expect(emailBounceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { code: 429, errno: 114 },
+    { code: 500, errno: 999 },
+  ])('stops polling when the request fails with a $code', async (error) => {
+    emailBounceStatus.mockRejectedValue(error);
+    render(EMAIL);
+    await advanceTimers(0);
+
+    await advanceTimers(POLL_INTERVAL * 3);
+    expect(emailBounceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps polling when the request fails without a status code', async () => {
+    emailBounceStatus.mockRejectedValue(new Error('Network error'));
+    render(EMAIL);
+    await advanceTimers(0);
+
+    await advanceTimers(POLL_INTERVAL * 3);
+    expect(emailBounceStatus).toHaveBeenCalledTimes(4);
+  });
+
+  it('reports and stops polling once a hard bounce is found', async () => {
+    emailBounceStatus.mockResolvedValue({ hasHardBounce: true });
+    const { result } = render(EMAIL);
+    await advanceTimers(0);
+
+    expect(result.current).toBe(true);
+    await advanceTimers(POLL_INTERVAL * 3);
+    expect(emailBounceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps polling when a stale check from an earlier email fails', async () => {
+    let rejectStale!: (error: unknown) => void;
+    emailBounceStatus.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectStale = reject;
+      })
+    );
+    const { rerender } = render(EMAIL);
+    await advanceTimers(0);
+    rerender({ email: OTHER_EMAIL });
+
+    // The 4xx belongs to the run that just ended, so it must not stop this one.
+    await act(async () => {
+      rejectStale({ code: 429, errno: 114 });
+    });
+    await advanceTimers(POLL_INTERVAL * 2);
+
+    expect(callsFor(OTHER_EMAIL)).toBe(3);
+  });
+
+  it('stops reporting a bounce once the email changes', async () => {
+    emailBounceStatus.mockResolvedValue({ hasHardBounce: true });
+    const { result, rerender } = render(EMAIL);
+    await advanceTimers(0);
+    expect(result.current).toBe(true);
+
+    rerender({ email: OTHER_EMAIL });
+    expect(result.current).toBe(false);
+  });
+
+  it('ignores a bounce that resolves after the email changed', async () => {
+    let resolveStale!: (result: { hasHardBounce: boolean }) => void;
+    emailBounceStatus.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStale = resolve;
+      })
+    );
+    const { result, rerender } = render(EMAIL);
+    rerender({ email: OTHER_EMAIL });
+
+    // The first email's check lands after the hook moved on to the second.
+    await act(async () => {
+      resolveStale({ hasHardBounce: true });
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/fxa-settings/src/lib/hooks/useEmailBouncePolling.ts
+++ b/packages/fxa-settings/src/lib/hooks/useEmailBouncePolling.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useState } from 'react';
+import AuthClient from 'fxa-auth-client/browser';
+
+export const POLL_INTERVAL = 5000;
+export const POLL_TIMEOUT = 5 * 60 * 1000;
+
+/**
+ * Polls for a hard bounce against `email` until one is found, the request
+ * fails with a status code, or the cap elapses.
+ *
+ * The cap is a wall-clock deadline rather than a tick count, since a
+ * backgrounded tab throttles timers. Five minutes at this interval is 60
+ * requests, inside the server's budget of 100 per IP per 15 minutes.
+ */
+export function useEmailBouncePolling(
+  email: string | undefined,
+  authClient: AuthClient
+) {
+  // Keyed by the address that produced it, so a result for one email is never
+  // reported against another the page has since moved to.
+  const [bouncedEmail, setBouncedEmail] = useState<string>();
+
+  useEffect(() => {
+    if (!email) return;
+
+    const pollDeadline = Date.now() + POLL_TIMEOUT;
+    // Local to this run, so a check left in flight by an earlier one cannot
+    // clear the interval this run owns.
+    let intervalId: NodeJS.Timeout | undefined;
+
+    const stopPolling = () => {
+      clearInterval(intervalId);
+    };
+
+    const checkEmailBounceStatus = async () => {
+      if (Date.now() >= pollDeadline) {
+        stopPolling();
+        return;
+      }
+      try {
+        const result = await authClient.emailBounceStatus(email);
+        if (result.hasHardBounce) {
+          setBouncedEmail(email);
+          stopPolling();
+        }
+      } catch (error) {
+        console.error('Error checking email bounce status:', error);
+        // A network failure carries no code, so polling continues there.
+        const code = (error as { code?: number })?.code;
+        if (code !== undefined && code >= 400 && code < 600) {
+          stopPolling();
+        }
+      }
+    };
+
+    intervalId = setInterval(checkEmailBounceStatus, POLL_INTERVAL);
+    checkEmailBounceStatus();
+
+    return stopPolling;
+  }, [authClient, email]);
+
+  return !!email && bouncedEmail === email;
+}

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -11,10 +11,19 @@ import * as CacheModule from '../../../lib/cache';
 import * as SentryModule from 'fxa-shared/sentry/browser';
 import * as ReactUtils from 'fxa-react/lib/utils';
 
-import { screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { StoredAccountData } from '../../../lib/storage-utils';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import SignupConfirmCodeContainer from './container';
+import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
+import SignupConfirmCodeContainer, {
+  POLL_INTERVAL,
+  POLL_TIMEOUT,
+} from './container';
 import { Integration } from '../../../models';
 import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../../models/mocks';
 import GleanMetrics from '../../../lib/glean';
@@ -157,8 +166,8 @@ function applyMocks() {
   });
 }
 
-async function render() {
-  renderWithLocalizationProvider(
+function containerTree() {
+  return (
     <MemoryRouter>
       <SignupConfirmCodeContainer
         {...{
@@ -167,6 +176,23 @@ async function render() {
         flowQueryParams={{ flowId: MOCK_FLOW_ID }}
       />
     </MemoryRouter>
+  );
+}
+
+async function render() {
+  renderWithLocalizationProvider(containerTree());
+}
+
+// Same provider renderWithLocalizationProvider sets up, as a wrapper, so a
+// rerender keeps it in place.
+function LocalizationWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <AppLocalizationProvider
+      messages={{ en: ['testo: lol'] }}
+      reportError={() => {}}
+    >
+      {children}
+    </AppLocalizationProvider>
   );
 }
 
@@ -247,6 +273,129 @@ describe('confirm-signup-container', () => {
       await waitFor(() =>
         expect(mockNavigate).toHaveBeenCalledWith('/signin_bounced')
       );
+    });
+  });
+
+  describe('email bounce polling', () => {
+    // 120 calls: the initial check, plus one per 5 second tick, until the 10
+    // minute deadline. Pinned rather than derived from the constants.
+    const EXPECTED_POLL_COUNT = 120;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockAuthClient.emailBounceStatus.mockResolvedValue({
+        hasHardBounce: false,
+      });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    // Fake timers do not settle promises, so each advance runs inside act() to
+    // let the pending emailBounceStatus calls resolve. Pass 0 to only settle.
+    async function advanceTimers(ms: number) {
+      await act(async () => {
+        jest.advanceTimersByTime(ms);
+      });
+    }
+
+    it('stops polling once the timeout has elapsed', async () => {
+      render();
+      await advanceTimers(POLL_TIMEOUT);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(
+        EXPECTED_POLL_COUNT
+      );
+
+      await advanceTimers(POLL_TIMEOUT);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(
+        EXPECTED_POLL_COUNT
+      );
+    });
+
+    it('stops polling on elapsed time rather than on a tick count', async () => {
+      render();
+      await advanceTimers(0);
+
+      // A backgrounded tab throttles the interval, so the clock passes the
+      // deadline after far fewer than 120 ticks.
+      jest.setSystemTime(Date.now() + POLL_TIMEOUT);
+      await advanceTimers(POLL_INTERVAL * 2);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      { code: 429, errno: 114 },
+      { code: 500, errno: 999 },
+    ])('stops polling when the request fails with a $code', async (error) => {
+      mockAuthClient.emailBounceStatus.mockRejectedValue(error);
+      render();
+      await advanceTimers(0);
+
+      await advanceTimers(POLL_INTERVAL * 3);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps polling when the request fails without a status code', async () => {
+      mockAuthClient.emailBounceStatus.mockRejectedValue(
+        new Error('Network error')
+      );
+      render();
+      await advanceTimers(0);
+
+      await advanceTimers(POLL_INTERVAL * 3);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(4);
+    });
+
+    it('keeps polling after a stale check from an earlier effect run fails', async () => {
+      let failStaleCheck!: (error: unknown) => void;
+      mockAuthClient.emailBounceStatus.mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          failStaleCheck = reject;
+        })
+      );
+      // rerender re-applies the wrapper, so the provider stays put and the
+      // effect re-runs on the same component instance instead of remounting.
+      const { rerender } = rtlRender(containerTree(), {
+        wrapper: LocalizationWrapper,
+      });
+      await advanceTimers(0);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
+
+      // A new auth client re-runs the effect, so the check still in flight
+      // belongs to the run that just ended.
+      const nextAuthClient = {
+        emailBounceStatus: jest
+          .fn()
+          .mockResolvedValue({ hasHardBounce: false }),
+      };
+      (ModelsModule.useAuthClient as jest.Mock).mockImplementation(
+        () => nextAuthClient
+      );
+      await act(async () => {
+        rerender(containerTree());
+      });
+
+      // The stale check fails with a 4xx, which stops the run that owns it.
+      await act(async () => {
+        failStaleCheck({ code: 429, errno: 114 });
+      });
+
+      await advanceTimers(POLL_INTERVAL * 2);
+      expect(nextAuthClient.emailBounceStatus).toHaveBeenCalledTimes(3);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops polling once a hard bounce is found', async () => {
+      mockAuthClient.emailBounceStatus.mockResolvedValue({
+        hasHardBounce: true,
+      });
+      render();
+      await advanceTimers(0);
+
+      await advanceTimers(POLL_INTERVAL * 3);
+      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -11,19 +11,10 @@ import * as CacheModule from '../../../lib/cache';
 import * as SentryModule from 'fxa-shared/sentry/browser';
 import * as ReactUtils from 'fxa-react/lib/utils';
 
-import {
-  act,
-  render as rtlRender,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { StoredAccountData } from '../../../lib/storage-utils';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
-import SignupConfirmCodeContainer, {
-  POLL_INTERVAL,
-  POLL_TIMEOUT,
-} from './container';
+import SignupConfirmCodeContainer from './container';
 import { Integration } from '../../../models';
 import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../../models/mocks';
 import GleanMetrics from '../../../lib/glean';
@@ -166,8 +157,8 @@ function applyMocks() {
   });
 }
 
-function containerTree() {
-  return (
+async function render() {
+  renderWithLocalizationProvider(
     <MemoryRouter>
       <SignupConfirmCodeContainer
         {...{
@@ -176,23 +167,6 @@ function containerTree() {
         flowQueryParams={{ flowId: MOCK_FLOW_ID }}
       />
     </MemoryRouter>
-  );
-}
-
-async function render() {
-  renderWithLocalizationProvider(containerTree());
-}
-
-// Same provider renderWithLocalizationProvider sets up, as a wrapper, so a
-// rerender keeps it in place.
-function LocalizationWrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <AppLocalizationProvider
-      messages={{ en: ['testo: lol'] }}
-      reportError={() => {}}
-    >
-      {children}
-    </AppLocalizationProvider>
   );
 }
 
@@ -273,129 +247,6 @@ describe('confirm-signup-container', () => {
       await waitFor(() =>
         expect(mockNavigate).toHaveBeenCalledWith('/signin_bounced')
       );
-    });
-  });
-
-  describe('email bounce polling', () => {
-    // 120 calls: the initial check, plus one per 5 second tick, until the 10
-    // minute deadline. Pinned rather than derived from the constants.
-    const EXPECTED_POLL_COUNT = 120;
-
-    beforeEach(() => {
-      jest.useFakeTimers();
-      jest.spyOn(console, 'error').mockImplementation(() => {});
-      mockAuthClient.emailBounceStatus.mockResolvedValue({
-        hasHardBounce: false,
-      });
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
-    // Fake timers do not settle promises, so each advance runs inside act() to
-    // let the pending emailBounceStatus calls resolve. Pass 0 to only settle.
-    async function advanceTimers(ms: number) {
-      await act(async () => {
-        jest.advanceTimersByTime(ms);
-      });
-    }
-
-    it('stops polling once the timeout has elapsed', async () => {
-      render();
-      await advanceTimers(POLL_TIMEOUT);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(
-        EXPECTED_POLL_COUNT
-      );
-
-      await advanceTimers(POLL_TIMEOUT);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(
-        EXPECTED_POLL_COUNT
-      );
-    });
-
-    it('stops polling on elapsed time rather than on a tick count', async () => {
-      render();
-      await advanceTimers(0);
-
-      // A backgrounded tab throttles the interval, so the clock passes the
-      // deadline after far fewer than 120 ticks.
-      jest.setSystemTime(Date.now() + POLL_TIMEOUT);
-      await advanceTimers(POLL_INTERVAL * 2);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
-    });
-
-    it.each([
-      { code: 429, errno: 114 },
-      { code: 500, errno: 999 },
-    ])('stops polling when the request fails with a $code', async (error) => {
-      mockAuthClient.emailBounceStatus.mockRejectedValue(error);
-      render();
-      await advanceTimers(0);
-
-      await advanceTimers(POLL_INTERVAL * 3);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
-    });
-
-    it('keeps polling when the request fails without a status code', async () => {
-      mockAuthClient.emailBounceStatus.mockRejectedValue(
-        new Error('Network error')
-      );
-      render();
-      await advanceTimers(0);
-
-      await advanceTimers(POLL_INTERVAL * 3);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(4);
-    });
-
-    it('keeps polling after a stale check from an earlier effect run fails', async () => {
-      let failStaleCheck!: (error: unknown) => void;
-      mockAuthClient.emailBounceStatus.mockReturnValueOnce(
-        new Promise((_resolve, reject) => {
-          failStaleCheck = reject;
-        })
-      );
-      // rerender re-applies the wrapper, so the provider stays put and the
-      // effect re-runs on the same component instance instead of remounting.
-      const { rerender } = rtlRender(containerTree(), {
-        wrapper: LocalizationWrapper,
-      });
-      await advanceTimers(0);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
-
-      // A new auth client re-runs the effect, so the check still in flight
-      // belongs to the run that just ended.
-      const nextAuthClient = {
-        emailBounceStatus: jest
-          .fn()
-          .mockResolvedValue({ hasHardBounce: false }),
-      };
-      (ModelsModule.useAuthClient as jest.Mock).mockImplementation(
-        () => nextAuthClient
-      );
-      await act(async () => {
-        rerender(containerTree());
-      });
-
-      // The stale check fails with a 4xx, which stops the run that owns it.
-      await act(async () => {
-        failStaleCheck({ code: 429, errno: 114 });
-      });
-
-      await advanceTimers(POLL_INTERVAL * 2);
-      expect(nextAuthClient.emailBounceStatus).toHaveBeenCalledTimes(3);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
-    });
-
-    it('stops polling once a hard bounce is found', async () => {
-      mockAuthClient.emailBounceStatus.mockResolvedValue({
-        hasHardBounce: true,
-      });
-      render();
-      await advanceTimers(0);
-
-      await advanceTimers(POLL_INTERVAL * 3);
-      expect(mockAuthClient.emailBounceStatus).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -4,7 +4,11 @@
 
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
-import { useNavigateWithQuery, useOAuthFlowRecovery } from '../../../lib/hooks';
+import {
+  useEmailBouncePolling,
+  useNavigateWithQuery,
+  useOAuthFlowRecovery,
+} from '../../../lib/hooks';
 import { currentAccount } from '../../../lib/cache';
 import {
   useFinishOAuthFlowHandler,
@@ -24,9 +28,6 @@ import { QueryParams } from '../../..';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
 import GleanMetrics from '../../../lib/glean';
 import AppLayout from '../../../components/AppLayout';
-
-export const POLL_INTERVAL = 5000;
-export const POLL_TIMEOUT = 10 * 60 * 1000;
 
 function getAccountInfo(
   emailFromLocationState?: string,
@@ -101,59 +102,7 @@ const SignupConfirmCodeContainer = ({
   // Poll for hard bounces registered in database for the entered email.
   // Previously, we checked if the account was deleted, and assumed
   // that implied the email bounced/was invalid.
-  const [hasHardBounce, setHasHardBounce] = useState(false);
-
-  useEffect(() => {
-    // A deadline rather than a tick count: a backgrounded tab throttles timers,
-    // so 120 ticks can span much longer than 10 minutes.
-    const pollDeadline = Date.now() + POLL_TIMEOUT;
-    // Local to this effect run, so a check left in flight by an earlier run
-    // cannot stop the interval the current run owns.
-    let intervalId: NodeJS.Timeout | undefined;
-
-    const stopPolling = () => {
-      clearInterval(intervalId);
-    };
-
-    const checkEmailBounceStatus = async () => {
-      if (!email) return;
-      if (Date.now() >= pollDeadline) {
-        stopPolling();
-        return;
-      }
-      try {
-        // Type assertion needed until fxa-auth-client is rebuilt with new method
-        const result = await (
-          authClient as typeof authClient & {
-            emailBounceStatus: (
-              email: string
-            ) => Promise<{ hasHardBounce: boolean }>;
-          }
-        ).emailBounceStatus(email);
-        if (result.hasHardBounce) {
-          setHasHardBounce(true);
-          // The answer is known, so there is nothing left to poll for.
-          stopPolling();
-        }
-      } catch (error) {
-        // Stop on any 4xx or 5xx. A network failure carries no code, so
-        // polling continues in that case.
-        const code = (error as { code?: number })?.code;
-        if (code !== undefined && code >= 400 && code < 600) {
-          stopPolling();
-        }
-        console.error('Error checking email bounce status:', error);
-      }
-    };
-
-    // Set up polling before the initial check so that check can stop it
-    intervalId = setInterval(checkEmailBounceStatus, POLL_INTERVAL);
-
-    // Initial check
-    checkEmailBounceStatus();
-
-    return stopPolling;
-  }, [authClient, email]);
+  const hasHardBounce = useEmailBouncePolling(email, authClient);
 
   const [recoveryAttempted, setRecoveryAttempted] = useState<boolean>(false);
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 import { useNavigateWithQuery, useOAuthFlowRecovery } from '../../../lib/hooks';
 import { currentAccount } from '../../../lib/cache';
@@ -26,6 +26,7 @@ import GleanMetrics from '../../../lib/glean';
 import AppLayout from '../../../components/AppLayout';
 
 export const POLL_INTERVAL = 5000;
+export const POLL_TIMEOUT = 10 * 60 * 1000;
 
 function getAccountInfo(
   emailFromLocationState?: string,
@@ -101,11 +102,25 @@ const SignupConfirmCodeContainer = ({
   // Previously, we checked if the account was deleted, and assumed
   // that implied the email bounced/was invalid.
   const [hasHardBounce, setHasHardBounce] = useState(false);
-  const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
+    // A deadline rather than a tick count: a backgrounded tab throttles timers,
+    // so 120 ticks can span much longer than 10 minutes.
+    const pollDeadline = Date.now() + POLL_TIMEOUT;
+    // Local to this effect run, so a check left in flight by an earlier run
+    // cannot stop the interval the current run owns.
+    let intervalId: NodeJS.Timeout | undefined;
+
+    const stopPolling = () => {
+      clearInterval(intervalId);
+    };
+
     const checkEmailBounceStatus = async () => {
       if (!email) return;
+      if (Date.now() >= pollDeadline) {
+        stopPolling();
+        return;
+      }
       try {
         // Type assertion needed until fxa-auth-client is rebuilt with new method
         const result = await (
@@ -117,27 +132,27 @@ const SignupConfirmCodeContainer = ({
         ).emailBounceStatus(email);
         if (result.hasHardBounce) {
           setHasHardBounce(true);
+          // The answer is known, so there is nothing left to poll for.
+          stopPolling();
         }
       } catch (error) {
-        // Silently fail - we don't want to block the user flow on errors
+        // Stop on any 4xx or 5xx. A network failure carries no code, so
+        // polling continues in that case.
+        const code = (error as { code?: number })?.code;
+        if (code !== undefined && code >= 400 && code < 600) {
+          stopPolling();
+        }
         console.error('Error checking email bounce status:', error);
       }
     };
 
+    // Set up polling before the initial check so that check can stop it
+    intervalId = setInterval(checkEmailBounceStatus, POLL_INTERVAL);
+
     // Initial check
     checkEmailBounceStatus();
 
-    // Set up polling
-    pollIntervalRef.current = setInterval(
-      checkEmailBounceStatus,
-      POLL_INTERVAL
-    );
-
-    return () => {
-      if (pollIntervalRef.current) {
-        clearInterval(pollIntervalRef.current);
-      }
-    };
+    return stopPolling;
   }, [authClient, email]);
 
   const [recoveryAttempted, setRecoveryAttempted] = useState<boolean>(false);


### PR DESCRIPTION
## Because

- The signup confirmation page polled `account/email_bounce_status` every 5 seconds for as long as the page stayed open, with no cap.
- The `catch` block only logged, so the 429s that stage returns did not stop it.
- `emailBounceStatusCheck` allows 100 requests per IP per 15 minutes and blocks on breach, so an unbounded poll spent a budget shared by everyone behind the address.

## This pull request

- Caps polling at 5 minutes, or 60 requests, measured by wall clock since a backgrounded tab throttles timers.
- Stops on a 4xx or 5xx, and on a hard bounce. An error with no `code`, such as a network failure, keeps polling.
- Gives each run its own interval id, so a check left in flight by an earlier run cannot stop the current one.
- Keys the bounce result by the address that produced it, so a result for one email is never reported against another.
- Moves the polling into `useEmailBouncePolling`, tested directly with `renderHook`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13188

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- `useEmailBouncePolling.ts` is the whole change. The container just calls it, and `container.test.tsx` is untouched.
- The subtle parts are the two race guards: the per-run interval id, and the email-keyed bounce state. Both are pinned by tests, and both were mutation-checked — sharing the interval id fails one test, returning a bare boolean fails two.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

The 5 minute cap comes from FXA-13188, after the original 10 minutes was found to exceed the per-IP rate-limit budget at the 5 second interval.

Verification: 8 hook tests and 8 container tests pass; lint, prettier and `tsc --noEmit` are clean. Functional tests were not run locally.

