### PR TITLE
feat(shared): raise the security events limit to 200

### DIFF
--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -88,7 +88,7 @@ export const EVENT_NAMES = {
 export type SecurityEventNames = keyof typeof EVENT_NAMES;
 
 // Default number of events returned to the account history endpoint.
-export const SECURITY_EVENTS_LIMIT = 100;
+export const SECURITY_EVENTS_LIMIT = 200;
 
 export function sanitizeIp(addr: string) {
   addr = addr.trim();


### PR DESCRIPTION
## Because

- The account history query returned at most 100 events. The ticket asks for the most recent 200.

## This pull request

- Raises `SECURITY_EVENTS_LIMIT` from 100 to 200 in `security-event.ts`.
- No call site changed. `SecurityEvent.findByUid` and the admin server `securityEvents` handler both default to this constant, so the admin panel returns 200 events now too.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-6766

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-shared/db/models/auth/security-event.ts`
- Suggested review order:
- Risky or complex parts: the admin panel default limit moves with the same constant.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

`findByUid` orders by `createdAt DESC` before it applies the limit, so this returns the most recent 200. No pagination work is included. No test was added: a test that asserts the constant equals 200 only restates the constant.
