### PR TITLE
test(functional): assert the de l10n bundle is delivered

### DIFF
--- a/packages/functional-tests/tests/misc/l10nBundleDelivery.spec.ts
+++ b/packages/functional-tests/tests/misc/l10nBundleDelivery.spec.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, test } from '../../lib/fixtures/standard';
+
+// German is well translated. Avoid the EN_GB_LOCALES set, en-NZ, en-SG and
+// en-MY: AppLocalizationProvider sources those from the en-GB bundle, so they
+// would not prove delivery.
+const LOCALE = 'de';
+
+// Matches the plain path and the hashed path the static asset manifest points
+// at, for example locales/de/main.ebcab539.ftl.
+const MAIN_FTL = new RegExp(`/locales/${LOCALE}/main(\\.[0-9a-f]+)?\\.ftl$`);
+
+test.describe('severity-1', () => {
+  test.use({ locale: LOCALE });
+
+  test(`delivers the ${LOCALE} main.ftl bundle`, async ({ target, page }) => {
+    // Register the wait before navigating. A request that never happens leaves
+    // this pending, so it rejects on timeout and the test fails.
+    const ftlResponse = page.waitForResponse((response) =>
+      MAIN_FTL.test(new URL(response.url()).pathname)
+    );
+
+    const [response] = await Promise.all([
+      ftlResponse,
+      page.goto(target.contentServerUrl),
+    ]);
+
+    const context = `If ${LOCALE} was dropped from the shipping locale set, this failure is correct and the fix is the locale set, not the test.`;
+
+    expect(
+      response.status(),
+      `The ${LOCALE} main.ftl bundle did not return 200. ${context}`
+    ).toBe(200);
+
+    // Any message line proves the body is a bundle rather than an error page
+    // served with a 200. No message id is named, so l10n churn cannot fail it.
+    expect(
+      await response.text(),
+      `The ${LOCALE} main.ftl bundle did not look like FTL. ${context}`
+    ).toMatch(/^[\w-]+\s*=/m);
+  });
+});


### PR DESCRIPTION
## Because

- FXA-14361 served English to every locale and nothing failed. Every response was a 200, and the only symptom was untranslated copy.
- `packages/functional-tests` has no l10n coverage, so neither PR CI nor the stage and production smoke runs would have caught it.

## This pull request

- Adds `l10nBundleDelivery.spec.ts` under `tests/misc/`. It forces `de` with Playwright's `locale` context option, waits for the `main.ftl` response, then asserts a 200 and a body that parses as FTL.
- Matches the plain path and the hashed manifest path, for example `locales/de/main.ebcab539.ftl`.
- Tags the block `severity-1`. That is what the stage and production Playwright runs grep for.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14366

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/functional-tests/tests/misc/l10nBundleDelivery.spec.ts`
- Suggested review order: one file.
- Risky or complex parts: the response wait. It is registered before `page.goto`, so a request that never happens keeps it pending and the test fails on timeout.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

How the locale reaches the fetch: `public/lang-fix.js` sets `document.documentElement.lang` from `navigator.languages`, `getCurrentLocale()` reads that value, and `AppLocalizationProvider` then fetches `main.ftl` for it.

The test asserts nothing about the static asset manifest, so #21060 needs no rework here. It asserts no translated string and no FTL message id. The body check matches any message line, which rules out an error page served with a 200.

Read this before you approve: I did not run the spec, and I did not exercise the negative case against a running stack. To confirm it, remove the `de` `main.ftl` entry from the manifest and check that the test fails.

Verification done here: `npx tsc -p packages/functional-tests/tsconfig.json --noEmit` reports only the three errors that already exist on `main`, in `lib/sub-helpers.ts` and `lib/testAccountTracker.ts`. `npx nx lint functional-tests` passes with no finding on the new file.
