### PR TITLE
task(settings): Implement pairing v2 flow

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -177,10 +177,10 @@ const PairSuppWaitForAuth = lazy(
 );
 
 const PairAuthorityApproveSignIn = lazy(
-  () => import('../../pages/Pair2/Authority/ApproveSignIn')
+  () => import('../../pages/Pair2/Authority/ApproveSignIn/container')
 );
 const PairAuthorityContinueOnMobile = lazy(
-  () => import('../../pages/Pair2/Authority/ContinueOnMobile')
+  () => import('../../pages/Pair2/Authority/ContinueOnMobile/container')
 );
 const PairAuthorityDownloadFirefox = lazy(
   () => import('../../pages/Pair2/Authority/DownloadFirefox')
@@ -192,15 +192,15 @@ const PairAuthoritySyncSuccess = lazy(
   () => import('../../pages/Pair2/Authority/SyncSuccess')
 );
 const PairAuthorityTimeoutAndCancel = lazy(
-  () => import('../../pages/Pair2/Authority/TimeoutAndCancel')
+  () => import('../../pages/Pair2/Authority/TimeoutAndCancel/container')
 );
 
 
 const PairSupplicantApproveSignIn = lazy(
-  () => import('../../pages/Pair2/Supplicant/ApproveSignIn')
+  () => import('../../pages/Pair2/Supplicant/ApproveSignIn/container')
 );
 const PairSupplicantConnectThisDevice = lazy(
-  () => import('../../pages/Pair2/Supplicant/ConnectThisDevice')
+  () => import('../../pages/Pair2/Supplicant/ConnectThisDevice/container')
 );
 const PairSupplicantDownloadFirefox = lazy(
   () => import('../../pages/Pair2/Supplicant/DownloadFirefox')
@@ -430,12 +430,20 @@ export const App = ({ flowQueryParams }: { flowQueryParams: QueryParams }) => {
     metricsEnabled,
   ]);
 
+  // A scanned QR drops the supplicant on `/pair#…v=2` with no client_id, so its
+  // client-info fetch always fails. Failing fast there would kill the hand-off
+  // before Pair gets a chance to route it.
+  const isPairingV2Handoff = () =>
+    !!window.location.pathname?.startsWith('/pair') &&
+    /\bv=2\b/.test(window.location.hash ?? '');
+
   // Fail fast: if the OAuth client-info fetch in useClientInfoState exhausted its
   // retries, surface the user-facing error immediately rather than waiting downstream
   // failures to occur.
   if (
     integration &&
     isOAuthIntegration(integration) &&
+    !isPairingV2Handoff() &&
     integration.clientInfoLoadFailed
   ) {
     try {
@@ -1066,30 +1074,15 @@ const AuthAndAccountSetupRoutes = ({
         <Route path="/pair/unsupported/*" element={<PairUnsupported />} />
         <Route
           path="/pair/*"
-          element={<PairIndex integration={integration} />}
+          element={<PairIndex {...{integration, fxaStatusResult: useFxAStatusResult}} />}
         />
         <Route
           path="/pair/authority/approve_signin/*"
-          element={<PairAuthorityApproveSignIn {...{
-            email: 'foo@mozilla.com',
-            remoteMetadata: {
-              deviceFamily: 'Mobile',
-              deviceOS: 'iOS',
-              ipAddress: '127.0.0.1',
-            },
-            onApprove: () => {
-              console.log('TBD!')
-            },
-            onChangePassword: () => {
-              console.log('TBD!')
-            }
-          }} />}
+          element={<PairAuthorityApproveSignIn {...{integration}} />}
         />
         <Route
           path="/pair/authority/continue_on_mobile/*"
-          element={<PairAuthorityContinueOnMobile {...{
-            onCancel: () => console.log('TBD')
-          }} />}
+          element={<PairAuthorityContinueOnMobile {...{integration}} />}
         />
         <Route
           path="/pair/authority/download_firefox/*"
@@ -1109,11 +1102,11 @@ const AuthAndAccountSetupRoutes = ({
         />
         <Route
           path="/pair/supplicant/approve_signin/*"
-          element={<PairSupplicantApproveSignIn />}
+          element={<PairSupplicantApproveSignIn {...{integration}} />}
         />
         <Route
           path="/pair/supplicant/connect_this_device/*"
-          element={<PairSupplicantConnectThisDevice />}
+          element={<PairSupplicantConnectThisDevice {...{integration}} />}
         />
         <Route
           path="/pair/supplicant/download_firefox/*"

--- a/packages/fxa-settings/src/components/FirefoxPromoBanner/index.test.tsx
+++ b/packages/fxa-settings/src/components/FirefoxPromoBanner/index.test.tsx
@@ -7,6 +7,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import * as ReactUtils from 'fxa-react/lib/utils';
 import FirefoxPromoBanner from './index';
 import { Constants } from '../../lib/constants';
 import { isProbablyFirefox, useAccount } from '../../models';
@@ -46,6 +47,7 @@ const mockIsFirefox = isProbablyFirefox as jest.Mock;
 const mockIsMobileOrTablet = isMobileOrTabletDevice as jest.Mock;
 const mockIsMobileDevice = isMobileDevice as jest.Mock;
 const mockUseAccount = useAccount as jest.Mock;
+let hardNavigateSpy: jest.SpyInstance;
 
 function renderBanner({ isSignedIntoFirefox = false } = {}) {
   return renderWithLocalizationProvider(
@@ -64,6 +66,13 @@ describe('FirefoxPromoBanner', () => {
     mockIsMobileDevice.mockImplementation(
       (client) => client?.deviceType === 'mobile'
     );
+    hardNavigateSpy = jest
+      .spyOn(ReactUtils, 'hardNavigate')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    hardNavigateSpy.mockRestore();
   });
 
   it('renders the mobile-install variant on desktop Firefox signed into the browser and emits view', () => {
@@ -112,6 +121,16 @@ describe('FirefoxPromoBanner', () => {
     expect(GleanMetrics.firefoxPromo.connectMobileSubmit).toHaveBeenCalledWith({
       event: { mobile_device_count: '1' },
     });
+  });
+
+  it('hard navigates to /pair so the integration is rebuilt', async () => {
+    const user = userEvent.setup();
+    mockIsFirefox.mockReturnValue(true);
+    mockIsMobileOrTablet.mockReturnValue(false);
+    renderBanner({ isSignedIntoFirefox: true });
+
+    await user.click(screen.getByRole('link', { name: 'Connect a device' }));
+    expect(hardNavigateSpy).toHaveBeenCalledWith('/pair');
   });
 
   it('renders the switch variant on desktop non-Firefox with the desktop download url', () => {

--- a/packages/fxa-settings/src/components/FirefoxPromoBanner/index.tsx
+++ b/packages/fxa-settings/src/components/FirefoxPromoBanner/index.tsx
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useLocation } from 'react-router';
-import { FtlMsg } from 'fxa-react/lib/utils';
+import { useLocation } from 'react-router';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { ReactComponent as IconClose } from '@fxa/shared/assets/images/close.svg';
 import { isProbablyFirefox, useAccount } from '../../models';
@@ -108,12 +108,23 @@ export const FirefoxPromoBannerView = ({
     bannerState === 'switch-mobile'
       ? Constants.FIREFOX_MOBILE_DOWNLOAD_URL
       : Constants.FIREFOX_DESKTOP_DOWNLOAD_URL;
+  const pairHref = `/pair${location.search ?? ''}`;
   const cta = (
     <FtlMsg id={variant.ctaId}>
       {bannerState === 'firefox-pair' ? (
-        <Link {...ctaProps} to={`/pair${location.search ?? ''}`}>
+        <a
+          {...ctaProps}
+          href={pairHref}
+          onClick={(e) => {
+            e.preventDefault();
+            emitMetric('submit');
+            // Full page load so the app re-bootstraps and rebuilds the
+            // integration from the /pair URL, as if the user had just arrived.
+            hardNavigate(pairHref);
+          }}
+        >
           {variant.cta}
-        </Link>
+        </a>
       ) : (
         <LinkExternal {...ctaProps} href={downloadUrl}>
           {variant.cta}

--- a/packages/fxa-settings/src/lib/channels/firefox.test.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.test.ts
@@ -9,6 +9,7 @@ import {
   FirefoxCommand,
   buildSyncOAuthSearch,
   FxAOAuthFlowBeginResponse,
+  FxAStatusResponse,
   PairOAuthFinishState,
   PairOAuthStartState,
 } from './firefox';
@@ -134,6 +135,7 @@ describe('Firefox pairing OAuth WebChannel methods', () => {
     state: 'mock-oauth-state',
     scope: 'profile https://identity.mozilla.com/apps/oldsync',
     code_challenge: 'mock-code-challenge',
+    code_challenge_method: 'mock-code-challenge-method',
     keys_jwk: 'mock-keys-jwk',
   };
 
@@ -142,6 +144,8 @@ describe('Firefox pairing OAuth WebChannel methods', () => {
     state: 'mock-oauth-state',
     scope: 'profile',
     code_challenge: 'mock-code-challenge',
+    code_challenge_method: 'mock-code-challenge-method',
+    keys_jwk: 'mock-keys-jwk'
   };
 
   const MOCK_FINISH_RESPONSE: PairOAuthFinishState = {
@@ -232,13 +236,9 @@ describe('Firefox pairing OAuth WebChannel methods', () => {
       await expect(promise).resolves.toEqual(MOCK_START_RESPONSE);
     });
 
-    // NOTE: two of the expected messages below are inaccurate in firefox.ts —
-    // every message is prefixed with PairOauthFinish rather than PairOauthStart,
-    // and an absent `scope` reports "missing code". Asserted as-is so the
-    // strings stay pinned; see the review note about correcting them.
     it.each([
       { field: 'state', message: 'missing state from event.details' },
-      { field: 'scope', message: 'missing code from event.details' },
+      { field: 'scope', message: 'missing scope from event.details' },
       {
         field: 'code_challenge',
         message: 'missing code_challenge from event.details',
@@ -254,7 +254,7 @@ describe('Firefox pairing OAuth WebChannel methods', () => {
           new CustomEvent(FirefoxCommand.PairOauthStart, { detail })
         );
         await expect(promise).rejects.toThrow(
-          `${FirefoxCommand.PairOauthFinish} ${message}`
+          `${FirefoxCommand.PairOauthStart} ${message}`
         );
       }
     );
@@ -364,7 +364,101 @@ describe('Firefox pairing OAuth WebChannel methods', () => {
       await promise;
 
       jest.advanceTimersByTime(SEND_TIMEOUT_MS);
-      expect(console.warn).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('Firefox fxaStatus', () => {
+  // Keep in sync with FXA_STATUS_ATTEMPTS/FXA_STATUS_TIMEOUT_MS in firefox.ts
+  // (not exported).
+  const ATTEMPTS = 3;
+  const TIMEOUT_MS = 1_000;
+
+  const MOCK_REQUEST = {
+    context: Constants.OAUTH_CONTEXT,
+    isPairing: true,
+    service: Constants.SYNC_SERVICE,
+  };
+
+  const MOCK_RESPONSE: FxAStatusResponse = {
+    capabilities: {
+      engines: ['bookmarks'],
+      multiService: true,
+      pairing: true,
+      pairingVersion: 2,
+    },
+  };
+
+  // Own instance so a listener left over from one case cannot settle another's
+  // promise.
+  let ff: Firefox;
+  let sendSpy: jest.SpyInstance;
+  const originalRAF = window.requestAnimationFrame;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    ff = new Firefox();
+    sendSpy = jest.spyOn(ff, 'send').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    window.requestAnimationFrame = originalRAF;
+    jest.useRealTimers();
+  });
+
+  it('resolves with the status from the response event', async () => {
+    const promise = ff.fxaStatus(MOCK_REQUEST);
+    expect(sendSpy).toHaveBeenCalledWith(
+      FirefoxCommand.FxAStatus,
+      MOCK_REQUEST
+    );
+
+    ff.dispatchEvent(
+      new CustomEvent(FirefoxCommand.FxAStatus, { detail: MOCK_RESPONSE })
+    );
+
+    await expect(promise).resolves.toEqual(MOCK_RESPONSE);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Firefox for Android binds its web channel handler per tab and routinely
+  // drops the first fxa_status. Resending is what takes that from a hang to a
+  // successful pairing.
+  it('resends and resolves when the first message is dropped', async () => {
+    const promise = ff.fxaStatus(MOCK_REQUEST);
+    await jest.advanceTimersByTimeAsync(TIMEOUT_MS);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+
+    ff.dispatchEvent(
+      new CustomEvent(FirefoxCommand.FxAStatus, { detail: MOCK_RESPONSE })
+    );
+
+    await expect(promise).resolves.toEqual(MOCK_RESPONSE);
+  });
+
+  it('resolves undefined once the attempts are exhausted', async () => {
+    const promise = ff.fxaStatus(MOCK_REQUEST);
+    await jest.advanceTimersByTimeAsync(TIMEOUT_MS * ATTEMPTS);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(sendSpy).toHaveBeenCalledTimes(ATTEMPTS);
+  });
+
+  it('stops resending once the browser has answered', async () => {
+    const promise = ff.fxaStatus(MOCK_REQUEST);
+    ff.dispatchEvent(
+      new CustomEvent(FirefoxCommand.FxAStatus, { detail: MOCK_RESPONSE })
+    );
+    await promise;
+
+    await jest.advanceTimersByTimeAsync(TIMEOUT_MS * ATTEMPTS);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -112,6 +112,7 @@ export type PairOAuthStartState = {
   state:string,
   scope:string,
   code_challenge: string,
+  code_challenge_method: string,
   keys_jwk:string
 }
 export type PairOAuthFinishState = {
@@ -245,6 +246,13 @@ export function buildSyncOAuthSearch(
 // max timeout of 100-200 ms would be optimal for an ultra-snappy UX, but could cause false negatives on mobile
 // compromising with 500ms for safer mobile support without being noticeably long if it times out
 const DEFAULT_SEND_TIMEOUT_LENGTH_MS = 500;
+
+// Firefox for Android binds its web channel handler per tab, so the first
+// fxa_status message is routinely dropped. Retrying a handful of times recovers
+// from that, and a longer per-attempt window than the default keeps a slow
+// mobile reply from being counted as a drop.
+const FXA_STATUS_ATTEMPTS = 3;
+const FXA_STATUS_TIMEOUT_MS = 1_000;
 
 let messageIdSuffix = 0;
 /**
@@ -415,23 +423,26 @@ export class Firefox extends EventTarget {
     this.broadcast(FirefoxCommand.ProfileChanged, profile);
   }
 
-  async fxaStatus(options: FxAStatusRequest): Promise<FxAStatusResponse> {
-    // We must wait for the browser to send a web channel message
-    // in response to the fxaLogin command. Without this we navigate the user before
-    // the login completes, resulting in an "Invalid token" error on the next page.
-    return new Promise((resolve) => {
-      const eventHandler = (firefoxEvent: any) => {
-        this.removeEventListener(FirefoxCommand.FxAStatus, eventHandler);
-        resolve(firefoxEvent.detail as FxAStatusResponse);
-      };
-      this.addEventListener(FirefoxCommand.FxAStatus, eventHandler);
-
-      // requestAnimationFrame ensures the event listener is added first
-      // otherwise, there is a race condition
-      requestAnimationFrame(() => {
-        this.send(FirefoxCommand.FxAStatus, options);
-      });
-    });
+  /**
+   * Asks the browser for its fxa_status. Resolves undefined once the attempts
+   * are exhausted, so callers settle on defaults instead of awaiting a reply
+   * that may never arrive — a dropped message used to leave the page spinning.
+   */
+  async fxaStatus(
+    options: FxAStatusRequest
+  ): Promise<FxAStatusResponse | undefined> {
+    for (let attempt = 0; attempt < FXA_STATUS_ATTEMPTS; attempt++) {
+      const status = await this._executeCommandWithResponse<FxAStatusResponse>(
+        FirefoxCommand.FxAStatus,
+        options,
+        (event) => event.detail as FxAStatusResponse,
+        FXA_STATUS_TIMEOUT_MS
+      );
+      if (status != null) {
+        return status;
+      }
+    }
+    return undefined;
   }
 
   fxaLogin(options: FxALoginRequest): void {
@@ -661,16 +672,19 @@ export class Firefox extends EventTarget {
       msg,
       (event) => {
         if (event?.detail?.state == null) {
-          throw new Error(`${FirefoxCommand.PairOauthFinish} missing state from event.details`);
+          throw new Error(`${FirefoxCommand.PairOauthStart} missing state from event.details`);
         }
         if (event?.detail?.scope == null) {
-          throw new Error(`${FirefoxCommand.PairOauthFinish} missing code from event.details`);
+          throw new Error(`${FirefoxCommand.PairOauthStart} missing scope from event.details`);
         }
         if (event?.detail?.code_challenge == null) {
-          throw new Error(`${FirefoxCommand.PairOauthFinish} missing code_challenge from event.details`);
+          throw new Error(`${FirefoxCommand.PairOauthStart} missing code_challenge from event.details`);
+        }
+        if (event?.detail?.code_challenge_method == null) {
+          throw new Error(`${FirefoxCommand.PairOauthStart} missing code_challenge_method from event.details`);
         }
         if (event?.detail?.keys_jwk == null) {
-          throw new Error(`${FirefoxCommand.PairOauthFinish} missing keys_jwk from event.details`);
+          throw new Error(`${FirefoxCommand.PairOauthStart} missing keys_jwk from event.details`);
         }
         return event.detail as PairOAuthStartState;
       }
@@ -683,6 +697,13 @@ export class Firefox extends EventTarget {
     state:string,
     scope:string,
     code_challenge:string,
+    code_challenge_method:string,
+    /**
+     * The supplicant's ephemeral public JWK. Firefox only wraps scoped keys into
+     * `keys_jwe` when this is present, so omitting it yields a code that grants
+     * the sync scope with no sync key behind it.
+     */
+    keys_jwk:string,
   }):Promise<PairOAuthFinishState|undefined> {
     return this._executeCommandWithResponse<PairOAuthFinishState>(
       FirefoxCommand.PairOauthFinish,

--- a/packages/fxa-settings/src/lib/channels/pairing-channel.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.ts
@@ -64,6 +64,17 @@ export type PairingChannelIncomingMessage = {
   state?: string;
 };
 
+export type PairingChannelV2SupplicantRequestMessage = {
+  remoteMetaData: PairingChannelRemoteMetadata;
+  client_id: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  keys_jwk: string;
+  scope:string;
+  state:string;
+}
+
+
 // Error definitions matching Backbone's pairing-channel-client-errors
 export const PairingChannelErrors = {
   UNEXPECTED_ERROR: { errno: 999, message: 'Unexpected error' },
@@ -246,11 +257,14 @@ export class PairingChannelClient extends EventTarget {
     data: Record<string, unknown> = {}
   ): Promise<void> {
     if (!this.channel) {
+      console.warn('No pairing channel!')
       throw new PairingChannelError('NOT_CONNECTED');
     }
     if (!message) {
+      console.warn('No message!')
       throw new PairingChannelError('INVALID_OUTBOUND_MESSAGE');
     }
+    console.info('Sending pairing message', message);
     await this.channel.send({ message, data });
   }
 
@@ -262,8 +276,10 @@ export class PairingChannelClient extends EventTarget {
     this.channel = null;
     this.removeChannelListeners(ch);
     try {
+      console.info('Closing channel ', ch._channelId)
       await ch.close();
     } catch (err) {
+      console.error("Error closing channel", err);
       sentryMetrics.captureException(err);
     }
   }
@@ -290,6 +306,8 @@ export class PairingChannelClient extends EventTarget {
       }
 
       const { data = {}, message } = payload;
+
+      console.info(`Receiving pairing message`, message)
 
       // Enrich with sender metadata (same shape as Backbone)
       data.remoteMetaData = {

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
@@ -200,7 +200,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.pairingEnabled).toBe(true);
+      expect(result.current.fxaStatus?.capabilities.pairing).toBe(true);
     });
 
     it('returns pairingEnabled: false when the pairing capability is absent', async () => {
@@ -211,7 +211,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.pairingEnabled).toBe(false);
+      expect(result.current.fxaStatus?.capabilities.pairing).toBe(false);
     });
 
     it('returns the pairingVersion reported by the browser', async () => {
@@ -222,7 +222,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.pairingVersion).toBe(2);
+      expect(result.current.fxaStatus?.capabilities.pairingVersion).toBe(2);
     });
 
     it('defaults pairingVersion to 1 when the browser omits it', async () => {
@@ -233,7 +233,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.pairingVersion).toBe(1);
+      expect(result.current.fxaStatus?.capabilities.pairingVersion).toBe(1);
     });
 
     it('defaults pairingVersion to 1 when the browser reports version 0', async () => {
@@ -244,7 +244,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.pairingVersion).toBe(1);
+      expect(result.current.fxaStatus?.capabilities.pairingVersion).toBe(1);
     });
 
     it('returns the hasSyncKeys when browser reports true', async () => {
@@ -255,7 +255,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.hasSyncKeys).toBe(true);
+      expect(result.current.fxaStatus?.capabilities.hasSyncKeys).toBe(true);
     });
 
     it('returns the hasSyncKeys when browser reports false', async () => {
@@ -266,7 +266,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.hasSyncKeys).toBe(false);
+      expect(result.current.fxaStatus?.capabilities.hasSyncKeys).toBe(false);
     });
 
     it('returns the hasSyncKeys when browser does not report', async () => {
@@ -277,7 +277,7 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.hasSyncKeys).toBe(undefined);
+      expect(result.current.fxaStatus?.capabilities.hasSyncKeys).toBe(undefined);
     });
 
     // Very old versions of Firefox iOS omit `capabilities` entirely.
@@ -289,8 +289,40 @@ describe('useFxAStatus', () => {
       );
       await waitForNextUpdate();
 
-      expect(result.current.pairingEnabled).toBe(false);
-      expect(result.current.pairingVersion).toBe(1);
+      expect(result.current.fxaStatus?.capabilities.pairing).toBe(false);
+      expect(result.current.fxaStatus?.capabilities.pairingVersion).toBe(1);
+    });
+  });
+
+  // firefox.fxaStatus gives up after a bounded number of attempts, and callers
+  // like Pair/Index render a spinner while `fxaStatus` is undefined. Settling on
+  // the defaults is what keeps a dropped web channel message from hanging them.
+  describe('browser never answers', () => {
+    const integration = {
+      type: IntegrationType.PairingAuthority,
+      isSync: () => true,
+      isFirefoxNonSync: () => false,
+      isPairing: () => true,
+    };
+
+    it('settles on the defaults instead of leaving fxaStatus undefined', async () => {
+      (firefox.fxaStatus as jest.Mock).mockResolvedValue(undefined);
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useFxAStatus(integration)
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.fxaStatus).toEqual({
+        capabilities: {
+          engines: [],
+          multiService: false,
+          pairing: false,
+          pairingVersion: 1,
+        },
+      });
+      expect(result.current.supportsKeysOptionalLogin).toBe(false);
+      expect(result.current.supportsCanLinkAccountUid).toBe(false);
     });
   });
 
@@ -318,8 +350,8 @@ describe('useFxAStatus', () => {
 
       const { result } = renderHook(() => useFxAStatus(integration));
 
-      expect(result.current.pairingEnabled).toBe(false);
-      expect(result.current.pairingVersion).toBe(1);
+      expect(result.current.fxaStatus?.capabilities.pairing).toBe(false);
+      expect(result.current.fxaStatus?.capabilities.pairingVersion).toBe(1);
     });
   });
 

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
@@ -16,13 +16,37 @@ import {
   syncEngineConfigs,
   webChannelDesktopV3EngineConfigs,
 } from '../../sync-engines';
-import firefox from '../../channels/firefox';
+import firefox, { FxAStatusResponse } from '../../channels/firefox';
 import { Constants } from '../../constants';
 
 type FxAStatusIntegration = Pick<
   Integration,
   'type' | 'isSync' | 'isFirefoxNonSync' | 'isPairing'
 >;
+
+type SyncEngineConfigs = typeof syncEngineConfigs | undefined;
+
+/**
+ * `pairing` is optional in the fxa_status response, and very old versions of
+ * Firefox iOS omit `capabilities` entirely. Normalizing here means callers can
+ * read the capability off `fxaStatus` instead of each re-deriving the default.
+ */
+const DEFAULT_PAIRING_CAPABILITIES = {
+  pairing: false,
+  pairingVersion: 1,
+};
+
+/**
+ * What we settle on when no fxa_status is coming — either the browser cannot
+ * answer at all, or it never replied within `firefox.fxaStatus`'s attempts.
+ */
+const DEFAULT_FXA_STATUS: FxAStatusResponse = {
+  capabilities: {
+    engines: [],
+    multiService: false,
+    ...DEFAULT_PAIRING_CAPABILITIES,
+  },
+};
 
 /**
  * If integration.isSync or integration is OAuthNative, sends firefox.fxaStatus to retrieve
@@ -34,36 +58,25 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
   const isSync = integration.isSync();
   const isPairing = integration.isPairing();
   const isOAuthNative = isOAuthNativeIntegration(integration);
-
-  const [webChannelEngines, setWebChannelEngines] = useState<
-    string[] | undefined
-  >();
-  const [offeredSyncEngineConfigs, setOfferedSyncEngineConfigs] = useState<
-    typeof syncEngineConfigs | undefined
-  >();
+  const [webChannelEngines, setWebChannelEngines] = useState<string[]>();
+  const [offeredSyncEngineConfigs, setOfferedSyncEngineConfigs] =
+    useState<SyncEngineConfigs>();
   const [declinedSyncEngines, setDeclinedSyncEngines] = useState<string[]>([]);
   const [supportsKeysOptionalLogin, setSupportsKeysOptionalLogin] =
     useState<boolean>(false);
+
   const [supportsCanLinkAccountUid, setSupportsCanLinkAccountUid] = useState<
     boolean | undefined
   >(undefined);
 
   // Undefined until the browser answers, so callers can tell "not yet known"
-  // from "no pairing support" rather than routing on an unresolved default.
-  const [pairingEnabled, setPairingEnabled] = useState<boolean | undefined>(
-    undefined
-  );
-  const [pairingVersion, setPairingVersion] = useState<number | undefined>(
-    undefined
-  );
-  const [hasSyncKeys, setHasSyncKeys] = useState<boolean | undefined>(
-    undefined
-  );
+  // from "settled, no pairing" rather than routing on an unresolved default.
+  const [fxaStatus, setFxaStatus] = useState<FxAStatusResponse>();
 
   useEffect(() => {
     // This sends a web channel message to the browser to prompt a response
     // that we listen for.
-    if ((isSync || isOAuthNative) && isProbablyFirefox()) {
+    if ((isSync || isOAuthNative || isPairing) && isProbablyFirefox()) {
       (async () => {
         const status = await firefox.fxaStatus({
           // TODO: Improve getting 'context', probably set this on the integration
@@ -74,9 +87,24 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
           service: Constants.SYNC_SERVICE,
         });
 
-        // Very old versions of Firefox iOS do not send `capabilities` in the
-        // fxa_status response. This suppresses TypeErrors due to this.
-        const capabilities = status.capabilities || {};
+        // `status` is undefined when the browser never answered, and very old
+        // versions of Firefox iOS answer without `capabilities`. Falling back to
+        // the defaults in both cases means callers settle rather than wait.
+        const capabilities = {
+          ...DEFAULT_FXA_STATUS.capabilities,
+          ...status?.capabilities,
+        };
+
+        setFxaStatus({
+          ...status,
+          capabilities: {
+            ...capabilities,
+            pairing: !!capabilities.pairing,
+            pairingVersion:
+              capabilities.pairingVersion ||
+              DEFAULT_PAIRING_CAPABILITIES.pairingVersion,
+          },
+        });
 
         if (!webChannelEngines && capabilities.engines) {
           // choose_what_to_sync may be disabled for mobile sync, see:
@@ -106,13 +134,11 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
         } else {
           setSupportsCanLinkAccountUid(false);
         }
-        setPairingEnabled(!!capabilities.pairing);
-        setPairingVersion(capabilities.pairingVersion || 1);
-        setHasSyncKeys(capabilities.hasSyncKeys);
       })();
     } else {
-      setPairingEnabled(false);
-      setPairingVersion(1);
+      // No fxa_status is coming, so settle on the defaults rather than leaving
+      // callers waiting on a reply that will never arrive.
+      setFxaStatus(DEFAULT_FXA_STATUS);
     }
   }, [
     isSync,
@@ -170,15 +196,13 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
   }, [isSync, declinedSyncEngines, offeredSyncEngines]);
 
   return {
-    pairingVersion,
-    pairingEnabled,
-    hasSyncKeys,
     offeredSyncEngines,
     offeredSyncEngineConfigs,
     declinedSyncEngines,
     selectedEnginesForGlean,
     supportsKeysOptionalLogin,
     supportsCanLinkAccountUid,
+    fxaStatus,
   };
 }
 

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
@@ -8,14 +8,12 @@ import type { UseFxAStatusResult } from '.';
 export function mockUseFxAStatus({
   pairingEnabled = true,
   pairingVersion = 1,
-  hasSyncKeys = undefined,
   offeredSyncEnginesOverride,
   supportsKeysOptionalLogin = false,
   supportsCanLinkAccountUid,
 }: {
-  pairingEnabled?:boolean,
-  pairingVersion?: 1,
-  hasSyncKeys?: undefined,
+  pairingEnabled?: boolean;
+  pairingVersion?: number;
   offeredSyncEnginesOverride?: ReturnType<typeof getSyncEngineIds>;
   supportsKeysOptionalLogin?: boolean;
   supportsCanLinkAccountUid?: boolean | undefined;
@@ -37,15 +35,23 @@ export function mockUseFxAStatus({
   );
 
   return {
-    pairingEnabled,
-    pairingVersion,
-    hasSyncKeys,
     offeredSyncEngines,
     offeredSyncEngineConfigs,
     declinedSyncEngines,
     selectedEnginesForGlean,
     supportsKeysOptionalLogin,
     supportsCanLinkAccountUid,
+    fxaStatus: {
+      capabilities: {
+        engines: [],
+        multiService: true,
+        choose_what_to_sync: true,
+        keys_optional: true,
+        can_link_account_uid: true,
+        pairing: pairingEnabled,
+        pairingVersion,
+      },
+    },
   } satisfies UseFxAStatusResult;
 }
 

--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
@@ -10,7 +10,7 @@ import { IntegrationFlags } from '../integrations/interfaces';
 // only) is the URL the v1 QR code resolves to, so requiring one would stop the
 // supplicant integration from being built for the flow's own entry point.
 const DEVICE_PAIRING_SUPPLICANT_PATHNAME_REGEXP = /^\/pair\/supp/;
-const DEVICE_PAIRING_V2_SUPPLICANT_PATHNAME_REGEXP = /^\/pair\/supplicant\//;
+const DEVICE_PAIRING_V2_SUPPLICANT_PATHNAME_REGEXP = /(^\/pair\/supplicant\/)|(^\/pair#.*v=2)/;
 const DEVICE_PAIRING_V2_AUTHORITY_PATHNAME_REGEXP = /^\/pair\/authority\//;
 
 /**
@@ -43,7 +43,7 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
     // OAuth redirect (not WebChannel) for the supplicant flow.
     return (
       DEVICE_PAIRING_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname) ||
-      DEVICE_PAIRING_V2_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname)
+      DEVICE_PAIRING_V2_SUPPLICANT_PATHNAME_REGEXP.test(this.pathname + this.urlQueryData.hash)
     );
   }
 

--- a/packages/fxa-settings/src/lib/model-data/data-stores/url-query-data.ts
+++ b/packages/fxa-settings/src/lib/model-data/data-stores/url-query-data.ts
@@ -97,6 +97,20 @@ export class UrlQueryData extends UrlData {
    */
   public async toSearchQuery() {
     await this.synchronized();
+    return this.search;
+  }
+
+  /**
+   * Exposes the location's raw search string
+   */
+  get search() {
     return this.window.location.search;
+  }
+
+  /**
+   * Exposes the location's raw hash string
+   */
+  get hash() {
+    return this.window.location.hash;
   }
 }

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -361,3 +361,38 @@ export function buildPairingDownloadUrl(entrypoint?: string | null): string {
     ? Constants.DOWNLOAD_LINK_PAIRING_QR_SEND_TAB
     : Constants.DOWNLOAD_LINK_PAIRING_QR_DEFAULT;
 }
+
+
+// Detect device type from user agent.
+export enum Devices {
+  FIREFOX_ANDROID = 'Firefox Android',
+  FIREFOX_DESKTOP = 'Firefox Desktop',
+  FIREFOX_IOS = 'Firefox iOS',
+  OTHER_ANDROID = 'Other Android',
+  OTHER_IOS = 'Other iOS',
+  OTHER = 'Other',
+}
+export function detectDevice(): Devices {
+  const ua = navigator.userAgent;
+  const isFirefox = /Firefox/i.test(ua) && !/FxiOS/i.test(ua);
+  const isFxiOS = /FxiOS/i.test(ua);
+  const isAndroid = /Android/i.test(ua);
+  const isIos = /iPhone|iPad|iPod/i.test(ua) || isFxiOS;
+
+  if (isFirefox && isAndroid) {
+    return Devices.FIREFOX_ANDROID;
+  }
+  if (isFxiOS) {
+    return Devices.FIREFOX_IOS;
+  }
+  if (isFirefox && !isAndroid) {
+    return Devices.FIREFOX_DESKTOP;
+  }
+  if (isIos) {
+    return Devices.OTHER_IOS;
+  }
+  if (isAndroid) {
+    return Devices.OTHER_ANDROID;
+  }
+  return Devices.OTHER;
+}

--- a/packages/fxa-settings/src/models/integrations/pairing-authority-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-authority-integration.test.ts
@@ -7,11 +7,13 @@ import {
   AuthorityState,
   PairingAuthorityIntegration,
 } from './pairing-authority-integration';
+import { OAUTH_ERRORS } from '../../lib/oauth';
 
 const CHANNEL_SERVER_URI = 'wss://channel.example.com';
 
 const mockCreate = jest.fn().mockResolvedValue(undefined);
 const mockChannelClose = jest.fn().mockResolvedValue(undefined);
+const mockChannelSend = jest.fn().mockResolvedValue(undefined);
 const mockRemoveEventListener = jest.fn();
 let mockListeners: Record<string, Function[]> = {};
 
@@ -22,6 +24,7 @@ jest.mock('../../lib/channels/pairing-channel', () => {
     PairingChannelClient: jest.fn().mockImplementation(() => ({
       create: mockCreate,
       close: mockChannelClose,
+      send: mockChannelSend,
       channelId: 'chan-1',
       channelKey: 'key-1',
       addEventListener: jest.fn((type: string, handler: Function) => {
@@ -32,6 +35,47 @@ jest.mock('../../lib/channels/pairing-channel', () => {
   };
 });
 
+/**
+ * Derived by `PairingChannelClient` from the channel server's `sender`
+ * envelope rather than read out of the payload — it is what the authority
+ * shows so the user can confirm which device is asking.
+ */
+const MOCK_REMOTE_METADATA = {
+  city: 'Vancouver',
+  country: 'Canada',
+  region: 'British Columbia',
+  ipAddress: '127.0.0.1',
+  ua: 'Mozilla/5.0 (Android 14; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0',
+};
+
+/**
+ * The OAuth params a supplicant sends in `pair:supp:request`. `keys_jwk` is the
+ * one Firefox needs to wrap the scoped keys, so it has to survive the hop to
+ * `pairOauthFinish`.
+ */
+const MOCK_SUPP_OAUTH_PARAMS = {
+  client_id: 'a2270f727f45f648',
+  scope: 'profile https://identity.mozilla.com/apps/oldsync',
+  state: 'mock-supp-state',
+  // A real S256 challenge is 43 base64url characters, which the validator
+  // enforces — a placeholder short enough to be obviously fake would be
+  // rejected before it ever reached `pairOauthFinish`.
+  code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+  code_challenge_method: 'S256',
+  keys_jwk: 'mock-keys-jwk',
+};
+
+/** A complete v2 supplicant request — nothing the authority needs is absent. */
+const MOCK_SUPP_REQUEST = {
+  ...MOCK_SUPP_OAUTH_PARAMS,
+  remoteMetaData: MOCK_REMOTE_METADATA,
+};
+
+const MOCK_OAUTH_CODE = {
+  code: 'mock-oauth-code',
+  state: MOCK_SUPP_OAUTH_PARAMS.state,
+};
+
 /** Deliver a channel event the way `PairingChannelClient` would. */
 function emit(type: string, detail?: unknown) {
   (mockListeners[type] || []).forEach((handler) =>
@@ -39,9 +83,27 @@ function emit(type: string, detail?: unknown) {
   );
 }
 
+/**
+ * The authority acks a supplicant request with `pair:auth:metadata` and only
+ * advances once that send resolves, so state assertions have to wait a
+ * microtask past the emit.
+ */
+async function emitSuppRequest(detail: unknown = MOCK_SUPP_REQUEST) {
+  emit('remote:pair:supp:request', detail);
+  await Promise.resolve();
+}
+
+/** A copy of the request with one required field left out. */
+function suppRequestWithout(field: string) {
+  const partial: Record<string, unknown> = { ...MOCK_SUPP_REQUEST };
+  delete partial[field];
+  return partial;
+}
+
 const mockPairSupplicantMetadata = jest.fn();
 const mockPairHeartbeat = jest.fn();
 const mockPairAuthorize = jest.fn();
+const mockPairOauthFinish = jest.fn();
 const mockPairDecline = jest.fn();
 const mockPairComplete = jest.fn();
 
@@ -51,6 +113,7 @@ jest.mock('../../lib/channels/firefox', () => ({
       mockPairSupplicantMetadata(...args),
     pairHeartbeat: (...args: unknown[]) => mockPairHeartbeat(...args),
     pairAuthorize: (...args: unknown[]) => mockPairAuthorize(...args),
+    pairOauthFinish: (...args: unknown[]) => mockPairOauthFinish(...args),
     pairDecline: (...args: unknown[]) => mockPairDecline(...args),
     pairComplete: (...args: unknown[]) => mockPairComplete(...args),
   },
@@ -95,6 +158,8 @@ describe('PairingAuthorityIntegration', () => {
     mockListeners = {};
     mockCreate.mockResolvedValue(undefined);
     mockChannelClose.mockResolvedValue(undefined);
+    mockChannelSend.mockResolvedValue(undefined);
+    mockPairOauthFinish.mockResolvedValue(MOCK_OAUTH_CODE);
   });
 
   afterEach(() => {
@@ -298,24 +363,24 @@ describe('PairingAuthorityIntegration', () => {
   });
 
   describe('actions', () => {
-    it('authorize sends WebChannel command', () => {
+    it('authorize sends WebChannel command', async () => {
       const integration = createIntegration();
-      integration.authorize();
+      await integration.authorize();
       expect(integration.authAuthorized).toBe(true);
       expect(mockPairAuthorize).toHaveBeenCalledWith('test-channel-id');
     });
 
-    it('decline stops heartbeat and sends command', () => {
+    it('decline stops heartbeat and sends command', async () => {
       const integration = createIntegration();
       integration.startHeartbeat();
-      integration.decline();
+      await integration.decline();
       expect(mockPairDecline).toHaveBeenCalledWith('test-channel-id');
     });
 
-    it('complete stops heartbeat and sends command', () => {
+    it('complete stops heartbeat and sends command', async () => {
       const integration = createIntegration();
       integration.startHeartbeat();
-      integration.complete();
+      await integration.complete();
       expect(mockPairComplete).toHaveBeenCalledWith('test-channel-id');
     });
   });
@@ -410,18 +475,10 @@ describe('PairingAuthorityIntegration', () => {
 
       // The supplicant's request carries no email or device name — it is not
       // signed in yet — so only the sender envelope is consumed.
-      it('records the supplicant device details from its request', () => {
+      it('records the supplicant device details from its request', async () => {
         emit('connected');
 
-        emit('remote:pair:supp:request', {
-          remoteMetaData: {
-            city: 'Vancouver',
-            country: 'Canada',
-            region: 'British Columbia',
-            ipAddress: '127.0.0.1',
-            ua: 'Mozilla/5.0 (Android 14; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0',
-          },
-        });
+        await emitSuppRequest();
 
         expect(integration.remoteMetadata).toEqual({
           city: 'Vancouver',
@@ -432,21 +489,37 @@ describe('PairingAuthorityIntegration', () => {
           deviceOS: 'Android',
           deviceName: 'Firefox',
         });
+      });
+
+      it('acks the request so the supplicant can approve', async () => {
+        emit('connected');
+
+        await emitSuppRequest();
+
+        expect(mockChannelSend).toHaveBeenCalledWith('pair:auth:metadata', {});
+      });
+
+      it('waits for both approvals once the request is acked', async () => {
+        emit('connected');
+
+        await emitSuppRequest();
+
         expect(integration.state).toBe(AuthorityState.WaitingForAuthorizations);
       });
 
-      it('still advances when the request carries no sender metadata', () => {
+      // Until the ack lands the supplicant has nothing to approve, so showing
+      // the approval screen would invite the user to act on a dead channel.
+      it('does not advance until the ack resolves', () => {
         emit('connected');
 
-        emit('remote:pair:supp:request', {});
+        emit('remote:pair:supp:request', MOCK_SUPP_REQUEST);
 
-        expect(integration.remoteMetadata).toBeNull();
-        expect(integration.state).toBe(AuthorityState.WaitingForAuthorizations);
+        expect(integration.state).toBe(AuthorityState.WaitingForMetadata);
       });
 
       it('supplicant first: waits for the authority, then completes', async () => {
         emit('connected');
-        emit('remote:pair:supp:request', {});
+        await emitSuppRequest();
 
         emit('remote:pair:supp:authorize');
         expect(integration.state).toBe(AuthorityState.WaitingForAuthority);
@@ -455,30 +528,116 @@ describe('PairingAuthorityIntegration', () => {
         expect(integration.state).toBe(AuthorityState.Complete);
       });
 
-      it('authority first: waits for the supplicant, then completes', async () => {
+      // Firefox only wraps the scoped keys into `keys_jwe` when it is handed a
+      // `keys_jwk`. Drop it and the supplicant gets a code granting the sync
+      // scope with no sync key behind it, which fails silently long after
+      // pairing looks like it worked.
+      it('forwards the whole supplicant OAuth request', async () => {
         emit('connected');
-        emit('remote:pair:supp:request', {});
+        await emitSuppRequest();
 
         await integration.authorize();
-        expect(integration.state).toBe(AuthorityState.WaitingForSupplicant);
 
-        emit('remote:pair:supp:authorize');
-        expect(integration.state).toBe(AuthorityState.Complete);
+        expect(mockPairOauthFinish).toHaveBeenCalledWith(
+          MOCK_SUPP_OAUTH_PARAMS
+        );
+      });
+
+      it('relays the granted code and state to the supplicant', async () => {
+        emit('connected');
+        await emitSuppRequest();
+
+        await integration.authorize();
+
+        expect(mockChannelSend).toHaveBeenCalledWith(
+          'pair:auth:authorize',
+          MOCK_OAUTH_CODE
+        );
       });
 
       // The v1 heartbeat reports the same fact, so the two sources must not
       // each fire the callback.
-      it('signals supplicant approval once', () => {
+      it('signals supplicant approval once', async () => {
         const onSuppAuthorized = jest.fn();
         integration.onSuppAuthorized = onSuppAuthorized;
         emit('connected');
-        emit('remote:pair:supp:request', {});
+        await emitSuppRequest();
 
         emit('remote:pair:supp:authorize');
         emit('remote:pair:supp:authorize');
 
         expect(onSuppAuthorized).toHaveBeenCalledTimes(1);
         expect(integration.suppAuthorized).toBe(true);
+      });
+    });
+
+    // Every one of these fields is needed to mint the OAuth code. A partial
+    // request used to be logged and waved through, which surfaced as a signin
+    // that either dies at `pairOauthFinish` or hands the supplicant a code
+    // with no sync key behind it — both long after pairing looked fine.
+    describe('incomplete supplicant request', () => {
+      beforeEach(async () => {
+        await integration.createChannel();
+        emit('connected');
+      });
+
+      // A throw from inside a channel listener reaches no caller: the flow
+      // would stall with no failure state and nothing in Sentry. Rejections
+      // route through fail() instead, which the containers already navigate on.
+      it.each([
+        'client_id',
+        'code_challenge',
+        'code_challenge_method',
+        'keys_jwk',
+        'scope',
+        'state',
+      ])('fails without throwing when %s is missing', (field) => {
+        expect(() =>
+          emit('remote:pair:supp:request', suppRequestWithout(field))
+        ).not.toThrow();
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({ errno: OAUTH_ERRORS.INVALID_PARAMETER.errno })
+        );
+      });
+
+      // Rules beyond presence live in pairing-request-validation.test.ts; these
+      // two only prove the authority is wired to the validator rather than to
+      // its own truthiness checks.
+      it.each([
+        { label: 'a client that cannot pair', field: 'client_id', value: '0123456789abcdef' },
+        { label: 'a PKCE method other than S256', field: 'code_challenge_method', value: 'plain' },
+      ])('fails on $label', ({ field, value }) => {
+        emit('remote:pair:supp:request', { ...MOCK_SUPP_REQUEST, [field]: value });
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+      });
+
+      // remoteMetaData is derived from the channel server's sender envelope
+      // rather than the payload, so its absence says nothing about the request.
+      it('still accepts a request that carries no sender metadata', async () => {
+        emit('remote:pair:supp:request', MOCK_SUPP_OAUTH_PARAMS);
+        await Promise.resolve();
+
+        expect(integration.remoteMetadata).toBeNull();
+        expect(integration.state).toBe(AuthorityState.WaitingForAuthorizations);
+      });
+
+      it('does not ack a request it rejected', () => {
+        emit('remote:pair:supp:request', suppRequestWithout('keys_jwk'));
+
+        expect(mockChannelSend).not.toHaveBeenCalled();
+      });
+
+      // Nothing was forwarded to Firefox, so there is no request to authorize
+      // against — and no code may be minted from a stale one.
+      it('cannot authorize after a rejected request', async () => {
+        emit('remote:pair:supp:request', suppRequestWithout('client_id'));
+
+        await expect(integration.authorize()).resolves.toBeUndefined();
+        expect(mockPairOauthFinish).not.toHaveBeenCalled();
+        expect(integration.state).toBe(AuthorityState.Failed);
       });
     });
 
@@ -517,7 +676,7 @@ describe('PairingAuthorityIntegration', () => {
 
       // A close after the handshake is the expected teardown, not a failure.
       it('ignores a close once the flow has completed', async () => {
-        emit('remote:pair:supp:request', {});
+        await emitSuppRequest();
         emit('remote:pair:supp:authorize');
         await integration.authorize();
         expect(integration.state).toBe(AuthorityState.Complete);
@@ -526,6 +685,68 @@ describe('PairingAuthorityIntegration', () => {
 
         expect(integration.state).toBe(AuthorityState.Complete);
         expect(onError).not.toHaveBeenCalled();
+      });
+
+      // The supplicant is waiting on this ack; without it neither side can
+      // move, so the authority has to surface the error rather than sit on
+      // the approval screen.
+      it('fails when the metadata ack cannot be sent', async () => {
+        const err = new Error('socket closed');
+        mockChannelSend.mockRejectedValueOnce(err);
+
+        await emitSuppRequest();
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(onError).toHaveBeenCalledWith(err);
+      });
+
+      it('fails when the granted code cannot be relayed', async () => {
+        const err = new Error('socket closed');
+        mockChannelSend.mockImplementation((command: string) =>
+          command === 'pair:auth:authorize'
+            ? Promise.reject(err)
+            : Promise.resolve()
+        );
+        await emitSuppRequest();
+
+        await integration.authorize();
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(onError).toHaveBeenCalledWith(err);
+      });
+
+      // The approve handler does not await authorize(), so a rejection escaping
+      // this method is an unhandled rejection that leaves the user waiting on
+      // the approval screen. It has to come back as Failed instead.
+      it('fails rather than rejecting when Firefox cannot finish the oauth pair', async () => {
+        const err = new Error('web channel timed out');
+        mockPairOauthFinish.mockRejectedValue(err);
+        await emitSuppRequest();
+
+        await expect(integration.authorize()).resolves.toBeUndefined();
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(onError).toHaveBeenCalledWith(err);
+      });
+
+      // A resolved-but-empty response is what the web channel returns when it
+      // times out, so it must not be relayed as if it were a grant.
+      it.each([
+        { label: 'no response at all', result: undefined },
+        { label: 'no code', result: { state: MOCK_SUPP_OAUTH_PARAMS.state } },
+        { label: 'no state', result: { code: 'mock-oauth-code' } },
+      ])('fails when the oauth finish returns $label', async ({ result }) => {
+        mockPairOauthFinish.mockResolvedValue(result);
+        await emitSuppRequest();
+        mockChannelSend.mockClear();
+
+        await integration.authorize();
+
+        expect(integration.state).toBe(AuthorityState.Failed);
+        expect(mockChannelSend).not.toHaveBeenCalledWith(
+          'pair:auth:authorize',
+          expect.anything()
+        );
       });
 
       it('does not re-fail once already failed', () => {

--- a/packages/fxa-settings/src/models/integrations/pairing-authority-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-authority-integration.ts
@@ -20,9 +20,13 @@ import { toGenericOSName } from '../../lib/utilities';
 import config from '../../lib/config';
 import {
   PairingChannelClient,
-  PairingChannelIncomingMessage,
   toRemoteMetadata,
 } from '../../lib/channels/pairing-channel';
+import { OAuthError } from '../../lib/oauth';
+import {
+  ValidatedSupplicantRequest,
+  validateSupplicantRequest,
+} from './pairing-request-validation';
 import * as Sentry from '@sentry/browser';
 
 const PAIR_HEARTBEAT_INTERVAL = 1000;
@@ -70,6 +74,8 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
   ]);
 
   private _channel: PairingChannelClient | null = null;
+  private _version: number | null = null;
+  public _iid: string | null = null;
   private _state: AuthorityState | null = null;
 
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -78,6 +84,7 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
   private _suppAuthorized = false;
   private _authAuthorized = false;
   private _cachedChannelId: string | null = null;
+  private _supRequest: ValidatedSupplicantRequest | null = null;
 
   public onSuppAuthorized: (() => void) | null = null;
   public onHeartbeatError: ((err: unknown) => void) | null = null;
@@ -91,6 +98,8 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
     public readonly opts: OAuthIntegrationOptions
   ) {
     super(data, storageData, opts, IntegrationType.PairingAuthority);
+    this._iid = crypto.randomUUID();
+    console.info('Created new PairingAuthorityIntegration', this._iid);
   }
 
   /**
@@ -132,6 +141,7 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
 
     const channel = new PairingChannelClient();
     this._channel = channel;
+    this._version = 2; // Only pairing v2 creates the authority channel
 
     channel.addEventListener('connected', this.handleConnected);
     channel.addEventListener('close', this.handleClose);
@@ -173,6 +183,7 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
 
   private setState(state: AuthorityState): void {
     this._state = state;
+    console.info('Emitting pairing authority state change event.', {id: this._iid, state: this.state});
     this.onStateChange?.(state);
   }
 
@@ -208,11 +219,58 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
    *    asking, and the only field of the message we consume.
    */
   private handleSuppRequest = (event: Event) => {
-    const data = (event as CustomEvent).detail as PairingChannelIncomingMessage;
+    const data = (event as CustomEvent).detail;
     if (data?.remoteMetaData) {
       this._remoteMetadata = toRemoteMetadata(data.remoteMetaData);
     }
-    this.setState(AuthorityState.WaitingForAuthorizations);
+
+    // In V2, FxA brokers pairing channel communications. Ack back to
+    // the supplicant with meta data, so the can approve the connection.
+    if (this._version === 2) {
+      if (!this._channel) {
+        this.fail(
+          new Error('Cannot handle a supplicant request without a channel.')
+        );
+        return;
+      }
+
+      // Vet the request as it arrives rather than in `authorize()`: approving is
+      // what turns these params into a real OAuth code with the account's Sync
+      // keys wrapped inside, so a request we would refuse must never reach the
+      // approval screen. Nothing throws out of this listener — a throw here
+      // reaches no caller, leaving the flow silently stalled.
+      const validation = validateSupplicantRequest(data);
+      if (!validation.ok) {
+        const err = new OAuthError('INVALID_PARAMETER', {
+          param: validation.failures.map((f) => f.field).join(', '),
+        });
+        // Field names and reasons only. The payload is remote-controlled, and
+        // `keys_jwk`/`code_challenge` do not belong in Sentry.
+        Sentry.captureException(err, {
+          extra: {
+            pairingRequestFailures: validation.failures
+              .map((f) => `${f.field}: ${f.reason}`)
+              .join('; '),
+          },
+        });
+        this.fail(err);
+        return;
+      }
+
+      this._supRequest = validation.request;
+
+      this._channel.send('pair:auth:metadata', {})
+        .then(()=>{
+           this.setState(AuthorityState.WaitingForAuthorizations);
+        })
+        .catch((err) => {
+          console.warn('Error sending pair:auth:metadata');
+          Sentry.captureException(err);
+          this.fail(err);
+        });
+    } else {
+      this.setState(AuthorityState.WaitingForAuthorizations);
+    }
   };
 
   /**
@@ -232,12 +290,17 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
       this.onSuppAuthorized?.();
     }
 
-    if (this._state === AuthorityState.WaitingForAuthorizations) {
-      // Supplicant approved first — the authority user has yet to act.
+    // In V2, the supplicant ALWAYS approves first!
+    if (this._version === 2) {
       this.setState(AuthorityState.WaitingForAuthority);
-    } else if (this._state === AuthorityState.WaitingForSupplicant) {
-      // Authority already approved. Handshake complete.
-      this.setState(AuthorityState.Complete);
+    } else {
+      if (this._state === AuthorityState.WaitingForAuthorizations) {
+        // Supplicant approved first — the authority user has yet to act.
+        this.setState(AuthorityState.WaitingForAuthority);
+      } else if (this._state === AuthorityState.WaitingForSupplicant) {
+        // Authority already approved. Handshake complete.
+        this.setState(AuthorityState.Complete);
+      }
     }
   };
 
@@ -400,8 +463,53 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
   /** Authority user approved the pairing request. */
   async authorize(): Promise<void> {
     this._authAuthorized = true;
-    await firefox.pairAuthorize(this.channelId);
 
+    if (this._version === 2) {
+      // `_supRequest` is only ever assigned from `validateSupplicantRequest`, so a
+      // non-null value here has already passed every rule. The type is the
+      // guarantee; re-checking the fields would only invite the two copies to drift.
+      const supRequest = this._supRequest;
+      if (!supRequest || !this._channel) {
+        this.fail(
+          new Error('Cannot authorize without a validated supplicant request.')
+        );
+        return;
+      }
+
+      try {
+        const result = await firefox.pairOauthFinish({
+          client_id: supRequest.client_id,
+          code_challenge: supRequest.code_challenge,
+          code_challenge_method: supRequest.code_challenge_method,
+          keys_jwk: supRequest.keys_jwk,
+          scope: supRequest.scope,
+          state: supRequest.state
+        });
+
+        if (!result?.code || !result.state) {
+          throw new Error('Failed to finalize oauth pair!');
+        }
+        console.info('OAuth pair finish success!')
+
+        await this._channel.send('pair:auth:authorize', {
+          code: result.code,
+          state: result.state
+        })
+      } catch (err) {
+        // pairOauthFinish rejects on its own timeout, on a missing code/state and
+        // on an echoed-state mismatch, and the send can reject too. The approve
+        // handler does not await this method, so anything thrown from here would
+        // be an unhandled rejection that leaves the user on the approval screen.
+        Sentry.captureException(err);
+        this.fail(err);
+        return;
+      }
+    }
+    else {
+      await firefox.pairAuthorize(this.channelId);
+    }
+
+    // The post-approval transition, shared by both pairing versions.
     if (this._state === AuthorityState.WaitingForAuthorizations) {
       this.setState(AuthorityState.WaitingForSupplicant);
     } else if (this._state === AuthorityState.WaitingForAuthority) {
@@ -426,6 +534,7 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
     this.stopHeartbeat();
     this.onSuppAuthorized = null;
     this.onHeartbeatError = null;
+    this._supRequest = null;
 
     this.onStateChange = null;
     this.onError = null;

--- a/packages/fxa-settings/src/models/integrations/pairing-request-validation.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-request-validation.test.ts
@@ -1,0 +1,297 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  ValidatedSupplicantRequest,
+  validateSupplicantRequest,
+} from './pairing-request-validation';
+
+// The allowlist is read at call time, so each case can set it.
+jest.mock('../../lib/config', () => ({
+  __esModule: true,
+  default: { pairing: { clients: [] as string[] } },
+}));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const config = require('../../lib/config').default;
+
+/** Fenix — in OAUTH_NATIVE_CLIENT_IDS. */
+const FENIX = 'a2270f727f45f648';
+/** Firefox for iOS — also native, used to test the config allowlist narrowing. */
+const FX_IOS = '1b1a3e44c54fbb58';
+/** 43 characters of base64url, the length a real S256 challenge always has. */
+const VALID_CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+const VALID_KEYS_JWK = 'eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2In0';
+
+const OLDSYNC = 'https://identity.mozilla.com/apps/oldsync';
+
+const validRequest = (
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> => ({
+  client_id: FENIX,
+  code_challenge: VALID_CODE_CHALLENGE,
+  code_challenge_method: 'S256',
+  keys_jwk: VALID_KEYS_JWK,
+  scope: `profile ${OLDSYNC}`,
+  state: 'mock-supp-state',
+  ...overrides,
+});
+
+/** The fields that failed, for asserting on a rejection. */
+const failedFields = (payload: unknown) => {
+  const result = validateSupplicantRequest(payload);
+  return result.ok ? [] : result.failures.map((f) => f.field);
+};
+
+beforeEach(() => {
+  config.pairing.clients = [];
+});
+
+describe('validateSupplicantRequest', () => {
+  it('accepts a well-formed request and returns only the OAuth params', () => {
+    const result = validateSupplicantRequest(
+      // A real payload also carries `remoteMetaData`, which must not survive
+      // into the value the authority hands to Firefox.
+      validRequest({ remoteMetaData: { city: 'Vancouver' } })
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      request: {
+        client_id: FENIX,
+        code_challenge: VALID_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        keys_jwk: VALID_KEYS_JWK,
+        scope: `profile ${OLDSYNC}`,
+        state: 'mock-supp-state',
+      } satisfies ValidatedSupplicantRequest,
+    });
+  });
+
+  // The supplicant normalizes its own scope before sending, but the authority
+  // cannot rely on a remote peer having done so.
+  it.each([
+    { input: `profile+${OLDSYNC}`, expected: `profile ${OLDSYNC}` },
+    { input: '  profile   profile ', expected: 'profile' },
+    { input: 'profile', expected: 'profile' },
+  ])('normalizes the scope $input', ({ input, expected }) => {
+    const result = validateSupplicantRequest(validRequest({ scope: input }));
+
+    expect(result.ok && result.request.scope).toBe(expected);
+  });
+
+  // The payload arrives as an unvalidated CustomEvent detail, so anything at all
+  // can show up here. Rejecting has to be a return value, not a throw: a throw
+  // inside the channel listener reaches no caller.
+  it.each([undefined, null, 'a string', 42, [], () => {}])(
+    'rejects %p without throwing',
+    (payload) => {
+      expect(() => validateSupplicantRequest(payload)).not.toThrow();
+      expect(validateSupplicantRequest(payload).ok).toBe(false);
+    }
+  );
+
+  it.each([
+    'client_id',
+    'code_challenge',
+    'code_challenge_method',
+    'keys_jwk',
+    'scope',
+    'state',
+  ])('reports %s when it is missing', (field) => {
+    expect(failedFields(validRequest({ [field]: undefined }))).toEqual([field]);
+  });
+
+  // These are the inputs that ruled out validating through GenericData /
+  // class-validator: its data store throws a plain Error on any non-string.
+  it.each([
+    { client_id: 123 },
+    { keys_jwk: {} },
+    { scope: ['profile'] },
+    { state: true },
+    { code_challenge_method: null },
+  ])('rejects the non-string value in %p without throwing', (override) => {
+    const payload = validRequest(override);
+
+    expect(() => validateSupplicantRequest(payload)).not.toThrow();
+    expect(failedFields(payload)).toEqual([Object.keys(override)[0]]);
+  });
+
+  it('reports every failing field in one pass', () => {
+    const failures = failedFields({
+      client_id: 'nope',
+      code_challenge_method: 'plain',
+      state: 'x'.repeat(513),
+    });
+
+    expect(failures).toEqual([
+      'client_id',
+      'code_challenge',
+      'code_challenge_method',
+      'keys_jwk',
+      'scope',
+      'state',
+    ]);
+  });
+
+  // The payload is remote-controlled, and `keys_jwk` / `code_challenge` are not
+  // for logs — the reasons end up in a Sentry extra.
+  it('never echoes a submitted value in its failure reasons', () => {
+    const result = validateSupplicantRequest(
+      validRequest({
+        code_challenge: 'short',
+        keys_jwk: 'not+base64url',
+        code_challenge_method: 'plain',
+      })
+    );
+
+    const reasons = result.ok ? '' : JSON.stringify(result.failures);
+    expect(reasons).not.toContain('short');
+    expect(reasons).not.toContain('not+base64url');
+    expect(reasons).not.toContain('plain');
+  });
+
+  describe('client_id', () => {
+    it.each(['A2270F727F45F648', 'a2270f727f45f64', 'a2270f727f45f6488', 'zz'])(
+      'rejects %p as malformed',
+      (clientId) => {
+        expect(failedFields(validRequest({ client_id: clientId }))).toEqual([
+          'client_id',
+        ]);
+      }
+    );
+
+    // Well-formed but not a browser: Firefox would still mint a code for it,
+    // carrying the account's wrapped Sync keys.
+    it('rejects a well-formed client id that is not a native pairing client', () => {
+      const result = validateSupplicantRequest(
+        validRequest({ client_id: '0123456789abcdef' })
+      );
+
+      expect(result.ok).toBe(false);
+      expect(!result.ok && result.failures[0].reason).toBe(
+        'not a native pairing client'
+      );
+    });
+
+    it('rejects a native client that is absent from a populated allowlist', () => {
+      config.pairing.clients = [FX_IOS];
+
+      const result = validateSupplicantRequest(validRequest());
+
+      expect(result.ok).toBe(false);
+      expect(!result.ok && result.failures[0].reason).toBe(
+        'not in the configured pairing allowlist'
+      );
+    });
+
+    it('accepts a native client that is in the allowlist', () => {
+      config.pairing.clients = [FENIX, FX_IOS];
+
+      expect(validateSupplicantRequest(validRequest()).ok).toBe(true);
+    });
+
+    // An unhydrated config must not widen the set of clients that may pair.
+    it('still requires a native client when the allowlist is empty', () => {
+      config.pairing.clients = [];
+
+      expect(failedFields(validRequest({ client_id: '0123456789abcdef' }))).toEqual(
+        ['client_id']
+      );
+    });
+  });
+
+  describe('code_challenge', () => {
+    it.each([
+      { label: '42 characters', value: 'a'.repeat(42) },
+      { label: '129 characters', value: 'a'.repeat(129) },
+      { label: 'standard base64 padding', value: `${'a'.repeat(41)}==` },
+      { label: 'a non-base64url character', value: `${'a'.repeat(42)}+` },
+    ])('rejects $label', ({ value }) => {
+      expect(failedFields(validRequest({ code_challenge: value }))).toEqual([
+        'code_challenge',
+      ]);
+    });
+
+    // v1 accepted 43-128, and so does the existing OAuthIntegrationData rule.
+    it.each([43, 128])('accepts a %i character challenge', (length) => {
+      expect(
+        validateSupplicantRequest(
+          validRequest({ code_challenge: 'a'.repeat(length) })
+        ).ok
+      ).toBe(true);
+    });
+  });
+
+  describe('code_challenge_method', () => {
+    it.each(['plain', 's256', 'S384'])('rejects %p', (method) => {
+      expect(
+        failedFields(validRequest({ code_challenge_method: method }))
+      ).toEqual(['code_challenge_method']);
+    });
+  });
+
+  describe('keys_jwk', () => {
+    it.each(['dGVzdA==', 'has spaces', 'has/slash+plus'])(
+      'rejects %p as not unpadded base64url',
+      (keysJwk) => {
+        expect(failedFields(validRequest({ keys_jwk: keysJwk }))).toEqual([
+          'keys_jwk',
+        ]);
+      }
+    );
+  });
+
+  describe('scope', () => {
+    it.each(['', '   ', '+', ' + '])('rejects %p as empty', (scope) => {
+      expect(failedFields(validRequest({ scope }))).toEqual(['scope']);
+    });
+
+    // Format only, by decision: an allowlist would block a future pairing
+    // client until FxA shipped a new constant. auth-server still bounds what
+    // each client may be granted.
+    it('accepts a scope outside the sync/profile pair', () => {
+      const result = validateSupplicantRequest(
+        validRequest({ scope: 'https://identity.mozilla.com/apps/relay' })
+      );
+
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('state', () => {
+    it('accepts 512 characters', () => {
+      expect(
+        validateSupplicantRequest(validRequest({ state: 'x'.repeat(512) })).ok
+      ).toBe(true);
+    });
+
+    it('rejects 513 characters', () => {
+      expect(failedFields(validRequest({ state: 'x'.repeat(513) }))).toEqual([
+        'state',
+      ]);
+    });
+  });
+
+  describe('access_type', () => {
+    it.each(['offline', 'online'])('accepts %p and returns it', (accessType) => {
+      const result = validateSupplicantRequest(
+        validRequest({ access_type: accessType })
+      );
+
+      expect(result.ok && result.request.access_type).toBe(accessType);
+    });
+
+    it('accepts a request that omits it, and returns no access_type', () => {
+      const result = validateSupplicantRequest(validRequest());
+
+      expect(result.ok && 'access_type' in result.request).toBe(false);
+    });
+
+    it('rejects an unknown value', () => {
+      expect(failedFields(validRequest({ access_type: 'bogus' }))).toEqual([
+        'access_type',
+      ]);
+    });
+  });
+});

--- a/packages/fxa-settings/src/models/integrations/pairing-request-validation.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-request-validation.ts
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { OAUTH_NATIVE_CLIENT_IDS } from '@fxa/accounts/oauth';
+import config from '../../lib/config';
+import { scopeStrToArray } from './oauth-web-integration';
+
+/**
+ * A PKCE S256 challenge is a base64url SHA-256 digest, so 43 characters. The
+ * upper bound matches what v1 accepted (Vat.codeChallenge, min 43 max 128) and
+ * `OAuthIntegrationData.codeChallenge`, so a v1 supplicant pairing with a v2
+ * authority is not tightened here. auth-server pins the exact length on the
+ * /authorization call the browser makes, which is the real gate.
+ */
+const CODE_CHALLENGE_MIN_LENGTH = 43;
+const CODE_CHALLENGE_MAX_LENGTH = 128;
+
+/** auth-server caps `state` at 512 characters. */
+const STATE_MAX_LENGTH = 512;
+
+/** Unpadded base64url — same rule as `@Matches` on `OAuthIntegrationData.keysJwk`. */
+const BASE64URL = /^[A-Za-z0-9-_]+$/;
+
+/** Client ids are canonically 16 lowercase hex characters. */
+const CLIENT_ID = /^[0-9a-f]{16}$/;
+
+const ACCESS_TYPES = ['offline', 'online'];
+
+/** OAuth params the authority is willing to hand to `firefox.pairOauthFinish`. */
+export type ValidatedSupplicantRequest = {
+  client_id: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  keys_jwk: string;
+  /** Normalized: '+' separators and duplicates collapsed to single spaces. */
+  scope: string;
+  state: string;
+  /** Validated, but not currently forwarded to `pairOauthFinish`. */
+  access_type?: string;
+};
+
+export type SupplicantRequestFailure = { field: string; reason: string };
+
+export type SupplicantRequestValidation =
+  | { ok: true; request: ValidatedSupplicantRequest }
+  | { ok: false; failures: SupplicantRequestFailure[] };
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+/**
+ * Vets a `pair:supp:request` payload before the authority will mint an OAuth
+ * code for it.
+ *
+ * v1 had no equivalent on the authority: `fxaccounts:pair_authorize` was a bare
+ * `{channel_id}` and Firefox's own pairing flow owned both the channel socket
+ * and the code minting. v1's rules for these fields lived on the *supplicant*,
+ * over its own URL (content-server `reliers/pairing/supplicant.js`). In v2 FxA
+ * brokers the channel and forwards the remote peer's params to the authority's
+ * Firefox, which mints a real code and wraps the account's Sync keys against the
+ * supplied `keys_jwk` — so the authority is a trust boundary that did not exist
+ * before, and this is the only place it can refuse.
+ *
+ * Takes `unknown` and never throws: the payload is remote-controlled, so a
+ * non-string field is an expected input rather than a programming error. Failure
+ * reasons never echo a submitted value, since `keys_jwk` and `code_challenge`
+ * do not belong in logs or Sentry.
+ */
+export function validateSupplicantRequest(
+  payload: unknown
+): SupplicantRequestValidation {
+  const failures: SupplicantRequestFailure[] = [];
+  const fail = (field: string, reason: string) =>
+    failures.push({ field, reason });
+
+  const data = (
+    typeof payload === 'object' && payload !== null ? payload : {}
+  ) as Record<string, unknown>;
+
+  // Firefox mints the code *for this client*, so a substituted client id yields
+  // a token carrying the victim's wrapped Sync keys. auth-server cannot catch
+  // that — any registered client passes its schema — which makes this the one
+  // rule here that is load bearing rather than defence in depth.
+  //
+  // OAUTH_NATIVE_CLIENT_IDS is the floor: it is compiled in and cannot be
+  // emptied by config. `pairing.clients` narrows further when it is populated
+  // (it carries the real mobile-client list in production, see
+  // fxa-content-server server/lib/configuration.js), but an unhydrated or empty
+  // list must not widen the floor.
+  const clientId = asString(data.client_id);
+  if (!clientId) {
+    fail('client_id', 'missing');
+  } else if (!CLIENT_ID.test(clientId)) {
+    fail('client_id', 'not 16 lowercase hex characters');
+  } else if (!OAUTH_NATIVE_CLIENT_IDS.has(clientId)) {
+    fail('client_id', 'not a native pairing client');
+  } else if (
+    (config.pairing?.clients?.length ?? 0) > 0 &&
+    !config.pairing.clients.includes(clientId)
+  ) {
+    fail('client_id', 'not in the configured pairing allowlist');
+  }
+
+  const codeChallenge = asString(data.code_challenge);
+  if (!codeChallenge) {
+    fail('code_challenge', 'missing');
+  } else if (
+    codeChallenge.length < CODE_CHALLENGE_MIN_LENGTH ||
+    codeChallenge.length > CODE_CHALLENGE_MAX_LENGTH ||
+    !BASE64URL.test(codeChallenge)
+  ) {
+    fail(
+      'code_challenge',
+      `not a base64url string of ${CODE_CHALLENGE_MIN_LENGTH}-${CODE_CHALLENGE_MAX_LENGTH} characters`
+    );
+  }
+
+  const codeChallengeMethod = asString(data.code_challenge_method);
+  if (!codeChallengeMethod) {
+    fail('code_challenge_method', 'missing');
+  } else if (codeChallengeMethod !== 'S256') {
+    fail('code_challenge_method', 'must be S256');
+  }
+
+  // Presence matters beyond format: Firefox only wraps the scoped keys into
+  // `keys_jwe` when it is handed a `keys_jwk`, so without one the supplicant
+  // gets a code granting oldsync with no Sync key behind it — a failure that
+  // surfaces long after pairing looked like it worked.
+  const keysJwk = asString(data.keys_jwk);
+  if (!keysJwk) {
+    fail('keys_jwk', 'missing');
+  } else if (!BASE64URL.test(keysJwk)) {
+    fail('keys_jwk', 'not an unpadded base64url string');
+  }
+
+  // Format only, matching v1 (`Vat.string().required().min(1)`). Normalized on
+  // the way out so a '+'-separated scope never reaches auth-server, rather than
+  // trusting the remote peer to have normalized it.
+  const rawScope = asString(data.scope);
+  let scope: string | undefined;
+  if (!rawScope) {
+    fail('scope', 'missing');
+  } else {
+    const requested = [...scopeStrToArray(rawScope)];
+    if (requested.length === 0) {
+      fail('scope', 'empty');
+    } else {
+      scope = requested.join(' ');
+    }
+  }
+
+  // Opaque to the authority — it is the supplicant's CSRF token and gets
+  // forwarded verbatim, so only its bounds are ours to check.
+  const state = asString(data.state);
+  if (!state) {
+    fail('state', 'missing');
+  } else if (state.length > STATE_MAX_LENGTH) {
+    fail('state', `longer than ${STATE_MAX_LENGTH} characters`);
+  }
+
+  const accessType = asString(data.access_type);
+  if (
+    data.access_type !== undefined &&
+    !ACCESS_TYPES.includes(accessType ?? '')
+  ) {
+    fail('access_type', `must be one of ${ACCESS_TYPES.join(', ')}`);
+  }
+
+  if (failures.length > 0) {
+    return { ok: false, failures };
+  }
+
+  return {
+    ok: true,
+    request: {
+      client_id: clientId!,
+      code_challenge: codeChallenge!,
+      code_challenge_method: codeChallengeMethod!,
+      keys_jwk: keysJwk!,
+      scope: scope!,
+      state: state!,
+      ...(accessType ? { access_type: accessType } : {}),
+    },
+  };
+}

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { waitFor } from '@testing-library/react';
 import { GenericData } from '../../lib/model-data';
 import {
   PAIR_COMPLETE_STORAGE_PREFIX,
   PairingSupplicantIntegration,
   SupplicantState,
 } from './pairing-supplicant-integration';
+import { firefox } from '../../lib/channels/firefox';
 
 // Mock PairingChannelClient
 const mockOpen = jest.fn().mockResolvedValue(undefined);
@@ -86,9 +88,13 @@ describe('PairingSupplicantIntegration', () => {
       emit('connected');
 
       expect(integration.state).toBe(SupplicantState.WaitingForMetadata);
-      expect(mockSend).toHaveBeenCalledWith(
-        'pair:supp:request',
-        expect.objectContaining({ client_id: '3c49430b43dfba77' })
+      // The params are resolved before the request goes out, so the send lands
+      // a microtask after the state change rather than with it.
+      await waitFor(() =>
+        expect(mockSend).toHaveBeenCalledWith(
+          'pair:supp:request',
+          expect.objectContaining({ client_id: '3c49430b43dfba77' })
+        )
       );
     });
 
@@ -191,6 +197,87 @@ describe('PairingSupplicantIntegration', () => {
       expect(
         sessionStorage.getItem(PAIR_COMPLETE_STORAGE_PREFIX + 'chan-42')
       ).toBe('1');
+    });
+  });
+
+  // v2 asks the browser for its OAuth params instead of reading them from the
+  // URL, so the state to check `pair:auth:authorize` against is the one
+  // `pairOauthStart` handed back — not `this.data.state`, which v2 never sets.
+  describe('v2 approval state machine', () => {
+    const BROWSER_STATE = 'browser-generated-state';
+
+    async function setupV2(): Promise<PairingSupplicantIntegration> {
+      jest.spyOn(firefox, 'pairOauthStart').mockResolvedValue({
+        state: BROWSER_STATE,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+        code_challenge: VALID_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        keys_jwk: 'dGVzdGtleXM',
+      });
+      jest.spyOn(firefox, 'fxaOAuthLogin').mockImplementation(() => {});
+
+      // No `state` query param, which is what a real v2 supplicant URL looks
+      // like — the whole point is that the check cannot lean on it.
+      const integration = createIntegration({ state: '' });
+      await integration.openChannel('wss://ch.example.com', 'c', 'k', 2);
+      emit('connected');
+      await waitFor(() =>
+        expect(mockSend).toHaveBeenCalledWith(
+          'pair:supp:request',
+          expect.objectContaining({ state: BROWSER_STATE })
+        )
+      );
+      emit('remote:pair:auth:metadata', {
+        email: 'u@e.com',
+        remoteMetaData: { ua: '' },
+      });
+      return integration;
+    }
+
+    it('completes when the authority echoes back the state we sent', async () => {
+      const integration = await setupV2();
+
+      emit('remote:pair:auth:authorize', {
+        code: VALID_OAUTH_CODE,
+        state: BROWSER_STATE,
+      });
+
+      expect(integration.state).toBe(SupplicantState.Complete);
+      expect(firefox.fxaOAuthLogin).toHaveBeenCalledWith(
+        expect.objectContaining({ code: VALID_OAUTH_CODE, action: 'pairing' })
+      );
+    });
+
+    it('fails on a state that is not the one we asked for', async () => {
+      const integration = await setupV2();
+
+      emit('remote:pair:auth:authorize', {
+        code: VALID_OAUTH_CODE,
+        state: 'some-other-flows-state',
+      });
+
+      expect(integration.state).toBe(SupplicantState.Failed);
+      expect(integration.error?.message).toBe('OAuth state mismatch');
+      expect(firefox.fxaOAuthLogin).not.toHaveBeenCalled();
+    });
+
+    // Arrives before `pairOauthStart` has resolved, so there is no state to
+    // compare against and the message cannot be an answer to our request.
+    it('fails on an authorize that arrives before we sent a request', async () => {
+      jest
+        .spyOn(firefox, 'pairOauthStart')
+        .mockReturnValue(new Promise(() => {}));
+      const integration = createIntegration({ state: '' });
+      await integration.openChannel('wss://ch.example.com', 'c', 'k', 2);
+      emit('connected');
+
+      emit('remote:pair:auth:authorize', {
+        code: VALID_OAUTH_CODE,
+        state: BROWSER_STATE,
+      });
+
+      expect(integration.state).toBe(SupplicantState.Failed);
+      expect(integration.error?.message).toContain('no request state recorded');
     });
   });
 
@@ -310,7 +397,11 @@ describe('PairingSupplicantIntegration', () => {
         remoteMetaData: { ua: '' },
       });
 
-      await integration.supplicantApprove();
+      // The rejection is rethrown so the caller can navigate to the failure
+      // screen; the integration records the failure either way.
+      await expect(integration.supplicantApprove()).rejects.toThrow(
+        'send failed'
+      );
       expect(integration.state).toBe(SupplicantState.Failed);
       expect(integration.error?.message).toBe('send failed');
     });

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
@@ -16,6 +16,8 @@ import {
 import { firefox } from '../../lib/channels/firefox';
 import { RemoteMetadata } from '../../lib/types';
 import config from '../../lib/config';
+import { detectDevice, Devices } from '../../lib/utilities';
+import { OAuthNativeClients } from '@fxa/accounts/oauth';
 
 /** Redirect URI used by OAuth WebChannel reliers (matches Backbone Constants.OAUTH_WEBCHANNEL_REDIRECT) */
 const OAUTH_WEBCHANNEL_REDIRECT =
@@ -74,6 +76,16 @@ export enum SupplicantState {
   Failed = 'failed',
 }
 
+export type OAuthStartParams = {
+  access_type: string;
+  client_id: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  keys_jwk: string;
+  scope: string;
+  state: string;
+};
+
 /**
  * Supplicant integration for the device-pairing flow.
  *
@@ -94,6 +106,15 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   private _email = '';
   private _deviceName = '';
   private _channelId: string | null = null;
+  private _version: number | null = null;
+  private _iid: string | null = null;
+  /**
+   * The `state` this supplicant asked for, remembered so the authority's
+   * `pair:auth:authorize` can be checked against it. In v2 the value comes from
+   * `firefox.pairOauthStart` rather than the URL, so `this.data.state` is empty
+   * and the round-trip check would otherwise pass for anything.
+   */
+  private _requestedState: string | null = null;
 
   public onStateChange: ((state: SupplicantState) => void) | null = null;
   public onError: ((error: unknown) => void) | null = null;
@@ -104,6 +125,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     public readonly opts: OAuthIntegrationOptions
   ) {
     super(data, storageData, opts, IntegrationType.PairingSupplicant);
+    this._iid = crypto.randomUUID();
   }
 
   /**
@@ -126,6 +148,11 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
       return true;
     }
     return allowedClients.includes(clientId);
+  }
+
+  getServiceName(): string {
+    // TBD: At somepoint we will need to encode the service in the pair url?
+    return 'sync';
   }
 
   get state(): SupplicantState {
@@ -162,6 +189,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
 
   private setState(state: SupplicantState): void {
     this._state = state;
+    console.info(`Emitting pairing supplicant state change event.`, {id: this._iid, state: this.state});
     this.onStateChange?.(state);
   }
 
@@ -192,6 +220,10 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     this.onError?.(this._error);
   }
 
+  hasChannel(channelId:string) {
+    return !!this._channel && this._channel.channelId === channelId;
+  }
+
   /**
    * Open the WebSocket channel and start the supplicant flow.
    * Called once when the Supp page mounts.
@@ -199,14 +231,27 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   async openChannel(
     channelServerUri: string,
     channelId: string,
-    channelKey: string
+    channelKey: string,
+    version:number = 1
   ): Promise<void> {
+
+    if (version === 2 && this._channel) {
+      if (channelId === this._channel.channelId) {
+        console.warn('Pairing channel already open!');
+        return; // already open
+      } else {
+        console.warn('Different pairing channel already open!');
+        this._channel.close();
+      }
+    }
+
     if (this._channel) {
       console.warn('Pairing channel already open!');
       return; // already open
     }
 
     this._channelId = channelId;
+    this._version = version;
     this._channel = new PairingChannelClient();
 
     // Listen for channel events
@@ -236,37 +281,46 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   /** Supplicant user approved the pairing. */
   async supplicantApprove(): Promise<void> {
     if (!this._channel) {
-      return;
+      throw new Error('Missing channel!');
     }
 
     try {
       await this._channel.send('pair:supp:authorize', {});
-
-      if (this._state === SupplicantState.WaitingForAuthorizations) {
-        // Supplicant approved first — wait for authority
-        this.setState(SupplicantState.WaitingForAuthority);
-      } else if (this._state === SupplicantState.WaitingForSupplicant) {
-        // Authority already approved — send result
-        this.sendResultToRelier();
-      }
     } catch (err: unknown) {
       this.fail(err);
+      throw err;
+    }
+
+    // In V2, the the UI flow forces the supplicant to approve first.
+    if (this._version === 2) {
+      this.setState(SupplicantState.WaitingForAuthority);
+    }
+    else {
+      if (this._state === SupplicantState.WaitingForAuthorizations) {
+        this.setState(SupplicantState.WaitingForAuthority);
+      } else if (this._state === SupplicantState.WaitingForSupplicant) {
+        this.sendResultToRelier();
+      }
     }
   }
 
   private handleConnected = () => {
     this.setState(SupplicantState.WaitingForMetadata);
 
-    // Send OAuth request to authority
-    const oauthParams = this.getOAuthParams();
-    if (!this._channel) {
-      return;
-    }
-    this._channel
-      .send('pair:supp:request', oauthParams as Record<string, unknown>)
-      .catch((err: unknown) => {
-        this.fail(err);
-      });
+    // Callback to the browser and get the oauth parameters
+    (async () => {
+      const oauthParams = await this.getOAuthParams();
+
+      // Send OAuth request to authority
+      if (!this._channel) {
+        throw new Error('Channel no longe exists!')
+      }
+      await this._channel
+        .send('pair:supp:request', oauthParams);
+
+    })().catch((err: unknown) => {
+      this.fail(err);
+    });
   };
 
   private handleAuthMetadata = (event: Event) => {
@@ -298,20 +352,43 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
       return;
     }
 
-    const expectedState = this.data.state;
-    if (expectedState && data.state !== expectedState) {
+    // v1 reads it from the URL, v2 from `pairOauthStart`, so prefer what we
+    // actually sent. Nothing to compare against means we never sent a request,
+    // which makes this authorize unsolicited.
+    const expectedState = this._requestedState ?? this.data.state;
+    if (!expectedState) {
+      this.fail(
+        new Error('Cannot verify OAuth state: no request state recorded')
+      );
+      return;
+    }
+    if (data.state !== expectedState) {
       this.fail(new Error('OAuth state mismatch'));
       return;
     }
-
     this._oauthCode = data.code;
 
-    if (this._state === SupplicantState.WaitingForAuthorizations) {
-      // Authority approved first — wait for supplicant user
-      this.setState(SupplicantState.WaitingForSupplicant);
-    } else if (this._state === SupplicantState.WaitingForAuthority) {
-      // Supplicant already approved — send result
-      this.sendResultToRelier();
+    // In V2, the authority always approves last, so we can just finish
+    // the process here.
+    if (this._version === 2) {
+      firefox.fxaOAuthLogin({
+        code: data.code,
+        state: data.state,
+        redirect: OAUTH_WEBCHANNEL_REDIRECT,
+        action: 'pairing',
+      });
+      if (this._channel?.channelId) {
+        setChannelComplete(this._channel.channelId);
+      }
+      this.setState(SupplicantState.Complete);
+    } else {
+      if (this._state === SupplicantState.WaitingForAuthorizations) {
+        // Authority approved first — wait for supplicant user
+        this.setState(SupplicantState.WaitingForSupplicant);
+      } else if (this._state === SupplicantState.WaitingForAuthority) {
+        // Supplicant already approved — send result
+        this.sendResultToRelier();
+      }
     }
   };
 
@@ -324,7 +401,38 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     );
   }
 
+  checkClientInfo () {
+    // no-op. The supplicant doesn't have client info.
+  }
+
+  getClientId(): string | undefined {
+    let clientId = super.getClientId();
+
+    // BAND-AIDE! We should get from the URL, or fxa status! Unfortunately
+    // there are situations like pairing where it's not in the URL and
+    // fxa status is also missing the value.
+    if (!clientId) {
+      const deviceType = detectDevice();
+      if (deviceType === Devices.FIREFOX_ANDROID) {
+        clientId = OAuthNativeClients.Fenix;
+      }
+      if (deviceType === Devices.FIREFOX_IOS) {
+        clientId = OAuthNativeClients.FirefoxIOS;
+      }
+      if (deviceType === Devices.FIREFOX_DESKTOP) {
+        clientId = OAuthNativeClients.FirefoxDesktop;
+      }
+    }
+
+    if (!clientId) {
+      console.warn("Could not resolve a valid clientId!")
+    }
+
+    return clientId;
+  }
+
   private handleClose = () => {
+    console.warn('Channel close event');
     if (this.isPostCompletionReconnect()) {
       return;
     }
@@ -335,12 +443,16 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   };
 
   private handleChannelError = (event: Event) => {
+
+    console.warn('Channel error event', event)
+
     if (this.isPostCompletionReconnect()) {
       return;
     }
     this.fail((event as CustomEvent).detail);
   };
 
+  // TODO: Remove after v1 is deprecated
   private sendResultToRelier(): void {
     this.setState(SupplicantState.SendingResult);
 
@@ -372,15 +484,47 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
    * keys_jwk, scope, state) throw on missing values to match Backbone's
    * Vat.*.required() validators.
    */
-  private getOAuthParams(): {
-    access_type: string;
-    client_id: string;
-    code_challenge: string;
-    code_challenge_method: string;
-    keys_jwk: string;
-    scope: string;
-    state: string;
-  } {
+  private async getOAuthParams(): Promise<OAuthStartParams> {
+    if (this._version === 2) {
+      const data = await firefox.pairOauthStart({});
+      if (!data) {
+        throw new Error('Firefox could not provide oauth params.')
+      }
+
+      // This following client id check is a bandaide for now, so we at least
+      // have a client id... We fail fast here if we can't figure anything
+      // out, since there's not point in proceeding.
+      const client_id = this.data.clientId || this.getClientId();
+      if (!client_id) {
+        console.warn('Could not determine clientId!')
+        throw new Error("Could not determine clientId! Cannot proceed.")
+      }
+
+      const scope = [
+        ...new Set(data?.scope.replace(/\+/g, ' ').trim().split(/\s+/)),
+      ].join(' ');
+
+      const result = {
+        access_type: this.data.accessType || 'offline',
+        client_id,
+        code_challenge: data.code_challenge,
+        code_challenge_method: data.code_challenge_method,
+        keys_jwk: data.keys_jwk,
+        scope,
+        state: data.state,
+      };
+
+      // Fail fast if something wasn't provided.
+      const missing = Object.entries(result).filter(([k,v]) => !v && k !== 'client_id').map(([k]) => k);
+      if (missing.length) {
+        throw new Error(`Missing required OAuth params: ${missing.join(', ')}`);
+      }
+
+      this._requestedState = result.state;
+      return result;
+    }
+
+    // Legacy v1 approach
     const clientId = this.data.clientId;
     const codeChallenge = this.data.codeChallenge;
     const codeChallengeMethod = this.data.codeChallengeMethod;
@@ -415,6 +559,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
       ...new Set(rawScope.replace(/\+/g, ' ').trim().split(/\s+/)),
     ].join(' ');
 
+    this._requestedState = state;
     return {
       access_type: this.data.accessType || 'offline',
       client_id: clientId,
@@ -427,6 +572,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   }
 
   async destroy(): Promise<void> {
+    console.info('Channel destroy')
     this.onStateChange = null;
     this.onError = null;
 

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
@@ -6,7 +6,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { MOCK_ACCOUNT, renderWithRouter } from '../../models/mocks';
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
-import ConnectAnotherDevice, { Devices, viewName } from '.';
+import ConnectAnotherDevice, { viewName } from '.';
 import { usePageViewEvent } from '../../lib/metrics';
 import {
   MOCK_BASIC_PROPS,
@@ -17,10 +17,10 @@ import {
   mockFxAStatus,
   mockPairingAppContext,
 } from './mocks';
-import { UseFxAStatusResult } from '../../lib/hooks';
 import { ENTRYPOINTS, REACT_ENTRYPOINT } from '../../constants';
 import firefox from '../../lib/channels/firefox';
 import * as ReactUtils from 'fxa-react/lib/utils';
+import { Devices } from '../../lib/utilities';
 
 jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -185,7 +185,7 @@ describe('ConnectAnotherDevice', () => {
     const FXA_PAIRING_V2 = 2;
 
     const renderPairingEligible = (
-      fxaStatus: Partial<UseFxAStatusResult>,
+      fxaStatus: Parameters<typeof mockFxAStatus>[0],
       fxaPairingVersion: number,
       route: string = MOCK_PAIRING_ELIGIBLE_ROUTE
     ) =>
@@ -214,7 +214,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('navigates to the v2 pairing flow when FxA and the browser both support version 2', async () => {
       renderPairingEligible(
-        { pairingEnabled: true, pairingVersion: 2 },
+        { pairing: true, pairingVersion: 2 },
         FXA_PAIRING_V2
       );
 
@@ -230,7 +230,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('reads the browser pairing capabilities from props instead of requesting fxaStatus', async () => {
       renderPairingEligible(
-        { pairingEnabled: true, pairingVersion: 2 },
+        { pairing: true, pairingVersion: 2 },
         FXA_PAIRING_V2
       );
 
@@ -246,7 +246,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('navigates to the v1 pairing flow when the browser only supports pairing version 1', async () => {
       renderPairingEligible(
-        { pairingEnabled: true, pairingVersion: 1 },
+        { pairing: true, pairingVersion: 1 },
         FXA_PAIRING_V2
       );
 
@@ -260,7 +260,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('navigates to the v1 pairing flow when the browser has pairing disabled', async () => {
       renderPairingEligible(
-        { pairingEnabled: false, pairingVersion: 2 },
+        { pairing: false, pairingVersion: 2 },
         FXA_PAIRING_V2
       );
 
@@ -274,7 +274,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('navigates to the v1 pairing flow when FxA pairing version is 1', async () => {
       renderPairingEligible(
-        { pairingEnabled: true, pairingVersion: 2 },
+        { pairing: true, pairingVersion: 2 },
         FXA_PAIRING_V1
       );
 
@@ -287,7 +287,10 @@ describe('ConnectAnotherDevice', () => {
     });
 
     it('navigates to the v1 pairing flow when the browser reports no pairing capability', async () => {
-      renderPairingEligible({}, FXA_PAIRING_V2);
+      renderPairingEligible(
+        { pairing: false, pairingVersion: undefined },
+        FXA_PAIRING_V2
+      );
 
       await waitFor(() => expect(hardNavigate).toHaveBeenCalledWith('/pair'));
       expect(hardNavigate).not.toHaveBeenCalledWith(
@@ -299,7 +302,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('navigates to the v2 pairing flow when the v=2 query param forces it, despite a v1 browser', async () => {
       renderPairingEligible(
-        { pairingEnabled: true, pairingVersion: 1 },
+        { pairing: true, pairingVersion: 1 },
         FXA_PAIRING_V2,
         `${MOCK_PAIRING_ELIGIBLE_ROUTE}&v=2`
       );
@@ -316,7 +319,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('renders the loading spinner while the browser capabilities are unresolved', async () => {
       renderPairingEligible(
-        { pairingEnabled: undefined, pairingVersion: undefined },
+        { overrides: { fxaStatus: undefined } },
         FXA_PAIRING_V2
       );
 
@@ -326,7 +329,7 @@ describe('ConnectAnotherDevice', () => {
 
     it('renders the page without pairing when the flow is not pairing-eligible', async () => {
       renderPairingEligible(
-        { pairingEnabled: true, pairingVersion: 2 },
+        { pairing: true, pairingVersion: 2 },
         FXA_PAIRING_V2,
         '/connect_another_device'
       );

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
@@ -16,6 +16,7 @@ import { getBasicAccountData } from '../../lib/account-storage';
 import firefox, { buildSyncOAuthSearch } from '../../lib/channels/firefox';
 import GleanMetrics from '../../lib/glean';
 import AppLayout from '../../components/AppLayout';
+import { detectDevice, Devices } from '../../lib/utilities';
 import { UseFxAStatusResult } from '../../lib/hooks';
 
 export type ConnectAnotherDeviceProps = {
@@ -30,14 +31,7 @@ export type ConnectAnotherDeviceProps = {
   fxaStatus: UseFxAStatusResult;
 };
 
-export enum Devices {
-  FIREFOX_ANDROID = 'Firefox Android',
-  FIREFOX_DESKTOP = 'Firefox Desktop',
-  FIREFOX_IOS = 'Firefox iOS',
-  OTHER_ANDROID = 'Other Android',
-  OTHER_IOS = 'Other iOS',
-  OTHER = 'Other',
-}
+
 // Validate entrypoint against known values, defaulting to FIREFOX_MENU_ENTRYPOINT.
 const VALID_ENTRYPOINTS = new Set(Object.values(ENTRYPOINTS));
 function getValidEntrypoint(raw: string | null): ENTRYPOINTS {
@@ -45,32 +39,6 @@ function getValidEntrypoint(raw: string | null): ENTRYPOINTS {
     return raw as ENTRYPOINTS;
   }
   return ENTRYPOINTS.FIREFOX_MENU_ENTRYPOINT;
-}
-
-// Detect device type from user agent.
-function detectDevice(): Devices {
-  const ua = navigator.userAgent;
-  const isFirefox = /Firefox/i.test(ua) && !/FxiOS/i.test(ua);
-  const isFxiOS = /FxiOS/i.test(ua);
-  const isAndroid = /Android/i.test(ua);
-  const isIos = /iPhone|iPad|iPod/i.test(ua) || isFxiOS;
-
-  if (isFirefox && isAndroid) {
-    return Devices.FIREFOX_ANDROID;
-  }
-  if (isFxiOS) {
-    return Devices.FIREFOX_IOS;
-  }
-  if (isFirefox && !isAndroid) {
-    return Devices.FIREFOX_DESKTOP;
-  }
-  if (isIos) {
-    return Devices.OTHER_IOS;
-  }
-  if (isAndroid) {
-    return Devices.OTHER_ANDROID;
-  }
-  return Devices.OTHER;
 }
 
 // Check if the browser supports Sync auth via WebChannels
@@ -194,7 +162,7 @@ const ConnectAnotherDevice = ({
 
   // The browser's pairing capabilities arrive asynchronously over the web
   // channel, so they start out undefined.
-  const capabilitiesResolved = fxaStatus.pairingVersion !== undefined;
+  const capabilitiesResolved = !!fxaStatus.fxaStatus?.capabilities;
 
   useEffect(() => {
     // Deciding the pairing route before the capabilities land would read an
@@ -237,8 +205,8 @@ const ConnectAnotherDevice = ({
         // Both FxA and Firefox have to signal that pairing v2 is enabled!
         if (
           config.pairing.version === 2 &&
-          fxaStatus.pairingEnabled === true &&
-          fxaStatus.pairingVersion === 2
+          fxaStatus.fxaStatus?.capabilities?.pairing === true &&
+          fxaStatus.fxaStatus?.capabilities?.pairingVersion === 2
         ) {
           hardNavigate('/pair/authority/scan_qr', {}, true);
           return;

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
@@ -2,31 +2,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Devices } from '.';
 import { ENTRYPOINTS } from '../../constants';
 import { getDefault } from '../../lib/config';
 import { SignedInUser } from '../../lib/channels/firefox';
 import { AppContextValue } from '../../models';
 import { UseFxAStatusResult } from '../../lib/hooks';
 import { MOCK_ACCOUNT, mockAppContext } from '../../models/mocks';
+import { Devices } from '../../lib/utilities';
 
 /**
  * The browser capabilities `useFxAStatus` resolves to, as the page receives
  * them. Defaults to a v1-pairing browser; pass overrides for the v2 cases.
  */
-export function mockFxAStatus(
-  overrides: Partial<UseFxAStatusResult> = {}
-): UseFxAStatusResult {
+export function mockFxAStatus({
+  overrides = {},
+  pairing = false,
+  pairingVersion = 1,
+}: {
+  overrides?: Partial<UseFxAStatusResult>;
+  pairing?: boolean;
+  pairingVersion?: number;
+} = {}): UseFxAStatusResult {
   return {
-    pairingEnabled: false,
-    pairingVersion: 1,
-    hasSyncKeys: undefined,
     offeredSyncEngines: [],
     offeredSyncEngineConfigs: undefined,
     declinedSyncEngines: [],
     selectedEnginesForGlean: {},
     supportsKeysOptionalLogin: false,
     supportsCanLinkAccountUid: undefined,
+    fxaStatus: {
+      capabilities: {
+        engines: [],
+        multiService: true,
+        choose_what_to_sync: true,
+        keys_optional: true,
+        can_link_account_uid: true,
+        pairing,
+        pairingVersion,
+      },
+    },
     ...overrides,
   };
 }

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
@@ -40,7 +40,7 @@ import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 // The MFA email-OTP guard is unit-tested separately (MfaGuardCore); here it is a
 // pass-through so the recovery setup (its children) renders directly. A mfa:2fa
 // JWT is seeded in setMocks so the JWT-guarded completion call resolves.
-jest.mock('../../components/Settings/MfaGuard', () => ({
+jest.mock('../../components/Settings/MfaGuard/MfaGuardCore', () => ({
   __esModule: true,
   MfaGuardCore: ({ children }: { children: ReactNode }) => children,
 }));

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
@@ -19,7 +19,7 @@ import {
   useFtlMsgResolver,
   useSensitiveDataClient,
 } from '../../models';
-import { MfaGuardCore } from '../../components/Settings/MfaGuard';
+import { MfaGuardCore } from '../../components/Settings/MfaGuard/MfaGuardCore';
 import { JwtTokenCache } from '../../lib/cache';
 import { clearMfaAndJwtCacheOnInvalidJwt } from '../../lib/mfa-guard-utils';
 import InlineRecoverySetup from './index';

--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { renderWithRouter } from '../../../models/mocks';
+import { mockAppContext, renderWithRouter } from '../../../models/mocks';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
@@ -12,8 +12,11 @@ import firefox from '../../../lib/channels/firefox';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import { MOCK_ERROR } from './mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
-import Pair, { viewName } from '.';
+import Pair, { parsePairingHash, viewName } from '.';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
+import { getDefault } from '../../../lib/config';
 import { PAIR_GLEAN_REASONS } from 'fxa-shared/metrics/glean/pair-reasons';
+import { Integration } from '../../../models';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -21,12 +24,14 @@ jest.mock('../../../lib/metrics', () => ({
 
 let mockLocationState: unknown = null;
 let mockLocationSearch = '';
+let mockLocationHash = '';
 const mockNavigate = jest.fn();
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useLocation: () => ({
     pathname: '/pair',
     search: mockLocationSearch,
+    hash: mockLocationHash,
     state: mockLocationState,
   }),
   useNavigate: () => mockNavigate,
@@ -78,6 +83,12 @@ jest.mock('../../../components/QRCode', () => ({
   }) => <img alt={localizedLabel} data-testid="pair-qr" data-value={value} />,
 }));
 
+// Pair holds a spinner until the browser answers fxa_status, so every render
+// needs a settled result.
+const defaultProps: React.ComponentProps<typeof Pair> = {
+  fxaStatusResult: mockUseFxAStatus(),
+};
+
 const sendTabIntegration = {
   data: { entrypoint: 'send-tab-toolbar-icon' },
 } as unknown as React.ComponentProps<typeof Pair>['integration'];
@@ -108,13 +119,14 @@ describe('Pair', () => {
     jest.clearAllMocks();
     mockLocationState = null;
     mockLocationSearch = '';
+    mockLocationHash = '';
   });
 
   // Render Pair and wait for the bootstrap spinner to clear before asserting.
   async function renderPair(
-    props: React.ComponentProps<typeof Pair> = {}
+    props: Partial<React.ComponentProps<typeof Pair>> = {}
   ): Promise<void> {
-    renderWithRouter(<Pair {...props} />);
+    renderWithRouter(<Pair {...defaultProps} {...props} />);
     await screen.findByLabelText(/I already have Firefox for mobile/);
   }
 
@@ -264,7 +276,7 @@ describe('Pair', () => {
 
   describe('download screen', () => {
     async function renderAndNavigateToDownload(
-      props: React.ComponentProps<typeof Pair> = {}
+      props: Partial<React.ComponentProps<typeof Pair>> = {}
     ): Promise<void> {
       await renderPair(props);
       fireEvent.click(screen.getByLabelText(/I don’t have Firefox for mobile/));
@@ -382,7 +394,7 @@ describe('Pair', () => {
       'starts an OAuth flow when fxa_status returns %s on every attempt',
       async (_, response) => {
         requestSignedInUserMock.mockResolvedValue(response);
-        renderWithRouter(<Pair />);
+        renderWithRouter(<Pair {...defaultProps} />);
         await waitFor(() =>
           expect(fxaOAuthFlowBeginMock).toHaveBeenCalledWith([
             'profile',
@@ -408,7 +420,7 @@ describe('Pair', () => {
 
     it('caps fxa_status at two asks before falling through to OAuth', async () => {
       requestSignedInUserMock.mockResolvedValue(undefined);
-      renderWithRouter(<Pair />);
+      renderWithRouter(<Pair {...defaultProps} />);
       await waitFor(() => expect(fxaOAuthFlowBeginMock).toHaveBeenCalled());
       expect(requestSignedInUserMock).toHaveBeenCalledTimes(2);
     });
@@ -429,7 +441,7 @@ describe('Pair', () => {
           code_challenge: 'cc',
           code_challenge_method: 'S256',
         });
-        renderWithRouter(<Pair />);
+        renderWithRouter(<Pair {...defaultProps} />);
         await waitFor(() => expect(hardNavigateSpy).toHaveBeenCalled());
         const [target] = hardNavigateSpy.mock.calls[0];
         const url = new URL(target, 'http://localhost');
@@ -515,7 +527,7 @@ describe('Pair', () => {
   describe('Send Tab variant', () => {
     const sendTabIntegration = {
       data: { entrypoint: 'send-tab-toolbar-icon' },
-    } as unknown as import('../../../models').Integration;
+    } as unknown as Integration;
 
     it('renders the send-tab heading without the grey "Connect another device" text', async () => {
       await renderPair({ integration: sendTabIntegration });
@@ -579,5 +591,126 @@ describe('Pair', () => {
       expect(continueBtn).not.toHaveClass('cta-primary-cms');
       expect(continueBtn.style.getPropertyValue('--cta-bg')).toBe('');
     });
+  });
+
+  // A supplicant that scanned the authority's QR lands on /pair with the
+  // channel in the hash, and belongs in the v2 supplicant flow rather than on
+  // this desktop-only choice screen.
+  describe('pairing v2 supplicant hand-off', () => {
+    const V2_HASH = '#channel_id=chan-1&channel_key=key-1&v=2';
+    const v2Props = {
+      fxaStatusResult: mockUseFxAStatus({
+        pairingEnabled: true,
+        pairingVersion: 2,
+      }),
+    };
+    // v2 routing is gated on the deployment config as well as the browser, so
+    // the suite has to opt in on both sides.
+    const v2AppContext = () => {
+      const config = getDefault();
+      config.pairing.version = 2;
+      return mockAppContext({ config } as Parameters<typeof mockAppContext>[0]);
+    };
+
+    it('hands the channel to the supplicant flow, dropping the hash', async () => {
+      mockLocationHash = V2_HASH;
+      renderWithRouter(<Pair {...v2Props} />, {}, v2AppContext());
+
+      await waitFor(() =>
+        // No hash on the destination: the channel key is the pairing PSK, and
+        // it travels in router state instead.
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/pair/supplicant/connect_this_device',
+          { state: { channelId: 'chan-1', channelKey: 'key-1', version: '2' } }
+        )
+      );
+    });
+
+    it('does not send the browser to /pair/unsupported while handing off', async () => {
+      mockLocationHash = V2_HASH;
+      renderWithRouter(<Pair {...v2Props} />, {}, v2AppContext());
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        '/pair/unsupported',
+        expect.anything()
+      );
+      expect(mockNavigate).not.toHaveBeenCalledWith('/pair/unsupported');
+    });
+
+    // Only desktop can be the authority, and it reaches /pair without a
+    // channel because it is the side that mints one.
+    it('reloads into the QR scanner when the hash carries no pairing channel', async () => {
+      // A hard navigate rather than a router hop: `useIntegration` is not keyed
+      // on location, so the authority integration only exists after a reload.
+      const hardNavigateSpy = jest
+        .spyOn(ReactUtils, 'hardNavigate')
+        .mockImplementation(() => {});
+      renderWithRouter(<Pair {...v2Props} />, {}, v2AppContext());
+
+      await waitFor(() =>
+        expect(hardNavigateSpy).toHaveBeenCalledWith(
+          '/pair/authority/scan_qr',
+          {},
+          true
+        )
+      );
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        '/pair/supplicant/connect_this_device',
+        expect.anything()
+      );
+      hardNavigateSpy.mockRestore();
+    });
+
+    it('falls through to the normal flow when the browser reports v1', async () => {
+      const status = { pairingEnabled: true, pairingVersion: 1 };
+      mockLocationHash = V2_HASH;
+      renderWithRouter(
+        <Pair fxaStatusResult={mockUseFxAStatus(status)} />,
+        {},
+        v2AppContext()
+      );
+
+      // The desktop UA is stubbed for this suite, so the bootstrap reaching the
+      // choice screen is what proves the hold expired. Waits past the grace
+      // period, which is longer than the default findBy timeout.
+      await screen.findByLabelText(/I already have Firefox for mobile/, undefined, {
+        timeout: 4000,
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        '/pair/supplicant/connect_this_device',
+        expect.anything()
+      );
+    });
+
+
+  });
+});
+
+describe('parseV2PairingHash', () => {
+  it('reads the channel out of an authority QR hash', () => {
+    expect(
+      parsePairingHash('#channel_id=chan-1&channel_key=key-1&v=2')
+    ).toEqual({ channelId: 'chan-1', channelKey: 'key-1', version: '2' });
+  });
+
+  it('accepts a hash without the leading #', () => {
+    expect(parsePairingHash('channel_id=chan-1&channel_key=key-1&v=2')).toEqual(
+      { channelId: 'chan-1', channelKey: 'key-1', version: '2' }
+    );
+  });
+
+  it.each([
+    ['an empty hash', ''],
+    ['an absent hash', undefined],
+    ['no version', '#channel_id=chan-1&channel_key=key-1'],
+    ['version 1', '#channel_id=chan-1&channel_key=key-1&v=1'],
+    // Half a channel cannot be opened, so it is no hand-off rather than a
+    // broken one.
+    ['no channel_key', '#channel_id=chan-1&v=2'],
+    ['no channel_id', '#channel_key=key-1&v=2'],
+    ['an empty channel_key', '#channel_id=chan-1&channel_key=&v=2'],
+  ])('returns undefined for %s', (_label, hash) => {
+    expect(parsePairingHash(hash)).toBeUndefined();
   });
 });

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -11,11 +11,11 @@ import React, {
 } from 'react';
 import { isPairGleanReason } from 'fxa-shared/metrics/glean/pair-reasons';
 import { Link, useLocation } from 'react-router';
-import { useNavigateWithQuery } from '../../../lib/hooks';
+import { UseFxAStatusResult, useNavigateWithQuery } from '../../../lib/hooks';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { useFtlMsgResolver } from '../../../models';
-import { useCmsInfoState } from '../../../models/hooks';
+import { useCmsInfoState, useConfig } from '../../../models/hooks';
 import { RelierCmsInfo } from '../../../models/integrations';
 import AppLayout from '../../../components/AppLayout';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
@@ -59,6 +59,44 @@ const PAIR_BANNER_FTL: Record<PairOrigin, { id: string; fallback: string }> = {
   },
 };
 
+/**
+ * The pairing channel the authority encodes into its QR code, handed to the
+ * supplicant flow as router state.
+ */
+export type PairingChannelInfo = {
+  channelId: string;
+  channelKey: string;
+  version: '1'|'2';
+};
+
+/**
+ * Read a v2 pairing channel out of a URL hash, as produced by the authority's
+ * QR code: `/pair#channel_id=...&channel_key=...&v=2`. The channel lives in the
+ * hash rather than the query string so the key is never sent to the server.
+ *
+ * Returns undefined unless the hash names version 2 and carries both halves of
+ * the channel — half a channel cannot be opened, so it is treated as no hand-off
+ * at all rather than as a broken one.
+ */
+export function parsePairingHash(
+  hash?: string
+): PairingChannelInfo | undefined {
+  const params = new URLSearchParams((hash ?? '').replace(/^#/, ''));
+
+  if (params.get('v') !== '2') {
+    return undefined;
+  }
+
+  const version = params.get('v') === '2' ? '2':'1';
+  const channelId = params.get('channel_id');
+  const channelKey = params.get('channel_key');
+  if (!channelId || !channelKey) {
+    return undefined;
+  }
+
+  return { channelId, channelKey, version };
+}
+
 type MobileChoice = 'has-mobile' | 'needs-mobile';
 
 const GLEAN_REASON_BY_CHOICE: Record<MobileChoice, string> = {
@@ -72,16 +110,24 @@ type PairProps = {
   error?: string;
   cmsInfo?: RelierCmsInfo;
   integration?: Integration;
+  fxaStatusResult: UseFxAStatusResult;
 };
 export const viewName = 'pair';
 
-const Pair = ({ error, cmsInfo: cmsInfoProp, integration }: PairProps) => {
+const Pair = ({
+  error,
+  cmsInfo: cmsInfoProp,
+  integration,
+  fxaStatusResult
+}: PairProps) => {
+
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedQRCodeLabel = ftlMsgResolver.getMsg(
     'pair-qr-code-aria-label',
     'QR code'
   );
+  const config = useConfig();
   const navigateWithQuery = useNavigateWithQuery();
   const location = useLocation();
 
@@ -107,10 +153,54 @@ const Pair = ({ error, cmsInfo: cmsInfoProp, integration }: PairProps) => {
     }
   }, [currentView]);
 
+  // A scanned QR lands here with the channel in the hash. `location.hash` is
+  // known at mount, so this is settled before the bootstrap effect below runs.
+  const pairingChannelInfo = useMemo(
+    () => parsePairingHash(location.hash),
+    [location.hash]
+  );
+
+
   useEffect(() => {
     const ua = navigator.userAgent;
     const isFirefoxDesktop =
       /Firefox/i.test(ua) && !/FxiOS/i.test(ua) && !/Android/i.test(ua);
+
+    // This is a signal that the initial fxa_status message is still pending.
+    // Don't move forwards with other evaluations until we have a definitive
+    // answer here.
+    if (!fxaStatusResult.fxaStatus) {
+      return;
+    }
+
+    // Switch on pairing version 2! Both FxA and Firefox have to signal that it
+    // is enabled, same gate as ConnectAnotherDevice.
+    const { pairingVersion } = fxaStatusResult.fxaStatus.capabilities;
+    if(
+      config.pairing.version === 2 &&
+      pairingVersion && pairingVersion === 2 &&
+      pairingChannelInfo && parseInt(pairingChannelInfo?.version) === 2
+    ) {
+      navigateWithQuery(
+        '/pair/supplicant/connect_this_device',
+        { state: pairingChannelInfo },
+        // The channel key is the pairing PSK. It travels in router state, so
+        // the hash it arrived in must not follow it into the next URL.
+        false
+      );
+      return;
+    }
+
+    if(
+      isFirefoxDesktop &&
+      config.pairing.version === 2 &&
+      pairingVersion && pairingVersion === 2
+    ) {
+      // Full reload: `useIntegration` is not keyed on location, so only a
+      // fresh page load rebuilds it as a PairingAuthorityIntegration.
+      hardNavigate('/pair/authority/scan_qr', {}, true);
+      return;
+    }
 
     if (!isFirefoxDesktop) {
       navigateWithQuery('/pair/unsupported');
@@ -162,7 +252,7 @@ const Pair = ({ error, cmsInfo: cmsInfoProp, integration }: PairProps) => {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [pairingChannelInfo, fxaStatusResult, navigateWithQuery]);
 
   // Banner variant is driven by router state from getSyncNavigate.
   const { origin: pairOrigin } = (location.state ?? {}) as Pick<
@@ -243,7 +333,7 @@ const Pair = ({ error, cmsInfo: cmsInfoProp, integration }: PairProps) => {
     openPairPreferences();
   }, [openPairPreferences]);
 
-  if (bootstrapping) {
+  if (bootstrapping || !fxaStatusResult.fxaStatus) {
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/container.test.tsx
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { MemoryRouter } from 'react-router';
+import * as Sentry from '@sentry/browser';
+import ApproveSignInContainer from './container';
+import { MOCK_EMAIL } from './mocks';
+import { MOCK_METADATA_WITH_DEVICE_NAME } from '../../../../components/DeviceInfoBlock/mocks';
+import { RemoteMetadata } from '../../../../lib/types';
+import {
+  AuthorityState,
+  Integration,
+  PairingAuthorityIntegration,
+  useAccount,
+} from '../../../../models';
+import { navigateWithQuery } from '../../../../lib/utilities';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../lib/utilities', () => ({
+  ...jest.requireActual('../../../../lib/utilities'),
+  navigateWithQuery: jest.fn(),
+}));
+
+jest.mock('../../../../models', () => ({
+  ...jest.requireActual('../../../../models'),
+  useAccount: jest.fn(),
+}));
+
+type MockAuthorityIntegration = PairingAuthorityIntegration & {
+  authorize: jest.Mock;
+  hasChannel: jest.Mock;
+};
+
+/**
+ * A `PairingAuthorityIntegration` with the approve surface stubbed. Built from
+ * the real prototype because the container narrows on `instanceof` before it
+ * touches any of it.
+ */
+function mockAuthorityIntegration({
+  remoteMetadata = MOCK_METADATA_WITH_DEVICE_NAME as RemoteMetadata | null,
+} = {}): MockAuthorityIntegration {
+  const integration = Object.create(
+    PairingAuthorityIntegration.prototype
+  ) as MockAuthorityIntegration;
+
+  // `remoteMetadata` is a getter on the prototype, so it cannot be assigned.
+  Object.defineProperty(integration, 'remoteMetadata', {
+    get: () => remoteMetadata,
+  });
+
+  return Object.assign(integration, {
+    authorize: jest.fn().mockResolvedValue(undefined),
+    hasChannel: jest.fn().mockReturnValue(true),
+    onStateChange: null,
+  });
+}
+
+const emitState = (
+  integration: MockAuthorityIntegration,
+  state: AuthorityState
+) => (integration as PairingAuthorityIntegration).onStateChange?.(state);
+
+// Approving is the point of no return: it makes Firefox mint an OAuth code with
+// the account's Sync keys wrapped inside. So this container's job is to fire
+// that exactly once, and to make sure a failure lands somewhere the user can
+// see rather than disappearing into an unhandled rejection.
+describe('Pair2/Authority/ApproveSignIn container', () => {
+  let integration: MockAuthorityIntegration;
+  let captureException: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    integration = mockAuthorityIntegration();
+    (useAccount as jest.Mock).mockReturnValue({ email: MOCK_EMAIL });
+    captureException = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(() => '');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderContainer = (i: Integration = integration) =>
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <ApproveSignInContainer integration={i} />
+      </MemoryRouter>
+    );
+
+  const clickApprove = async () => {
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('button', { name: 'Yes, approve sign-in' })
+    );
+  };
+
+  it('renders the approval screen for the device that scanned the code', () => {
+    renderContainer();
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Approve sign-in?'
+    );
+    screen.getByText(MOCK_EMAIL);
+  });
+
+  it('waits for the device details before rendering the approval', () => {
+    integration = mockAuthorityIntegration({ remoteMetadata: null });
+
+    renderContainer();
+
+    expect(
+      screen.queryByRole('heading', { level: 1, name: 'Approve sign-in?' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('authorizes when the user approves', async () => {
+    renderContainer();
+
+    await clickApprove();
+
+    expect(integration.authorize).toHaveBeenCalledTimes(1);
+  });
+
+  // Two codes would be minted, and the second `pair:auth:authorize` would go
+  // out after the flow had already completed.
+  it('authorizes once even if approve is clicked twice', async () => {
+    integration.authorize.mockReturnValue(new Promise(() => {}));
+    renderContainer();
+
+    await clickApprove();
+    await clickApprove();
+
+    expect(integration.authorize).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates to the success screen once pairing completes', () => {
+    renderContainer();
+
+    emitState(integration, AuthorityState.Complete);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/authority/sync_success',
+      {},
+      true
+    );
+  });
+
+  // `authorize()` routes the failures it expects through `fail()`. Without a
+  // Failed case the user would sit on this screen with no feedback.
+  it('navigates to the cancel screen when the flow fails', () => {
+    renderContainer();
+
+    emitState(integration, AuthorityState.Failed);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/authority/timeout_and_cancel',
+      {},
+      true
+    );
+  });
+
+  it('reports and leaves the screen when authorize rejects outright', async () => {
+    const err = new Error('web channel exploded');
+    integration.authorize.mockRejectedValue(err);
+    renderContainer();
+
+    await clickApprove();
+
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/authority/timeout_and_cancel',
+      {},
+      true
+    );
+  });
+
+  it('offers the change-password recovery path', async () => {
+    const user = userEvent.setup();
+    renderContainer();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Change your password' })
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith('/settings/change_password');
+  });
+
+  // The channel outlives this page, but the handler must not. The integration
+  // lasts the whole session, so a state change arriving after the user has
+  // left pairing would otherwise pull them back into the flow.
+  it('stops routing state changes once unmounted', async () => {
+    const { unmount } = renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    unmount();
+
+    expect(integration.onStateChange).toBeNull();
+    emitState(integration, AuthorityState.Complete);
+    expect(navigateWithQuery).not.toHaveBeenCalled();
+  });
+
+  it('throws when handed an integration that is not the pairing authority', () => {
+    expect(() => renderContainer({} as Integration)).toThrow(
+      'Invalid integration type.'
+    );
+  });
+
+  it('throws before the pairing channel exists', () => {
+    integration.hasChannel.mockReturnValue(false);
+
+    expect(() => renderContainer()).toThrow('Pairing channel missing!');
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/container.tsx
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { RemoteMetadata } from '../../../../lib/types';
+import { AuthorityState, Integration, PairingAuthorityIntegration, useAccount } from '../../../../models';
+import { useNavigate } from 'react-router';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import ApproveSignIn from '.';
+import { navigateWithQuery } from '../../../../lib/utilities';
+import * as Sentry from '@sentry/browser';
+
+export const ApproveSignInContainer = ({
+  integration
+}: { integration?: Integration|PairingAuthorityIntegration }) => {
+  if (!(integration instanceof PairingAuthorityIntegration)) {
+    throw new Error('Invalid integration type.');
+  }
+  if (!integration.hasChannel()) {
+    throw new Error('Pairing channel missing!')
+  }
+
+  const navigate = useNavigate();
+  const account = useAccount();
+  const [remoteMetadata, setRemoteMetadata] = useState<RemoteMetadata|null>(integration.remoteMetadata);
+
+  useEffect(() => {
+    integration.onStateChange = (state:AuthorityState) => {
+      switch (state) {
+        case AuthorityState.WaitingForAuthorizations:
+          setRemoteMetadata(integration.remoteMetadata);
+          break;
+        case AuthorityState.Complete:
+          navigateWithQuery('/pair/authority/sync_success', {}, true)
+          break;
+        case AuthorityState.Failed:
+          navigateWithQuery('/pair/authority/timeout_and_cancel', {}, true);
+          break;
+        default:
+          console.warn('Unexpected state change: ' + state);
+          break;
+      }
+    };
+
+    return () => {
+      // Unsubscribe only — the channel outlives this page for sync_success.
+      integration.onStateChange = null;
+    };
+  }, [integration]);
+
+  // A second click would mint a second OAuth code and send another
+  // `pair:auth:authorize`, the latter after the flow has already completed.
+  const approving = useRef(false);
+  const onApprove = () => {
+    if (approving.current) {
+      return;
+    }
+    approving.current = true;
+    // `authorize()` routes the failures it expects through `fail()`, which lands
+    // on the Failed case above. This catch is the backstop so nothing here
+    // becomes an unhandled rejection.
+    integration.authorize().catch((err) => {
+      Sentry.captureException(err);
+      navigateWithQuery('/pair/authority/timeout_and_cancel', {}, true);
+    });
+  }
+
+  const onChangePassword = () => {
+    navigate('/settings/change_password');
+  }
+
+  if (!remoteMetadata) {
+    return <LoadingSpinner />
+  }
+
+  return <ApproveSignIn {...{remoteMetadata, email:account.email, onApprove, onChangePassword }} />
+};
+
+export default ApproveSignInContainer;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.test.tsx
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { MemoryRouter } from 'react-router';
+import * as Sentry from '@sentry/browser';
+import ContinueOnMobileContainer from './container';
+import {
+  MOCK_NON_PAIRING_INTEGRATION,
+  MockAuthorityIntegration,
+  emitState,
+  mockAuthorityIntegration,
+} from './mocks';
+import { AuthorityState, Integration } from '../../../../models';
+import { navigateWithQuery } from '../../../../lib/utilities';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../lib/utilities', () => ({
+  ...jest.requireActual('../../../../lib/utilities'),
+  navigateWithQuery: jest.fn(),
+}));
+
+// This is a passive waiting screen: the authority sits here while the
+// supplicant works through the flow on its phone, so everything the container
+// does is a reaction to the integration's state or to Cancel.
+describe('Pair2/Authority/ContinueOnMobile container', () => {
+  let integration: MockAuthorityIntegration;
+  let captureException: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    integration = mockAuthorityIntegration();
+    captureException = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(() => '');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderContainer = (i: Integration = integration) =>
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <ContinueOnMobileContainer integration={i} />
+      </MemoryRouter>
+    );
+
+  it('renders the ContinueOnMobile page', () => {
+    renderContainer();
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Continue on your mobile device'
+    );
+  });
+
+  it('navigates to the approve-sign-in screen once the supplicant asks for authorization', async () => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, AuthorityState.WaitingForAuthority);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/authority/approve_signin',
+      {},
+      true
+    );
+  });
+
+  // The pairing request is dead in this state — cancelled or timed out — so the
+  // authority must never be asked to approve a sign-in for it.
+  it('navigates to the cancel screen when pairing fails', async () => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, AuthorityState.Failed);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/authority/timeout_and_cancel',
+      {},
+      true
+    );
+  });
+
+  it.each([
+    AuthorityState.Connecting,
+    AuthorityState.WaitingForMetadata,
+    AuthorityState.WaitingForAuthorizations,
+  ])('stays on the page in the %s state', async (state) => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, state);
+
+    expect(navigateWithQuery).not.toHaveBeenCalled();
+  });
+
+  describe('cancel', () => {
+    const clickCancel = async () => {
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    };
+
+    it('closes the channel before leaving for the cancel screen', async () => {
+      renderContainer();
+
+      await clickCancel();
+
+      await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/pair/authority/timeout_and_cancel'
+      );
+    });
+
+    // The user asked to stop, so a channel that will not close cleanly cannot
+    // keep them on a screen that is waiting on a pairing they cancelled.
+    it('still leaves for the cancel screen when the channel cannot be closed', async () => {
+      const err = new Error('channel server unreachable');
+      integration.destroy.mockRejectedValue(err);
+      renderContainer();
+
+      await clickCancel();
+
+      await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/pair/authority/timeout_and_cancel'
+      );
+    });
+  });
+
+  // The channel outlives this page, but the handler must not. The integration
+  // lasts the whole session, so a state change arriving after the user has
+  // left pairing would otherwise pull them back into the flow.
+  it('stops routing state changes once unmounted', async () => {
+    const { unmount } = renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    unmount();
+
+    expect(integration.onStateChange).toBeNull();
+    emitState(integration, AuthorityState.WaitingForAuthority);
+    expect(navigateWithQuery).not.toHaveBeenCalled();
+  });
+
+  it('throws when handed an integration that is not the pairing authority', () => {
+    expect(() => renderContainer(MOCK_NON_PAIRING_INTEGRATION)).toThrow(
+      'Invalid integration. Expecting instance of PairingAuthorityIntegration.'
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/container.tsx
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import * as Sentry from '@sentry/browser';
+import { AuthorityState, Integration, PairingAuthorityIntegration } from '../../../../models';
+import ContinueOnMobile from '.';
+import { navigateWithQuery } from '../../../../lib/utilities';
+
+export type ContinueOnMobileContainerProps = {
+  integration?: Integration|PairingAuthorityIntegration
+};
+
+const ContinueOnMobileContainer = ({ integration }: ContinueOnMobileContainerProps) => {
+  if (!(integration instanceof PairingAuthorityIntegration)) {
+    throw new Error('Invalid integration. Expecting instance of PairingAuthorityIntegration.');
+  }
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    integration.onStateChange = (state:AuthorityState) => {
+      switch (state) {
+        case AuthorityState.WaitingForAuthority:
+          navigateWithQuery('/pair/authority/approve_signin', {}, true);
+          break;
+        case AuthorityState.Failed:
+          // The pairing request is dead — cancelled or timed out — so the
+          // authority must not be shown a sign-in to approve for it.
+          navigateWithQuery('/pair/authority/timeout_and_cancel', {}, true);
+          break;
+        default:
+          console.warn('Unexpected state change: ' + state);
+          break;
+      }
+    }
+
+    return () => {
+      // Unsubscribe only — the channel outlives this page for approve_signin.
+      integration.onStateChange = null;
+    };
+  }, [integration]);
+
+  const onCancel = () => {
+    integration.destroy()
+      .then(() => {
+        navigate('/pair/authority/timeout_and_cancel')
+      })
+      .catch((err) => {
+        Sentry.captureException(err);
+        navigate('/pair/authority/timeout_and_cancel');
+      });
+  };
+
+  return <ContinueOnMobile {...{onCancel}}/>
+};
+
+export default ContinueOnMobileContainer;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/index.tsx
@@ -24,7 +24,7 @@ export type ContinueOnMobileProps = {
  * channel reports the mobile device is done, so there is deliberately no
  * primary action. Cancel is the only control.
  */
-const ContinueOnMobile = ({ onCancel }: ContinueOnMobileProps) => (
+export const ContinueOnMobile = ({ onCancel }: ContinueOnMobileProps) => (
   <AppLayout>
     <div className="flex flex-col items-center text-center">
       <FtlMsg id="pair2-authority-continue-on-mobile-heading">

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ContinueOnMobile/mocks.tsx
@@ -3,9 +3,48 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import ContinueOnMobile, { ContinueOnMobileProps } from '.';
+import {
+  AuthorityState,
+  Integration,
+  PairingAuthorityIntegration,
+} from '../../../../models';
 
 export const Subject = ({
   onCancel = () => {},
 }: Partial<ContinueOnMobileProps> = {}) => (
   <ContinueOnMobile {...{ onCancel }} />
 );
+
+export type MockAuthorityIntegration = PairingAuthorityIntegration & {
+  destroy: jest.Mock;
+};
+
+/**
+ * A `PairingAuthorityIntegration` with the container's surface stubbed. Built
+ * from the real prototype because the container narrows on `instanceof` before
+ * it touches any of it.
+ */
+export function mockAuthorityIntegration(
+  overrides: Partial<Record<keyof MockAuthorityIntegration, unknown>> = {}
+): MockAuthorityIntegration {
+  const integration = Object.create(
+    PairingAuthorityIntegration.prototype
+  ) as MockAuthorityIntegration;
+
+  return Object.assign(integration, {
+    destroy: jest.fn().mockResolvedValue(undefined),
+    onStateChange: null,
+    ...overrides,
+  });
+}
+
+/** Drives the integration's state machine the way the channel would. */
+export function emitState(
+  integration: MockAuthorityIntegration,
+  state: AuthorityState
+) {
+  (integration as PairingAuthorityIntegration).onStateChange?.(state);
+}
+
+/** A non-pairing integration, for the container's narrowing guard. */
+export const MOCK_NON_PAIRING_INTEGRATION = {} as Integration;

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.test.tsx
@@ -129,6 +129,10 @@ describe('Pair2/Authority/ScanQR container', () => {
       ''
     );
     expect(integration.getPairUrl).not.toHaveBeenCalled();
+
+    // Nothing downstream can use a half-created channel, so this is the one
+    // path that does tear it down.
+    expect(integration.destroy).toHaveBeenCalled();
   });
 
   // The channel exists but its URL cannot be built — same user-visible outcome
@@ -156,16 +160,20 @@ describe('Pair2/Authority/ScanQR container', () => {
 
     emitState(integration, AuthorityState.WaitingForAuthorizations);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/pair/authority/approve_signin');
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/pair/authority/continue_on_mobile'
+    );
   });
 
-  it('navigates to the approval screen once the supplicant joins', async () => {
+  it('navigates to the continue-on-mobile screen once the supplicant joins', async () => {
     renderContainer();
     await waitFor(() => expect(integration.onStateChange).toBeTruthy());
 
     emitState(integration, AuthorityState.WaitingForAuthorizations);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/pair/authority/approve_signin');
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/pair/authority/continue_on_mobile'
+    );
   });
 
   it('navigates to the cancel screen when pairing fails', async () => {
@@ -191,26 +199,30 @@ describe('Pair2/Authority/ScanQR container', () => {
     }
   );
 
-  it('destroys the integration on unmount so leaving cannot leak a socket', async () => {
+  // The channel outlives this page: the authority moves on to the next pairing
+  // screen while the supplicant is still joining, so tearing it down on unmount
+  // would drop the socket mid-flow.
+  it('leaves the channel open on unmount', async () => {
     const { unmount } = renderContainer();
     await waitFor(() => expect(integration.createChannel).toHaveBeenCalled());
 
     unmount();
 
-    expect(integration.destroy).toHaveBeenCalled();
+    expect(integration.destroy).not.toHaveBeenCalled();
   });
 
-  // Effect cleanup cannot await, so a rejected close has to be caught rather
-  // than escaping as an unhandled rejection.
-  it('reports a failed teardown to Sentry', async () => {
-    const err = new Error('close failed');
-    integration.destroy.mockRejectedValue(err);
+  // The channel outlives this page, but the handler must not. The integration
+  // lasts the whole session, so a state change arriving after the user has
+  // left pairing would otherwise pull them back into the flow.
+  it('stops routing state changes once unmounted', async () => {
     const { unmount } = renderContainer();
-    await waitFor(() => expect(integration.createChannel).toHaveBeenCalled());
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
 
     unmount();
 
-    await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+    expect(integration.onStateChange).toBeNull();
+    emitState(integration, AuthorityState.WaitingForAuthorizations);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('throws when handed an integration that is not the pairing authority', () => {

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/container.tsx
@@ -4,21 +4,22 @@
 
 import React, { useEffect, useState } from 'react';
 import * as Sentry from '@sentry/react';
-import { useNavigate } from 'react-router';
 import ScanQR from '.';
 import {
   AuthorityState,
   Integration,
   PairingAuthorityIntegration,
 } from '../../../../models';
+import { useNavigateWithQuery } from '../../../../lib/hooks';
 
 /**
  * Owns the pairing channel for the authority. Mints a channel on mount so the
- * QR always scans to one that exists on the channel server, and closes it on
- * unmount so leaving the page cannot leak a socket.
+ * QR always scans to one that exists on the channel server. The channel then
+ * outlives this page — the authority moves on while the supplicant is still
+ * joining — so it is only torn down when creation itself fails.
  */
 const ScanQRContainer = ({ integration }: { integration: Integration }) => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const [qrCodeValue, setQrCodeValue] = useState('');
 
   if (!(integration instanceof PairingAuthorityIntegration)) {
@@ -34,10 +35,10 @@ const ScanQRContainer = ({ integration }: { integration: Integration }) => {
     integration.onStateChange = (state: AuthorityState) => {
       switch (state) {
         case AuthorityState.WaitingForAuthorizations:
-          navigate('/pair/authority/approve_signin');
+          navigateWithQuery('/pair/authority/continue_on_mobile');
           break;
         case AuthorityState.Failed:
-          navigate('/pair/authority/timeout_and_cancel');
+          navigateWithQuery('/pair/authority/timeout_and_cancel');
           break;
         default:
           // Connecting and WaitingForMetadata both resolve on this page.
@@ -52,15 +53,18 @@ const ScanQRContainer = ({ integration }: { integration: Integration }) => {
       } catch (err) {
         setQrCodeValue('');
         Sentry.captureException(err);
+        // A half-created channel is unusable downstream, so this is the one
+        // path that closes it. Guarded because effect code cannot let the
+        // rejection escape.
+        await integration.destroy().catch((e) => Sentry.captureException(e));
       }
     })();
 
     return () => {
-      // `destroy` is async and effect cleanup cannot await it; catch so a
-      // failed socket close does not surface as an unhandled rejection.
-      integration.destroy().catch((err) => Sentry.captureException(err));
+      // Unsubscribe only — the channel outlives this page for continue_on_mobile.
+      integration.onStateChange = null;
     };
-  }, [integration, navigate]);
+  }, [integration, navigateWithQuery]);
 
   return <ScanQR {...{ qrCodeValue }} />;
 };

--- a/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/TimeoutAndCancel/container.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import TimeoutAndCancel from '.';
+import { useLocation, useNavigate } from 'react-router';
+import firefox from '../../../../lib/channels/firefox';
+
+export type TimeoutAndCancelContainerProps = {}
+
+/**
+ * The desktop screen shown once pairing stops without succeeding — either it
+ * timed out or someone canceled it. Both reasons offer "Try again"; the
+ * secondary action differs, because a timeout leaves the user mid-flow with
+ * something to abandon while a cancel has already ended it.
+ */
+const TimeoutAndCancelContainer = (_props: TimeoutAndCancelContainerProps) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const onTryAgain = () => {
+    navigate('/pair/authority/scan_qr');
+  }
+
+  const onCancel = () => {
+    navigate('/')
+  }
+
+  const onSyncSettings = () => {
+    firefox.fxaOpenSyncPreferences()
+  }
+
+  return (
+    <TimeoutAndCancel {...{reason:location.state?.reason || 'timeout', onTryAgain, onCancel, onSyncSettings}} />
+  );
+};
+
+export default TimeoutAndCancelContainer;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.test.tsx
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { MemoryRouter } from 'react-router';
+import * as Sentry from '@sentry/browser';
+import ApproveSignInContainer from './container';
+import { MOCK_METADATA_WITH_DEVICE_NAME } from '../../../../components/DeviceInfoBlock/mocks';
+import { RemoteMetadata } from '../../../../lib/types';
+import {
+  Integration,
+  PairingSupplicantIntegration,
+  SupplicantState,
+} from '../../../../models';
+import { navigateWithQuery } from '../../../../lib/utilities';
+
+jest.mock('../../../../lib/utilities', () => ({
+  ...jest.requireActual('../../../../lib/utilities'),
+  navigateWithQuery: jest.fn(),
+}));
+
+type MockSupplicantIntegration = PairingSupplicantIntegration & {
+  destroy: jest.Mock;
+};
+
+/**
+ * A `PairingSupplicantIntegration` with the cancel surface stubbed. Built from
+ * the real prototype because the container narrows on `instanceof` before it
+ * touches any of it.
+ */
+function mockSupplicantIntegration({
+  remoteMetadata = MOCK_METADATA_WITH_DEVICE_NAME as RemoteMetadata | null,
+} = {}): MockSupplicantIntegration {
+  const integration = Object.create(
+    PairingSupplicantIntegration.prototype
+  ) as MockSupplicantIntegration;
+
+  // `remoteMetadata` is a getter on the prototype, so it cannot be assigned.
+  Object.defineProperty(integration, 'remoteMetadata', {
+    get: () => remoteMetadata,
+  });
+
+  return Object.assign(integration, {
+    destroy: jest.fn().mockResolvedValue(undefined),
+    onStateChange: null,
+  });
+}
+
+const emitState = (
+  integration: MockSupplicantIntegration,
+  state: SupplicantState
+) => (integration as PairingSupplicantIntegration).onStateChange?.(state);
+
+// The supplicant waits here while the authority approves on the other device,
+// so everything this container does is a reaction to the channel's state or to
+// Cancel.
+describe('Pair2/Supplicant/ApproveSignIn container', () => {
+  let integration: MockSupplicantIntegration;
+  let captureException: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    integration = mockSupplicantIntegration();
+    captureException = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(() => '');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderContainer = (i: Integration = integration) =>
+    renderWithLocalizationProvider(
+      <MemoryRouter>
+        <ApproveSignInContainer integration={i} />
+      </MemoryRouter>
+    );
+
+  it('navigates to the success screen once pairing completes', () => {
+    renderContainer();
+
+    emitState(integration, SupplicantState.Complete);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/supplicant/sync_success',
+      {},
+      true
+    );
+  });
+
+  it('navigates to the cancel screen when the flow fails', () => {
+    renderContainer();
+
+    emitState(integration, SupplicantState.Failed);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/supplicant/timeout_and_cancel',
+      {},
+      true
+    );
+  });
+
+  describe('cancel', () => {
+    const clickCancel = async () => {
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    };
+
+    it('closes the channel before leaving for the cancel screen', async () => {
+      renderContainer();
+
+      await clickCancel();
+
+      await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
+      expect(navigateWithQuery).toHaveBeenCalledWith(
+        '/pair/supplicant/timeout_and_cancel',
+        {},
+        true
+      );
+    });
+
+    // The user asked to stop, so a channel that will not close cleanly cannot
+    // keep them on a screen that is waiting on a pairing they cancelled.
+    it('still leaves for the cancel screen when the channel cannot be closed', async () => {
+      const err = new Error('channel server unreachable');
+      integration.destroy.mockRejectedValue(err);
+      renderContainer();
+
+      await clickCancel();
+
+      await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+      expect(navigateWithQuery).toHaveBeenCalledWith(
+        '/pair/supplicant/timeout_and_cancel',
+        {},
+        true
+      );
+    });
+  });
+
+  // The channel outlives this page, but the handler must not. The integration
+  // lasts the whole session, so a state change arriving after the user has
+  // left pairing would otherwise pull them back into the flow.
+  it('stops routing state changes once unmounted', async () => {
+    const { unmount } = renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    unmount();
+
+    expect(integration.onStateChange).toBeNull();
+    emitState(integration, SupplicantState.Complete);
+    expect(navigateWithQuery).not.toHaveBeenCalled();
+  });
+
+  it('throws when handed an integration that is not the pairing supplicant', () => {
+    expect(() => renderContainer({} as Integration)).toThrow(
+      'Invalid integration. Expecting instance of PairingSupplicantIntegration'
+    );
+  });
+
+  // Without the metadata there is no device for the user to recognise, so the
+  // screen cannot ask them to approve anything.
+  it('throws before the authority metadata has arrived', () => {
+    integration = mockSupplicantIntegration({ remoteMetadata: null });
+
+    expect(() => renderContainer()).toThrow(
+      'Invalid integration state. Remote meta data should be populated.'
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.tsx
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/browser";
+import ApproveSignIn from ".";
+import { Integration, PairingSupplicantIntegration, SupplicantState } from "../../../../models";
+import { navigateWithQuery } from "../../../../lib/utilities";
+
+
+export const ApproveSignInContainer = ({integration}:{integration:Integration|PairingSupplicantIntegration}) => {
+  if (!(integration instanceof PairingSupplicantIntegration)) {
+     throw new Error('Invalid integration. Expecting instance of PairingSupplicantIntegration');
+  }
+  if (!integration.remoteMetadata) {
+    throw new Error('Invalid integration state. Remote meta data should be populated.');
+  }
+
+  useEffect(() => {
+    integration.onStateChange = (state) => {
+      switch(state) {
+        case SupplicantState.Complete:
+          navigateWithQuery('/pair/supplicant/sync_success', {}, true);
+          break;
+        case SupplicantState.Failed:
+          console.warn('SupplicantState failed', { tags: { state } })
+          navigateWithQuery('/pair/supplicant/timeout_and_cancel', {}, true);
+          break;
+        default:
+          console.warn('Unexpected state change: ' + state);
+          break;
+      }
+    }
+
+    return () => {
+      // Unsubscribe only — the channel outlives this page for sync_success.
+      integration.onStateChange = null;
+    };
+  },[integration])
+
+  const onCancel = () => {
+    integration.destroy()
+      .then(() => {
+        navigateWithQuery('/pair/supplicant/timeout_and_cancel', {}, true)
+      }).catch((err) => {
+        Sentry.captureException(err);
+        navigateWithQuery('/pair/supplicant/timeout_and_cancel', {}, true)
+      });
+  }
+
+  return <ApproveSignIn {...{ remoteMetadata:integration.remoteMetadata, onCancel }}/>
+}
+
+export default ApproveSignInContainer

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/index.tsx
@@ -31,7 +31,7 @@ export type ApproveSignInProps = {
  * tells them to finish approving the sign-in on their computer and shows the
  * requesting device's details for verification. Cancel is the only action.
  */
-const ApproveSignIn = ({ remoteMetadata, onCancel }: ApproveSignInProps) => {
+export const ApproveSignIn = ({ remoteMetadata, onCancel }: ApproveSignInProps) => {
   remoteMetadata = remoteMetadata ?? {
       deviceName: 'name-foo',
       deviceFamily: 'family-foo',

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.test.tsx
@@ -1,0 +1,249 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import * as Sentry from '@sentry/browser';
+import ConnectThisDeviceContainer from './container';
+import { MOCK_METADATA_WITH_DEVICE_NAME } from '../../../../components/DeviceInfoBlock/mocks';
+import { MOCK_EMAIL } from '../../../mocks';
+import {
+  Integration,
+  PairingSupplicantIntegration,
+  SupplicantState,
+} from '../../../../models';
+import { navigateWithQuery } from '../../../../lib/utilities';
+
+const mockNavigate = jest.fn();
+
+// The channel credentials reach this page in router state rather than the URL,
+// so the location is mocked instead of driving a real router entry.
+let mockLocationState: unknown = {
+  version: '2',
+  channelId: 'chan-1',
+  channelKey: 'key-1',
+};
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ state: mockLocationState }),
+}));
+
+jest.mock('../../../../lib/utilities', () => ({
+  ...jest.requireActual('../../../../lib/utilities'),
+  navigateWithQuery: jest.fn(),
+}));
+
+type MockSupplicantIntegration = PairingSupplicantIntegration & {
+  openChannel: jest.Mock;
+  supplicantApprove: jest.Mock;
+  destroy: jest.Mock;
+};
+
+/**
+ * A `PairingSupplicantIntegration` with the channel surface stubbed. Built from
+ * the real prototype because the container narrows on `instanceof` before it
+ * touches any of it.
+ */
+function mockSupplicantIntegration(): MockSupplicantIntegration {
+  const integration = Object.create(
+    PairingSupplicantIntegration.prototype
+  ) as MockSupplicantIntegration;
+
+  // Both are getters on the prototype, so they cannot be assigned.
+  Object.defineProperty(integration, 'remoteMetadata', {
+    get: () => MOCK_METADATA_WITH_DEVICE_NAME,
+  });
+  Object.defineProperty(integration, 'email', { get: () => MOCK_EMAIL });
+
+  return Object.assign(integration, {
+    openChannel: jest.fn().mockResolvedValue(undefined),
+    supplicantApprove: jest.fn().mockResolvedValue(undefined),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    onStateChange: null,
+  });
+}
+
+const emitState = (
+  integration: MockSupplicantIntegration,
+  state: SupplicantState
+) => (integration as PairingSupplicantIntegration).onStateChange?.(state);
+
+// This container owns the supplicant's end of the channel: it opens one from
+// the credentials the QR carried, then waits for the authority's metadata
+// before it can ask the user to connect.
+describe('Pair2/Supplicant/ConnectThisDevice container', () => {
+  let integration: MockSupplicantIntegration;
+  let captureException: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocationState = {
+      version: '2',
+      channelId: 'chan-1',
+      channelKey: 'key-1',
+    };
+    integration = mockSupplicantIntegration();
+    captureException = jest
+      .spyOn(Sentry, 'captureException')
+      .mockImplementation(() => '');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderContainer = (i: Integration = integration) =>
+    renderWithLocalizationProvider(
+      <ConnectThisDeviceContainer integration={i} />
+    );
+
+  // The credentials come off the scanned QR, so the channel this page opens has
+  // to be the one the authority minted.
+  it('opens the channel the QR pointed at', async () => {
+    renderContainer();
+
+    await waitFor(() =>
+      expect(integration.openChannel).toHaveBeenCalledWith(
+        expect.anything(),
+        'chan-1',
+        'key-1',
+        2
+      )
+    );
+  });
+
+  it('renders the device details once the authority metadata arrives', async () => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, SupplicantState.WaitingForAuthorizations);
+
+    expect(
+      await screen.findByRole('heading', { level: 1 })
+    ).toBeInTheDocument();
+    screen.getByText(MOCK_EMAIL);
+  });
+
+  it('navigates to the approve-sign-in screen once the supplicant is approved', async () => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, SupplicantState.WaitingForAuthority);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/supplicant/approve_signin',
+      {},
+      true
+    );
+  });
+
+  it('navigates to the cancel screen when pairing fails', async () => {
+    renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    emitState(integration, SupplicantState.Failed);
+
+    expect(navigateWithQuery).toHaveBeenCalledWith(
+      '/pair/supplicant/timeout_and_cancel',
+      {},
+      true
+    );
+  });
+
+  // A channel that never opens leaves the user on a spinner forever, so the
+  // failure has to route rather than disappear into an unhandled rejection.
+  it('reports and leaves the screen when the channel cannot be opened', async () => {
+    const err = new Error('channel server unreachable');
+    integration.openChannel.mockRejectedValue(err);
+
+    renderContainer();
+
+    await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/pair/supplicant/timeout_and_cancel'
+    );
+  });
+
+  describe('once the user can act', () => {
+    const renderReady = async () => {
+      const result = renderContainer();
+      await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+      emitState(integration, SupplicantState.WaitingForAuthorizations);
+      await screen.findByRole('button', { name: 'Connect' });
+      return result;
+    };
+
+    it('approves on the pairing channel when the user connects', async () => {
+      const user = userEvent.setup();
+      await renderReady();
+
+      await user.click(
+        screen.getByRole('button', { name: 'Connect' })
+      );
+
+      expect(integration.supplicantApprove).toHaveBeenCalledTimes(1);
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/pair/supplicant/approve_signin'
+        )
+      );
+    });
+
+    it('closes the channel before leaving for the cancel screen', async () => {
+      const user = userEvent.setup();
+      await renderReady();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/pair/supplicant/timeout_and_cancel'
+      );
+    });
+  });
+
+  // The channel outlives this page: the supplicant moves on to approve_signin
+  // while the authority is still approving, so tearing it down on unmount would
+  // drop the socket mid-flow.
+  it('leaves the channel open on unmount', async () => {
+    const { unmount } = renderContainer();
+    await waitFor(() => expect(integration.openChannel).toHaveBeenCalled());
+
+    unmount();
+
+    expect(integration.destroy).not.toHaveBeenCalled();
+  });
+
+  // The flip side: the handler must not outlive the page. The integration lasts
+  // the whole session, so a state change arriving after the user has left
+  // pairing would otherwise pull them back into the flow.
+  it('stops routing state changes once unmounted', async () => {
+    const { unmount } = renderContainer();
+    await waitFor(() => expect(integration.onStateChange).toBeTruthy());
+
+    unmount();
+
+    expect(integration.onStateChange).toBeNull();
+    emitState(integration, SupplicantState.WaitingForAuthority);
+    expect(navigateWithQuery).not.toHaveBeenCalled();
+  });
+
+  it('throws when handed an integration that is not the pairing supplicant', () => {
+    expect(() => renderContainer({} as Integration)).toThrow(
+      'Invalid integration. Expecting instance of PairingSupplicantIntegration'
+    );
+  });
+
+  // Only pairing v2 routes through this page; a v1 channel would be driven by
+  // the legacy supplicant screens instead.
+  it('throws when the router state is not a v2 pairing', () => {
+    mockLocationState = { version: '1' };
+
+    expect(() => renderContainer()).toThrow(
+      'Invalid location state. Expecting version of 2.'
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.tsx
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect, useState } from 'react';
+import * as Sentry from '@sentry/browser';
+import { RemoteMetadata } from '../../../../lib/types';
+import { useLocation, useNavigate } from 'react-router';
+import {
+  Integration,
+  PairingSupplicantIntegration,
+  SupplicantState,
+} from '../../../../models';
+import config from '../../../../lib/config';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import ConnectThisDevice from '.';
+import { navigateWithQuery } from '../../../../lib/utilities';
+
+export const ConnectThisDeviceContainer = ({
+  integration
+}:{
+  integration?: Integration|PairingSupplicantIntegration
+}) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [remoteMetadata, setRemoteMetadata] = useState<RemoteMetadata|null>(null);
+  const [email, setEmail] = useState<string|undefined>();
+  const [ready, setReady] = useState<boolean>(false);
+
+  if (!(integration instanceof PairingSupplicantIntegration)) {
+    throw new Error('Invalid integration. Expecting instance of PairingSupplicantIntegration');
+  }
+  if (location.state?.version !== '2') {
+    throw new Error('Invalid location state. Expecting version of 2.');
+  }
+
+  useEffect(() => {
+    integration.onStateChange = (state:SupplicantState) => {
+      switch (state) {
+        case SupplicantState.WaitingForAuthorizations:
+          // The following data should have been relayed over the pairing channel
+          // and stored on the integration just prior to this state change.
+          setEmail(integration.email);
+          setRemoteMetadata({
+            ipAddress: integration.remoteMetadata?.ipAddress || 'Unknown',
+            city: integration.remoteMetadata?.city || 'Unknown',
+            country: integration.remoteMetadata?.country || 'Unknown',
+            deviceFamily: integration.remoteMetadata?.deviceFamily  || 'Unknown',
+            deviceName: integration.remoteMetadata?.deviceName || 'Unknown',
+            deviceOS: integration.remoteMetadata?.deviceOS  || 'Unknown',
+            region: integration.remoteMetadata?.region || 'Unknown',
+          });
+          break;
+        case SupplicantState.WaitingForAuthority:
+          navigateWithQuery('/pair/supplicant/approve_signin', {}, true);
+          break;
+        case SupplicantState.Failed:
+          navigateWithQuery('/pair/supplicant/timeout_and_cancel', {}, true);
+          break;
+        default:
+          console.warn('Unexpected state change: ' + state);
+          break;
+      }
+    }
+
+
+    (async () => {
+      await integration.openChannel(
+        config.pairing?.serverBaseUri,
+        location.state.channelId,
+        location.state.channelKey,
+        2
+      )
+      setReady(true);
+    })().catch((err) => {
+      Sentry.captureException(err);
+      navigate('/pair/supplicant/timeout_and_cancel');
+    });
+
+    return () => {
+      // Unsubscribe only — the channel outlives this page for approve_signin.
+      integration.onStateChange = null;
+    };
+  }, [integration, location, navigate]);
+
+  const onCancel = () => {
+    integration.destroy()
+      .then(() => {
+        navigate('/pair/supplicant/timeout_and_cancel')
+      })
+      .catch((err) => {
+        Sentry.captureException(err);
+        navigate('/pair/supplicant/timeout_and_cancel');
+      });
+  }
+
+  const onConnect = () => {
+    integration
+      .supplicantApprove()
+      .then(() => {
+        navigate('/pair/supplicant/approve_signin')
+      })
+      .catch((err) => {
+        Sentry.captureException(err);
+        navigate('/pair/supplicant/timeout_and_cancel')
+      });
+  };
+
+  if (!ready || !remoteMetadata) {
+    return <LoadingSpinner />
+  }
+
+  return <ConnectThisDevice {...{remoteMetadata, email, onCancel, onConnect }} />
+}
+
+export default ConnectThisDeviceContainer;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.stories.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import ConnectThisDevice from '.';
+import { ConnectThisDevice } from '.';
 import {
   MOCK_METADATA_UNKNOWN_LOCATION,
   MOCK_METADATA_WITH_LOCATION,

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
@@ -23,7 +23,7 @@ export type ConnectThisDeviceProps = {
    * the request came from their own computer. Supplied by the caller — this
    * component does not read the pairing channel itself.
    */
-  remoteMetadata?: RemoteMetadata;
+  remoteMetadata: RemoteMetadata;
   /**
    * Completes pairing. Required so that routing this card cannot leave an
    * action inert — the flow logic itself lands with the route.
@@ -40,22 +40,15 @@ export type ConnectThisDeviceProps = {
  * them to confirm connecting this device to their account. It shows the
  * requesting computer's details so they can verify the request.
  */
-const ConnectThisDevice = ({
+export const ConnectThisDevice = ({
   email,
   remoteMetadata,
   onConnect,
   onCancel,
 }: ConnectThisDeviceProps) => {
+  const awaitingRemoteMetadata = remoteMetadata == null;
   email = email ?? 'foo@mozilla.com';
-  remoteMetadata = remoteMetadata ?? {
-    deviceName: 'name-foo',
-    deviceFamily: 'family-foo',
-    deviceOS: 'os-foo',
-    ipAddress: 'ip-foo',
-    country: 'country-foo',
-    region: 'region-foo',
-    city: 'city-foo',
-  };
+
   return <AppLayout>
     <div className="flex flex-col items-center text-center">
       <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
@@ -80,6 +73,7 @@ const ConnectThisDevice = ({
         <button
           type="button"
           onClick={onConnect}
+          disabled={awaitingRemoteMetadata}
           className="cta-primary cta-xl mt-6 w-full"
         >
           Connect
@@ -89,6 +83,7 @@ const ConnectThisDevice = ({
         <button
           type="button"
           onClick={onCancel}
+          disabled={awaitingRemoteMetadata}
           className="link-dark-grey"
         >
           Cancel

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/mocks.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import ConnectThisDevice, { ConnectThisDeviceProps } from '.';
+import { ConnectThisDevice, ConnectThisDeviceProps } from '.';
 import { MOCK_METADATA_WITH_DEVICE_NAME } from '../../../../components/DeviceInfoBlock/mocks';
 import { RemoteMetadata } from '../../../../lib/types';
 import { MOCK_EMAIL } from '../../../mocks';

--- a/packages/fxa-settings/src/pages/PocPairStart/index.tsx
+++ b/packages/fxa-settings/src/pages/PocPairStart/index.tsx
@@ -69,6 +69,8 @@ const PocPairStart = ({integration}:{ integration: Integration }) => {
           state:startResult.state,
           scope:startResult.scope,
           code_challenge: startResult.code_challenge,
+          code_challenge_method: startResult.code_challenge_method,
+          keys_jwk: startResult.keys_jwk
         });
         if (finishResult == null) {
           throw new Error('Failed to get response for pair oauth finish web channel message.');

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -41,6 +41,7 @@ import { ModelDataProvider } from '../../lib/model-data';
 import { AuthServerError } from 'fxa-auth-client/browser';
 import { MemoryRouter } from 'react-router';
 import { MOCK_FLOW_ID, mockGetWebChannelServices } from '../mocks';
+import { mockUseFxAStatus } from '../../lib/hooks/useFxAStatus/mocks';
 
 // TIP - Sometimes, we want to mock inputs. In this case they can be mocked directly and
 // often times a mocking util isn't even necessary. Note that using the Dependency Inversion
@@ -187,17 +188,10 @@ async function render(text?: string) {
           integration,
           serviceName,
         }}
-        useFxAStatusResult={{
-          pairingEnabled: true,
-          pairingVersion: 1,
-          hasSyncKeys: true,
-          offeredSyncEngines: [],
-          offeredSyncEngineConfigs: [],
-          selectedEnginesForGlean: {},
-          declinedSyncEngines: [],
-          supportsKeysOptionalLogin: false,
+        useFxAStatusResult={mockUseFxAStatus({
+          offeredSyncEnginesOverride: [],
           supportsCanLinkAccountUid: false,
-        }}
+        })}
         flowQueryParams={{ flowId: MOCK_FLOW_ID }}
       />
     </MemoryRouter>

--- a/packages/fxa-settings/src/pages/WebChannelExample/index.tsx
+++ b/packages/fxa-settings/src/pages/WebChannelExample/index.tsx
@@ -53,11 +53,11 @@ const WebChannelExample = () => {
                   context: 'fx_desktop_v3',
                 });
                 signedInUser.authAt = Date.now();
-                signedInUser.email = status.signedInUser?.email || 'unknown';
+                signedInUser.email = status?.signedInUser?.email || 'unknown';
                 signedInUser.sessionToken =
-                  status.signedInUser?.sessionToken || 'unknown';
-                signedInUser.uid = status.signedInUser?.uid || 'unknown';
-                signedInUser.verified = status.signedInUser?.verified || false;
+                  status?.signedInUser?.sessionToken || 'unknown';
+                signedInUser.uid = status?.signedInUser?.uid || 'unknown';
+                signedInUser.verified = status?.signedInUser?.verified || false;
                 setSignedInUser(signedInUser);
                 setFxaStatusResult(JSON.stringify(status, null, 1));
               }}


### PR DESCRIPTION
## Because

- We want to implement the new and improved pairing v2 flows:
  - We want to support the new v2 QR format
  - We want to support native camera scanning
  - We want to adhere to new figma designs.
  - We want to refine the pairing confirmation process
  
## This pull request

- Ensures the /pair page sends users into the pairing v2 flows when appropriate.
- Uses the new `/Pair2/*` components for the pairing flow.
- Updates pairing integrations to handle the pairing channel events for the v2 flow.
  - Notably, the authority now handles all channel server communication
- Creates container components to handle pairing state changes and subsequent navigation.
- Enforces the correct integration is provided per pairing component.
- Fixes bug found in Firefox promo banner navigation. The redirect to /pair must force a new integration be created. A simple way to force this is by using a hard navigate.

## Issue that this pull request solves

Closes: FXA-13867, FXA-13865

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)
**Prereqs**: 
- Have Firefox desktop and Firefox for Android builds that support the new pairing web channel commands and have the config `identity.fxaccounts.pairing.version` set to `2`. As of writing nightly should currently support this.
- Enable pairing version 2 in FxA's config. This can be done by setting the `PAIRING_VERSION` env to `2` or adding a config override to `packages/fxa-content-server/server/config/local.json`.

Steps:
- On desktop, sign in with sync.
- From the sync menu in Firefox, select connect another device.
- You should be directed to the `/pair/authority/scan_qr` page.
- Scan this code with an Android device's native camera. 
- Follow the instructions.
- Observe that Firefox on your mobile phone is now connected.

## Other information (Optional)

This PR is for the pairing 'happy path'. It doesn't address situations where Firefox is not installed, or Firefox is not set as the default browser on the mobile device.

This PR is non breaking and backward compatible. Existing pairing flows (i.e. when pairing.version is not set to 2) should continue to work. Scanning with the in-app camera should also continue to work.
