### PR TITLE
fix(auth-server): handle cancelled billing agreement NVP error

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal/helper.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.spec.ts
@@ -22,6 +22,7 @@ import { StripeHelper } from '../stripe';
 import { CurrencyHelper } from '../currencies';
 import {
   PAYPAL_BILLING_AGREEMENT_INVALID,
+  PAYPAL_BILLING_TRANSACTION_WRONG_ACCOUNT,
   PAYPAL_APP_ERRORS,
   PAYPAL_RETRY_ERRORS,
 } from './error-codes';
@@ -839,6 +840,18 @@ describe('PayPalHelper', () => {
   });
 
   describe('updateStripeNameFromBA', () => {
+    function makeNVPErr(errorCode: number) {
+      const failedResponse = deepCopy(failedDoReferenceTransactionResponse);
+      failedResponse.L_ERRORCODE0 = errorCode;
+      const rawString = objectToNVP(failedResponse);
+      const parsedNvpObject = nvpToObject(rawString) as NVPErrorResponse;
+      const nvpError = new PayPalNVPError(rawString, parsedNvpObject, {
+        message: (parsedNvpObject.L as any[])[0].LONGMESSAGE,
+        errorCode: parseInt((parsedNvpObject.L as any[])[0].ERRORCODE),
+      });
+      return new PayPalClientError([nvpError], rawString, parsedNvpObject);
+    }
+
     it('updates the name on the stripe customer', async () => {
       mockStripeHelper.updateCustomerBillingAddress = jest
         .fn()
@@ -881,6 +894,47 @@ describe('PayPalHelper', () => {
           message: 'Billing agreement was cancelled.',
         })
       );
+    });
+
+    it('throws an internal validation error if the billing agreement is invalid', async () => {
+      mockStripeHelper.updateCustomerBillingAddress = jest
+        .fn()
+        .mockResolvedValue({});
+      const throwErr = makeNVPErr(PAYPAL_BILLING_AGREEMENT_INVALID);
+      paypalHelper.agreementDetails = jest.fn().mockRejectedValue(throwErr);
+
+      const caughtError = await paypalHelper
+        .updateStripeNameFromBA(mockCustomer, 'mock-agreement-id')
+        .catch((err: any) => err);
+
+      expect(caughtError.errno).toBe(error.ERRNO.INTERNAL_VALIDATION_ERROR);
+      expect(caughtError.output.payload.op).toBe('updateStripeNameFromBA');
+      expect(caughtError.output.payload.data.message).toBe(
+        'Billing agreement was cancelled.'
+      );
+      expect(caughtError.jse_cause).toBe(throwErr);
+      expect(paypalHelper.agreementDetails).toHaveBeenCalledTimes(1);
+      expect(paypalHelper.agreementDetails).toHaveBeenCalledWith({
+        billingAgreementId: 'mock-agreement-id',
+      });
+      expect(
+        mockStripeHelper.updateCustomerBillingAddress
+      ).not.toHaveBeenCalled();
+    });
+
+    it('rethrows an unrecognized PayPal error', async () => {
+      const throwErr = makeNVPErr(PAYPAL_BILLING_TRANSACTION_WRONG_ACCOUNT);
+      mockStripeHelper.updateCustomerBillingAddress = jest
+        .fn()
+        .mockResolvedValue({});
+      paypalHelper.agreementDetails = jest.fn().mockRejectedValue(throwErr);
+
+      await expect(
+        paypalHelper.updateStripeNameFromBA(mockCustomer, 'mock-agreement-id')
+      ).rejects.toBe(throwErr);
+      expect(
+        mockStripeHelper.updateCustomerBillingAddress
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/fxa-auth-server/lib/payments/paypal/helper.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal/helper.ts
@@ -373,9 +373,24 @@ export class PayPalHelper {
     billingAgreementId: string
   ): Promise<Stripe.Customer> {
     this.metrics.increment('paypal.updateStripeNameFromBA');
-    const agreementDetails = await this.agreementDetails({
-      billingAgreementId,
-    });
+    let agreementDetails: AgreementDetails;
+    try {
+      agreementDetails = await this.agreementDetails({
+        billingAgreementId,
+      });
+    } catch (err) {
+      if (
+        PayPalClientError.hasPayPalNVPError(err) &&
+        err.getPrimaryError().errorCode === PAYPAL_BILLING_AGREEMENT_INVALID
+      ) {
+        throw error.internalValidationError(
+          'updateStripeNameFromBA',
+          { message: 'Billing agreement was cancelled.' },
+          err
+        );
+      }
+      throw err;
+    }
     if (agreementDetails.status === 'cancelled') {
       throw error.internalValidationError('updateStripeNameFromBA', {
         message: 'Billing agreement was cancelled.',


### PR DESCRIPTION
## Because

- Cancelled PayPal billing agreements make `invoice.created` webhooks return 500, so Stripe retries the delivery and Sentry reports every attempt (FXA-AUTH-2TC).
- The handling added for this case in 2022 never runs, because PayPal reports a cancelled agreement as an API error rather than as a cancelled status.

## This pull request

- Translates PayPal NVP error 10201 in `updateStripeNameFromBA` into the internal validation error the webhook already handles.
- Rethrows any other PayPal error unchanged.
- Adds unit coverage for the cancelled-agreement branch and the rethrow path.

## Issue that this pull request solves

Closes: PAY-3778

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the new catch in `updateStripeNameFromBA`.
- Suggested review order: `helper.ts`, then the two new tests.
- Risky or complex parts: the fix works via `stripe-webhook.ts` matching on errno, which this PR does not touch. That contract is now asserted in the helper spec.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The stale billing agreement is deliberately left on the Stripe customer. The ticket does not ask for it, and the IPN `mpCancel` path already owns clearing agreements.

No pre-merge review skill was run: the production change is 13 lines reusing an existing in-file idiom (`processor.ts:243`) and mutates no state.
