### PR TITLE
feat(content-server): add __heartbeat__ endpoint

### DIFF
--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -31,6 +31,7 @@ module.exports = function (config, i18n, statsd, glean) {
     require('./routes/get-client.json')(i18n),
     require('./routes/get-config')(i18n),
     require('./routes/get-fxa-client-configuration')(config),
+    require('./routes/get-heartbeat')(),
     require('./routes/get-lbheartbeat')(),
     require('./routes/get-openid-configuration')(config),
     require('./routes/get-version.json'),

--- a/packages/fxa-content-server/server/lib/routes/get-heartbeat.js
+++ b/packages/fxa-content-server/server/lib/routes/get-heartbeat.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+module.exports = function () {
+  const route = {};
+
+  route.method = 'get';
+  route.path = '/__heartbeat__';
+
+  route.process = function (req, res) {
+    res.status(200).json({});
+  };
+
+  return route;
+};


### PR DESCRIPTION
## Because

- `accounts.firefox.com/__heartbeat__` returns 404, while auth-server,
  profile-server, and the NestJS services all serve it.
- Dockerflow expects `__heartbeat__` alongside `__lbheartbeat__` and `__version__`.

## This pull request

- Adds `get-heartbeat.js`, returning a static 200 with an empty JSON body.
- Registers the route in the content-server route table.

## Issue that this pull request solves

Closes: FXA-14399

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

No tests: `/__lbheartbeat__` has no coverage anywhere in the repo, and
content-server has no server-side unit test harness — `tests/` holds only
`functional`. Added at parity with its sibling rather than standing up a harness.

Pre-merge review waived as trivial: 18 lines, no auth/payments/crypto/session
surface, handler copied from the existing sibling route.