### PR TITLE
chore(blender): disable investigations to stop re-investigation loop

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -5,7 +5,7 @@ node_version: "24.15.0"
 install_command: "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable --inline-builds"
 
 investigate:
-  enabled: true
+  enabled: false
   dismiss_unaffected: true
   max_claude_turns: 100
   max_budget_usd: 6.00


### PR DESCRIPTION
Turns off BLEnder investigations on fxa to stop a loop that keeps re-running the same alerts every sweep (and re-billing Claude each time, with nothing to show for it).

Auto-merge is unaffected and stays on. We'll re-enable once the upstream fix lands.