### PR TITLE
refactor(settings): scope inline TOTP MFA guard to enrolment step

### DIFF
--- a/packages/functional-tests/pages/inlineTotpSetup.tsx
+++ b/packages/functional-tests/pages/inlineTotpSetup.tsx
@@ -36,18 +36,4 @@ export class InlineTotpSetupPage extends BaseLayout {
       .fill(code);
     await this.page.getByRole('button', { name: 'Confirm' }).click();
   }
-
-  async confirmMfaGuardIfVisible(email: string) {
-    // The guard modal and the setup UI are mutually exclusive on this route.
-    // Wait for whichever renders first so this doesn't race a not-yet-shown
-    // modal (a bare isVisible() check can skip a guard that is still mounting),
-    // then confirm only when it is the guard.
-    await Promise.race([
-      this.mfaGuardHeading.waitFor({ state: 'visible' }),
-      this.introHeading.waitFor({ state: 'visible' }),
-    ]);
-    if (await this.mfaGuardHeading.isVisible()) {
-      await this.confirmMfaGuard(email);
-    }
-  }
 }

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -248,11 +248,9 @@ export class TotpPage extends SettingsLayout {
     recoveryPhoneAvailable: boolean
   ): Promise<string> {
     await this.page.waitForURL(/inline_totp_setup/);
-    // Conditional: some callers confirm the guard themselves (e.g. to assert
-    // the passkey banner) before reaching this helper.
-    await inlineTotpSetup.confirmMfaGuardIfVisible(credentials.email);
     await expect(inlineTotpSetup.introHeading).toBeVisible();
     await inlineTotpSetup.continueButton.click();
+    await inlineTotpSetup.confirmMfaGuard(credentials.email);
     const secret = await this.setUp2faAppWithManualCode(credentials);
     await this.page.waitForURL(/inline_recovery_setup/);
     if (recoveryPhoneAvailable) {

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -81,9 +81,9 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/inline_totp_setup/);
 
-      await inlineTotpSetup.confirmMfaGuard(credentials.email);
       await expect(inlineTotpSetup.introHeading).toBeVisible();
       await inlineTotpSetup.continueButton.click();
+      await inlineTotpSetup.confirmMfaGuard(credentials.email);
       await expect(totp.setup2faAppHeading).toBeVisible();
       await totp.setUp2faAppWithManualCode(credentials);
 
@@ -119,9 +119,9 @@ test.describe('OAuth totp with recovery phone (local only)', () => {
 
     await page.waitForURL(/inline_totp_setup/);
 
-    await inlineTotpSetup.confirmMfaGuard(credentials.email);
     await expect(inlineTotpSetup.introHeading).toBeVisible();
     await inlineTotpSetup.continueButton.click();
+    await inlineTotpSetup.confirmMfaGuard(credentials.email);
     await expect(totp.setup2faAppHeading).toBeVisible();
     await totp.setUp2faAppWithManualCode(credentials);
 

--- a/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkey-signin.spec.ts
@@ -248,11 +248,8 @@ test.describe('severity-1 #smoke', () => {
         await page.waitForURL(/inline_totp_setup/);
       });
 
-      // Inline TOTP enrolment is gated by an MFA email-OTP (FXA-14311); the
-      // setup UI (incl. the passkey banner) only renders once the guard passes.
-      await inlineTotpSetup.confirmMfaGuard(credentials.email);
-      // The passkey context must survive the divert, so the page explains why
-      // 2FA is still needed rather than implying the passkey was insufficient.
+      // The passkey context survives the divert: the intro explains why 2FA is
+      // still needed rather than implying the passkey was insufficient.
       await expect(inlineTotpSetup.passkeySuccessBanner).toBeVisible();
 
       // Force TOTP enrollment so non-passkey sign-ins also satisfy AMR.
@@ -480,9 +477,6 @@ test.describe('severity-1 #smoke', () => {
         await page.waitForURL(/inline_totp_setup/);
       });
 
-      // The setup UI renders only after the MFA email-OTP guard is satisfied
-      // (FXA-14311).
-      await inlineTotpSetup.confirmMfaGuard(email);
       await expect(inlineTotpSetup.passkeySuccessBanner).toBeVisible();
     });
 
@@ -658,10 +652,7 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutPasswordForm(credentials.password);
 
       await page.waitForURL(/inline_totp_setup/);
-      await inlineTotpSetup.confirmMfaGuard(credentials.email);
-      await expect(
-        page.getByRole('heading', { name: /Set up two-step authentication/i })
-      ).toBeVisible();
+      await expect(inlineTotpSetup.introHeading).toBeVisible();
     });
 
     test('shows the passkey button on prompt=login re-auth and completes sign-in via passkey', async ({

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/InlineTotpEnrolment.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/InlineTotpEnrolment.test.tsx
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import { UserEvent, userEvent } from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import InlineTotpEnrolment from './InlineTotpEnrolment';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import {
+  MOCK_QUERY_PARAMS,
+  MOCK_SIGNIN_LOCATION_STATE,
+  MOCK_SIGNIN_RECOVERY_LOCATION_STATE,
+  MOCK_TOTP_TOKEN,
+} from './mocks';
+import { SigninLocationState } from '../Signin/interfaces';
+import { JwtTokenCache } from '../../lib/cache';
+import { MfaContext, MfaSessionTokenContext } from '../../lib/hooks';
+import { queryParamsToMetricsContext } from '../../lib/metrics';
+import GleanMetrics from '../../lib/glean';
+
+const mockCreateTotpTokenWithJwt = jest.fn();
+const mockVerifyTotpSetupCodeWithJwt = jest.fn();
+
+jest.mock('../../models', () => ({
+  ...jest.requireActual('../../models'),
+  useAuthClient: () => ({
+    createTotpTokenWithJwt: mockCreateTotpTokenWithJwt,
+    verifyTotpSetupCodeWithJwt: mockVerifyTotpSetupCodeWithJwt,
+  }),
+}));
+
+const JWT = 'test-jwt';
+const SESSION_TOKEN = MOCK_SIGNIN_LOCATION_STATE.sessionToken;
+const metricsContext = queryParamsToMetricsContext(
+  MOCK_QUERY_PARAMS as unknown as Record<string, string>
+);
+
+const navTo = jest.fn();
+const onBackButtonClick = jest.fn();
+
+// Render under the MFA contexts MfaGuardCore normally provides, so
+// useMfaErrorHandler resolves the scope and session token.
+const renderEnrolment = () =>
+  renderWithLocalizationProvider(
+    <MfaContext.Provider value="2fa">
+      <MfaSessionTokenContext.Provider value={SESSION_TOKEN}>
+        <InlineTotpEnrolment
+          sessionToken={SESSION_TOKEN}
+          signinState={
+            MOCK_SIGNIN_LOCATION_STATE as unknown as SigninLocationState
+          }
+          metricsContext={metricsContext}
+          navTo={navTo}
+          currentStep={1}
+          onBackButtonClick={onBackButtonClick}
+        />
+      </MfaSessionTokenContext.Provider>
+    </MfaContext.Provider>
+  );
+
+describe('InlineTotpEnrolment', () => {
+  let user: UserEvent;
+
+  const submitCode = async (code: string) => {
+    await user.type(await screen.findByLabelText('Enter 6-digit code'), code);
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+  };
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    navTo.mockReset();
+    onBackButtonClick.mockReset();
+    mockCreateTotpTokenWithJwt.mockReset();
+    mockVerifyTotpSetupCodeWithJwt.mockReset();
+    // Spy (not mock) so FlowSetup2faApp's other Glean calls still run for real.
+    jest
+      .spyOn(GleanMetrics.accountPref, 'twoStepAuthQrCodeSuccess')
+      .mockImplementation(() => {});
+    mockCreateTotpTokenWithJwt.mockResolvedValue(MOCK_TOTP_TOKEN);
+    // Seed the JWT the guard would have obtained via email OTP.
+    JwtTokenCache.setToken(SESSION_TOKEN, '2fa', JWT);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shows the card loading spinner while the TOTP token is being created', () => {
+    mockCreateTotpTokenWithJwt.mockImplementation(() => new Promise(() => {}));
+    renderEnrolment();
+    expect(screen.getByLabelText('Loading…')).toBeInTheDocument();
+  });
+
+  it('creates the TOTP token with the cached JWT and shows the QR code', async () => {
+    renderEnrolment();
+
+    expect(
+      await screen.findByRole('progressbar', { name: 'Step 1 of 4.' })
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/Scan this QR code/)).toBeInTheDocument();
+    expect(mockCreateTotpTokenWithJwt).toHaveBeenCalledWith(JWT, {
+      metricsContext,
+    });
+  });
+
+  it('calls onBackButtonClick when the back button is clicked', async () => {
+    renderEnrolment();
+    await user.click(await screen.findByRole('button', { name: 'Back' }));
+    expect(onBackButtonClick).toHaveBeenCalled();
+  });
+
+  it('verifies the code and redirects to inline_recovery_setup on success', async () => {
+    mockVerifyTotpSetupCodeWithJwt.mockResolvedValue({ success: true });
+    renderEnrolment();
+    await submitCode('123456');
+
+    await waitFor(() =>
+      expect(navTo).toHaveBeenCalledWith(
+        '/inline_recovery_setup',
+        MOCK_SIGNIN_RECOVERY_LOCATION_STATE
+      )
+    );
+    expect(mockVerifyTotpSetupCodeWithJwt).toHaveBeenCalledWith(JWT, '123456', {
+      metricsContext,
+    });
+    expect(GleanMetrics.accountPref.twoStepAuthQrCodeSuccess).toHaveBeenCalled();
+  });
+
+  it('shows an error and does not redirect on an incorrect code', async () => {
+    mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(new Error('bad code'));
+    renderEnrolment();
+    await submitCode('000000');
+
+    expect(
+      await screen.findByText(/Invalid or expired code/)
+    ).toBeInTheDocument();
+    expect(navTo).not.toHaveBeenCalled();
+  });
+
+  it('clears the cached JWT and shows no code error when the MFA token is invalid', async () => {
+    const invalidJwtError = Object.assign(new Error('invalid mfa token'), {
+      errno: AuthUiErrors.INVALID_MFA_TOKEN.errno,
+    });
+    mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(invalidJwtError);
+    renderEnrolment();
+    await submitCode('101010');
+
+    // The guard re-prompts (JWT dropped); the stale JWT is not surfaced as a
+    // bad-code error.
+    await waitFor(() =>
+      expect(JwtTokenCache.hasToken(SESSION_TOKEN, '2fa')).toBe(false)
+    );
+    expect(
+      screen.queryByText(/Invalid or expired code/)
+    ).not.toBeInTheDocument();
+    expect(navTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/InlineTotpEnrolment.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/InlineTotpEnrolment.tsx
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { RelierCmsInfo, useAuthClient, useFtlMsgResolver } from '../../models';
+import { CardLoadingSpinner } from '../../components/CardLoadingSpinner';
+import FlowSetup2faApp from '../../components/Settings/FlowSetup2faApp';
+import { TotpInfo } from '../../lib/types';
+import { SigninLocationState } from '../Signin/interfaces';
+import { JwtTokenCache } from '../../lib/cache';
+import { useMfaErrorHandler } from '../../lib/hooks';
+import GleanMetrics from '../../lib/glean';
+import * as Sentry from '@sentry/browser';
+import { MetricsContext, NavTo } from './interfaces';
+
+// Includes the later recovery-method and backup-code steps.
+const numberOfSteps = 4;
+
+// Runs behind MfaGuardCore: the cached mfa:2fa JWT gates createTotp/verify (FXA-14311).
+export const InlineTotpEnrolment = ({
+  sessionToken,
+  signinState,
+  metricsContext,
+  navTo,
+  currentStep,
+  onBackButtonClick,
+  cmsInfo,
+}: {
+  sessionToken: string;
+  signinState: SigninLocationState;
+  metricsContext: MetricsContext;
+  navTo: NavTo;
+  currentStep: number;
+  onBackButtonClick: () => void;
+  cmsInfo?: RelierCmsInfo;
+}) => {
+  const authClient = useAuthClient();
+  const ftlMsgResolver = useFtlMsgResolver();
+  // Clears the guard's JWT on a stale-token error so it re-prompts; returns true
+  // when it handled the error.
+  const handleMfaError = useMfaErrorHandler();
+  const [totp, setTotp] = useState<TotpInfo>();
+  const isTotpCreating = useRef(false);
+
+  const localizedPageTitle = ftlMsgResolver.getMsg(
+    'inline-totp-setup-page-title',
+    'Two-step authentication'
+  );
+
+  useEffect(() => {
+    if (totp !== undefined || isTotpCreating.current) {
+      return;
+    }
+    (async () => {
+      isTotpCreating.current = true;
+      try {
+        const jwt = JwtTokenCache.getToken(sessionToken, '2fa');
+        const totpResp = await authClient.createTotpTokenWithJwt(jwt, {
+          metricsContext,
+        });
+        setTotp(totpResp);
+      } catch (error) {
+        // A stale JWT re-prompts the guard rather than bouncing the user out.
+        if (handleMfaError(error)) {
+          isTotpCreating.current = false;
+          return;
+        }
+        Sentry.captureException(error);
+        navTo('/');
+      }
+    })();
+  }, [authClient, metricsContext, navTo, totp, sessionToken, handleMfaError]);
+
+  const verifyCode = useCallback(
+    async (code: string): Promise<{ error?: boolean }> => {
+      try {
+        const jwt = JwtTokenCache.getToken(sessionToken, '2fa');
+        await authClient.verifyTotpSetupCodeWithJwt(jwt, code, {
+          metricsContext,
+        });
+
+        const state = {
+          ...Object.assign({}, signinState),
+          ...(totp ? { totp } : {}),
+        };
+        GleanMetrics.accountPref.twoStepAuthQrCodeSuccess();
+        navTo(
+          '/inline_recovery_setup',
+          Object.keys(state).length > 0 ? state : undefined
+        );
+        return {};
+      } catch (error) {
+        // A stale JWT re-prompts the guard, so don't surface a bad-code error.
+        if (handleMfaError(error)) {
+          return {};
+        }
+        return { error: true };
+      }
+    },
+    [
+      authClient,
+      navTo,
+      totp,
+      signinState,
+      sessionToken,
+      metricsContext,
+      handleMfaError,
+    ]
+  );
+
+  if (totp === undefined) {
+    return <CardLoadingSpinner />;
+  }
+
+  return (
+    <FlowSetup2faApp
+      localizedPageTitle={localizedPageTitle}
+      showProgressBar
+      currentStep={currentStep}
+      numberOfSteps={numberOfSteps}
+      totpInfo={totp}
+      verifyCode={verifyCode}
+      onBackButtonClick={onBackButtonClick}
+      cmsInfo={cmsInfo}
+    />
+  );
+};
+
+export default InlineTotpEnrolment;

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -10,19 +10,14 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 import { MozServices } from '../../lib/types';
 import { IntegrationType, OAuthIntegration } from '../../models';
 import InlineTotpSetupContainer from './container';
-import GleanMetrics from '../../lib/glean';
 import {
-  MOCK_TOTP_TOKEN,
   MOCK_QUERY_PARAMS,
   MOCK_SIGNIN_LOCATION_STATE,
   MOCK_SIGNIN_LOCATION_STATE_PASSKEY,
-  MOCK_SIGNIN_RECOVERY_LOCATION_STATE,
 } from './mocks';
 import { screen, waitFor } from '@testing-library/react';
-import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { AuthUiError } from '../../lib/auth-errors/auth-errors';
 import { MOCK_FLOW_ID } from '../Signin/mocks';
-import { ReactNode } from 'react';
-import { JwtTokenCache } from '../../lib/cache';
 
 const mockLocationHook = jest.fn();
 const mockNavigateHook = jest.fn();
@@ -35,39 +30,20 @@ jest.mock('react-router', () => {
 });
 
 const mockSessionHook = jest.fn();
-const mockVerifyTotpSetupCodeWithJwt = jest.fn();
 const mockSendVerificationCode = jest.fn();
-const mockCreateTotpTokenWithJwt = jest.fn();
 const mockCheckTotpTokenExists = jest.fn();
 
+// The container only calls checkTotpTokenExists directly; the enrolment's
+// JWT-guarded calls live in InlineTotpEnrolment (InlineTotpSetup is mocked out).
 jest.mock('../../models', () => {
   return {
     ...jest.requireActual('../../models'),
     useSession: () => mockSessionHook(),
     useAuthClient: () => ({
-      verifyTotpSetupCodeWithJwt: mockVerifyTotpSetupCodeWithJwt,
-      createTotpTokenWithJwt: mockCreateTotpTokenWithJwt,
       checkTotpTokenExists: mockCheckTotpTokenExists,
     }),
   };
 });
-
-// The MFA email-OTP guard is unit-tested separately (MfaGuardCore); here it is a
-// pass-through so the enrolment (its children) renders directly. A mfa:2fa JWT
-// is seeded in setMocks so the JWT-guarded enrolment calls resolve.
-jest.mock('../../components/Settings/MfaGuard', () => ({
-  __esModule: true,
-  MfaGuardCore: ({ children }: { children: ReactNode }) => children,
-}));
-
-jest.mock('../../lib/glean', () => ({
-  __esModule: true,
-  default: {
-    accountPref: {
-      twoStepAuthQrCodeSuccess: jest.fn(),
-    },
-  },
-}));
 
 function setMocks() {
   const search = '?' + new URLSearchParams(MOCK_QUERY_PARAMS);
@@ -82,24 +58,14 @@ function setMocks() {
     search,
     state: MOCK_SIGNIN_LOCATION_STATE,
   });
-  mockVerifyTotpSetupCodeWithJwt.mockReset();
   mockSendVerificationCode.mockReset();
-  mockCreateTotpTokenWithJwt.mockReset();
   mockCheckTotpTokenExists.mockReset();
   mockSessionHook.mockReturnValue({
     isSessionVerified: async () => true,
     sendVerificationCode: mockSendVerificationCode,
   });
-  // Default: TOTP doesn't exist, so we need to create one
+  // Default: TOTP doesn't exist, so enrolment should proceed
   mockCheckTotpTokenExists.mockResolvedValue({ exists: false, verified: false });
-  mockCreateTotpTokenWithJwt.mockResolvedValue(MOCK_TOTP_TOKEN);
-  // Seed the mfa:2fa JWT the enrolment reads (the guard would have obtained it
-  // via email OTP; here it's pre-seeded so the guard pass-through renders).
-  JwtTokenCache.setToken(
-    MOCK_SIGNIN_LOCATION_STATE.sessionToken,
-    '2fa',
-    'test-jwt'
-  );
   jest.spyOn(InlineTotpSetupModule, 'default');
   (InlineTotpSetupModule.default as jest.Mock).mockReset();
   mockNavigateHook.mockReset();
@@ -232,18 +198,17 @@ describe('InlineTotpSetupContainer', () => {
       });
     });
 
-    it('does not call createTotpToken while TOTP status is loading', async () => {
+    it('does not render enrolment while TOTP status is loading', async () => {
       // Simulate loading by not resolving the promise
       mockCheckTotpTokenExists.mockImplementation(() => new Promise(() => {}));
 
       render();
 
-      // Wait a bit to ensure the component has mounted
       await new Promise((resolve) => setTimeout(resolve, 100));
-      expect(mockCreateTotpTokenWithJwt).not.toHaveBeenCalled();
+      expect(InlineTotpSetupModule.default).not.toHaveBeenCalled();
     });
 
-    it('does not call createTotpToken when TOTP is already verified', async () => {
+    it('does not render enrolment when TOTP is already verified', async () => {
       mockSessionHook.mockImplementationOnce(() => ({
         isSessionVerified: async () => true,
       }));
@@ -257,7 +222,7 @@ describe('InlineTotpSetupContainer', () => {
       await waitFor(() => {
         expect(mockNavigateHook).toHaveBeenCalled();
       });
-      expect(mockCreateTotpTokenWithJwt).not.toHaveBeenCalled();
+      expect(InlineTotpSetupModule.default).not.toHaveBeenCalled();
     });
   });
 
@@ -271,18 +236,20 @@ describe('InlineTotpSetupContainer', () => {
       expect(InlineTotpSetupModule.default).not.toHaveBeenCalled();
     });
 
-    it('invokes InlineTotpSetup with the correct props', async () => {
+    it('invokes InlineTotpSetup at the intro step with the correct props', async () => {
       render();
       await waitFor(() => {
         expect(InlineTotpSetupModule.default).toHaveBeenCalled();
         const args = (InlineTotpSetupModule.default as jest.Mock).mock
           .calls[0][0];
-        expect(args.totp).toEqual(MOCK_TOTP_TOKEN);
+        expect(args.currentStep).toBe(0);
+        expect(typeof args.onContinue).toBe('function');
         expect(args.serviceName).toBe(MozServices.Default);
+        expect(args.enrolment).toBeTruthy();
       });
     });
 
-    it('passes signedInWithPasskey when the signin state came from a passkey ceremony', async () => {
+    it('passes signedInWithPasskey when the ceremony used a passkey', async () => {
       mockLocationHook.mockReturnValue({
         pathname: '/inline_totp_setup',
         search: '?' + new URLSearchParams(MOCK_QUERY_PARAMS),
@@ -294,112 +261,18 @@ describe('InlineTotpSetupContainer', () => {
       await waitFor(() => {
         expect(InlineTotpSetupModule.default).toHaveBeenCalled();
       });
-      const args = (InlineTotpSetupModule.default as jest.Mock).mock
-        .calls[0][0];
+      const args = (InlineTotpSetupModule.default as jest.Mock).mock.calls[0][0];
       expect(args.signedInWithPasskey).toBe(true);
     });
 
-    it('passes signedInWithPasskey as false for a non-passkey signin state', async () => {
+    it('passes signedInWithPasskey as false for a normal sign-in', async () => {
       render();
 
       await waitFor(() => {
         expect(InlineTotpSetupModule.default).toHaveBeenCalled();
       });
-      const args = (InlineTotpSetupModule.default as jest.Mock).mock
-        .calls[0][0];
+      const args = (InlineTotpSetupModule.default as jest.Mock).mock.calls[0][0];
       expect(args.signedInWithPasskey).toBe(false);
-    });
-
-    describe('callbacks', () => {
-      describe('verifyCodeHandler', () => {
-        it('throws an error when the server rejects the code', async () => {
-          mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(new Error('bad'));
-          render();
-          await waitFor(() => {
-            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
-          });
-          const args = (InlineTotpSetupModule.default as jest.Mock).mock
-            .calls[0][0];
-          const verifyCodeHandler = args.verifyCodeHandler;
-
-          // jest didn't like some syntax in AuthUiErrors when I tried to use
-          // expect().toThrow()
-          try {
-            await verifyCodeHandler('0101');
-            expect(true).toBe(false); // an error should've been thrown
-          } catch (err) {
-            // eslint-disable-next-line jest/no-conditional-expect
-            expect(err).toBe(AuthUiErrors.INVALID_TOTP_CODE);
-          }
-        });
-
-        it('throws an error when checking the code errors', async () => {
-          mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(new Error('err'));
-          render();
-          await waitFor(() => {
-            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
-          });
-          const args = (InlineTotpSetupModule.default as jest.Mock).mock
-            .calls[0][0];
-          const verifyCodeHandler = args.verifyCodeHandler;
-
-          // jest didn't like some syntax in AuthUiErrors when I tried to use
-          // expect().toThrow()
-          try {
-            await verifyCodeHandler('1010');
-            expect(true).toBe(false); // an error should've been thrown
-          } catch (err) {
-            // eslint-disable-next-line jest/no-conditional-expect
-            expect(err).toBe(AuthUiErrors.INVALID_TOTP_CODE);
-          }
-        });
-
-        it('clears the cached JWT and rethrows the original error when the MFA token is invalid', async () => {
-          const invalidJwtError = Object.assign(new Error('invalid mfa token'), {
-            errno: AuthUiErrors.INVALID_MFA_TOKEN.errno,
-          });
-          mockVerifyTotpSetupCodeWithJwt.mockRejectedValue(invalidJwtError);
-          render();
-          await waitFor(() => {
-            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
-          });
-          const args = (InlineTotpSetupModule.default as jest.Mock).mock
-            .calls[0][0];
-          const verifyCodeHandler = args.verifyCodeHandler;
-
-          expect(
-            JwtTokenCache.hasToken(MOCK_SIGNIN_LOCATION_STATE.sessionToken, '2fa')
-          ).toBe(true);
-
-          // Rethrown as-is, not mislabeled as INVALID_TOTP_CODE.
-          await expect(verifyCodeHandler('1010')).rejects.toBe(invalidJwtError);
-
-          // Token dropped so MfaGuardCore re-prompts for a fresh email OTP
-          // instead of retrying the dead JWT.
-          expect(
-            JwtTokenCache.hasToken(MOCK_SIGNIN_LOCATION_STATE.sessionToken, '2fa')
-          ).toBe(false);
-        });
-
-        it('redirects to inline_recovery_setup when the code is valid', async () => {
-          mockVerifyTotpSetupCodeWithJwt.mockResolvedValue({ success: true });
-          render();
-          await waitFor(() => {
-            expect(InlineTotpSetupModule.default).toHaveBeenCalled();
-          });
-          const args = (InlineTotpSetupModule.default as jest.Mock).mock
-            .calls[0][0];
-          const verifyCodeHandler = args.verifyCodeHandler;
-          await verifyCodeHandler('1010');
-          expect(
-            GleanMetrics.accountPref.twoStepAuthQrCodeSuccess
-          ).toHaveBeenCalled();
-          expect(mockNavigateHook).toHaveBeenCalledWith(
-            `/inline_recovery_setup?${new URLSearchParams(MOCK_QUERY_PARAMS)}`,
-            { state: MOCK_SIGNIN_RECOVERY_LOCATION_STATE }
-          );
-        });
-      });
     });
   });
 });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -6,129 +6,16 @@ import { useLocation } from 'react-router';
 import { useNavigateWithQuery } from '../../lib/hooks';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import InlineTotpSetup from '.';
-import { MfaReason, MozServices, TotpInfo } from '../../lib/types';
+import InlineTotpEnrolment from './InlineTotpEnrolment';
+import { MfaReason, MozServices } from '../../lib/types';
 import AppLayout from '../../components/AppLayout';
 import { Integration, useSession, useAuthClient } from '../../models';
-import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { MfaGuardCore } from '../../components/Settings/MfaGuard';
 import { getSigninState } from '../Signin/utils';
 import { SigninLocationState } from '../Signin/interfaces';
-import { SigninRecoveryLocationState } from '../InlineRecoverySetupFlow/interfaces';
 import { QueryParams } from '../..';
 import { queryParamsToMetricsContext } from '../../lib/metrics';
-import GleanMetrics from '../../lib/glean';
-import * as Sentry from '@sentry/browser';
-import { MfaGuardCore } from '../../components/Settings/MfaGuard';
-import { JwtTokenCache } from '../../lib/cache';
-import { clearMfaAndJwtCacheOnInvalidJwt } from '../../lib/mfa-guard-utils';
-
-type MetricsContext = ReturnType<typeof queryParamsToMetricsContext>;
-
-type NavTo = (
-  uri:
-    | '/'
-    | '/signin_token_code'
-    | '/signin_totp_code'
-    | '/inline_recovery_setup',
-  state?: SigninLocationState | SigninRecoveryLocationState
-) => void;
-
-/**
- * Runs the actual TOTP enrolment. Rendered as a child of `MfaGuardCore`, so a
- * `mfa:2fa` JWT is already cached and the enrolment calls use the JWT-guarded
- * `/mfa/totp/*` routes (FXA-14311).
- */
-const InlineTotpEnrolment = ({
-  sessionToken,
-  signinState,
-  serviceName,
-  integration,
-  metricsContext,
-  navTo,
-}: {
-  sessionToken: string;
-  signinState: SigninLocationState;
-  serviceName: MozServices;
-  integration: Integration;
-  metricsContext: MetricsContext;
-  navTo: NavTo;
-}) => {
-  const authClient = useAuthClient();
-  const [totp, setTotp] = useState<TotpInfo>();
-  const isTotpCreating = useRef(false);
-
-  // Trigger TOTP setup once the guard has provided the JWT.
-  useEffect(() => {
-    if (totp !== undefined || isTotpCreating.current) {
-      return;
-    }
-    (async () => {
-      isTotpCreating.current = true;
-      try {
-        const jwt = JwtTokenCache.getToken(sessionToken, '2fa');
-        const totpResp = await authClient.createTotpTokenWithJwt(jwt, {
-          metricsContext,
-        });
-        setTotp(totpResp);
-      } catch (error) {
-        // The short-lived mfa:2fa JWT can expire mid-flow. On a stale/invalid
-        // JWT, drop it so MfaGuardCore re-prompts for a fresh email OTP rather
-        // than bouncing the user out. Keyed on the guard's `sessionToken`, not
-        // the global one, since this flow supplies its own.
-        if (clearMfaAndJwtCacheOnInvalidJwt(error, '2fa', sessionToken)) {
-          isTotpCreating.current = false;
-          return;
-        }
-        Sentry.captureException(error);
-        navTo('/');
-      }
-    })();
-  }, [authClient, metricsContext, navTo, totp, sessionToken]);
-
-  const verifyCodeHandler = useCallback(
-    async (code: string) => {
-      try {
-        const jwt = JwtTokenCache.getToken(sessionToken, '2fa');
-        await authClient.verifyTotpSetupCodeWithJwt(jwt, code, {
-          metricsContext,
-        });
-
-        const state = {
-          ...Object.assign({}, signinState),
-          ...(totp ? { totp } : {}),
-        };
-        GleanMetrics.accountPref.twoStepAuthQrCodeSuccess();
-        navTo(
-          '/inline_recovery_setup',
-          Object.keys(state).length > 0 ? state : undefined
-        );
-      } catch (error) {
-        // A stale/expired MFA JWT surfaces here as an invalid-JWT error, not a
-        // bad code. Clearing it drops the cached token so MfaGuardCore
-        // re-prompts for a fresh email OTP; genuine verification failures fall
-        // through to INVALID_TOTP_CODE. (The thrown value is not user-visible —
-        // the parent collapses any rejection into a generic error.)
-        if (clearMfaAndJwtCacheOnInvalidJwt(error, '2fa', sessionToken)) {
-          throw error;
-        }
-        // TODO: handle this error better
-        // auth-server may return more specific errors (including throttling)
-        throw AuthUiErrors.INVALID_TOTP_CODE;
-      }
-    },
-    [authClient, navTo, totp, signinState, sessionToken, metricsContext]
-  );
-
-  if (totp === undefined) {
-    return <AppLayout loading />;
-  }
-
-  return (
-    <InlineTotpSetup
-      {...{ totp, serviceName, verifyCodeHandler, integration }}
-      signedInWithPasskey={!!signinState.isPasskeySession}
-    />
-  );
-};
+import { NavTo } from './interfaces';
 
 export const InlineTotpSetupContainer = ({
   isSignedIn,
@@ -159,6 +46,11 @@ export const InlineTotpSetupContainer = ({
     flowQueryParams as unknown as Record<string, string>
   );
   const isTotpStatusChecked = useRef(false);
+
+  const [currentStep, setCurrentStep] = useState<number>(0);
+  const navigateBackward = useCallback(() => {
+    setCurrentStep((step) => Math.max(0, step - 1));
+  }, []);
 
   const signinState = getSigninState(location.state);
 
@@ -247,27 +139,39 @@ export const InlineTotpSetupContainer = ({
     return <AppLayout loading />;
   }
 
-  // Gate enrolment behind an MFA email-OTP so a hijacked session cannot silently
-  // add a second factor (FXA-14311).
-  return (
+  // Gate enrolment behind an MFA email-OTP so a hijacked session can't silently
+  // add a second factor. Wraps only step 1, so the intro shows no OTP (FXA-14311).
+  const enrolment = (
     <MfaGuardCore
       requiredScope="2fa"
       reason={MfaReason.createTotp}
       email={signinState.email}
       sessionToken={signinState.sessionToken}
-      onDismiss={() => navTo('/')}
+      onDismiss={() => setCurrentStep(0)}
       onSessionInvalid={() => navigateWithQuery('/signin')}
-      onFatalError={() => navTo('/')}
+      onFatalError={() => navigateWithQuery('/signin')}
     >
       <InlineTotpEnrolment
         sessionToken={signinState.sessionToken}
         signinState={signinState}
-        serviceName={serviceName}
-        integration={integration}
         metricsContext={metricsContext}
         navTo={navTo}
+        currentStep={currentStep}
+        onBackButtonClick={navigateBackward}
+        cmsInfo={integration?.getCmsInfo?.()}
       />
     </MfaGuardCore>
+  );
+
+  return (
+    <InlineTotpSetup
+      currentStep={currentStep}
+      onContinue={() => setCurrentStep(1)}
+      serviceName={serviceName}
+      integration={integration}
+      signedInWithPasskey={!!signinState.isPasskeySession}
+      enrolment={enrolment}
+    />
   );
 };
 

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
@@ -5,11 +5,11 @@
 import InlineTotpSetup from '.';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
-import { MOCK_TOTP_TOKEN } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { action } from '@storybook/addon-actions';
-import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
-import { createMockIntegrationWithCms } from '../mocks';
+import { Integration } from '../../models';
+import FlowSetup2faApp from '../../components/Settings/FlowSetup2faApp';
+import { MOCK_TOTP_TOKEN } from './mocks';
 
 export default {
   title: 'Pages/InlineTotpSetup',
@@ -17,44 +17,34 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const verifyCodeHandler = (code: string) => {
-  action('verifyCodeHandler')(code);
-  return Promise.resolve();
+const commonProps = {
+  onContinue: () => action('onContinue')(),
+  serviceName: MozServices.Addons,
+  integration: {} as Integration,
+  enrolment: null,
 };
 
+// Step 0: the intro the container renders before gating enrolment behind the guard.
 export const Default = () => (
-  <InlineTotpSetup
-    totp={MOCK_TOTP_TOKEN}
-    serviceName={MozServices.Addons}
-    verifyCodeHandler={verifyCodeHandler}
-  />
+  <InlineTotpSetup {...commonProps} currentStep={0} />
 );
 
-export const SignedInWithPasskey = () => (
+// Step 1: what the user sees once the guard passes and the TOTP token is created.
+// The real page composes this behind MfaGuardCore; here we render FlowSetup2faApp
+// directly for a visual reference (see its own stories for more variants).
+export const EnrolmentStep = () => (
   <InlineTotpSetup
-    totp={MOCK_TOTP_TOKEN}
-    serviceName={MozServices.Addons}
-    verifyCodeHandler={verifyCodeHandler}
-    signedInWithPasskey
-  />
-);
-
-export const onError = () => (
-  <InlineTotpSetup
-    totp={MOCK_TOTP_TOKEN}
-    serviceName={MozServices.Addons}
-    verifyCodeHandler={(code) => {
-      action('verifyCodeHandler')(code);
-      return Promise.reject(AuthUiErrors.INVALID_TOTP_CODE);
-    }}
-  />
-);
-
-export const WithCms = () => (
-  <InlineTotpSetup
-    totp={MOCK_TOTP_TOKEN}
-    serviceName={MozServices.Addons}
-    verifyCodeHandler={verifyCodeHandler}
-    integration={createMockIntegrationWithCms()}
+    {...commonProps}
+    currentStep={1}
+    enrolment={
+      <FlowSetup2faApp
+        localizedPageTitle="Two-step authentication"
+        totpInfo={MOCK_TOTP_TOKEN}
+        verifyCode={async () => ({})}
+        showProgressBar
+        currentStep={1}
+        numberOfSteps={4}
+      />
+    }
   />
 );

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -6,36 +6,39 @@ import { screen } from '@testing-library/react';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import InlineTotpSetup from '.';
-import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
-import { MOCK_TOTP_TOKEN } from './mocks';
 import { MozServices } from '../../lib/types';
+import { Integration } from '../../models';
+import { InlineTotpSetupProps } from './interfaces';
 
-const cancelSetupHandler = jest.fn();
-const verifyCodeHandler = jest.fn();
-const mockProps = {
-  totp: MOCK_TOTP_TOKEN,
+const onContinue = jest.fn();
+
+const ENROLMENT_TESTID = 'enrolment-step';
+const enrolment = <div data-testid={ENROLMENT_TESTID}>enrolment</div>;
+
+const buildProps = (
+  overrides: Partial<InlineTotpSetupProps> = {}
+): InlineTotpSetupProps => ({
+  currentStep: 0,
+  onContinue,
   serviceName: MozServices.Addons,
-  cancelSetupHandler,
-  verifyCodeHandler,
-};
+  integration: {} as Integration,
+  signedInWithPasskey: false,
+  enrolment,
+  ...overrides,
+});
 
 describe('InlineTotpSetup', () => {
   let user: UserEvent;
 
-  const clickContinue = async () => {
-    await user.click(await screen.findByRole('button', { name: 'Continue' }));
-  };
-
   beforeEach(() => {
     user = userEvent.setup();
+    onContinue.mockReset();
   });
 
-  it('renders the intro as expected', () => {
-    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
+  it('renders the intro at step 0', () => {
+    renderWithLocalizationProvider(<InlineTotpSetup {...buildProps()} />);
 
-    screen.getByRole('heading', {
-      name: 'Two-step authentication',
-    });
+    screen.getByRole('heading', { name: 'Two-step authentication' });
     expect(
       screen.getByText('Set up two-step authentication')
     ).toBeInTheDocument();
@@ -44,21 +47,16 @@ describe('InlineTotpSetup', () => {
         'Add-ons requires you to set up two-step authentication to keep your account safe.'
       )
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Continue' })
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId(ENROLMENT_TESTID)).not.toBeInTheDocument();
   });
 
   it('renders the passkey intro when signedInWithPasskey is set', () => {
     renderWithLocalizationProvider(
-      <InlineTotpSetup {...mockProps} signedInWithPasskey />
+      <InlineTotpSetup {...buildProps({ signedInWithPasskey: true })} />
     );
 
     expect(
       screen.getByText('Successfully signed in with passkey')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/also requires two-step authentication for your/)
     ).toBeInTheDocument();
     expect(
       screen.queryByText(
@@ -67,62 +65,20 @@ describe('InlineTotpSetup', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders step 1 as expected, showing the QR code by default', async () => {
-    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    await clickContinue();
-    expect(
-      await screen.findByRole('progressbar', {
-        name: 'Step 1 of 4.',
-      })
-    ).toBeInTheDocument();
-    expect(await screen.findByText(/Scan this QR code/)).toBeInTheDocument();
+  it('calls onContinue when the intro Continue button is clicked', async () => {
+    renderWithLocalizationProvider(<InlineTotpSetup {...buildProps()} />);
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(onContinue).toHaveBeenCalled();
   });
 
-  it('can go back to intro from step 1', async () => {
-    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    await clickContinue();
-    expect(
-      await screen.findByText('Connect to your authenticator app')
-    ).toBeInTheDocument();
-    user.click(screen.getByRole('button', { name: 'Back' }));
-    expect(
-      await screen.findByText('Set up two-step authentication')
-    ).toBeInTheDocument();
-  });
-
-  it('calls verifyCodeHandler on code submission', async () => {
-    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    await clickContinue();
-    await user.type(
-      await screen.findByLabelText('Enter 6-digit code'),
-      '123456'
-    );
-    await clickContinue();
-    expect(verifyCodeHandler).toHaveBeenCalledWith('123456');
-  });
-
-  it('shows error on incorrect totp submission', async () => {
-    const verifyCodeHandler = jest
-      .fn()
-      .mockRejectedValue(AuthUiErrors.INVALID_TOTP_CODE);
+  it('renders the enrolment step at step 1', () => {
     renderWithLocalizationProvider(
-      <InlineTotpSetup
-        {...{
-          ...mockProps,
-          verifyCodeHandler,
-        }}
-      />
+      <InlineTotpSetup {...buildProps({ currentStep: 1 })} />
     );
 
-    await clickContinue();
-    await user.type(
-      await screen.findByLabelText('Enter 6-digit code'),
-      '000000'
-    );
-    await clickContinue();
-    expect(verifyCodeHandler).toHaveBeenCalledWith('000000');
+    expect(screen.getByTestId(ENROLMENT_TESTID)).toBeInTheDocument();
     expect(
-      await screen.findByText(/Invalid or expired code/)
-    ).toBeInTheDocument();
+      screen.queryByText('Set up two-step authentication')
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -2,40 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useFtlMsgResolver } from '../../models';
 import AppLayout from '../../components/AppLayout';
 import { InlineTotpSetupProps } from './interfaces';
 import FlowSetup2faPrompt from '../../components/Settings/FlowSetup2faPrompt';
-import FlowSetup2faApp from '../../components/Settings/FlowSetup2faApp';
-
-// Total number of steps in the TOTP setup flow, including the recovery method setup.
-const numberOfSteps = 4;
 
 export const InlineTotpSetup = ({
-  totp,
+  currentStep,
+  onContinue,
   serviceName,
-  verifyCodeHandler,
   integration,
   signedInWithPasskey,
+  enrolment,
 }: InlineTotpSetupProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
-  const [currentStep, setCurrentStep] = useState<number>(0);
-
-  const onSubmit = async (code: string) => {
-    try {
-      await verifyCodeHandler(code);
-    } catch (err) {
-      return { error: true };
-    }
-    return { error: false };
-  };
-
-  const navigateBackward = () => {
-    if (currentStep > 0) {
-      setCurrentStep(currentStep - 1);
-    }
-  };
 
   const localizedPageTitle = ftlMsgResolver.getMsg(
     'inline-totp-setup-page-title',
@@ -48,25 +29,14 @@ export const InlineTotpSetup = ({
     <AppLayout wrapInCard={false} cmsInfo={cmsInfo}>
       {currentStep === 0 && (
         <FlowSetup2faPrompt
-          onContinue={() => setCurrentStep(currentStep + 1)}
+          onContinue={onContinue}
           localizedPageTitle={localizedPageTitle}
           serviceName={serviceName}
           cmsInfo={cmsInfo}
           signedInWithPasskey={signedInWithPasskey}
         />
       )}
-      {currentStep === 1 && (
-        <FlowSetup2faApp
-          localizedPageTitle={localizedPageTitle}
-          showProgressBar
-          currentStep={currentStep}
-          numberOfSteps={numberOfSteps}
-          totpInfo={totp}
-          verifyCode={onSubmit}
-          onBackButtonClick={navigateBackward}
-          cmsInfo={cmsInfo}
-        />
-      )}
+      {currentStep === 1 && enrolment}
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
@@ -2,15 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReactNode } from 'react';
 import { MozServices, TotpInfo } from '../../lib/types';
 import { Integration } from '../../models';
+import { queryParamsToMetricsContext } from '../../lib/metrics';
+import { SigninLocationState } from '../Signin/interfaces';
+import { SigninRecoveryLocationState } from '../InlineRecoverySetupFlow/interfaces';
+
+export type MetricsContext = ReturnType<typeof queryParamsToMetricsContext>;
+
+export type NavTo = (
+  uri:
+    | '/'
+    | '/signin_token_code'
+    | '/signin_totp_code'
+    | '/inline_recovery_setup',
+  state?: SigninLocationState | SigninRecoveryLocationState
+) => void;
 
 export interface InlineTotpSetupProps {
-  totp: TotpInfo;
+  currentStep: number;
+  onContinue: () => void;
   serviceName: MozServices;
-  verifyCodeHandler: (code: string) => void;
-  integration?: Integration;
+  integration: Integration;
   signedInWithPasskey?: boolean;
+  /** The guarded enrolment step, composed by the container and rendered at step 1. */
+  enrolment: ReactNode;
 }
 
 export interface InlineTotpSetupPropsOld {


### PR DESCRIPTION
## Because

- The inline TOTP setup flow requested an email OTP on page load, before the user saw the "set up two-step authentication" intro.
- Users who never proceed past the intro were forced through an unnecessary email-OTP round-trip.

## This pull request

- Wraps only the enrolment step in `MfaGuardCore` so the intro renders without an OTP; the modal now appears after "Continue", not on page load.
- Container owns the `currentStep` machine and composes the guarded enrolment; `index.tsx` is a presentational `AppLayout` + step-dispatch shell.
- Extracts `InlineTotpEnrolment` (JWT-guarded `createTotp`/`verify`) into its own file, rendered under the guard at step 1.
- Returns to the intro on guard dismiss; shows `CardLoadingSpinner` while the TOTP token is created.
- Reorders the functional inline TOTP specs to confirm the guard after "Continue"; splits unit tests into enrolment, presentational-shell, and container-wiring suites.

## Issue that this pull request solves

Closes: FXA-14407

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `container.tsx` (step state + guard composition), `InlineTotpEnrolment.tsx` (JWT create/verify), `index.tsx` (presentational shell).
- Suggested review order: `interfaces.ts` → `container.tsx` → `InlineTotpEnrolment.tsx` → `index.tsx` → tests.
- Risky or complex parts: confirm no enrolment path reaches `createTotp`/`verify` without the `mfa:2fa` JWT — the guard must gate step 1, and the enrolment stays a child of `MfaGuardCore` (the JWT only exists once the guard renders its children).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Behavior change: the email-OTP modal now appears when the user clicks "Continue", not on page load. The intro and QR-code UI are visually unchanged.
- Structure reflects review feedback: `currentStep` + the MFA guard live in the container, keeping `index.tsx` presentational.
- Follow-up refactor to the MFA guard introduced in FXA-14311 (PR #21001).
