### PR TITLE
feat(payments): Reduce delay in activating paid subscription failed payment after free trial ended

### DIFF
--- a/libs/payments/customer/src/lib/invoice.manager.spec.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Logger } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { StatsD } from 'hot-shots';
 import { MockLoggerProvider } from '@fxa/shared/log';
 
 import {
@@ -36,7 +39,7 @@ import {
   MockCurrencyConfigProvider,
 } from '@fxa/payments/currency';
 import { STRIPE_CUSTOMER_METADATA, STRIPE_INVOICE_METADATA } from './types';
-import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
+import { MockStatsDProvider, StatsDService } from '@fxa/shared/metrics/statsd';
 import { UpgradeCustomerMissingCurrencyInvoiceError } from './customer.error';
 
 jest.mock('../lib/util/stripeInvoiceToFirstInvoicePreviewDTO');
@@ -53,6 +56,8 @@ describe('InvoiceManager', () => {
   let invoiceManager: InvoiceManager;
   let stripeClient: StripeClient;
   let paypalClient: PayPalClient;
+  let mockLogger: LoggerService;
+  let mockStatsd: StatsD;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -72,6 +77,12 @@ describe('InvoiceManager', () => {
     invoiceManager = module.get(InvoiceManager);
     stripeClient = module.get(StripeClient);
     paypalClient = module.get(PayPalClient);
+    mockLogger = module.get(Logger);
+    mockStatsd = module.get(StatsDService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('finalizeWithoutAutoAdvance', () => {
@@ -202,9 +213,12 @@ describe('InvoiceManager', () => {
         StripeUpcomingInvoiceFactory()
       );
       const mockPromotionCode = StripePromotionCodeFactory({
-        coupon: StripeCouponFactory({
-          valid: true,
-        }),
+        promotion: {
+          type: 'coupon',
+          coupon: StripeCouponFactory({
+            valid: true,
+          }),
+        },
       });
 
       const mockTaxAddress = TaxAddressFactory();
@@ -993,6 +1007,142 @@ describe('InvoiceManager', () => {
       );
 
       expect(callOrder).toEqual(['invoicesFinalizeInvoice', 'chargeCustomer']);
+    });
+  });
+
+  describe('retryPaymentForOpenInvoices', () => {
+    const mockCustomerId = 'cus_retry123';
+    const mockPaymentMethodId = 'pm_retry123';
+
+    const openInvoice = () =>
+      StripeInvoiceFactory({ status: 'open', customer: mockCustomerId });
+
+    let payChargeAttemptSpy: jest.SpyInstance;
+    let incrementSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      payChargeAttemptSpy = jest
+        .spyOn(stripeClient, 'invoicesPayChargeAttempt')
+        .mockImplementation((invoiceId) =>
+          Promise.resolve(
+            StripeResponseFactory(StripeInvoiceFactory({ id: invoiceId }))
+          )
+        );
+      incrementSpy = jest.spyOn(mockStatsd, 'increment');
+      warnSpy = jest.spyOn(mockLogger, 'warn');
+    });
+
+    const stubOpenInvoices = (invoices: ReturnType<typeof openInvoice>[]) =>
+      jest
+        .spyOn(stripeClient, 'invoicesList')
+        .mockResolvedValue(StripeApiListFactory(invoices));
+
+    it('lists only open invoices collected automatically for the customer', async () => {
+      stubOpenInvoices([]);
+
+      await invoiceManager.retryPaymentForOpenInvoices(
+        mockCustomerId,
+        mockPaymentMethodId
+      );
+
+      expect(stripeClient.invoicesList).toHaveBeenCalledWith({
+        customer: mockCustomerId,
+        status: 'open',
+        collection_method: 'charge_automatically',
+      });
+    });
+
+    it('attempts payment on each open invoice with the supplied payment method', async () => {
+      const invoice1 = openInvoice();
+      const invoice2 = openInvoice();
+      stubOpenInvoices([invoice1, invoice2]);
+
+      await invoiceManager.retryPaymentForOpenInvoices(
+        mockCustomerId,
+        mockPaymentMethodId
+      );
+
+      expect(payChargeAttemptSpy).toHaveBeenCalledTimes(2);
+      expect(payChargeAttemptSpy).toHaveBeenNthCalledWith(1, invoice1.id, {
+        payment_method: mockPaymentMethodId,
+      });
+      expect(payChargeAttemptSpy).toHaveBeenNthCalledWith(2, invoice2.id, {
+        payment_method: mockPaymentMethodId,
+      });
+    });
+
+    it('counts a successful charge', async () => {
+      stubOpenInvoices([openInvoice()]);
+
+      await invoiceManager.retryPaymentForOpenInvoices(
+        mockCustomerId,
+        mockPaymentMethodId
+      );
+
+      expect(incrementSpy).toHaveBeenCalledWith(
+        'invoice_retry_payment_success'
+      );
+    });
+
+    it('does not attempt payment when there are no open invoices', async () => {
+      stubOpenInvoices([]);
+
+      await invoiceManager.retryPaymentForOpenInvoices(
+        mockCustomerId,
+        mockPaymentMethodId
+      );
+
+      expect(payChargeAttemptSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not reject when the charge attempt is declined', async () => {
+      stubOpenInvoices([openInvoice()]);
+      payChargeAttemptSpy.mockRejectedValue(
+        new Error('Your card was declined')
+      );
+
+      await expect(
+        invoiceManager.retryPaymentForOpenInvoices(
+          mockCustomerId,
+          mockPaymentMethodId
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('counts and logs a failed charge attempt', async () => {
+      stubOpenInvoices([openInvoice()]);
+      payChargeAttemptSpy.mockRejectedValue(
+        new Error('Your card was declined')
+      );
+
+      await invoiceManager.retryPaymentForOpenInvoices(
+        mockCustomerId,
+        mockPaymentMethodId
+      );
+
+      expect(incrementSpy).toHaveBeenCalledWith(
+        'invoice_retry_payment_failure'
+      );
+      expect(warnSpy).toHaveBeenCalledWith('retryPaymentForOpenInvoices', {
+        message: 'Failed to retry payment for open invoices',
+        customerId: mockCustomerId,
+        error: 'Your card was declined',
+      });
+    });
+
+    it('does not reject when listing invoices fails', async () => {
+      jest
+        .spyOn(stripeClient, 'invoicesList')
+        .mockRejectedValue(new Error('Stripe API error'));
+
+      await expect(
+        invoiceManager.retryPaymentForOpenInvoices(
+          mockCustomerId,
+          mockPaymentMethodId
+        )
+      ).resolves.toBeUndefined();
+      expect(payChargeAttemptSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
+import { StatsD } from 'hot-shots';
 import { Stripe } from 'stripe';
 
+import { StatsDService } from '@fxa/shared/metrics/statsd';
 import {
   StripeClient,
   StripeCustomer,
@@ -42,7 +45,9 @@ export class InvoiceManager {
   constructor(
     private stripeClient: StripeClient,
     private paypalClient: PayPalClient,
-    private currencyManager: CurrencyManager
+    private currencyManager: CurrencyManager,
+    @Inject(Logger) private log: LoggerService,
+    @Inject(StatsDService) private statsd: StatsD
   ) {}
 
   // Finalize an invoice, rejecting re-finalization of an invoice
@@ -339,6 +344,50 @@ export class InvoiceManager {
     // transitions to paid automatially.
     // https://stripe.com/docs/billing/invoices/subscription#sub-invoice-lifecycle
     return this.safeFinalizeWithoutAutoAdvance(invoiceId);
+  }
+
+  /**
+   * Attempt immediate payment on a customer's open invoices, so someone who
+   * fixes their card does not wait for Stripe's automatic retry (24h+).
+   *
+   * `paymentMethodId` is explicit because Stripe resolves the customer default
+   * only when creating a PaymentIntent, not when re-confirming the failed one --
+   * omitting it retries the card that failed.
+   *
+   * Never throws, so a failed charge cannot fail the payment method update.
+   */
+  async retryPaymentForOpenInvoices(
+    customerId: string,
+    paymentMethodId: string
+  ): Promise<void> {
+    try {
+      // Safe only while every enabled payment method settles synchronously.
+      // PayPal is excluded by collection_method, but enabled methods come from
+      // the Stripe Dashboard, not from code -- add SEPA or ACH and this starts
+      // charging against payments already in flight unless it also filters on
+      // payment status.
+      const invoices = await this.stripeClient.invoicesList({
+        customer: customerId,
+        status: 'open',
+        collection_method: 'charge_automatically',
+      });
+
+      for (const invoice of invoices.data) {
+        await this.stripeClient.invoicesPayChargeAttempt(invoice.id, {
+          payment_method: paymentMethodId,
+        });
+        this.statsd.increment('invoice_retry_payment_success');
+      }
+    } catch (err) {
+      // One catch for the loop, so a failure stops the rest: a decline is
+      // card-level and an API failure global, so they would fail the same way.
+      this.statsd.increment('invoice_retry_payment_failure');
+      this.log.warn('retryPaymentForOpenInvoices', {
+        message: 'Failed to retry payment for open invoices',
+        customerId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**

--- a/libs/payments/management/src/lib/subscriptionManagement.service.in.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.in.spec.ts
@@ -46,9 +46,7 @@ import {
   MockAppleIapClientConfigProvider,
   MockGoogleIapClientConfigProvider,
 } from '@fxa/payments/iap';
-import {
-  SubscriptionManagementService,
-} from '@fxa/payments/management';
+import { SubscriptionManagementService } from '@fxa/payments/management';
 import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 import {
   MockPaypalClientConfigProvider,
@@ -215,6 +213,9 @@ describe('SubscriptionManagementService integration', () => {
 
     jest.spyOn(profileClient, 'deleteCache').mockResolvedValue(undefined);
     jest.spyOn(notifierService, 'send').mockReturnValue(undefined);
+    jest
+      .spyOn(invoiceManager, 'retryPaymentForOpenInvoices')
+      .mockResolvedValue();
   });
 
   describe('cancelSubscriptionAtPeriodEnd', () => {
@@ -789,12 +790,8 @@ describe('SubscriptionManagementService integration', () => {
       jest
         .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
         .mockResolvedValue(mockAccountCustomer);
-      jest
-        .spyOn(appleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
-      jest
-        .spyOn(googleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
+      jest.spyOn(appleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      jest.spyOn(googleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
 
       const result =
         await subscriptionManagementService.getPageContent(mockUid);
@@ -816,12 +813,8 @@ describe('SubscriptionManagementService integration', () => {
       jest
         .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
         .mockResolvedValue(mockAccountCustomer);
-      jest
-        .spyOn(appleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
-      jest
-        .spyOn(googleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
+      jest.spyOn(appleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      jest.spyOn(googleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
 
       const result =
         await subscriptionManagementService.getPageContent(mockUid);
@@ -869,9 +862,7 @@ describe('SubscriptionManagementService integration', () => {
       jest
         .spyOn(customerManager, 'retrieve')
         .mockResolvedValue(mockStripeCustomer);
-      jest
-        .spyOn(subscriptionManager, 'listForCustomer')
-        .mockResolvedValue([]);
+      jest.spyOn(subscriptionManager, 'listForCustomer').mockResolvedValue([]);
       jest
         .spyOn(paymentMethodManager, 'getDefaultPaymentMethod')
         .mockResolvedValue(mockPaymentMethodInfo);
@@ -880,12 +871,8 @@ describe('SubscriptionManagementService integration', () => {
         .mockResolvedValue(
           mockProductMap as unknown as PageContentByPriceIdsResultUtil
         );
-      jest
-        .spyOn(appleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
-      jest
-        .spyOn(googleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
+      jest.spyOn(appleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      jest.spyOn(googleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
 
       const result =
         await subscriptionManagementService.getPageContent(mockUid);
@@ -975,12 +962,8 @@ describe('SubscriptionManagementService integration', () => {
           reason: 'feature_disabled',
           cmsOfferContent: null,
         });
-      jest
-        .spyOn(appleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
-      jest
-        .spyOn(googleIapPurchaseManager, 'getForUser')
-        .mockResolvedValue([]);
+      jest.spyOn(appleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
+      jest.spyOn(googleIapPurchaseManager, 'getForUser').mockResolvedValue([]);
 
       const result =
         await subscriptionManagementService.getPageContent(mockUid);

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -658,9 +658,7 @@ describe('SubscriptionManagementService', () => {
       expect(result.defaultPaymentMethod?.type).toBe(
         SubPlatPaymentMethodType.PayPal
       );
-      expect(
-        result.defaultPaymentMethod?.hasPaymentMethodError
-      ).toBeDefined();
+      expect(result.defaultPaymentMethod?.hasPaymentMethodError).toBeDefined();
       expect(
         result.defaultPaymentMethod?.hasPaymentMethodError?.bannerType
       ).toBe(BannerVariant.Error);
@@ -1191,7 +1189,9 @@ describe('SubscriptionManagementService', () => {
         trial_start: trialStart,
         items: {
           object: 'list',
-          data: [StripeSubscriptionItemFactory({ current_period_start: trialEnd })],
+          data: [
+            StripeSubscriptionItemFactory({ current_period_start: trialEnd }),
+          ],
           has_more: false,
           url: '',
         },
@@ -1383,9 +1383,7 @@ describe('SubscriptionManagementService', () => {
       const mockPrice = StripePriceFactory({ recurring: null });
 
       await expect(
-        (
-          subscriptionManagementService as any
-        ).getTrialSubscriptionContent(
+        (subscriptionManagementService as any).getTrialSubscriptionContent(
           mockSubscription,
           mockCustomer,
           mockPrice,
@@ -1619,9 +1617,7 @@ describe('SubscriptionManagementService', () => {
         .mockResolvedValue(mockUpcomingInvoice);
       const previewSpy = jest.spyOn(invoiceManager, 'preview');
 
-      await (
-        subscriptionManagementService as any
-      ).getTrialSubscriptionContent(
+      await (subscriptionManagementService as any).getTrialSubscriptionContent(
         mockSubscription,
         mockCustomer,
         mockPrice,
@@ -1776,6 +1772,7 @@ describe('SubscriptionManagementService', () => {
             email: null,
             name: null,
             phone: null,
+            tax_id: null,
           },
         })
       );
@@ -1946,6 +1943,9 @@ describe('SubscriptionManagementService', () => {
       jest
         .spyOn(customerManager, 'retrieve')
         .mockResolvedValue(customerWithShipping());
+      jest
+        .spyOn(invoiceManager, 'retryPaymentForOpenInvoices')
+        .mockResolvedValue();
     });
 
     it('updates the stripe customer payment method details', async () => {
@@ -2146,6 +2146,7 @@ describe('SubscriptionManagementService', () => {
             address: null,
             email: null,
             phone: null,
+            tax_id: null,
           },
         })
       );
@@ -2265,6 +2266,58 @@ describe('SubscriptionManagementService', () => {
       );
     });
 
+    it('retries payment for open invoices with the newly confirmed payment method', async () => {
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory()
+      );
+      const mockCustomer = StripeResponseFactory(
+        StripeCustomerFactory({
+          currency: faker.finance.currencyCode().toLowerCase(),
+          invoice_settings: {
+            custom_fields: null,
+            default_payment_method: mockPaymentMethod.id,
+            footer: null,
+            rendering_options: null,
+          },
+        })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomer.id,
+      });
+      const mockSetupIntent = StripeResponseFactory(
+        StripeSetupIntentFactory({
+          customer: mockCustomer.id,
+          payment_method: mockPaymentMethod.id,
+          status: 'succeeded',
+        })
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(setupIntentManager, 'createAndConfirm')
+        .mockResolvedValue(mockSetupIntent);
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+      jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
+      const retrySpy = jest
+        .spyOn(invoiceManager, 'retryPaymentForOpenInvoices')
+        .mockResolvedValue();
+
+      await subscriptionManagementService.updateStripePaymentDetails(
+        mockAccountCustomer.uid,
+        '123',
+        mockIp
+      );
+
+      expect(retrySpy).toHaveBeenCalledWith(
+        mockCustomer.id,
+        mockPaymentMethod.id
+      );
+    });
+
     it('throws ManagePaymentMethodTaxAddressRequiredError when tax address is unresolvable', async () => {
       const mockCustomerWithoutShipping = StripeResponseFactory(
         StripeCustomerFactory({ shipping: null })
@@ -2317,10 +2370,16 @@ describe('SubscriptionManagementService', () => {
       jest
         .spyOn(customerManager, 'retrieve')
         .mockResolvedValue(customerWithShipping());
+      jest
+        .spyOn(invoiceManager, 'retryPaymentForOpenInvoices')
+        .mockResolvedValue();
     });
 
     it("updates the customer's payment details", async () => {
-      const mockAccountCustomer = ResultAccountCustomerFactory();
+      const mockStripeCustomerId = 'cus_setdefault123';
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomerId,
+      });
       const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
       const mockPaymentMethod = StripeResponseFactory(
         StripePaymentMethodFactory()
@@ -2332,13 +2391,16 @@ describe('SubscriptionManagementService', () => {
       jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
 
       await subscriptionManagementService.setDefaultStripePaymentDetails(
-        mockCustomer.id,
+        mockAccountCustomer.uid,
         mockPaymentMethod.id,
         mockIp
       );
 
+      expect(
+        accountCustomerManager.getAccountCustomerByUid
+      ).toHaveBeenCalledWith(mockAccountCustomer.uid);
       expect(customerManager.update).toHaveBeenCalledWith(
-        mockAccountCustomer.stripeCustomerId,
+        mockStripeCustomerId,
         {
           invoice_settings: {
             default_payment_method: mockPaymentMethod.id,
@@ -2447,6 +2509,59 @@ describe('SubscriptionManagementService', () => {
       ).rejects.toBeInstanceOf(ManagePaymentMethodTaxAddressRequiredError);
       expect(customerManager.update).not.toHaveBeenCalled();
     });
+
+    it('retries payment for open invoices with the newly authenticated payment method', async () => {
+      const mockStripeCustomerId = 'cus_setdefaultretry123';
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomerId,
+      });
+      const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory()
+      );
+
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
+
+      await subscriptionManagementService.setDefaultStripePaymentDetails(
+        mockAccountCustomer.uid,
+        mockPaymentMethod.id,
+        mockIp
+      );
+
+      expect(invoiceManager.retryPaymentForOpenInvoices).toHaveBeenCalledWith(
+        mockStripeCustomerId,
+        mockPaymentMethod.id
+      );
+    });
+
+    it('does not retry payment for open invoices when the tax address is unresolvable', async () => {
+      const mockCustomerWithoutShipping = StripeResponseFactory(
+        StripeCustomerFactory({ shipping: null })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomerWithoutShipping.id,
+      });
+
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest.spyOn(taxService, 'getTaxAddress').mockResolvedValue(undefined);
+
+      await expect(
+        subscriptionManagementService.setDefaultStripePaymentDetails(
+          mockAccountCustomer.uid,
+          'pm_12345',
+          mockIp
+        )
+      ).rejects.toBeInstanceOf(ManagePaymentMethodTaxAddressRequiredError);
+      expect(invoiceManager.retryPaymentForOpenInvoices).not.toHaveBeenCalled();
+    });
   });
 
   describe('getCurrencyForCustomer', () => {
@@ -2536,6 +2651,7 @@ describe('SubscriptionManagementService', () => {
             email: '',
             name: '',
             phone: '',
+            tax_id: '',
           },
         })
       );

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -627,10 +627,7 @@ export class SubscriptionManagementService {
     supportUrl: string,
     offeringApiIdentifier: string
   ): Promise<TrialSubscriptionContent | null> {
-    if (
-      subscription.trial_end === null &&
-      subscription.trial_start === null
-    ) {
+    if (subscription.trial_end === null && subscription.trial_start === null) {
       return null;
     }
 
@@ -697,8 +694,8 @@ export class SubscriptionManagementService {
       } = latestInvoice;
 
       const totalExclusiveTax = taxAmounts
-      .filter((tax) => !tax.inclusive)
-      .reduce((sum, tax) => sum + tax.amount, 0);
+        .filter((tax) => !tax.inclusive)
+        .reduce((sum, tax) => sum + tax.amount, 0);
 
       failedInvoiceDate = invoiceDate;
       failedInvoiceTax = Math.max(0, totalExclusiveTax);
@@ -830,9 +827,9 @@ export class SubscriptionManagementService {
         );
 
       if (!productMap) {
-        throw new SubscriptionManagementCouldNotRetrieveProductNamesFromCMSError([
-          priceId,
-        ]);
+        throw new SubscriptionManagementCouldNotRetrieveProductNamesFromCMSError(
+          [priceId]
+        );
       }
 
       const cmsPurchase = productMap.purchaseForPriceId(priceId);
@@ -953,9 +950,9 @@ export class SubscriptionManagementService {
         );
 
       if (!productMap) {
-        throw new SubscriptionManagementCouldNotRetrieveProductNamesFromCMSError([
-          priceId,
-        ]);
+        throw new SubscriptionManagementCouldNotRetrieveProductNamesFromCMSError(
+          [priceId]
+        );
       }
 
       const cmsPurchase = productMap.purchaseForPriceId(priceId);
@@ -1226,6 +1223,13 @@ export class SubscriptionManagementService {
       name: paymentMethod.billing_details.name ?? undefined,
     });
 
+    // The server-derived customer id, not setupIntent.customer, matching
+    // setDefaultStripePaymentDetails below.
+    await this.invoiceManager.retryPaymentForOpenInvoices(
+      accountCustomer.stripeCustomerId,
+      setupIntent.payment_method
+    );
+
     return {
       id: setupIntent.id,
       clientSecret: setupIntent.client_secret,
@@ -1259,6 +1263,19 @@ export class SubscriptionManagementService {
         default_payment_method: paymentMethodId,
       },
     });
+
+    // This is the path taken when the payment method required authentication,
+    // since updateStripePaymentDetails returns before its own collection in
+    // that case.
+    //
+    // `paymentMethodId` is client-supplied, and the customerManager.update above
+    // is what rejects one that is not this customer's -- Stripe refuses a
+    // default payment method that is not attached to the customer. It must stay
+    // ahead of the collection, which charges with that id.
+    await this.invoiceManager.retryPaymentForOpenInvoices(
+      accountCustomer.stripeCustomerId,
+      paymentMethodId
+    );
   }
 
   @SanitizeExceptions()

--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -41,6 +41,10 @@ const mockStripeInvoicesFinalizeInvoice =
   mockJestFnGenerator<typeof Stripe.prototype.invoices.finalizeInvoice>();
 const mockStripeInvoicesRetrieve =
   mockJestFnGenerator<typeof Stripe.prototype.invoices.retrieve>();
+const mockStripeInvoicesList =
+  mockJestFnGenerator<typeof Stripe.prototype.invoices.list>();
+const mockStripeInvoicesPay =
+  mockJestFnGenerator<typeof Stripe.prototype.invoices.pay>();
 const mockStripePaymentMethodsAttach =
   mockJestFnGenerator<typeof Stripe.prototype.paymentMethods.attach>();
 const mockStripePricesRetrieve =
@@ -85,6 +89,8 @@ jest.mock('stripe', () => {
         finalizeInvoice: mockStripeInvoicesFinalizeInvoice,
         retrieve: mockStripeInvoicesRetrieve,
         createPreview: mockStripeCreatePreviewInvoice,
+        list: mockStripeInvoicesList,
+        pay: mockStripeInvoicesPay,
       },
       paymentMethods: {
         attach: mockStripePaymentMethodsAttach,
@@ -332,6 +338,103 @@ describe('StripeClient', () => {
           'lines.data.taxes.tax_rate_details.tax_rate',
           'total_taxes.tax_rate_details.tax_rate',
         ],
+      });
+    });
+  });
+
+  describe('invoicesList', () => {
+    const mockCustomerId = 'cus_list123';
+
+    it('returns the matching invoices from Stripe', async () => {
+      const mockResponse = StripeResponseFactory(
+        StripeApiListFactory([StripeInvoiceFactory()])
+      );
+
+      mockStripeInvoicesList.mockResolvedValue(mockResponse);
+
+      const result = await stripeClient.invoicesList({
+        customer: mockCustomerId,
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('passes the caller filters through to Stripe', async () => {
+      mockStripeInvoicesList.mockResolvedValue(
+        StripeResponseFactory(StripeApiListFactory([]))
+      );
+
+      // `limit` is a plain pass-through -- nothing defaults, clamps or rejects
+      // it -- so this pins that the wrapper forwards params untouched.
+      await stripeClient.invoicesList({
+        customer: mockCustomerId,
+        status: 'open',
+        collection_method: 'charge_automatically',
+        limit: 3,
+      });
+
+      expect(mockStripeInvoicesList).toHaveBeenCalledWith({
+        customer: mockCustomerId,
+        status: 'open',
+        collection_method: 'charge_automatically',
+        limit: 3,
+      });
+    });
+
+    it('propagates a Stripe error to the caller', async () => {
+      mockStripeInvoicesList.mockRejectedValueOnce(
+        new Error('Stripe is unavailable')
+      );
+
+      await expect(
+        stripeClient.invoicesList({ customer: mockCustomerId })
+      ).rejects.toThrow('Stripe is unavailable');
+    });
+  });
+
+  describe('invoicesPayChargeAttempt', () => {
+    it('returns the paid invoice from Stripe', async () => {
+      const mockInvoice = StripeInvoiceFactory({ status: 'paid' });
+      const mockResponse = StripeResponseFactory(mockInvoice);
+
+      mockStripeInvoicesPay.mockResolvedValueOnce(mockResponse);
+
+      const result = await stripeClient.invoicesPayChargeAttempt(
+        mockInvoice.id
+      );
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('forwards the payment method to Stripe', async () => {
+      const mockInvoice = StripeInvoiceFactory({ status: 'paid' });
+      const mockPaymentMethodId = 'pm_charge123';
+
+      mockStripeInvoicesPay.mockResolvedValueOnce(
+        StripeResponseFactory(mockInvoice)
+      );
+
+      await stripeClient.invoicesPayChargeAttempt(mockInvoice.id, {
+        payment_method: mockPaymentMethodId,
+      });
+
+      expect(mockStripeInvoicesPay).toHaveBeenCalledWith(mockInvoice.id, {
+        off_session: true,
+        payment_method: mockPaymentMethodId,
+      });
+    });
+
+    it('charges off-session by default', async () => {
+      const mockInvoice = StripeInvoiceFactory({ status: 'paid' });
+
+      mockStripeInvoicesPay.mockResolvedValueOnce(
+        StripeResponseFactory(mockInvoice)
+      );
+
+      await stripeClient.invoicesPayChargeAttempt(mockInvoice.id);
+
+      expect(mockStripeInvoicesPay).toHaveBeenCalledWith(mockInvoice.id, {
+        off_session: true,
       });
     });
   });

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -280,6 +280,11 @@ export class StripeClient {
     return result as StripeResponse<StripeInvoice>;
   }
 
+  /**
+   * Marks an invoice paid without collecting funds, for money already received
+   * out of band (PayPal). Does not charge a payment method -- see
+   * `invoicesPayChargeAttempt` for that.
+   */
   @CaptureTimingWithStatsD()
   async invoicesPay(invoiceId: string) {
     try {
@@ -293,6 +298,32 @@ export class StripeClient {
       }
       throw err;
     }
+  }
+
+  @CaptureTimingWithStatsD()
+  async invoicesList(
+    params: Omit<Stripe.InvoiceListParams, 'expand' | 'customer'> & {
+      customer: string;
+    }
+  ) {
+    const result = await this.stripe.invoices.list({
+      ...params,
+      expand: undefined,
+    });
+    return result as StripeApiList<StripeInvoice>;
+  }
+
+  @CaptureTimingWithStatsD()
+  async invoicesPayChargeAttempt(
+    invoiceId: string,
+    params?: Pick<Stripe.InvoicePayParams, 'payment_method'>
+  ) {
+    const result = await this.stripe.invoices.pay(invoiceId, {
+      off_session: true,
+      ...params,
+      expand: undefined,
+    });
+    return result as StripeResponse<StripeInvoice>;
   }
 
   @CaptureTimingWithStatsD()


### PR DESCRIPTION
## Because

- After updating payment method, the customer whose payment failed at free trial end currently waits up to 24 hours (or more) for Stripe's automatic retry before access is restored

## This pull request

- Adds invoicesList and invoicesPayChargeAttempt
- Existing invoicesPay marks an invoice paid out of band and cannot charge a card
- Adds retryPaymentForOpeninvoices to invoiceManager to pay open invoice with newly saved payment method

## Issue that this pull request solves

Closes: PAY-3793

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## How to review (Optional)
- Create subscription for free trial using a test card that declines after attaching (4000000000000341)
- Simulate time in Stripe dashboard passed free trial end date
- Go Subscription Management page to observe information about updating payment method to restore access
- Click "Update Payment Method" button and update payment method:
  - Using a test card for successful payment (4242424242424242), or
  - Using a 3D Secure authentication test card (4000002500003155)
- Subscription Management should now display the free trial subscription under Active Subscriptions