### PR TITLE
feat(admin-panel): format the account history additional info

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
@@ -570,4 +570,40 @@ describe('account history', () => {
       queryByRole('button', { name: 'Show more' })
     ).not.toBeInTheDocument();
   });
+
+  const renderWithAdditionalInfo = (additionalInfo?: string) => {
+    const [securityEvent] = buildSecurityEvents(1);
+    return render(
+      <Account
+        {...accountResponse}
+        securityEvents={[{ ...securityEvent, additionalInfo }]}
+      />
+    );
+  };
+
+  it('indents valid JSON additional info', () => {
+    const { container } = renderWithAdditionalInfo(
+      '{"userAgent":"Firefox","location":{"city":"Toronto"}}'
+    );
+
+    expect(container.querySelector('pre')?.textContent).toBe(
+      '{\n  "userAgent": "Firefox",\n  "location": {\n    "city": "Toronto"\n  }\n}'
+    );
+  });
+
+  it('shows the original string when additional info is not JSON', () => {
+    const { container } = renderWithAdditionalInfo('not json at all');
+
+    expect(container.querySelector('pre')?.textContent).toBe('not json at all');
+  });
+
+  it('shows nothing when there is no additional info', () => {
+    const { container, getByText } = renderWithAdditionalInfo(undefined);
+
+    expect(container.querySelector('pre')).toBeNull();
+    // The empty cell must stay, or the row loses a column.
+    expect(
+      getByText('event-0').closest('tr')?.querySelectorAll('td')
+    ).toHaveLength(4);
+  });
 });

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -30,6 +30,15 @@ import { Carts } from '../Cart';
 
 const INITIAL_SECURITY_EVENT_COUNT = 10;
 
+// The column holds a raw database value, so indent it only when it parses.
+const formatAdditionalInfo = (additionalInfo: string) => {
+  try {
+    return JSON.stringify(JSON.parse(additionalInfo), null, 2);
+  } catch {
+    return additionalInfo;
+  }
+};
+
 export type AccountProps = AccountType & {
   onCleared: () => void;
   query: string;
@@ -492,7 +501,13 @@ export const Account = ({
                     <>{securityEvent.name}</>
                     <>{getFormattedDate(securityEvent.createdAt)}</>
                     <>{securityEvent.ipAddr}</>
-                    <>{securityEvent.additionalInfo}</>
+                    <>
+                      {securityEvent.additionalInfo && (
+                        <pre className="whitespace-pre-wrap">
+                          {formatAdditionalInfo(securityEvent.additionalInfo)}
+                        </pre>
+                      )}
+                    </>
                   </TableRowXHeader>
                 );
               })}


### PR DESCRIPTION
## Because

- The "Additional Info" column of the Account History table prints the raw database value on one line. That value is a JSON blob, so it is hard to read.

## This pull request

- Adds `formatAdditionalInfo` to `Account/index.tsx`. It re-serializes the value with `JSON.stringify(value, null, 2)`.
- Prints the original string unchanged when the value does not parse as JSON.
- Renders nothing when the value is absent, so the row keeps its fourth cell.
- Wraps the output in `<pre className="whitespace-pre-wrap">`. HTML collapses newlines and leading spaces, so a formatted string alone would look the same as today.
- Covers the three cases in `Account/index.test.tsx`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14386

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the Account History table in `packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx`.
- Suggested review order: the helper, then the render site, then the tests.
- Risky or complex parts: the fourth child stays a fragment on purpose. `TableRowXHeader` builds the cells with `Children.toArray`, which drops `null`, so returning `null` there would cost the row a column. Nothing else in the table changes, and there is no new dependency.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Verified with `rescripts test --testPathPattern "PageAccountSearch/Account/index.test.tsx"` (32 passed, 0 failed) and `npx nx lint fxa-admin-panel` (exit 0). Functional tests did not run in this environment.
