### PR TITLE
task(settings): Display v2 QR code

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -186,7 +186,7 @@ const PairAuthorityDownloadFirefox = lazy(
   () => import('../../pages/Pair2/Authority/DownloadFirefox')
 );
 const PairAuthorityScanQR = lazy(
-  () => import('../../pages/Pair2/Authority/ScanQR')
+  () => import('../../pages/Pair2/Authority/ScanQR/container')
 );
 const PairAuthoritySyncSuccess = lazy(
   () => import('../../pages/Pair2/Authority/SyncSuccess')
@@ -1031,9 +1031,7 @@ const AuthAndAccountSetupRoutes = ({
         {/* Pairing */}
         <Route
           path="/connect_another_device/*"
-          element={<ConnectAnotherDevice
-            pairingEnabled={useFxAStatusResult.pairingEnabled}
-            pairingVersion={useFxAStatusResult.pairingVersion} />}
+          element={<ConnectAnotherDevice fxaStatus={useFxAStatusResult} />}
         />
         <Route
           path="/pair/supp/allow/*"
@@ -1099,7 +1097,7 @@ const AuthAndAccountSetupRoutes = ({
         />
         <Route
           path="/pair/authority/scan_qr/*"
-          element={<PairAuthorityScanQR { ...{integration}} />}
+          element={<PairAuthorityScanQR integration={integration} />}
         />
         <Route
           path="/pair/authority/sync_success/*"

--- a/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { PairingChannelClient, PairingChannelError } from './pairing-channel';
+import {
+  PairingChannelClient,
+  PairingChannelError,
+  toRemoteMetadata,
+} from './pairing-channel';
 
 // Valid base64url key (decodes to 'testkey1')
 const VALID_KEY = 'dGVzdGtleTE';
@@ -15,6 +19,8 @@ let mockChannel: {
   close: jest.Mock;
   addEventListener: jest.Mock;
   removeEventListener: jest.Mock;
+  _channelId?: string;
+  _channelKey?: Uint8Array;
 };
 
 jest.mock(
@@ -22,6 +28,7 @@ jest.mock(
   () => ({
     PairingChannel: {
       connect: jest.fn(() => Promise.resolve(mockChannel)),
+      create: jest.fn(() => Promise.resolve(mockChannel)),
     },
   })
 );
@@ -45,6 +52,9 @@ describe('PairingChannelClient', () => {
       close: jest.fn().mockResolvedValue(undefined),
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
+      // 'testkey1' — the same bytes VALID_KEY decodes to.
+      _channelId: CHAN,
+      _channelKey: new TextEncoder().encode('testkey1'),
     };
     jest.clearAllMocks();
     client = new PairingChannelClient();
@@ -71,6 +81,92 @@ describe('PairingChannelClient', () => {
       await expect(client.open(SERVER, CHAN, VALID_KEY)).rejects.toThrow(
         'Already connected'
       );
+    });
+  });
+
+  // The authority mints a channel rather than joining one, so the ids come back
+  // on the client and get encoded into the QR the supplicant scans.
+  describe('create', () => {
+    it('connects and dispatches connected event', async () => {
+      const onConnected = jest.fn();
+      client.addEventListener('connected', onConnected);
+
+      await client.create(SERVER);
+
+      expect(client.isConnected).toBe(true);
+      expect(onConnected).toHaveBeenCalled();
+    });
+
+    it('passes the channel server uri to the pairing channel bundle', async () => {
+      const {
+        PairingChannel,
+      } = require('fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js');
+
+      await client.create(SERVER);
+
+      expect(PairingChannel.create).toHaveBeenCalledWith(SERVER);
+    });
+
+    it('exposes the channel id and base64url-encoded key', async () => {
+      await client.create(SERVER);
+
+      expect(client.channelId).toBe(CHAN);
+      expect(client.channelKey).toBe(VALID_KEY);
+    });
+
+    it('has no channel id or key before a channel exists', () => {
+      expect(client.channelId).toBeNull();
+      expect(client.channelKey).toBeNull();
+    });
+
+    it('has no channel id or key after close', async () => {
+      await client.create(SERVER);
+      await client.close();
+
+      expect(client.channelId).toBeNull();
+      expect(client.channelKey).toBeNull();
+    });
+
+    it('throws for a missing channel server uri', async () => {
+      await expect(client.create('')).rejects.toThrow(
+        'Invalid channel server configuration'
+      );
+    });
+
+    it('throws if already connected', async () => {
+      await client.create(SERVER);
+
+      await expect(client.create(SERVER)).rejects.toThrow('Already connected');
+    });
+
+    // The caller has to be able to tell a failed create from a successful one:
+    // resolving anyway would encode `channel_id=null` into a real QR code.
+    it('rethrows and dispatches error when the bundle rejects', async () => {
+      const {
+        PairingChannel,
+      } = require('fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js');
+      const err = new Error('channel server unreachable');
+      PairingChannel.create.mockRejectedValueOnce(err);
+      const onError = jest.fn();
+      client.addEventListener('error', onError);
+
+      await expect(client.create(SERVER)).rejects.toThrow(
+        'channel server unreachable'
+      );
+      expect(client.isConnected).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('allows a retry after a failed create', async () => {
+      const {
+        PairingChannel,
+      } = require('fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js');
+      PairingChannel.create.mockRejectedValueOnce(new Error('nope'));
+      await expect(client.create(SERVER)).rejects.toThrow('nope');
+
+      await client.create(SERVER);
+
+      expect(client.isConnected).toBe(true);
     });
   });
 
@@ -237,5 +333,64 @@ describe('PairingChannelError', () => {
     expect(err.errno).toBe(1002);
     expect(err.message).toBe('Not connected to channel server');
     expect(err.name).toBe('PairingChannelError');
+  });
+});
+
+// Both sides of the flow show the remote device's details so the user can
+// confirm which device is asking, so the derivation is shared.
+describe('toRemoteMetadata', () => {
+  const FIREFOX_IOS_UA =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/119.0 Mobile/15E148 Safari/605.1.15';
+  const REMOTE = {
+    city: 'Vancouver',
+    country: 'Canada',
+    region: 'British Columbia',
+    ipAddress: '127.0.0.1',
+    ua: FIREFOX_IOS_UA,
+  };
+
+  it('derives the device family and OS from the user agent', () => {
+    expect(toRemoteMetadata(REMOTE)).toEqual({
+      city: 'Vancouver',
+      country: 'Canada',
+      region: 'British Columbia',
+      ipAddress: '127.0.0.1',
+      deviceFamily: 'Firefox',
+      deviceOS: 'iOS',
+      deviceName: 'Firefox',
+    });
+  });
+
+  it('prefers an explicit device name over the browser name', () => {
+    expect(toRemoteMetadata(REMOTE, "Dana's iPhone").deviceName).toBe(
+      "Dana's iPhone"
+    );
+  });
+
+  it('normalizes the OS name reported by the user agent', () => {
+    const androidUa =
+      'Mozilla/5.0 (Android 14; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0';
+
+    expect(toRemoteMetadata({ ...REMOTE, ua: androidUa }).deviceOS).toBe(
+      'Android'
+    );
+  });
+
+  // The channel server does not guarantee any of the sender fields, and a
+  // blank heading in the UI is worse than a generic one.
+  it('falls back to Unknown when the user agent cannot be parsed', () => {
+    expect(toRemoteMetadata({ ...REMOTE, ua: 'not-a-user-agent' })).toEqual({
+      city: 'Vancouver',
+      country: 'Canada',
+      region: 'British Columbia',
+      ipAddress: '127.0.0.1',
+      deviceFamily: 'Unknown',
+      deviceOS: 'Unknown',
+      deviceName: 'Unknown',
+    });
+  });
+
+  it('defaults a missing ip address to an empty string', () => {
+    expect(toRemoteMetadata({ ua: FIREFOX_IOS_UA }).ipAddress).toBe('');
   });
 });

--- a/packages/fxa-settings/src/lib/channels/pairing-channel.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.ts
@@ -12,6 +12,10 @@
  */
 
 import sentryMetrics from 'fxa-shared/sentry/browser';
+import { RemoteMetadata } from '../types';
+import UAParser from 'ua-parser-js';
+import { toGenericOSName } from '../utilities';
+import { base64urlToBytes, bytesToBase64url } from '../base64url';
 
 // Types
 
@@ -27,6 +31,30 @@ export type PairingChannelRemoteMetadata = {
   ua?: string;
   ipAddress?: string;
 };
+
+/**
+ * Derive the device details shown to the user from the channel server's
+ * `sender` envelope. Shared by both sides of the flow: the supplicant reads it
+ * off `pair:auth:metadata`, the authority off `pair:supp:request`.
+ */
+export function toRemoteMetadata(
+  remote: PairingChannelRemoteMetadata,
+  deviceName?: string
+): RemoteMetadata {
+  const parser = new UAParser(remote.ua || '');
+  const browser = parser.getBrowser();
+  const os = parser.getOS();
+
+  return {
+    city: remote.city,
+    country: remote.country,
+    region: remote.region,
+    ipAddress: remote.ipAddress || '',
+    deviceFamily: browser.name || 'Unknown',
+    deviceOS: toGenericOSName(os.name || ''),
+    deviceName: deviceName || browser.name || 'Unknown',
+  };
+}
 
 export type PairingChannelIncomingMessage = {
   remoteMetaData: PairingChannelRemoteMetadata;
@@ -81,19 +109,6 @@ export class PairingChannelError extends Error {
   }
 }
 
-/** Decode a base64url string to Uint8Array (for PSK). */
-function base64urlToUint8Array(base64url: string): Uint8Array {
-  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
-  const pad =
-    base64.length % 4 === 0 ? '' : '='.repeat(4 - (base64.length % 4));
-  const binary = atob(base64 + pad);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
 /**
  * EventTarget-based client that wraps fxa-pairing-channel for PSK-encrypted
  * WebSocket communication with the channel server.
@@ -110,12 +125,77 @@ type PairingChannelSocket = {
   close(): Promise<void>;
   addEventListener(type: string, listener: EventListener): void;
   removeEventListener(type: string, listener: EventListener): void;
+  _channelId?: string;
+  _channelKey?: Uint8Array;
 };
 
 export class PairingChannelClient extends EventTarget {
   private channel: PairingChannelSocket | null = null;
   private _opening = false;
 
+  get channelKey() {
+    if (this.channel?._channelKey) {
+      return bytesToBase64url(this.channel._channelKey);
+    }
+    return null;
+  }
+
+  get channelId() {
+    if (this.channel?._channelId) {
+      return this.channel._channelId;
+    }
+    return null;
+  }
+
+  /**
+   * Creates a new pairing channel. Once opened, a channelId and channelKey
+   * should be populated on this instance.
+   *
+   * @param channelServerUri The channel server to connect to.
+   */
+  async create(channelServerUri: string): Promise<void> {
+    if (this.channel || this._opening) {
+      throw new PairingChannelError('ALREADY_CONNECTED');
+    }
+
+    if (!channelServerUri) {
+      throw new PairingChannelError('INVALID_CONFIGURATION');
+    }
+
+    this._opening = true;
+    try {
+      const { PairingChannel } = await import(
+        /* webpackChunkName: "fxaPairingChannel" */
+        'fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js'
+      );
+      const channel = await PairingChannel.create(channelServerUri);
+      this.channel = channel;
+
+      // Listeners go on before `connected` so a message that arrives in the
+      // same tick as the handshake completing is not dropped.
+      channel.addEventListener('message', this.handleMessage);
+      channel.addEventListener('error', this.handleError);
+      channel.addEventListener('close', this.handleClose);
+
+      this.dispatchEvent(new CustomEvent('connected'));
+    } catch (err) {
+      sentryMetrics.captureException(err);
+      this.dispatchEvent(new CustomEvent('error', { detail: err }));
+      // Rethrow so the caller can tell a failed create from a successful one.
+      // Without this the authority resolves as if it had a channel and encodes
+      // `channel_id=null` into a QR code the supplicant cannot join.
+      throw err;
+    } finally {
+      this._opening = false;
+    }
+  }
+
+  /**
+   * Opens an existing pairing channel connection
+   * @param channelServerUri Channel server to connect to
+   * @param channelId Id of channel to open
+   * @param channelKey Key for channel
+   */
   async open(
     channelServerUri: string,
     channelId: string,
@@ -131,7 +211,7 @@ export class PairingChannelClient extends EventTarget {
 
     this._opening = true;
     try {
-      const psk = base64urlToUint8Array(channelKey);
+      const psk = base64urlToBytes(channelKey);
 
       // Dynamic import — fxa-pairing-channel UMD bundle exposes PairingChannel.connect()
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
@@ -42,6 +42,7 @@ describe('useFxAStatus', () => {
         type: IntegrationType.SyncDesktopV3,
         isSync: () => true,
         isFirefoxNonSync: () => false,
+        isPairing: () => false,
       };
 
       const { waitForNextUpdate } = renderHook(() => useFxAStatus(integration));
@@ -68,6 +69,7 @@ describe('useFxAStatus', () => {
         type: IntegrationType.OAuthNative,
         isSync: () => true,
         isFirefoxNonSync: () => false,
+        isPairing: () => false,
       };
 
       const { waitForNextUpdate } = renderHook(() => useFxAStatus(integration));
@@ -76,6 +78,30 @@ describe('useFxAStatus', () => {
       expect(firefox.fxaStatus).toHaveBeenCalledWith({
         context: Constants.OAUTH_CONTEXT,
         isPairing: false,
+        service: Constants.SYNC_SERVICE,
+      });
+    });
+
+    // The browser answers a pairing request differently, so the flag has to
+    // reach it rather than being hardcoded false as it was before pairing v2.
+    it('sends isPairing: true for a pairing integration', async () => {
+      (firefox.fxaStatus as jest.Mock).mockResolvedValue({
+        capabilities: { engines: [] },
+      });
+
+      const integration = {
+        type: IntegrationType.PairingAuthority,
+        isSync: () => true,
+        isFirefoxNonSync: () => false,
+        isPairing: () => true,
+      };
+
+      const { waitForNextUpdate } = renderHook(() => useFxAStatus(integration));
+      await waitForNextUpdate();
+
+      expect(firefox.fxaStatus).toHaveBeenCalledWith({
+        context: Constants.OAUTH_CONTEXT,
+        isPairing: true,
         service: Constants.SYNC_SERVICE,
       });
     });
@@ -92,6 +118,7 @@ describe('useFxAStatus', () => {
         type: IntegrationType.OAuthNative,
         isSync: () => true,
         isFirefoxNonSync: () => false,
+        isPairing: () => false,
       };
 
       const { result, waitForNextUpdate } = renderHook(() =>
@@ -125,6 +152,7 @@ describe('useFxAStatus', () => {
           type: IntegrationType.OAuthNative,
           isSync: () => false,
           isFirefoxNonSync: () => true,
+          isPairing: () => false,
         };
         const { result, waitForNextUpdate } = renderHook(() =>
           useFxAStatus(integration)
@@ -139,6 +167,7 @@ describe('useFxAStatus', () => {
           type: IntegrationType.OAuthNative,
           isSync: () => true,
           isFirefoxNonSync: () => false,
+          isPairing: () => false,
         };
         const { result, waitForNextUpdate } = renderHook(() =>
           useFxAStatus(integration)
@@ -154,6 +183,7 @@ describe('useFxAStatus', () => {
       type: IntegrationType.OAuthNative,
       isSync: () => true,
       isFirefoxNonSync: () => false,
+      isPairing: () => false,
     };
 
     const mockCapabilities = (
@@ -270,6 +300,7 @@ describe('useFxAStatus', () => {
         type: IntegrationType.Web,
         isSync: () => false,
         isFirefoxNonSync: () => false,
+        isPairing: () => false,
       };
 
       renderHook(() => useFxAStatus(integration));
@@ -282,6 +313,7 @@ describe('useFxAStatus', () => {
         type: IntegrationType.Web,
         isSync: () => false,
         isFirefoxNonSync: () => false,
+        isPairing: () => false,
       };
 
       const { result } = renderHook(() => useFxAStatus(integration));
@@ -299,6 +331,7 @@ describe('useFxAStatus', () => {
         type: IntegrationType.SyncDesktopV3,
         isSync: () => true,
         isFirefoxNonSync: () => false,
+        isPairing: () => false,
       };
 
       renderHook(() => useFxAStatus(integration));

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
@@ -21,7 +21,7 @@ import { Constants } from '../../constants';
 
 type FxAStatusIntegration = Pick<
   Integration,
-  'type' | 'isSync' | 'isFirefoxNonSync'
+  'type' | 'isSync' | 'isFirefoxNonSync' | 'isPairing'
 >;
 
 /**
@@ -32,6 +32,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
   const isSyncOAuth = isOAuthIntegration(integration) && integration.isSync();
   const isSyncDesktopV3 = isSyncDesktopV3Integration(integration);
   const isSync = integration.isSync();
+  const isPairing = integration.isPairing();
   const isOAuthNative = isOAuthNativeIntegration(integration);
 
   const [webChannelEngines, setWebChannelEngines] = useState<
@@ -47,10 +48,17 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
     boolean | undefined
   >(undefined);
 
-  const [pairingEnabled,setPairingEnabled] = useState(false);
-  const [pairingVersion,setPairingVersion] = useState(1);
-  const [hasSyncKeys, setHasSyncKeys] = useState<boolean|undefined>(undefined);
-
+  // Undefined until the browser answers, so callers can tell "not yet known"
+  // from "no pairing support" rather than routing on an unresolved default.
+  const [pairingEnabled, setPairingEnabled] = useState<boolean | undefined>(
+    undefined
+  );
+  const [pairingVersion, setPairingVersion] = useState<number | undefined>(
+    undefined
+  );
+  const [hasSyncKeys, setHasSyncKeys] = useState<boolean | undefined>(
+    undefined
+  );
 
   useEffect(() => {
     // This sends a web channel message to the browser to prompt a response
@@ -62,7 +70,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
           context: isSyncDesktopV3
             ? Constants.FX_DESKTOP_V3_CONTEXT
             : Constants.OAUTH_CONTEXT,
-          isPairing: false,
+          isPairing,
           service: Constants.SYNC_SERVICE,
         });
 
@@ -98,13 +106,17 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
         } else {
           setSupportsCanLinkAccountUid(false);
         }
-        setPairingEnabled(capabilities.pairing || false);
+        setPairingEnabled(!!capabilities.pairing);
         setPairingVersion(capabilities.pairingVersion || 1);
         setHasSyncKeys(capabilities.hasSyncKeys);
       })();
+    } else {
+      setPairingEnabled(false);
+      setPairingVersion(1);
     }
   }, [
     isSync,
+    isPairing,
     isOAuthNative,
     isSyncDesktopV3,
     isSyncOAuth,

--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.test.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.test.ts
@@ -35,6 +35,15 @@ describe('lib/integrations/integration-factory-flags', function () {
     expect(integrationFlags.isDevicePairingAsAuthority()).toBeTruthy();
   });
 
+  it('isDevicePairingAsAuthority from the v2 authority pathname', () => {
+    sandbox.replaceGetter(
+      queryData,
+      'pathName',
+      () => '/pair/authority/scan_qr'
+    );
+    expect(integrationFlags.isDevicePairingAsAuthority()).toBeTruthy();
+  });
+
   it('isDevicePairingAsSupplicant', () => {
     expect(integrationFlags.isDevicePairingAsSupplicant()).toBeFalsy();
     sandbox.replaceGetter(queryData, 'pathName', () => '/pair/supplicant');
@@ -48,6 +57,25 @@ describe('lib/integrations/integration-factory-flags', function () {
     queryData.set('context', Constants.OAUTH_WEBCHANNEL_CONTEXT);
     expect(integrationFlags.isDevicePairingAsSupplicant()).toBeTruthy();
   });
+
+  it.each([
+    '/pair/supp',
+    '/pair/supp/',
+    '/pair/supp/allow',
+    '/pair/supplicant',
+    '/pair/supplicant/connect_this_device',
+  ])('isDevicePairingAsSupplicant for the pathname %s', (pathName) => {
+    sandbox.replaceGetter(queryData, 'pathName', () => pathName);
+    expect(integrationFlags.isDevicePairingAsSupplicant()).toBe(true);
+  });
+
+  it.each(['/pair', '/pair/auth/allow', '/supp'])(
+    'isDevicePairingAsSupplicant is false for the pathname %s',
+    (pathName) => {
+      sandbox.replaceGetter(queryData, 'pathName', () => pathName);
+      expect(integrationFlags.isDevicePairingAsSupplicant()).toBe(false);
+    }
+  );
 
   describe('isOAuth', () => {
     beforeEach(() => {

--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
@@ -6,7 +6,12 @@ import { Constants } from '../constants';
 import { ModelDataStore, UrlQueryData } from '../model-data';
 import { IntegrationFlags } from '../integrations/interfaces';
 
+// The trailing separator is optional: `/pair/supp` (no slash, query and hash
+// only) is the URL the v1 QR code resolves to, so requiring one would stop the
+// supplicant integration from being built for the flow's own entry point.
 const DEVICE_PAIRING_SUPPLICANT_PATHNAME_REGEXP = /^\/pair\/supp/;
+const DEVICE_PAIRING_V2_SUPPLICANT_PATHNAME_REGEXP = /^\/pair\/supplicant\//;
+const DEVICE_PAIRING_V2_AUTHORITY_PATHNAME_REGEXP = /^\/pair\/authority\//;
 
 /**
  * Extrapolates flags from the state of the current data store. The collective state of these flags are used by
@@ -27,7 +32,8 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
   isDevicePairingAsAuthority() {
     return (
       this.searchParam('redirect_uri') ===
-      Constants.DEVICE_PAIRING_AUTHORITY_REDIRECT_URI
+        Constants.DEVICE_PAIRING_AUTHORITY_REDIRECT_URI ||
+      DEVICE_PAIRING_V2_AUTHORITY_PATHNAME_REGEXP.test(this.pathname)
     );
   }
 
@@ -35,7 +41,10 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
     // Match Backbone behavior (app-start.js): only check pathname.
     // Do NOT require isOAuthWebChannelContext() — Firefox iOS uses
     // OAuth redirect (not WebChannel) for the supplicant flow.
-    return DEVICE_PAIRING_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname);
+    return (
+      DEVICE_PAIRING_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname) ||
+      DEVICE_PAIRING_V2_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname)
+    );
   }
 
   isOAuth() {

--- a/packages/fxa-settings/src/models/integrations/integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/integration.test.ts
@@ -78,4 +78,12 @@ describe('Integration Model', function () {
       expect(model.isTrusted()).toBeTruthy();
     });
   });
+
+  // Only the two pairing integrations override this; `useFxAStatus` reads it to
+  // decide whether to tell the browser a pairing flow is underway.
+  describe('isPairing', function () {
+    it('returns `false`', () => {
+      expect(model.isPairing()).toBe(false);
+    });
+  });
 });

--- a/packages/fxa-settings/src/models/integrations/integration.ts
+++ b/packages/fxa-settings/src/models/integrations/integration.ts
@@ -104,6 +104,13 @@ export class GenericIntegration<
     return false;
   }
 
+  /**
+   * Signals that the integration supports pairing. By default this is false.
+   */
+  isPairing() {
+    return false;
+  }
+
   // Practically, this will never be called unless the integration is
   // an oauth-native-integration, but provide a reasonable default.
   getWebChannelServices(

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
@@ -5,6 +5,7 @@
 import { ModelDataStore, GenericData } from '../../lib/model-data';
 import {
   OAuthWebIntegration,
+  normalizeError,
   replaceItemInArray,
 } from './oauth-web-integration';
 import * as Sentry from '@sentry/browser';
@@ -512,6 +513,41 @@ describe('models/integrations/oauth-relier', function () {
 
     it('handles empty replacement', () => {
       expect(replaceItemInArray(['a', 'b', 'c'], 'a', [])).toEqual(['b', 'c']);
+    });
+  });
+
+  // The pairing integrations surface whatever the channel handed them, which
+  // may be a DOM error, a channel-server errno object, or a bare string.
+  describe('normalizeError', () => {
+    it('passes an Error through unchanged', () => {
+      const err = new Error('boom');
+
+      expect(normalizeError(err)).toBe(err);
+    });
+
+    it('passes an errno object through unchanged', () => {
+      const err = { errno: 1006, message: 'Connection closed' };
+
+      expect(normalizeError(err)).toBe(err);
+    });
+
+    it('preserves an Error subclass', () => {
+      const err = new OAuthError(OAUTH_ERRORS.INVALID_TOKEN.errno);
+
+      expect(normalizeError(err)).toBe(err);
+    });
+
+    it.each([
+      ['a string', 'something went wrong', 'something went wrong'],
+      ['null', null, 'null'],
+      ['undefined', undefined, 'undefined'],
+      ['a number', 42, '42'],
+      ['an object with no errno', { foo: 'bar' }, '[object Object]'],
+    ])('wraps %s in an Error', (_label, input, expected) => {
+      const result = normalizeError(input);
+
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).message).toBe(expected);
     });
   });
 

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -379,6 +379,23 @@ export class OAuthWebIntegration extends GenericIntegration<
   }
 }
 
+export function normalizeError(
+    err: unknown
+  ): Error | { errno: number; message: string } {
+    if (err instanceof Error) {
+      return err;
+    }
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      'errno' in err &&
+      'message' in err
+    ) {
+      return err as { errno: number; message: string };
+    }
+    return new Error(String(err));
+  }
+
 export function scopeStrToArray(scopes: string) {
   const arrScopes = scopes
     .trim()

--- a/packages/fxa-settings/src/models/integrations/pairing-authority-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-authority-integration.test.ts
@@ -3,7 +3,41 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { GenericData } from '../../lib/model-data';
-import { PairingAuthorityIntegration } from './pairing-authority-integration';
+import {
+  AuthorityState,
+  PairingAuthorityIntegration,
+} from './pairing-authority-integration';
+
+const CHANNEL_SERVER_URI = 'wss://channel.example.com';
+
+const mockCreate = jest.fn().mockResolvedValue(undefined);
+const mockChannelClose = jest.fn().mockResolvedValue(undefined);
+const mockRemoveEventListener = jest.fn();
+let mockListeners: Record<string, Function[]> = {};
+
+jest.mock('../../lib/channels/pairing-channel', () => {
+  const actual = jest.requireActual('../../lib/channels/pairing-channel');
+  return {
+    ...actual,
+    PairingChannelClient: jest.fn().mockImplementation(() => ({
+      create: mockCreate,
+      close: mockChannelClose,
+      channelId: 'chan-1',
+      channelKey: 'key-1',
+      addEventListener: jest.fn((type: string, handler: Function) => {
+        (mockListeners[type] ||= []).push(handler);
+      }),
+      removeEventListener: mockRemoveEventListener,
+    })),
+  };
+});
+
+/** Deliver a channel event the way `PairingChannelClient` would. */
+function emit(type: string, detail?: unknown) {
+  (mockListeners[type] || []).forEach((handler) =>
+    handler(new CustomEvent(type, { detail }))
+  );
+}
 
 const mockPairSupplicantMetadata = jest.fn();
 const mockPairHeartbeat = jest.fn();
@@ -24,7 +58,9 @@ jest.mock('../../lib/channels/firefox', () => ({
 
 jest.mock('../../lib/config', () => ({
   __esModule: true,
-  default: { pairing: { clients: [] } },
+  default: {
+    pairing: { clients: [], serverBaseUri: 'wss://channel.example.com' },
+  },
 }));
 
 function createIntegration(
@@ -56,6 +92,9 @@ describe('PairingAuthorityIntegration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockListeners = {};
+    mockCreate.mockResolvedValue(undefined);
+    mockChannelClose.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -179,7 +218,7 @@ describe('PairingAuthorityIntegration', () => {
       await Promise.resolve();
 
       expect(onHeartbeatError).toHaveBeenCalled();
-      integration.destroy();
+      await integration.destroy();
     });
 
     it('does not start twice', () => {
@@ -190,7 +229,7 @@ describe('PairingAuthorityIntegration', () => {
       integration.stopHeartbeat();
     });
 
-    it('calls onHeartbeatError when channelId is missing', () => {
+    it('calls onHeartbeatError when channelId is missing', async () => {
       // No channel_id in URL or channelData
       Object.defineProperty(window, 'location', {
         value: { search: '' },
@@ -204,7 +243,7 @@ describe('PairingAuthorityIntegration', () => {
 
       expect(onHeartbeatError).toHaveBeenCalled();
       expect(mockPairHeartbeat).not.toHaveBeenCalled();
-      integration.destroy();
+      await integration.destroy();
     });
 
     it('stops heartbeat when pairHeartbeat rejects', async () => {
@@ -219,7 +258,7 @@ describe('PairingAuthorityIntegration', () => {
       await Promise.resolve();
 
       expect(onHeartbeatError).toHaveBeenCalled();
-      integration.destroy();
+      await integration.destroy();
     });
 
     it('skips overlapping heartbeat ticks', async () => {
@@ -281,17 +320,289 @@ describe('PairingAuthorityIntegration', () => {
     });
   });
 
+  describe('isPairing', () => {
+    it('returns true', () => {
+      expect(createIntegration().isPairing()).toBe(true);
+    });
+  });
+
+  describe('pairing channel', () => {
+    let integration: PairingAuthorityIntegration;
+    let onStateChange: jest.Mock;
+    let onError: jest.Mock;
+
+    beforeEach(() => {
+      integration = createIntegration();
+      onStateChange = jest.fn();
+      onError = jest.fn();
+      integration.onStateChange = onStateChange;
+      integration.onError = onError;
+    });
+
+    describe('createChannel', () => {
+      it('creates a channel against the configured channel server', async () => {
+        await integration.createChannel();
+
+        expect(mockCreate).toHaveBeenCalledWith(CHANNEL_SERVER_URI);
+        expect(integration.hasChannel()).toBe(true);
+      });
+
+      it('does not create a second channel', async () => {
+        await integration.createChannel();
+        await integration.createChannel();
+
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+      });
+
+      it('rethrows and fails when the channel cannot be created', async () => {
+        const err = new Error('channel server unreachable');
+        mockCreate.mockRejectedValueOnce(err);
+
+        await expect(integration.createChannel()).rejects.toThrow(
+          'channel server unreachable'
+        );
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(onError).toHaveBeenCalledWith(err);
+      });
+
+      it('drops the channel after a failed create so it can be retried', async () => {
+        mockCreate.mockRejectedValueOnce(new Error('nope'));
+        await expect(integration.createChannel()).rejects.toThrow('nope');
+
+        expect(integration.hasChannel()).toBe(false);
+
+        await integration.createChannel();
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('getPairUrl', () => {
+      it('encodes the channel credentials in the fragment', async () => {
+        await integration.createChannel();
+
+        expect(integration.getPairUrl('2')).toBe(
+          `${window.location.origin}/pair#channel_id=chan-1&channel_key=key-1&v=2`
+        );
+      });
+
+      // Better to fail loudly than to render a QR that scans to a channel the
+      // supplicant cannot join.
+      it('throws before the channel exists', () => {
+        expect(() => integration.getPairUrl('2')).toThrow(
+          'Cannot build a pair URL before the channel is created.'
+        );
+      });
+    });
+
+    describe('state machine', () => {
+      beforeEach(async () => {
+        await integration.createChannel();
+      });
+
+      it('waits for metadata once connected', () => {
+        emit('connected');
+
+        expect(integration.state).toBe(AuthorityState.WaitingForMetadata);
+        expect(onStateChange).toHaveBeenCalledWith(
+          AuthorityState.WaitingForMetadata
+        );
+      });
+
+      // The supplicant's request carries no email or device name — it is not
+      // signed in yet — so only the sender envelope is consumed.
+      it('records the supplicant device details from its request', () => {
+        emit('connected');
+
+        emit('remote:pair:supp:request', {
+          remoteMetaData: {
+            city: 'Vancouver',
+            country: 'Canada',
+            region: 'British Columbia',
+            ipAddress: '127.0.0.1',
+            ua: 'Mozilla/5.0 (Android 14; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0',
+          },
+        });
+
+        expect(integration.remoteMetadata).toEqual({
+          city: 'Vancouver',
+          country: 'Canada',
+          region: 'British Columbia',
+          ipAddress: '127.0.0.1',
+          deviceFamily: 'Firefox',
+          deviceOS: 'Android',
+          deviceName: 'Firefox',
+        });
+        expect(integration.state).toBe(AuthorityState.WaitingForAuthorizations);
+      });
+
+      it('still advances when the request carries no sender metadata', () => {
+        emit('connected');
+
+        emit('remote:pair:supp:request', {});
+
+        expect(integration.remoteMetadata).toBeNull();
+        expect(integration.state).toBe(AuthorityState.WaitingForAuthorizations);
+      });
+
+      it('supplicant first: waits for the authority, then completes', async () => {
+        emit('connected');
+        emit('remote:pair:supp:request', {});
+
+        emit('remote:pair:supp:authorize');
+        expect(integration.state).toBe(AuthorityState.WaitingForAuthority);
+
+        await integration.authorize();
+        expect(integration.state).toBe(AuthorityState.Complete);
+      });
+
+      it('authority first: waits for the supplicant, then completes', async () => {
+        emit('connected');
+        emit('remote:pair:supp:request', {});
+
+        await integration.authorize();
+        expect(integration.state).toBe(AuthorityState.WaitingForSupplicant);
+
+        emit('remote:pair:supp:authorize');
+        expect(integration.state).toBe(AuthorityState.Complete);
+      });
+
+      // The v1 heartbeat reports the same fact, so the two sources must not
+      // each fire the callback.
+      it('signals supplicant approval once', () => {
+        const onSuppAuthorized = jest.fn();
+        integration.onSuppAuthorized = onSuppAuthorized;
+        emit('connected');
+        emit('remote:pair:supp:request', {});
+
+        emit('remote:pair:supp:authorize');
+        emit('remote:pair:supp:authorize');
+
+        expect(onSuppAuthorized).toHaveBeenCalledTimes(1);
+        expect(integration.suppAuthorized).toBe(true);
+      });
+    });
+
+    describe('failures', () => {
+      beforeEach(async () => {
+        await integration.createChannel();
+        emit('connected');
+      });
+
+      it('fails with errno 1006 when the channel closes before completion', () => {
+        emit('close');
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(onError).toHaveBeenCalledWith({
+          errno: 1006,
+          message: 'Connection to remote device closed, please try again',
+        });
+      });
+
+      it('fails with the channel error detail', () => {
+        const err = new Error('socket exploded');
+
+        emit('error', err);
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(onError).toHaveBeenCalledWith(err);
+      });
+
+      it('normalizes a non-Error channel failure', () => {
+        emit('error', 'something went wrong');
+
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'something went wrong' })
+        );
+      });
+
+      // A close after the handshake is the expected teardown, not a failure.
+      it('ignores a close once the flow has completed', async () => {
+        emit('remote:pair:supp:request', {});
+        emit('remote:pair:supp:authorize');
+        await integration.authorize();
+        expect(integration.state).toBe(AuthorityState.Complete);
+
+        emit('close');
+
+        expect(integration.state).toBe(AuthorityState.Complete);
+        expect(onError).not.toHaveBeenCalled();
+      });
+
+      it('does not re-fail once already failed', () => {
+        emit('close');
+        emit('error', new Error('and again'));
+
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
   describe('destroy', () => {
-    it('cleans up timers and callbacks', () => {
+    it('cleans up timers and callbacks', async () => {
       const integration = createIntegration();
       integration.onSuppAuthorized = jest.fn();
       integration.onHeartbeatError = jest.fn();
       integration.startHeartbeat();
 
-      integration.destroy();
+      await integration.destroy();
 
       expect(integration.onSuppAuthorized).toBeNull();
       expect(integration.onHeartbeatError).toBeNull();
+    });
+
+    it('clears the pairing callbacks', async () => {
+      const integration = createIntegration();
+      integration.onStateChange = jest.fn();
+      integration.onError = jest.fn();
+
+      await integration.destroy();
+
+      expect(integration.onStateChange).toBeNull();
+      expect(integration.onError).toBeNull();
+    });
+
+    it('closes the channel and drops it', async () => {
+      const integration = createIntegration();
+      await integration.createChannel();
+
+      await integration.destroy();
+
+      expect(mockChannelClose).toHaveBeenCalled();
+      expect(integration.hasChannel()).toBe(false);
+    });
+
+    // A listener left on a closed channel would keep the integration alive and
+    // able to fire callbacks the page has already torn down.
+    it('removes every channel listener it registered', async () => {
+      const integration = createIntegration();
+      await integration.createChannel();
+
+      await integration.destroy();
+
+      expect(
+        mockRemoveEventListener.mock.calls.map(([type]: [string]) => type)
+      ).toEqual([
+        'connected',
+        'close',
+        'error',
+        'remote:pair:supp:request',
+        'remote:pair:supp:authorize',
+      ]);
+    });
+
+    // Callers tear down in effect cleanup and cannot handle a rejection.
+    it('reports a failed close rather than rejecting', async () => {
+      const integration = createIntegration();
+      await integration.createChannel();
+      mockChannelClose.mockRejectedValueOnce(new Error('close failed'));
+
+      await expect(integration.destroy()).resolves.toBeUndefined();
+      expect(integration.hasChannel()).toBe(false);
+    });
+
+    it('is safe to call when no channel was ever created', async () => {
+      await expect(createIntegration().destroy()).resolves.toBeUndefined();
+      expect(mockChannelClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-settings/src/models/integrations/pairing-authority-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-authority-integration.ts
@@ -8,6 +8,7 @@ import { IntegrationType } from './integration';
 import {
   OAuthWebIntegration,
   OAuthIntegrationOptions,
+  normalizeError,
 } from './oauth-web-integration';
 import {
   firefox,
@@ -17,8 +18,40 @@ import { RemoteMetadata } from '../../lib/types';
 import UAParser from 'ua-parser-js';
 import { toGenericOSName } from '../../lib/utilities';
 import config from '../../lib/config';
+import {
+  PairingChannelClient,
+  PairingChannelIncomingMessage,
+  toRemoteMetadata,
+} from '../../lib/channels/pairing-channel';
+import * as Sentry from '@sentry/browser';
 
 const PAIR_HEARTBEAT_INTERVAL = 1000;
+
+/**
+ * Authority state — a simple enum that React components can switch on.
+ *
+ * The `WaitingFor*` members name *who the flow is waiting on*, not who owns
+ * the state, so they read the same on both sides of the channel as
+ * `SupplicantState`.
+ */
+export enum AuthorityState {
+  /** Connecting WebSocket to channel server */
+  Connecting = 'connecting',
+  /** Sending OAuth params, waiting for authority metadata */
+  WaitingForMetadata = 'waiting_for_metadata',
+  /** Showing approval screen — waiting for both sides to approve */
+  WaitingForAuthorizations = 'waiting_for_authorizations',
+  /** Supplicant approved, waiting for authority approval */
+  WaitingForAuthority = 'waiting_for_authority',
+  /** Authority approved, waiting for supplicant user action */
+  WaitingForSupplicant = 'waiting_for_supplicant',
+  /** Sending OAuth result to relier */
+  SendingResult = 'sending_result',
+  /** Complete */
+  Complete = 'complete',
+  /** Error / failure */
+  Failed = 'failed',
+}
 
 /**
  * Authority integration for the device-pairing flow.
@@ -31,6 +64,14 @@ const PAIR_HEARTBEAT_INTERVAL = 1000;
  * Ported from: fxa-content-server/app/scripts/models/auth_brokers/pairing/authority.js
  */
 export class PairingAuthorityIntegration extends OAuthWebIntegration {
+  private static readonly TERMINAL_STATES = new Set([
+    AuthorityState.Complete,
+    AuthorityState.Failed,
+  ]);
+
+  private _channel: PairingChannelClient | null = null;
+  private _state: AuthorityState | null = null;
+
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private _remoteMetadata: RemoteMetadata | null = null;
   private _metadataPromise: Promise<RemoteMetadata> | null = null;
@@ -40,6 +81,8 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
 
   public onSuppAuthorized: (() => void) | null = null;
   public onHeartbeatError: ((err: unknown) => void) | null = null;
+  public onError: ((error: unknown) => void) | null = null;
+  public onStateChange: ((state: AuthorityState) => void) | null = null;
 
   constructor(
     data: ModelDataStore,
@@ -49,6 +92,154 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
   ) {
     super(data, storageData, opts, IntegrationType.PairingAuthority);
   }
+
+  /**
+   * Signals that the integration supports pairing. Which in this case will always be true.
+   */
+  isPairing(): boolean {
+    return true;
+  }
+
+  get state(): AuthorityState | null {
+    return this._state;
+  }
+
+  hasChannel() {
+    return this._channel !== null;
+  }
+
+  /**
+   * The URL encoded into the QR code. The supplicant reads the channel
+   * credentials out of the fragment, which is never sent to the server.
+   */
+  getPairUrl(v: '1' | '2') {
+    if (!this._channel?.channelId || !this._channel?.channelKey) {
+      throw new Error('Cannot build a pair URL before the channel is created.');
+    }
+    return (
+      `${window.location.origin}/pair` +
+      `#channel_id=${this._channel.channelId}` +
+      `&channel_key=${this._channel.channelKey}` +
+      `&v=${v}`
+    );
+  }
+
+  async createChannel(): Promise<void> {
+    if (this._channel) {
+      console.warn('Pairing channel already exists!')
+      return;
+    }
+
+    const channel = new PairingChannelClient();
+    this._channel = channel;
+
+    channel.addEventListener('connected', this.handleConnected);
+    channel.addEventListener('close', this.handleClose);
+    channel.addEventListener('error', this.handleChannelError);
+    channel.addEventListener(
+      'remote:pair:supp:request',
+      this.handleSuppRequest
+    );
+    channel.addEventListener(
+      'remote:pair:supp:authorize',
+      this.handleSuppAuthorize
+    );
+
+    try {
+      await channel.create(config.pairing.serverBaseUri);
+    } catch (err) {
+      // Reset _channel so a subsequent createChannel() call can retry.
+      this._channel = null;
+      this.fail(err);
+      throw err;
+    }
+  }
+
+  /**
+   * A close is only unexpected before the handshake finishes. `fail()` already
+   * ignores calls made from a terminal state, so completion needs no separate
+   * guard here.
+   */
+  private handleClose = () => {
+    this.fail({
+      errno: 1006,
+      message: 'Connection to remote device closed, please try again',
+    });
+  };
+
+  private handleChannelError = (event: Event) => {
+    this.fail((event as CustomEvent).detail);
+  };
+
+  private setState(state: AuthorityState): void {
+    this._state = state;
+    this.onStateChange?.(state);
+  }
+
+  private fail(err: unknown): void {
+    if (
+      this._state &&
+      PairingAuthorityIntegration.TERMINAL_STATES.has(this._state)
+    ) {
+      return;
+    }
+    this.setState(AuthorityState.Failed);
+    this.onError?.(normalizeError(err));
+  }
+
+  private handleConnected = () => {
+    this.setState(AuthorityState.WaitingForMetadata);
+  };
+
+  /**
+   * Authority: the supplicant scanned the QR, joined the channel and sent its
+   * OAuth request. This is the mirror of `handleAuthMetadata`, but the payloads
+   * are *not* symmetric, so the auth-side logic does not carry over wholesale:
+   *
+   *  - The message is `pair:supp:request`, not `pair:supp:metadata`. The
+   *    supplicant only ever sends `pair:supp:request` (OAuth params) and
+   *    `pair:supp:authorize`; there is no supplicant metadata message.
+   *  - `deviceName` and `email` are authority-owned — the supplicant is not
+   *    signed in yet, so its request carries neither. Reading them here would
+   *    always blank out the account details, so they are left alone.
+   *  - `remoteMetaData` *is* present either way: PairingChannelClient derives it
+   *    from the channel server's `sender` envelope, not from the payload. That
+   *    is what the authority shows so the user can confirm which device is
+   *    asking, and the only field of the message we consume.
+   */
+  private handleSuppRequest = (event: Event) => {
+    const data = (event as CustomEvent).detail as PairingChannelIncomingMessage;
+    if (data?.remoteMetaData) {
+      this._remoteMetadata = toRemoteMetadata(data.remoteMetaData);
+    }
+    this.setState(AuthorityState.WaitingForAuthorizations);
+  };
+
+  /**
+   * Authority: the supplicant user tapped Connect.
+   *
+   * `pair:supp:authorize` is sent with an empty payload (see
+   * `supplicantApprove`, and Backbone's supplicant-state-machine.js, which
+   * sends it with no data at all), so unlike `pair:auth:authorize` there is
+   * nothing in `event.detail` to validate — the message arriving *is* the
+   * signal. The channel is PSK-encrypted and PairingChannelClient has already
+   * rejected anything without a well-formed envelope and sender, so the detail
+   * is deliberately not read here.
+   */
+  private handleSuppAuthorize = () => {
+    if (!this._suppAuthorized) {
+      this._suppAuthorized = true;
+      this.onSuppAuthorized?.();
+    }
+
+    if (this._state === AuthorityState.WaitingForAuthorizations) {
+      // Supplicant approved first — the authority user has yet to act.
+      this.setState(AuthorityState.WaitingForAuthority);
+    } else if (this._state === AuthorityState.WaitingForSupplicant) {
+      // Authority already approved. Handshake complete.
+      this.setState(AuthorityState.Complete);
+    }
+  };
 
   /**
    * Validate that the client_id is in the pairing allowlist.
@@ -210,6 +401,12 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
   async authorize(): Promise<void> {
     this._authAuthorized = true;
     await firefox.pairAuthorize(this.channelId);
+
+    if (this._state === AuthorityState.WaitingForAuthorizations) {
+      this.setState(AuthorityState.WaitingForSupplicant);
+    } else if (this._state === AuthorityState.WaitingForAuthority) {
+      this.setState(AuthorityState.Complete);
+    }
   }
 
   /** Authority user declined the pairing request. */
@@ -225,9 +422,34 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
   }
 
   /** Clean up timers on unmount. */
-  destroy(): void {
+  async destroy() {
     this.stopHeartbeat();
     this.onSuppAuthorized = null;
     this.onHeartbeatError = null;
+
+    this.onStateChange = null;
+    this.onError = null;
+
+    if (this._channel) {
+      this._channel.removeEventListener('connected', this.handleConnected);
+      this._channel.removeEventListener('close', this.handleClose);
+      this._channel.removeEventListener('error', this.handleChannelError);
+      this._channel.removeEventListener(
+        'remote:pair:supp:request',
+        this.handleSuppRequest
+      );
+      this._channel.removeEventListener(
+        'remote:pair:supp:authorize',
+        this.handleSuppAuthorize
+      );
+
+      try {
+        await this._channel.close();
+      } catch (err) {
+        Sentry.captureException(err)
+      } finally {
+        this._channel = null;
+      }
+    }
   }
 }

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
@@ -15,7 +15,10 @@ const mockSend = jest.fn().mockResolvedValue(undefined);
 const mockClose = jest.fn().mockResolvedValue(undefined);
 const listeners: Record<string, Function[]> = {};
 
+// Only the client is stubbed; `toRemoteMetadata` is a pure helper the
+// integration relies on for the device details it shows the user.
 jest.mock('../../lib/channels/pairing-channel', () => ({
+  ...jest.requireActual('../../lib/channels/pairing-channel'),
   PairingChannelClient: jest.fn().mockImplementation(() => ({
     open: mockOpen,
     send: mockSend,
@@ -334,6 +337,12 @@ describe('PairingSupplicantIntegration', () => {
       await integration.openChannel('wss://ch.example.com', 'c', 'k');
       expect(integration.state).toBe(SupplicantState.Failed);
       expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  describe('isPairing', () => {
+    it('returns true', () => {
+      expect(createIntegration().isPairing()).toBe(true);
     });
   });
 

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
@@ -11,11 +11,10 @@ import {
 import {
   PairingChannelClient,
   PairingChannelIncomingMessage,
+  toRemoteMetadata,
 } from '../../lib/channels/pairing-channel';
 import { firefox } from '../../lib/channels/firefox';
 import { RemoteMetadata } from '../../lib/types';
-import UAParser from 'ua-parser-js';
-import { toGenericOSName } from '../../lib/utilities';
 import config from '../../lib/config';
 
 /** Redirect URI used by OAuth WebChannel reliers (matches Backbone Constants.OAUTH_WEBCHANNEL_REDIRECT) */
@@ -108,6 +107,13 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   }
 
   /**
+   * Signals that the integration supports pairing. Which in this case will always be true.
+   */
+  isPairing(): boolean {
+    return true;
+  }
+
+  /**
    * Validate that the client_id is in the pairing allowlist.
    * Matches Backbone supplicant.js behavior which throws INVALID_PAIRING_CLIENT.
    * Called by the integration factory after construction.
@@ -196,6 +202,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     channelKey: string
   ): Promise<void> {
     if (this._channel) {
+      console.warn('Pairing channel already open!');
       return; // already open
     }
 
@@ -270,19 +277,10 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     this._email = data.email || '';
 
     if (data.remoteMetaData) {
-      const parser = new UAParser(data.remoteMetaData.ua || '');
-      const browser = parser.getBrowser();
-      const os = parser.getOS();
-
-      this._remoteMetadata = {
-        city: data.remoteMetaData.city,
-        country: data.remoteMetaData.country,
-        region: data.remoteMetaData.region,
-        ipAddress: data.remoteMetaData.ipAddress || '',
-        deviceFamily: browser.name || 'Unknown',
-        deviceOS: toGenericOSName(os.name || ''),
-        deviceName: data.deviceName || browser.name || 'Unknown',
-      };
+      this._remoteMetadata = toRemoteMetadata(
+        data.remoteMetaData,
+        data.deviceName
+      );
     }
 
     this.setState(SupplicantState.WaitingForAuthorizations);

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
@@ -12,6 +12,7 @@ import {
   MOCK_BASIC_PROPS,
   MOCK_DEFAULTS,
   MOCK_DEVICE_BASIC_PROPS,
+  mockFxAStatus,
 } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 
@@ -39,6 +40,7 @@ export const CanSignInNoSuccessMessage = () => (
       isSignUp={false}
       isSignedIn={false}
       canSignIn
+      fxaStatus={mockFxAStatus()}
     />
   </AppLayout>
 );
@@ -57,6 +59,7 @@ export const WithSignupSuccessMessage = () => (
       isSignedIn={false}
       canSignIn
       {...MOCK_DEFAULTS}
+      fxaStatus={mockFxAStatus()}
     />
   </AppLayout>
 );
@@ -70,6 +73,7 @@ export const WithSignInSuccessMessage = () => (
       isSignedIn={false}
       canSignIn
       {...MOCK_DEFAULTS}
+      fxaStatus={mockFxAStatus()}
     />
   </AppLayout>
 );

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
@@ -14,12 +14,13 @@ import {
   MOCK_DEVICE_BASIC_PROPS,
   MOCK_DEFAULTS,
   MOCK_PAIRING_ELIGIBLE_ROUTE,
+  mockFxAStatus,
   mockPairingAppContext,
 } from './mocks';
+import { UseFxAStatusResult } from '../../lib/hooks';
 import { ENTRYPOINTS, REACT_ENTRYPOINT } from '../../constants';
 import firefox from '../../lib/channels/firefox';
 import * as ReactUtils from 'fxa-react/lib/utils';
-import { navigateWithQuery } from '../../lib/utilities';
 
 jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -33,11 +34,6 @@ jest.mock('../../lib/channels/firefox', () => ({
     fxaOAuthFlowBegin: jest.fn(),
     fxaStatus: jest.fn(),
   },
-}));
-
-jest.mock('../../lib/utilities', () => ({
-  ...jest.requireActual('../../lib/utilities'),
-  navigateWithQuery: jest.fn(),
 }));
 
 jest.mock('../../lib/glean', () => ({
@@ -90,6 +86,7 @@ describe('ConnectAnotherDevice', () => {
         isSignedIn
         canSignIn={false}
         {...MOCK_DEFAULTS}
+        fxaStatus={mockFxAStatus()}
       />
     );
     // testAllL10n(screen, bundle);
@@ -107,6 +104,7 @@ describe('ConnectAnotherDevice', () => {
         isSignedIn={false}
         canSignIn
         {...MOCK_DEFAULTS}
+        fxaStatus={mockFxAStatus()}
       />
     );
 
@@ -124,6 +122,7 @@ describe('ConnectAnotherDevice', () => {
         isSignedIn={false}
         canSignIn
         {...MOCK_DEFAULTS}
+        fxaStatus={mockFxAStatus()}
       />
     );
     // testAllL10n(screen, bundle);
@@ -141,6 +140,7 @@ describe('ConnectAnotherDevice', () => {
         device={Devices.FIREFOX_DESKTOP}
         isSignedIn={false}
         canSignIn
+        fxaStatus={mockFxAStatus()}
       />
     );
     // testAllL10n(screen, bundle);
@@ -185,15 +185,12 @@ describe('ConnectAnotherDevice', () => {
     const FXA_PAIRING_V2 = 2;
 
     const renderPairingEligible = (
-      props: {
-        pairingEnabled?: boolean;
-        pairingVersion?: number;
-      },
+      fxaStatus: Partial<UseFxAStatusResult>,
       fxaPairingVersion: number,
       route: string = MOCK_PAIRING_ELIGIBLE_ROUTE
     ) =>
       renderWithRouter(
-        <ConnectAnotherDevice {...props} />,
+        <ConnectAnotherDevice fxaStatus={mockFxAStatus(fxaStatus)} />,
         { route },
         mockPairingAppContext(fxaPairingVersion)
       );
@@ -222,11 +219,13 @@ describe('ConnectAnotherDevice', () => {
       );
 
       await waitFor(() =>
-        expect(navigateWithQuery).toHaveBeenCalledWith(
-          '/pair/authority/scan_qr'
+        expect(hardNavigate).toHaveBeenCalledWith(
+          '/pair/authority/scan_qr',
+          {},
+          true
         )
       );
-      expect(hardNavigate).not.toHaveBeenCalled();
+      expect(hardNavigate).not.toHaveBeenCalledWith('/pair');
     });
 
     it('reads the browser pairing capabilities from props instead of requesting fxaStatus', async () => {
@@ -236,8 +235,10 @@ describe('ConnectAnotherDevice', () => {
       );
 
       await waitFor(() =>
-        expect(navigateWithQuery).toHaveBeenCalledWith(
-          '/pair/authority/scan_qr'
+        expect(hardNavigate).toHaveBeenCalledWith(
+          '/pair/authority/scan_qr',
+          {},
+          true
         )
       );
       expect(firefox.fxaStatus).not.toHaveBeenCalled();
@@ -250,7 +251,11 @@ describe('ConnectAnotherDevice', () => {
       );
 
       await waitFor(() => expect(hardNavigate).toHaveBeenCalledWith('/pair'));
-      expect(navigateWithQuery).not.toHaveBeenCalled();
+      expect(hardNavigate).not.toHaveBeenCalledWith(
+        '/pair/authority/scan_qr',
+        {},
+        true
+      );
     });
 
     it('navigates to the v1 pairing flow when the browser has pairing disabled', async () => {
@@ -260,7 +265,11 @@ describe('ConnectAnotherDevice', () => {
       );
 
       await waitFor(() => expect(hardNavigate).toHaveBeenCalledWith('/pair'));
-      expect(navigateWithQuery).not.toHaveBeenCalled();
+      expect(hardNavigate).not.toHaveBeenCalledWith(
+        '/pair/authority/scan_qr',
+        {},
+        true
+      );
     });
 
     it('navigates to the v1 pairing flow when FxA pairing version is 1', async () => {
@@ -270,14 +279,22 @@ describe('ConnectAnotherDevice', () => {
       );
 
       await waitFor(() => expect(hardNavigate).toHaveBeenCalledWith('/pair'));
-      expect(navigateWithQuery).not.toHaveBeenCalled();
+      expect(hardNavigate).not.toHaveBeenCalledWith(
+        '/pair/authority/scan_qr',
+        {},
+        true
+      );
     });
 
-    it('navigates to the v1 pairing flow when no pairing props are supplied', async () => {
+    it('navigates to the v1 pairing flow when the browser reports no pairing capability', async () => {
       renderPairingEligible({}, FXA_PAIRING_V2);
 
       await waitFor(() => expect(hardNavigate).toHaveBeenCalledWith('/pair'));
-      expect(navigateWithQuery).not.toHaveBeenCalled();
+      expect(hardNavigate).not.toHaveBeenCalledWith(
+        '/pair/authority/scan_qr',
+        {},
+        true
+      );
     });
 
     it('navigates to the v2 pairing flow when the v=2 query param forces it, despite a v1 browser', async () => {
@@ -288,10 +305,22 @@ describe('ConnectAnotherDevice', () => {
       );
 
       await waitFor(() =>
-        expect(navigateWithQuery).toHaveBeenCalledWith(
-          '/pair/authority/scan_qr'
+        expect(hardNavigate).toHaveBeenCalledWith(
+          '/pair/authority/scan_qr',
+          {},
+          true
         )
       );
+      expect(hardNavigate).not.toHaveBeenCalledWith('/pair');
+    });
+
+    it('renders the loading spinner while the browser capabilities are unresolved', async () => {
+      renderPairingEligible(
+        { pairingEnabled: undefined, pairingVersion: undefined },
+        FXA_PAIRING_V2
+      );
+
+      expect(await screen.findByLabelText('Loading…')).toBeInTheDocument();
       expect(hardNavigate).not.toHaveBeenCalled();
     });
 
@@ -307,7 +336,6 @@ describe('ConnectAnotherDevice', () => {
           name: 'A computer and a mobile phone and a tablet with a pulsing heart on each',
         })
       ).toBeInTheDocument();
-      expect(navigateWithQuery).not.toHaveBeenCalled();
       expect(hardNavigate).not.toHaveBeenCalled();
     });
   });

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
@@ -16,7 +16,7 @@ import { getBasicAccountData } from '../../lib/account-storage';
 import firefox, { buildSyncOAuthSearch } from '../../lib/channels/firefox';
 import GleanMetrics from '../../lib/glean';
 import AppLayout from '../../components/AppLayout';
-import { navigateWithQuery } from '../../lib/utilities';
+import { UseFxAStatusResult } from '../../lib/hooks';
 
 export type ConnectAnotherDeviceProps = {
   email?: string;
@@ -27,8 +27,7 @@ export type ConnectAnotherDeviceProps = {
   isSignIn?: boolean;
   canSignIn?: boolean;
   device?: Devices;
-  pairingEnabled?: boolean;
-  pairingVersion?: number;
+  fxaStatus: UseFxAStatusResult;
 };
 
 export enum Devices {
@@ -106,8 +105,7 @@ const ConnectAnotherDevice = ({
   isSignIn: isSignInProp,
   canSignIn: canSignInProp,
   device: deviceProp,
-  pairingEnabled: pairingEnabledProp,
-  pairingVersion: pairingVersionProp,
+  fxaStatus
 }: ConnectAnotherDeviceProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
@@ -194,7 +192,18 @@ const ConnectAnotherDevice = ({
     );
   }, [entrypoint, searchParams]);
 
+  // The browser's pairing capabilities arrive asynchronously over the web
+  // channel, so they start out undefined.
+  const capabilitiesResolved = fxaStatus.pairingVersion !== undefined;
+
   useEffect(() => {
+    // Deciding the pairing route before the capabilities land would read an
+    // unresolved v2 browser as v1 and hard-navigate out of the v2 flow, so the
+    // whole bootstrap waits rather than just the render below.
+    if (!capabilitiesResolved) {
+      return;
+    }
+
     if (propsDriveRender) {
       GleanMetrics.cad.view();
       return;
@@ -225,19 +234,20 @@ const ConnectAnotherDevice = ({
       );
       if (browserSignedIn && isEligibleForPairing()) {
 
-        // Check that FxA has pairing version 2 supported. And that the current Firefox
-        // instance also supports version 2. If so send user into the v2 pairing flow!
-        if (config.pairing.version === 2) {
-          if (pairingEnabledProp === true && pairingVersionProp === 2) {
-            navigateWithQuery('/pair/authority/scan_qr');
-            return;
-          }
+        // Both FxA and Firefox have to signal that pairing v2 is enabled!
+        if (
+          config.pairing.version === 2 &&
+          fxaStatus.pairingEnabled === true &&
+          fxaStatus.pairingVersion === 2
+        ) {
+          hardNavigate('/pair/authority/scan_qr', {}, true);
+          return;
         }
 
         // Escape hatch. Allow the query params to force a v2 pairing flow. Useuful initially for testing, probably
         // won't stick around forever...
         if (searchParams.get('v') === '2') {
-          navigateWithQuery('/pair/authority/scan_qr');
+          hardNavigate('/pair/authority/scan_qr', {}, true);
           return;
         }
 
@@ -260,9 +270,9 @@ const ConnectAnotherDevice = ({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [capabilitiesResolved]);
 
-  if (bootstrapping) {
+  if (bootstrapping || !capabilitiesResolved) {
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
@@ -7,7 +7,29 @@ import { ENTRYPOINTS } from '../../constants';
 import { getDefault } from '../../lib/config';
 import { SignedInUser } from '../../lib/channels/firefox';
 import { AppContextValue } from '../../models';
+import { UseFxAStatusResult } from '../../lib/hooks';
 import { MOCK_ACCOUNT, mockAppContext } from '../../models/mocks';
+
+/**
+ * The browser capabilities `useFxAStatus` resolves to, as the page receives
+ * them. Defaults to a v1-pairing browser; pass overrides for the v2 cases.
+ */
+export function mockFxAStatus(
+  overrides: Partial<UseFxAStatusResult> = {}
+): UseFxAStatusResult {
+  return {
+    pairingEnabled: false,
+    pairingVersion: 1,
+    hasSyncKeys: undefined,
+    offeredSyncEngines: [],
+    offeredSyncEngineConfigs: undefined,
+    declinedSyncEngines: [],
+    selectedEnginesForGlean: {},
+    supportsKeysOptionalLogin: false,
+    supportsCanLinkAccountUid: undefined,
+    ...overrides,
+  };
+}
 
 export const MOCK_DEFAULTS = {
   email: MOCK_ACCOUNT.primaryEmail.email,
@@ -20,6 +42,7 @@ export const MOCK_BASIC_PROPS = {
   showSuccessMessage: true,
   isSignedIn: true,
   canSignIn: false,
+  fxaStatus: mockFxAStatus(),
 };
 
 export const MOCK_DEVICE_BASIC_PROPS = {
@@ -30,6 +53,7 @@ export const MOCK_DEVICE_BASIC_PROPS = {
   isSignUp: true,
   isSignedIn: true,
   canSignIn: false,
+  fxaStatus: mockFxAStatus(),
 };
 
 /**

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.test.tsx
@@ -25,7 +25,7 @@ jest.mock('../../../models/integrations/pairing-authority-integration', () => ({
     channelId = 'test-channel-id';
     getSupplicantMetadata = jest.fn().mockResolvedValue(null);
     complete = jest.fn();
-    destroy = jest.fn();
+    destroy = jest.fn().mockResolvedValue(undefined);
   },
 }));
 
@@ -180,7 +180,7 @@ describe('AuthComplete page', () => {
       const mockIntegration = {
         getSupplicantMetadata: jest.fn().mockResolvedValue(null),
         complete: jest.fn(),
-        destroy: jest.fn(),
+        destroy: jest.fn().mockResolvedValue(undefined),
         data: { entrypoint: 'send-tab-toolbar-icon' },
       };
       renderWithLocalizationProvider(
@@ -215,7 +215,7 @@ describe('AuthComplete page', () => {
       const mockIntegration = {
         getSupplicantMetadata: jest.fn().mockResolvedValue(null),
         complete: jest.fn(),
-        destroy: jest.fn(),
+        destroy: jest.fn().mockResolvedValue(undefined),
         data: { entrypoint: 'preferences' },
       };
       renderWithLocalizationProvider(

--- a/packages/fxa-settings/src/pages/Pair/AuthComplete/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/AuthComplete/index.tsx
@@ -90,7 +90,9 @@ const AuthComplete = ({
   useEffect(() => {
     authorityIntegration?.complete();
     return () => {
-      authorityIntegration?.destroy();
+      // `destroy` is async and effect cleanup cannot await it; catch so a
+      // failed socket close does not surface as an unhandled rejection.
+      authorityIntegration?.destroy().catch(() => {});
       try {
         if (deviceInfoKey) {
           sessionStorage.removeItem(deviceInfoKey);

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.test.tsx
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { MemoryRouter } from 'react-router';
+import * as Sentry from '@sentry/react';
+import ScanQRContainer from './container';
+import {
+  MOCK_NON_PAIRING_INTEGRATION,
+  MOCK_PAIR_URL,
+  MockAuthorityIntegration,
+  emitState,
+  mockAuthorityIntegration,
+} from './mocks';
+import { AuthorityState, Integration } from '../../../../models';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockNavigate,
+}));
+
+// Stub QRCode so the test can read the encoded value without decoding an SVG.
+// The container's contract is the value it hands down; how that value is drawn
+// is the page's concern, covered in index.test.tsx.
+jest.mock('../../../../components/QRCode', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    localizedLabel,
+    loading,
+  }: {
+    value: string;
+    localizedLabel: string;
+    loading?: boolean;
+  }) => (
+    <img
+      alt={localizedLabel}
+      data-testid="scan-qr-code"
+      data-value={value}
+      data-loading={String(!!loading)}
+    />
+  ),
+}));
+
+// The container owns the pairing channel: it mints one on mount so the QR
+// always scans to a channel that exists on the channel server, routes the
+// integration's state changes, and closes the channel on the way out.
+describe('Pair2/Authority/ScanQR container', () => {
+  let integration: MockAuthorityIntegration;
+  let captureException: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    integration = mockAuthorityIntegration();
+    captureException = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(() => '');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderContainer = (i: Integration = integration) =>
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <ScanQRContainer integration={i} />
+      </MemoryRouter>
+    );
+
+  it('renders the ScanQR page', () => {
+    renderContainer();
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Scan to connect your mobile device'
+    );
+  });
+
+  it('creates a channel and encodes its pair URL in the QR', async () => {
+    renderContainer();
+
+    await waitFor(() => expect(integration.createChannel).toHaveBeenCalled());
+    expect(integration.getPairUrl).toHaveBeenCalledWith('2');
+    expect(await screen.findByTestId('scan-qr-code')).toHaveAttribute(
+      'data-value',
+      MOCK_PAIR_URL
+    );
+  });
+
+  it('shows the QR as loading until the channel is created', () => {
+    renderContainer();
+
+    expect(screen.getByTestId('scan-qr-code')).toHaveAttribute(
+      'data-loading',
+      'true'
+    );
+  });
+
+  // Storing the pair URL re-renders the container. If the effect were keyed on
+  // anything that changes per render, that re-render would tear the channel
+  // down and mint a second one the supplicant's QR no longer points at.
+  it('creates the channel once, not again on the re-render its own state causes', async () => {
+    renderContainer();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('scan-qr-code')).toHaveAttribute(
+        'data-value',
+        MOCK_PAIR_URL
+      )
+    );
+    expect(integration.createChannel).toHaveBeenCalledTimes(1);
+    expect(integration.destroy).not.toHaveBeenCalled();
+  });
+
+  // A failed create must not leave a QR encoding a channel the supplicant
+  // cannot join.
+  it('leaves the QR unset and reports to Sentry when the channel cannot be created', async () => {
+    const err = new Error('channel server unreachable');
+    integration.createChannel.mockRejectedValue(err);
+
+    renderContainer();
+
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+    expect(screen.getByTestId('scan-qr-code')).toHaveAttribute(
+      'data-value',
+      ''
+    );
+    expect(integration.getPairUrl).not.toHaveBeenCalled();
+  });
+
+  // The channel exists but its URL cannot be built — same user-visible outcome
+  // as a failed create, and it must not escape as an unhandled rejection.
+  it('leaves the QR unset and reports to Sentry when the pair URL cannot be built', async () => {
+    const err = new Error('missing channel key');
+    integration.getPairUrl.mockImplementation(() => {
+      throw err;
+    });
+
+    renderContainer();
+
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+    expect(screen.getByTestId('scan-qr-code')).toHaveAttribute(
+      'data-value',
+      ''
+    );
+  });
+
+  // The handler is assigned before the channel is awaited, so a state change
+  // arriving mid-creation still routes.
+  it('routes a state change that arrives before the channel is created', () => {
+    integration.createChannel.mockReturnValue(new Promise(() => {}));
+    renderContainer();
+
+    emitState(integration, AuthorityState.WaitingForAuthorizations);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/pair/authority/approve_signin');
+  });
+
+  it('navigates to the approval screen once the supplicant joins', async () => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, AuthorityState.WaitingForAuthorizations);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/pair/authority/approve_signin');
+  });
+
+  it('navigates to the cancel screen when pairing fails', async () => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, AuthorityState.Failed);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/pair/authority/timeout_and_cancel'
+    );
+  });
+
+  it.each([AuthorityState.Connecting, AuthorityState.WaitingForMetadata])(
+    'stays on the page in the %s state, which resolves here',
+    async (state) => {
+      renderContainer();
+      await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+      emitState(integration, state);
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    }
+  );
+
+  it('destroys the integration on unmount so leaving cannot leak a socket', async () => {
+    const { unmount } = renderContainer();
+    await waitFor(() => expect(integration.createChannel).toHaveBeenCalled());
+
+    unmount();
+
+    expect(integration.destroy).toHaveBeenCalled();
+  });
+
+  // Effect cleanup cannot await, so a rejected close has to be caught rather
+  // than escaping as an unhandled rejection.
+  it('reports a failed teardown to Sentry', async () => {
+    const err = new Error('close failed');
+    integration.destroy.mockRejectedValue(err);
+    const { unmount } = renderContainer();
+    await waitFor(() => expect(integration.createChannel).toHaveBeenCalled());
+
+    unmount();
+
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+  });
+
+  it('throws when handed an integration that is not the pairing authority', () => {
+    expect(() => renderContainer(MOCK_NON_PAIRING_INTEGRATION)).toThrow(
+      'Invalid integration type. Expected PairingAuthorityIntegration.'
+    );
+  });
+
+  // The authority is the already-signed-in desktop browser; a phone cannot
+  // display a QR for another phone to scan.
+  it('throws when the authority is a Firefox mobile client', () => {
+    integration.isFirefoxMobileClient.mockReturnValue(true);
+
+    expect(() => renderContainer()).toThrow('Mobile to desktop not supported!');
+  });
+
+  it('never opens a channel for a rejected integration', () => {
+    integration.isFirefoxMobileClient.mockReturnValue(true);
+
+    expect(() => renderContainer()).toThrow();
+    expect(integration.createChannel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.tsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect, useState } from 'react';
+import * as Sentry from '@sentry/react';
+import { useNavigate } from 'react-router';
+import ScanQR from '.';
+import {
+  AuthorityState,
+  Integration,
+  PairingAuthorityIntegration,
+} from '../../../../models';
+
+/**
+ * Owns the pairing channel for the authority. Mints a channel on mount so the
+ * QR always scans to one that exists on the channel server, and closes it on
+ * unmount so leaving the page cannot leak a socket.
+ */
+const ScanQRContainer = ({ integration }: { integration: Integration }) => {
+  const navigate = useNavigate();
+  const [qrCodeValue, setQrCodeValue] = useState('');
+
+  if (!(integration instanceof PairingAuthorityIntegration)) {
+    throw new Error(
+      'Invalid integration type. Expected PairingAuthorityIntegration.'
+    );
+  }
+  if (integration.isFirefoxMobileClient()) {
+    throw new Error('Mobile to desktop not supported!');
+  }
+
+  useEffect(() => {
+    integration.onStateChange = (state: AuthorityState) => {
+      switch (state) {
+        case AuthorityState.WaitingForAuthorizations:
+          navigate('/pair/authority/approve_signin');
+          break;
+        case AuthorityState.Failed:
+          navigate('/pair/authority/timeout_and_cancel');
+          break;
+        default:
+          // Connecting and WaitingForMetadata both resolve on this page.
+          break;
+      }
+    };
+
+    (async () => {
+      try {
+        await integration.createChannel();
+        setQrCodeValue(integration.getPairUrl('2'));
+      } catch (err) {
+        setQrCodeValue('');
+        Sentry.captureException(err);
+      }
+    })();
+
+    return () => {
+      // `destroy` is async and effect cleanup cannot await it; catch so a
+      // failed socket close does not surface as an unhandled rejection.
+      integration.destroy().catch((err) => Sentry.captureException(err));
+    };
+  }, [integration, navigate]);
+
+  return <ScanQR {...{ qrCodeValue }} />;
+};
+
+export default ScanQRContainer;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.test.tsx
@@ -7,7 +7,7 @@ import { FluentBundle } from '@fluent/bundle';
 import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { MOCK_QR_CODE_VALUE, Subject } from './mocks';
-import { Constants } from '../../../../lib/constants'
+import { Constants } from '../../../../lib/constants';
 
 // Stub QRCode so the test can read the encoded value without decoding an SVG;
 // the real rendering is covered in its own test. The stub keeps the accessible
@@ -17,11 +17,18 @@ jest.mock('../../../../components/QRCode', () => ({
   default: ({
     value,
     localizedLabel,
+    loading,
   }: {
     value: string;
     localizedLabel: string;
+    loading?: boolean;
   }) => (
-    <img alt={localizedLabel} data-testid="scan-qr-code" data-value={value} />
+    <img
+      alt={localizedLabel}
+      data-testid="scan-qr-code"
+      data-value={value}
+      data-loading={String(!!loading)}
+    />
   ),
 }));
 
@@ -91,6 +98,21 @@ describe('Pair2/Authority/ScanQR page', () => {
     expect(screen.getByTestId('scan-qr-code')).toHaveAttribute(
       'data-value',
       MOCK_QR_CODE_VALUE
+    );
+    expect(screen.getByTestId('scan-qr-code')).toHaveAttribute(
+      'data-loading',
+      'false'
+    );
+  });
+
+  // Until the channel exists there is nothing to encode, and a QR built from an
+  // empty string would scan to the bare origin.
+  it('marks the QR as loading while there is no value to encode', () => {
+    renderWithLocalizationProvider(<Subject qrCodeValue="" />);
+
+    expect(screen.getByTestId('scan-qr-code')).toHaveAttribute(
+      'data-loading',
+      'true'
     );
   });
 

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.tsx
@@ -8,9 +8,8 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import AppLayout from '../../../../components/AppLayout';
 import QRCode from '../../../../components/QRCode';
 import { QrPhoneFrameImage } from '../../../../components/images';
-import { Integration, useFtlMsgResolver } from '../../../../models';
+import { useFtlMsgResolver } from '../../../../models';
 import { Constants } from '../../../../lib/constants';
-
 
 export type ScanQRProps = {
   /**
@@ -19,9 +18,6 @@ export type ScanQRProps = {
    * pairing value lands with the flow wiring, and this card only renders it.
    */
   qrCodeValue?: string;
-
-  /** The active integraiton state. */
-  integration?: Integration;
 };
 
 /**
@@ -29,7 +25,7 @@ export type ScanQRProps = {
  * their phone or tablet to start syncing; there is no button to press, so the
  * only action is the link out to scanning help.
  */
-const ScanQR = ({ qrCodeValue, integration }: ScanQRProps) => {
+const ScanQR = ({ qrCodeValue }: ScanQRProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   // `QRCode` takes a plain string, so this is the one label on the card that
   // cannot be resolved with `FtlMsg`.
@@ -37,17 +33,6 @@ const ScanQR = ({ qrCodeValue, integration }: ScanQRProps) => {
     'pair2-authority-scan-qr-code-aria-label',
     'QR code to connect your mobile device'
   );
-
-  if (integration && integration.isFirefoxMobileClient()) {
-    throw new Error('Mobile to desktop not supported!')
-  }
-
-  function createQrCodeUrl() {
-    // TODO: Create new pairing channel and create URL
-    const key = `000000000`;
-    const id = `111111111`;
-    return qrCodeValue || `${window.location.origin}/pair#channel_id=${id}&channel_key=${key}&v=2`;
-  }
 
   return (
     <AppLayout>
@@ -83,7 +68,8 @@ const ScanQR = ({ qrCodeValue, integration }: ScanQRProps) => {
                 proportion as the card narrows. */}
             <div className="w-[41%]">
               <QRCode
-                value={createQrCodeUrl()}
+                value={qrCodeValue ?? ''}
+                loading={!qrCodeValue}
                 localizedLabel={localizedQrCodeLabel}
                 className="w-full border-none [&_svg]:h-auto [&_svg]:w-full"
               />

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/mocks.tsx
@@ -3,6 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import ScanQR, { ScanQRProps } from '.';
+import {
+  AuthorityState,
+  Integration,
+  PairingAuthorityIntegration,
+} from '../../../../models';
 
 // Deliberately not a pairing URL — building the real value lands with the flow
 // wiring, and a lookalike here would invite someone to trust it.
@@ -15,3 +20,46 @@ export const MOCK_LONG_QR_CODE_VALUE = MOCK_QR_CODE_VALUE.repeat(12);
 export const Subject = ({
   qrCodeValue = MOCK_QR_CODE_VALUE,
 }: Partial<ScanQRProps> = {}) => <ScanQR {...{ qrCodeValue }} />;
+
+/** The channel URL a successfully created channel resolves to. */
+export const MOCK_PAIR_URL = `${window.location.origin}/pair#channel_id=chan-1&channel_key=key-1&v=2`;
+
+export type MockAuthorityIntegration = PairingAuthorityIntegration & {
+  createChannel: jest.Mock;
+  getPairUrl: jest.Mock;
+  destroy: jest.Mock;
+  isFirefoxMobileClient: jest.Mock;
+};
+
+/**
+ * A `PairingAuthorityIntegration` with the channel surface stubbed. Built from
+ * the real prototype rather than a plain object because the container narrows
+ * on `instanceof` before it touches any of these.
+ */
+export function mockAuthorityIntegration(
+  overrides: Partial<Record<keyof MockAuthorityIntegration, unknown>> = {}
+): MockAuthorityIntegration {
+  const integration = Object.create(
+    PairingAuthorityIntegration.prototype
+  ) as MockAuthorityIntegration;
+
+  return Object.assign(integration, {
+    createChannel: jest.fn().mockResolvedValue(undefined),
+    getPairUrl: jest.fn().mockReturnValue(MOCK_PAIR_URL),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    isFirefoxMobileClient: jest.fn().mockReturnValue(false),
+    onStateChange: null,
+    ...overrides,
+  });
+}
+
+/** Drives the integration's state machine the way the channel would. */
+export function emitState(
+  integration: MockAuthorityIntegration,
+  state: AuthorityState
+) {
+  (integration as PairingAuthorityIntegration).onStateChange?.(state);
+}
+
+/** A non-pairing integration, for the container's narrowing guard. */
+export const MOCK_NON_PAIRING_INTEGRATION = {} as Integration;

--- a/packages/fxa-settings/src/react-app-env.d.ts
+++ b/packages/fxa-settings/src/react-app-env.d.ts
@@ -86,6 +86,8 @@ declare module 'fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js' 
     close(): Promise<void>;
     addEventListener(type: string, listener: EventListener): void;
     removeEventListener(type: string, listener: EventListener): void;
+    _channelId:string|undefined;
+    _channelKey:Uint8Array|undefined;
   }
 
   export const PairingChannel: {
@@ -94,5 +96,7 @@ declare module 'fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js' 
       channelId: string,
       psk: Uint8Array
     ): Promise<FxaPairingChannelSocket>;
+
+    create(channelServerUri: string): Promise<FxaPairingChannelSocket>;
   };
 }


### PR DESCRIPTION
## Because
- When v2 pairing is enabled we want to take the user directly to the scan_qr page
- We want the authority to render QR code and open the web-channel.

## This pull request

- Exposes pairingVersion and pairingEnabled from the useFxaStatus hook.
- Adds a new isPairing flag to our integrations, which is then relied on in the useFxaStatus hook.
- Adds ability to pairing-channel.ts to create a new pairing channel.
- Updates the pairing-authority-integration providing the ability to create a new pairing channel.
- Updates the integration factory to return the correct pairing integration type given the new pairing path names.
- Updates the ConnectAnotherDevice page to route the user to the ScanQR page when pairing version 2 is flipped on.
- Hoists toRemoteMetaData to the parent class
- ScanQR now creates and renders a v2 pairing QR code!

## Issue that this pull request solves

Closes: FXA-13868

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Use pairing.version 2 enabled build of firefox
- Add `"pairing": { "version": 2 }` to local.json in content-server config overrides.
- Signin to sync from browser
- Go to sync menu and select 'add device'
- Observe the QR code. Scan or decode the QR code to validate it has pairing channel id/key encoded in it.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
