### PR TITLE
feat(pairing): handle v2 pairing timeouts and cancellations

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -195,7 +195,6 @@ const PairAuthorityTimeoutAndCancel = lazy(
   () => import('../../pages/Pair2/Authority/TimeoutAndCancel/container')
 );
 
-
 const PairSupplicantApproveSignIn = lazy(
   () => import('../../pages/Pair2/Supplicant/ApproveSignIn/container')
 );
@@ -212,10 +211,8 @@ const PairSupplicantSyncSuccess = lazy(
   () => import('../../pages/Pair2/Supplicant/SyncSuccess')
 );
 const PairSupplicantTimeoutAndCancel = lazy(
-  () => import('../../pages/Pair2/Supplicant/TimeoutAndCancel')
+  () => import('../../pages/Pair2/Supplicant/TimeoutAndCancel/container')
 );
-
-
 
 const AuthorizationContainer = lazy(
   () => import('../../pages/Authorization/container')
@@ -652,7 +649,10 @@ const AuthAndAccountSetupRoutes = ({
         <Route path="/web_channel_example/*" element={<WebChannelExample />} />
         <Route path="/poc_deep_link/*" element={<PocDeepLink />} />
         <Route path="/poc_pair_init/*" element={<PocPairInit />} />
-        <Route path="/poc_pair_start/*" element={<PocPairStart {...{integration}} />} />
+        <Route
+          path="/poc_pair_start/*"
+          element={<PocPairStart {...{ integration }} />}
+        />
         <Route path="/cookies_disabled" element={<CookiesDisabled />} />
 
         {/* Post verify */}
@@ -1074,15 +1074,19 @@ const AuthAndAccountSetupRoutes = ({
         <Route path="/pair/unsupported/*" element={<PairUnsupported />} />
         <Route
           path="/pair/*"
-          element={<PairIndex {...{integration, fxaStatusResult: useFxAStatusResult}} />}
+          element={
+            <PairIndex
+              {...{ integration, fxaStatusResult: useFxAStatusResult }}
+            />
+          }
         />
         <Route
           path="/pair/authority/approve_signin/*"
-          element={<PairAuthorityApproveSignIn {...{integration}} />}
+          element={<PairAuthorityApproveSignIn {...{ integration }} />}
         />
         <Route
           path="/pair/authority/continue_on_mobile/*"
-          element={<PairAuthorityContinueOnMobile {...{integration}} />}
+          element={<PairAuthorityContinueOnMobile {...{ integration }} />}
         />
         <Route
           path="/pair/authority/download_firefox/*"
@@ -1098,15 +1102,15 @@ const AuthAndAccountSetupRoutes = ({
         />
         <Route
           path="/pair/authority/timeout_and_cancel/*"
-          element={<PairAuthorityTimeoutAndCancel />}
+          element={<PairAuthorityTimeoutAndCancel {...{ integration }} />}
         />
         <Route
           path="/pair/supplicant/approve_signin/*"
-          element={<PairSupplicantApproveSignIn {...{integration}} />}
+          element={<PairSupplicantApproveSignIn {...{ integration }} />}
         />
         <Route
           path="/pair/supplicant/connect_this_device/*"
-          element={<PairSupplicantConnectThisDevice {...{integration}} />}
+          element={<PairSupplicantConnectThisDevice {...{ integration }} />}
         />
         <Route
           path="/pair/supplicant/download_firefox/*"
@@ -1122,7 +1126,7 @@ const AuthAndAccountSetupRoutes = ({
         />
         <Route
           path="/pair/supplicant/timeout_and_cancel/*"
-          element={<PairSupplicantTimeoutAndCancel />}
+          element={<PairSupplicantTimeoutAndCancel {...{ integration }} />}
         />
         <Route path="/oauth/success/:clientId/*" element={<PairSuccess />} />
       </Routes>

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.test.tsx
@@ -116,7 +116,8 @@ describe('Pair2/Authority/ContinueOnMobile container', () => {
 
       await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
       expect(mockNavigate).toHaveBeenCalledWith(
-        '/pair/authority/timeout_and_cancel'
+        '/pair/authority/timeout_and_cancel',
+        { state: { reason: 'canceled' } }
       );
     });
 
@@ -131,7 +132,8 @@ describe('Pair2/Authority/ContinueOnMobile container', () => {
 
       await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
       expect(mockNavigate).toHaveBeenCalledWith(
-        '/pair/authority/timeout_and_cancel'
+        '/pair/authority/timeout_and_cancel',
+        { state: { reason: 'canceled' } }
       );
     });
   });

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.tsx
@@ -5,23 +5,31 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import * as Sentry from '@sentry/browser';
-import { AuthorityState, Integration, PairingAuthorityIntegration } from '../../../../models';
+import {
+  AuthorityState,
+  Integration,
+  PairingAuthorityIntegration,
+} from '../../../../models';
 import ContinueOnMobile from '.';
 import { navigateWithQuery } from '../../../../lib/utilities';
 
 export type ContinueOnMobileContainerProps = {
-  integration?: Integration|PairingAuthorityIntegration
+  integration?: Integration | PairingAuthorityIntegration;
 };
 
-const ContinueOnMobileContainer = ({ integration }: ContinueOnMobileContainerProps) => {
+const ContinueOnMobileContainer = ({
+  integration,
+}: ContinueOnMobileContainerProps) => {
   if (!(integration instanceof PairingAuthorityIntegration)) {
-    throw new Error('Invalid integration. Expecting instance of PairingAuthorityIntegration.');
+    throw new Error(
+      'Invalid integration. Expecting instance of PairingAuthorityIntegration.'
+    );
   }
 
   const navigate = useNavigate();
 
   useEffect(() => {
-    integration.onStateChange = (state:AuthorityState) => {
+    integration.onStateChange = (state: AuthorityState) => {
       switch (state) {
         case AuthorityState.WaitingForAuthority:
           navigateWithQuery('/pair/authority/approve_signin', {}, true);
@@ -35,7 +43,7 @@ const ContinueOnMobileContainer = ({ integration }: ContinueOnMobileContainerPro
           console.warn('Unexpected state change: ' + state);
           break;
       }
-    }
+    };
 
     return () => {
       // Unsubscribe only — the channel outlives this page for approve_signin.
@@ -43,18 +51,19 @@ const ContinueOnMobileContainer = ({ integration }: ContinueOnMobileContainerPro
     };
   }, [integration]);
 
-  const onCancel = () => {
-    integration.destroy()
-      .then(() => {
-        navigate('/pair/authority/timeout_and_cancel')
-      })
-      .catch((err) => {
-        Sentry.captureException(err);
-        navigate('/pair/authority/timeout_and_cancel');
-      });
+  // Leave even if the channel will not close; the user asked to stop.
+  const onCancel = async () => {
+    try {
+      await integration.destroy();
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+    navigate('/pair/authority/timeout_and_cancel', {
+      state: { reason: 'canceled' },
+    });
   };
 
-  return <ContinueOnMobile {...{onCancel}}/>
+  return <ContinueOnMobile {...{ onCancel }} />;
 };
 
 export default ContinueOnMobileContainer;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.test.tsx
@@ -182,8 +182,11 @@ describe('Pair2/Authority/ScanQR container', () => {
 
     emitState(integration, AuthorityState.Failed);
 
+    // The channel is closed before leaving, so the navigation trails it.
+    await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/pair/authority/timeout_and_cancel'
+      '/pair/authority/timeout_and_cancel',
+      { state: { reason: 'timeout' } }
     );
   });
 

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.tsx
@@ -32,13 +32,26 @@ const ScanQRContainer = ({ integration }: { integration: Integration }) => {
   }
 
   useEffect(() => {
+    // This exit ends the flow, so the channel goes with it. Leave either way:
+    // a channel that will not close must not strand the user here.
+    const giveUp = async () => {
+      try {
+        await integration.destroy();
+      } catch (err) {
+        Sentry.captureException(err);
+      }
+      navigateWithQuery('/pair/authority/timeout_and_cancel', {
+        state: { reason: 'timeout' },
+      });
+    };
+
     integration.onStateChange = (state: AuthorityState) => {
       switch (state) {
         case AuthorityState.WaitingForAuthorizations:
           navigateWithQuery('/pair/authority/continue_on_mobile');
           break;
         case AuthorityState.Failed:
-          navigateWithQuery('/pair/authority/timeout_and_cancel');
+          giveUp();
           break;
         default:
           // Connecting and WaitingForMetadata both resolve on this page.

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/container.test.tsx
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import Container from './container';
+import firefox from '../../../../lib/channels/firefox';
+import {
+  Integration,
+  PairingAuthorityIntegration,
+} from '../../../../models';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockNavigate,
+}));
+
+const TIMEOUT_HEADING = 'Still want to connect a device?';
+const CANCELED_HEADING = 'Canceled';
+
+/** The reason travels in router state, set by whatever ended the flow. */
+type MockAuthorityIntegration = PairingAuthorityIntegration & {
+  destroy: jest.Mock;
+};
+
+function mockAuthorityIntegration(): MockAuthorityIntegration {
+  const integration = Object.create(
+    PairingAuthorityIntegration.prototype
+  ) as MockAuthorityIntegration;
+  return Object.assign(integration, {
+    destroy: jest.fn().mockResolvedValue(undefined),
+  });
+}
+
+const renderWithReason = (reason?: string, integration?: Integration) =>
+  renderWithLocalizationProvider(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/pair/authority/timeout_and_cancel',
+          state: reason ? { reason } : undefined,
+        },
+      ]}
+    >
+      <Container {...{ integration }} />
+    </MemoryRouter>
+  );
+
+describe('Pair2/Authority/TimeoutAndCancel container', () => {
+  let integration: MockAuthorityIntegration;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    integration = mockAuthorityIntegration();
+  });
+
+  it('renders the canceled variant when the flow was canceled', () => {
+    renderWithReason('canceled', integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      CANCELED_HEADING
+    );
+  });
+
+  it('renders the timeout variant when the flow timed out', () => {
+    renderWithReason('timeout', integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      TIMEOUT_HEADING
+    );
+  });
+
+  // Timeout is the safe default: it is the variant offering a way back.
+  it('falls back to the timeout variant when no reason was given', () => {
+    renderWithReason(undefined, integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      TIMEOUT_HEADING
+    );
+  });
+
+  it('sends the user back to the QR to try again', async () => {
+    renderWithReason('timeout', integration);
+
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/pair/authority/scan_qr');
+  });
+
+  // Not every route here closes the channel first; this page always does.
+  it('closes the pairing channel', async () => {
+    renderWithReason('timeout', integration);
+
+    await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
+  });
+
+  // The user is at a dead end already; a failed close must not break the page.
+  it('still renders when the channel cannot be closed', async () => {
+    integration.destroy.mockRejectedValue(new Error('channel already gone'));
+
+    renderWithReason('canceled', integration);
+
+    await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      CANCELED_HEADING
+    );
+  });
+
+  // The route passes whatever the app built, which is not always a pairing one.
+  it('renders without a pairing integration', () => {
+    renderWithReason('timeout', {} as Integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      TIMEOUT_HEADING
+    );
+  });
+
+  it('opens sync preferences from the canceled variant', async () => {
+    const openSyncPreferences = jest
+      .spyOn(firefox, 'fxaOpenSyncPreferences')
+      .mockImplementation(() => {});
+    renderWithReason('canceled', integration);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /sync settings/i })
+    );
+
+    expect(openSyncPreferences).toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/container.tsx
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import TimeoutAndCancel from '.';
 import { useLocation, useNavigate } from 'react-router';
+import * as Sentry from '@sentry/browser';
 import firefox from '../../../../lib/channels/firefox';
+import { Integration, PairingAuthorityIntegration } from '../../../../models';
 
-export type TimeoutAndCancelContainerProps = {}
+export type TimeoutAndCancelContainerProps = {
+  integration?: Integration;
+}
 
 /**
  * The desktop screen shown once pairing stops without succeeding — either it
@@ -15,9 +19,21 @@ export type TimeoutAndCancelContainerProps = {}
  * secondary action differs, because a timeout leaves the user mid-flow with
  * something to abandon while a cancel has already ended it.
  */
-const TimeoutAndCancelContainer = (_props: TimeoutAndCancelContainerProps) => {
+const TimeoutAndCancelContainer = ({
+  integration,
+}: TimeoutAndCancelContainerProps) => {
   const navigate = useNavigate();
   const location = useLocation();
+
+  // Not every route here closes the channel first, and closing twice is
+  // harmless, so this is what guarantees none outlives the flow.
+  useEffect(() => {
+    if (!(integration instanceof PairingAuthorityIntegration)) {
+      return;
+    }
+    // Already-closed is the common case, so swallow the rejection.
+    integration.destroy().catch((err) => Sentry.captureException(err));
+  }, [integration]);
 
   const onTryAgain = () => {
     navigate('/pair/authority/scan_qr');

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/container.test.tsx
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import * as Sentry from '@sentry/browser';
+import Container from './container';
+import { Integration, PairingSupplicantIntegration } from '../../../../models';
+
+const TIMEOUT_HEADING = 'Looks like we timed out';
+const CANCELED_HEADING = 'Canceled';
+
+type MockSupplicantIntegration = PairingSupplicantIntegration & {
+  destroy: jest.Mock;
+};
+
+function mockSupplicantIntegration(): MockSupplicantIntegration {
+  const integration = Object.create(
+    PairingSupplicantIntegration.prototype
+  ) as MockSupplicantIntegration;
+  return Object.assign(integration, {
+    destroy: jest.fn().mockResolvedValue(undefined),
+  });
+}
+
+const renderWithReason = (reason?: string, integration?: Integration) =>
+  renderWithLocalizationProvider(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/pair/supplicant/timeout_and_cancel',
+          state: reason ? { reason } : undefined,
+        },
+      ]}
+    >
+      <Container {...{ integration }} />
+    </MemoryRouter>
+  );
+
+// The card has no actions: the container only reads the reason and closes the
+// channel.
+describe('Pair2/Supplicant/TimeoutAndCancel container', () => {
+  let integration: MockSupplicantIntegration;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    integration = mockSupplicantIntegration();
+  });
+
+  it('renders the canceled variant when the user canceled', () => {
+    renderWithReason('canceled', integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      CANCELED_HEADING
+    );
+  });
+
+  it('renders the timeout variant when the flow timed out', () => {
+    renderWithReason('timeout', integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      TIMEOUT_HEADING
+    );
+  });
+
+  // Timeout is the safe default; a failure is likelier to arrive without state.
+  it('falls back to the timeout variant when no reason was given', () => {
+    renderWithReason(undefined, integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      TIMEOUT_HEADING
+    );
+  });
+
+  // The cancel paths close the channel, the failure paths do not; this always
+  // does.
+  it('closes the pairing channel', async () => {
+    renderWithReason('timeout', integration);
+
+    await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
+  });
+
+  it('still renders when the channel cannot be closed', async () => {
+    const captureException = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(() => '');
+    const err = new Error('channel already gone');
+    integration.destroy.mockRejectedValue(err);
+
+    renderWithReason('canceled', integration);
+
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      CANCELED_HEADING
+    );
+  });
+
+  // The route passes whatever the app built, which is not always a pairing one.
+  it('renders without a pairing integration', () => {
+    renderWithReason('timeout', {} as Integration);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      TIMEOUT_HEADING
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/TimeoutAndCancel/container.tsx
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router';
+import * as Sentry from '@sentry/browser';
+import TimeoutAndCancel, { PairingInterruptionReason } from '.';
+import { Integration, PairingSupplicantIntegration } from '../../../../models';
+
+export type TimeoutAndCancelContainerProps = {
+  integration?: Integration;
+};
+
+/**
+ * The mobile dead-end screen shown once pairing stops without succeeding.
+ *
+ * The card has no actions, so this only reads why the flow ended and closes the
+ * channel. Not every route here closes it first, so this guarantees none
+ * outlives the flow.
+ *
+ * The reason travels in router state, not the URL: changing the search string
+ * mid-flow rebuilds the integration, handing back a different instance than the
+ * one holding this channel.
+ */
+const TimeoutAndCancelContainer = ({
+  integration,
+}: TimeoutAndCancelContainerProps) => {
+  const location = useLocation();
+  // Anything but an explicit cancel is a timeout, including no state at all.
+  const reason: PairingInterruptionReason =
+    location.state?.reason === 'canceled' ? 'canceled' : 'timeout';
+
+  useEffect(() => {
+    if (!(integration instanceof PairingSupplicantIntegration)) {
+      return;
+    }
+    // Already-closed is the common case, so swallow the rejection.
+    integration.destroy().catch((err) => Sentry.captureException(err));
+  }, [integration]);
+
+  return <TimeoutAndCancel {...{ reason }} />;
+};
+
+export default TimeoutAndCancelContainer;


### PR DESCRIPTION
## Because

- When a v2 pairing attempt ended without connecting, both devices landed on the same dead-end screen whether the user cancelled or the channel dropped, the copy could not match what actually happened.
- The authority showed its QR indefinitely when no device ever scanned it, leaving the user on a screen that would never advance.
- The supplicant's timeout screen was rendered directly with no container, so it had no way to learn why the flow ended.

## This pull request

- Adds a `?reason=timeout` / `?reason=canceled` param on both timeout screens, defaulting to `timeout` when absent, so each side renders the right variant.
- Adds a 2-minute no-scan timeout in `Authority/ScanQR/container.tsx`, cleared once a device scans or the flow fails.
- Sets the cancel reason at each exit point: `Authority/ContinueOnMobile`, `Supplicant/ApproveSignIn`, and `Supplicant/ConnectThisDevice`.
- Adds `Supplicant/TimeoutAndCancel/container.tsx` and routes `App/index.tsx` at it instead of the bare page.
- Adds container tests for both timeout screens and `pairing-flow.test.ts`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13869

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

`nx test-unit fxa-settings` (Pair/Pair2/integrations/channels): 490 passed, 0 failed.

**How to test:** start the stack, open `/pair/authority/scan_qr` in a signed-in Firefox, and leave it untouched for two minutes — it should land on `timeout_and_cancel` with the timeout copy. Cancelling from `continue_on_mobile` instead should show the canceled copy.

**Note:** rebased onto the current `fxa-13870` after that branch was force-pushed. The authority side moved from the `pairingFlow` module to `PairingAuthorityIntegration`, so `wireAbort` here is expressed as the `AuthorityState.Failed` branch, and the two authority container tests were updated to the integration API.