### PR TITLE
fix(auth-server): raise the JWT bound so /oauth/token stops 500ing

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/validators.js
+++ b/packages/fxa-auth-server/lib/oauth/validators.js
@@ -74,7 +74,7 @@ exports.jwe = Joi.string()
   );
 
 exports.jwt = Joi.string()
-  .max(1024)
+  .max(2048)
   // JWT format: 'header.payload.signature'
   .regex(/^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$/);
 

--- a/packages/fxa-auth-server/lib/oauth/validators.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/validators.spec.ts
@@ -36,3 +36,52 @@ describe('oauth scope validator', () => {
     expect(error.message).toContain('needs to be a valid scope string');
   });
 });
+
+describe('oauth accessToken validator', () => {
+  // Shaped like a real Fenix access token: a 75-character base64url header and
+  // a 342-character RS256 signature, with the payload making up the rest.
+  const HEADER_LENGTH = 75;
+  const SIGNATURE_LENGTH = 342;
+  const jwtOfLength = (length: number) =>
+    [
+      'h'.repeat(HEADER_LENGTH),
+      'p'.repeat(length - HEADER_LENGTH - SIGNATURE_LENGTH - 2),
+      's'.repeat(SIGNATURE_LENGTH),
+    ].join('.');
+
+  const OPAQUE_ACCESS_TOKEN = 'a'.repeat(64);
+
+  it('accepts an opaque 64-character hex access token', () => {
+    const { error } = validators.accessToken.validate(OPAQUE_ACCESS_TOKEN);
+    expect(error).toBeUndefined();
+  });
+
+  // A JWT access token grows with the scopes on the grant: real tokens reach
+  // ~1150 characters with sync, session, VPN and Relay together. The bound
+  // also gates the is-this-a-JWT test in ./token.js, so an undersized one
+  // breaks verification as well as minting.
+  it.each([1030, 1147])(
+    'accepts a %i character JWT access token',
+    (length: number) => {
+      const jwt = jwtOfLength(length);
+      expect(jwt).toHaveLength(length);
+      expect(validators.accessToken.validate(jwt).error).toBeUndefined();
+      expect(validators.jwt.validate(jwt).error).toBeUndefined();
+    }
+  );
+
+  it('accepts a JWT at the 2048 character bound', () => {
+    const { error } = validators.accessToken.validate(jwtOfLength(2048));
+    expect(error).toBeUndefined();
+  });
+
+  it('rejects a JWT longer than 2048 characters', () => {
+    const { error } = validators.accessToken.validate(jwtOfLength(2049));
+    expect(error).toBeDefined();
+  });
+
+  it('rejects a token that is neither hex nor JWT shaped', () => {
+    const { error } = validators.accessToken.validate('not.a@token');
+    expect(error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Because

- `/v1/oauth/token` returns 500 errno 999 whenever the access token it just minted is longer than the response schema allows
- Mobile Relay token exchange is worst hit. The subject refresh token is already revoked by the time the response fails, so the device loses Sync, gets 401s on `/account/device`, and cannot obtain a VPN or Relay token until the user signs in again.

## This pull request

- Raises the `exports.jwt` bound in `lib/oauth/validators.js` from 1024 to 2048 characters.
- Adds `accessToken` coverage for opaque tokens, JWTs at the two lengths observed in prod, and both sides of the new bound.

## Issue that this pull request solves

Closes: FXA-14391

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
