### PR TITLE
chore(blender): re-enable BLEnder investigations

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -5,7 +5,7 @@ node_version: "24.15.0"
 install_command: "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable --inline-builds"
 
 investigate:
-  enabled: false
+  enabled: true
   dismiss_unaffected: true
   max_claude_turns: 100
   max_budget_usd: 6.00


### PR DESCRIPTION
Flips `investigate.enabled` back to `true` now that the upstream loop fixes have all merged.

Why it's safe now:
- **No loop** — a failed remediation still tags the alert (mozilla/blender#130), so nothing gets re-investigated every sweep (that was the original runaway).
- **Remediation works** — yarn transitive bumps land in-range (mozilla/blender#123) and out-of-range via a resolutions fallback (mozilla/blender#131).
- **Affected alerts** route to `advisory_only` (flagged for manual fix) — no longer loops; auto-fixing them is tracked in mozilla/blender#133 (not a blocker).

What to expect after merge:
- A one-time sweep over the open alert backlog (~100) — real but bounded Claude spend (no loop, and max_budget/turns are capped per alert).
- Safe transitive advisories get bump PRs; unaffected low/medium get dismissed; affected ones get an advisory for manual handling.