### PR TITLE
fix(admin-panel): serve index.html for three missing client routes

### DIFF
--- a/packages/fxa-admin-panel/server/lib/server.test.ts
+++ b/packages/fxa-admin-panel/server/lib/server.test.ts
@@ -52,3 +52,27 @@ describe('Test simple server routes', () => {
     expect(response.text).toStrictEqual('Ok');
   });
 });
+
+// Each route the client router declares must serve index.html, or a refresh returns a 404.
+describe('Test client routes', () => {
+  it.each([
+    '/',
+    '/account-search',
+    '/account-delete',
+    '/account-reset',
+    '/relying-parties',
+    '/rate-limiting',
+    '/waf-tokens',
+    '/permissions',
+    '/domain-blocklist',
+    '/email-blocklist',
+    '/oauth-scopes',
+  ])('%s serves index.html', async (route) => {
+    const response = await request(app).get(route);
+    expect(response.status).toStrictEqual(200);
+    expect(response.header['content-type']).toStrictEqual(
+      'text/html; charset=utf-8'
+    );
+    expect(response.text).toContain('<div id="root">');
+  });
+});

--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -133,6 +133,9 @@ if (proxyUrl) {
     '/rate-limiting',
     '/waf-tokens',
     '/permissions',
+    '/domain-blocklist',
+    '/email-blocklist',
+    '/oauth-scopes',
   ].forEach((route) => {
     // FIXME: should set ETag, Not-Modified:
     app.get(route, (req, res) => {


### PR DESCRIPTION
## Because

- Refreshing `/domain-blocklist`, `/email-blocklist` or `/oauth-scopes` in the admin panel returned "Cannot GET /<page>".
- The 404 replaced the SPA, so the back button stopped working after it.

## This pull request

- Adds the three paths to the route list in `server/lib/server.ts` that serves `index.html`.
- Extends `server/lib/server.test.ts` to assert every client route serves `index.html`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14387

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `server/lib/server.ts`
- Suggested review order: the server route list, then the spec
- Risky or complex parts: none; the array is only read at startup

## Screenshots (Optional)

## Other information (Optional)

The route list is hardcoded, so it will drift again on the next new page. The `TODO` above it suggests a wildcard matcher. I left that for a follow-up on purpose: a catch-all has to be ordered against `serveStatic` and the `/api` routes, and getting that wrong serves `index.html` for genuine 404s and for missing assets.
