### PR TITLE
fix(functional-tests): drop the 500ms header timeout in cookiesDisabled

### DIFF
--- a/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
+++ b/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
@@ -53,10 +53,8 @@ test.describe('cookies disabled', () => {
     await page.waitForURL(/\/cookies_disabled/);
 
     // Verify the Cookies disabled header
-    // Updated in FXA-9323 as waitForTimeOut tests can be flaky in production:
-    // https://playwright.dev/docs/api/class-page#page-wait-for-timeout
-    await expect(cookiesDisabled.cookiesDisabledHeader()).resolves.toBeVisible({
-      timeout: 500,
-    });
+    // FXA-9323 replaced waitForTimeout here, but its 500ms budget was too short
+    // for CI. The page object already waits, so let its waitFor() govern.
+    await expect(await cookiesDisabled.cookiesDisabledHeader()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Because

- `misc/cookiesDisabled.spec.ts` "visit verify page with localStorage disabled" fails at random on the Playwright PR job. It blocks the merge gate, then passes on a rerun. It hit #21061, #21067 and #21071 on the same day.
- The assertion gave `.card-header` a 500ms visibility budget. A loaded CI container needs longer than that to paint the element.
- The budget was also redundant. `pages/cookiesDisabled.ts` already waits with `header.waitFor()`, so the 500ms only capped a wait that was already correct.

## This pull request

- Removes the explicit `timeout: 500` from the header assertion.
- Awaits the page object helper instead, so its own `waitFor()` governs the wait. This is the form the sibling test at line 29 has always used, on the same element, and that call site has not been reported flaky.
- Rewrites the comment above the assertion. It still credits FXA-9323, which correctly replaced `waitForTimeout`, and now says why the 500ms budget went away.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14384

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/functional-tests/tests/misc/cookiesDisabled.spec.ts`
- Suggested review order: read the changed assertion, then compare it to line 29 of the same file.
- Risky or complex parts: none. The diff is one assertion plus a comment.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

I did not run the spec locally. It needs a live stack, so CI is the check.

What I did run:

- `npx tsc -p packages/functional-tests/tsconfig.json --noEmit`. It reports the three errors that already exist on main, in `lib/sub-helpers.ts` and `lib/testAccountTracker.ts`. This change adds none.
- `npx nx lint functional-tests`. Exit 0, no errors.

The test box above is unticked on purpose: the test changed, but I could not run it here.
