### PR TITLE
fix(auth-server): stop opening l10n PRs when no CMS strings changed

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/cms/localization.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/cms/localization.spec.ts
@@ -81,6 +81,10 @@ describe('CMSLocalization', () => {
   });
 
   describe('strapiToFtl', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('converts Strapi data to FTL format', () => {
       const strapiData = [
         {
@@ -101,7 +105,6 @@ describe('CMSLocalization', () => {
 
       const result = localization.strapiToFtl(strapiData);
 
-      expect(result).toContain('# Generated on');
       expect(result).toContain('# FTL file for CMS localization');
       expect(result).toContain(
         '# desktopSyncFirefoxCms - Firefox Desktop Sync'
@@ -126,9 +129,26 @@ describe('CMSLocalization', () => {
     it('handles empty Strapi data', () => {
       const result = localization.strapiToFtl([]);
 
-      expect(result).toContain('# Generated on');
       expect(result).toContain('# FTL file for CMS localization');
       expect(result).not.toContain('=');
+    });
+
+    it('returns identical content for the same entries at different times', () => {
+      const strapiData = [
+        {
+          l10nId: 'desktopSyncFirefoxCms',
+          name: 'Firefox Desktop Sync',
+          SigninPage: { headline: 'Enter your password' },
+        },
+      ];
+
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-07-06T19:55:05.237Z'));
+      const first = localization.strapiToFtl(strapiData);
+      jest.setSystemTime(new Date('2026-08-19T20:40:29.858Z'));
+      const second = localization.strapiToFtl(strapiData);
+
+      expect(second).toBe(first);
     });
 
     it('filters out non-string fields', () => {
@@ -453,6 +473,60 @@ describe('CMSLocalization', () => {
           branch: 'test-branch',
         });
       });
+
+      it('skips the commit when the branch already holds the content', async () => {
+        localization.octokit.pulls.get.mockResolvedValue({
+          data: { head: { ref: 'test-branch' } },
+        });
+        localization.octokit.repos.getContent.mockResolvedValue({
+          data: {
+            sha: 'existing-sha',
+            encoding: 'base64',
+            content: Buffer.from('test content').toString('base64'),
+          },
+        });
+
+        await localization.updateExistingPR(123, 'test content');
+
+        expect(
+          localization.octokit.repos.createOrUpdateFileContents
+        ).not.toHaveBeenCalled();
+        expect(mockLog.info).toHaveBeenCalledWith(
+          'cms.integrations.github.pr.unchanged',
+          { prNumber: 123, fileName: 'cms.ftl', branch: 'test-branch' }
+        );
+      });
+
+      it('commits when the branch holds different content', async () => {
+        localization.octokit.pulls.get.mockResolvedValue({
+          data: { head: { ref: 'test-branch' } },
+        });
+        localization.octokit.repos.getContent.mockResolvedValue({
+          data: {
+            sha: 'existing-sha',
+            encoding: 'base64',
+            content: Buffer.from('previous content').toString('base64'),
+          },
+        });
+        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue(
+          undefined
+        );
+
+        await localization.updateExistingPR(123, 'test content');
+
+        expect(
+          localization.octokit.repos.createOrUpdateFileContents
+        ).toHaveBeenCalledWith({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          path: 'locales/en/cms.ftl',
+          message:
+            '🔄 Update CMS localization file (cms.ftl) - Strapi webhook sync',
+          content: Buffer.from('test content').toString('base64'),
+          sha: 'existing-sha',
+          branch: 'test-branch',
+        });
+      });
     });
 
     describe('createGitHubPR', () => {
@@ -535,6 +609,102 @@ describe('CMSLocalization', () => {
           content: expect.any(String),
           sha: 'existing-file-sha',
           branch: expect.any(String),
+        });
+      });
+
+      it('opens no PR when the base branch already holds the content', async () => {
+        localization.octokit.git.getRef.mockResolvedValue({
+          data: { object: { sha: 'base-sha' } },
+        });
+        localization.octokit.repos.getContent.mockResolvedValue({
+          data: {
+            sha: 'existing-file-sha',
+            encoding: 'base64',
+            content: Buffer.from('test content').toString('base64'),
+          },
+        });
+
+        await localization.createGitHubPR('test content', 'desktop-sync');
+
+        expect(localization.octokit.git.createRef).not.toHaveBeenCalled();
+        expect(
+          localization.octokit.repos.createOrUpdateFileContents
+        ).not.toHaveBeenCalled();
+        expect(localization.octokit.pulls.create).not.toHaveBeenCalled();
+        expect(mockLog.info).toHaveBeenCalledWith(
+          'cms.integrations.github.pr.unchanged',
+          { fileName: 'cms.ftl', branch: 'main' }
+        );
+      });
+
+      it('opens a PR when the base branch holds different content', async () => {
+        localization.octokit.git.getRef.mockResolvedValue({
+          data: { object: { sha: 'ref-sha' } },
+        });
+        localization.octokit.git.createRef.mockResolvedValue(undefined);
+        localization.octokit.repos.getContent.mockResolvedValue({
+          data: {
+            sha: 'existing-file-sha',
+            encoding: 'base64',
+            content: Buffer.from('previous content').toString('base64'),
+          },
+        });
+        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue(
+          undefined
+        );
+        localization.octokit.pulls.create.mockResolvedValue({
+          data: { number: 123, html_url: 'https://github.com/test/pr/123' },
+        });
+
+        await localization.createGitHubPR('test content', 'desktop-sync');
+
+        expect(localization.octokit.pulls.create).toHaveBeenCalledWith({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          title: '🌐 Add CMS localization file (cms.ftl)',
+          body: expect.any(String),
+          head: expect.any(String),
+          base: 'main',
+        });
+      });
+
+      it('pins the file read and the new branch to the same base commit', async () => {
+        localization.octokit.git.getRef.mockResolvedValue({
+          data: { object: { sha: 'base-sha' } },
+        });
+        localization.octokit.git.createRef.mockResolvedValue(undefined);
+        localization.octokit.repos.getContent.mockResolvedValue({
+          data: {
+            sha: 'existing-file-sha',
+            encoding: 'base64',
+            content: Buffer.from('previous content').toString('base64'),
+          },
+        });
+        localization.octokit.repos.createOrUpdateFileContents.mockResolvedValue(
+          undefined
+        );
+        localization.octokit.pulls.create.mockResolvedValue({
+          data: { number: 123, html_url: 'https://github.com/test/pr/123' },
+        });
+
+        await localization.createGitHubPR('test content', 'desktop-sync');
+
+        expect(
+          localization.octokit.git.getRef.mock.invocationCallOrder[0]
+        ).toBeLessThan(
+          localization.octokit.repos.getContent.mock.invocationCallOrder[0]
+        );
+        expect(localization.octokit.repos.getContent).toHaveBeenCalledWith({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          path: 'locales/en/cms.ftl',
+          ref: 'base-sha',
+        });
+        expect(localization.octokit.git.createRef).toHaveBeenCalledWith({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          ref: expect.stringMatching(/^refs\/heads\/cms-localization-\d+$/),
+          sha: 'base-sha',
         });
       });
     });

--- a/packages/fxa-auth-server/lib/routes/utils/cms/localization.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/cms/localization.ts
@@ -9,6 +9,17 @@ import { Octokit } from '@octokit/rest';
 import { RelyingPartyConfigurationManager } from '@fxa/shared/cms';
 import { StatsD } from 'hot-shots';
 
+/**
+ * Decode the base64 payload GitHub returns for a file. Undefined when the
+ * response carries no base64 content, which makes the caller commit rather
+ * than compare against a body it cannot read.
+ */
+function decodeFileContent(fileData: any): string | undefined {
+  return fileData.encoding === 'base64' && typeof fileData.content === 'string'
+    ? Buffer.from(fileData.content, 'base64').toString('utf8')
+    : undefined;
+}
+
 export class CMSLocalization {
   private octokit: Octokit;
 
@@ -133,13 +144,13 @@ export class CMSLocalization {
    * Convert Strapi JSON to FTL format using hash-only IDs
    * Each string field gets a unique hash ID based on its content.
    * Identical English strings will share the same translation across all contexts.
+   *
+   * The output is deterministic, so callers can compare it with the committed
+   * file and skip a no-op commit.
    */
   strapiToFtl(strapiData: any[]): string {
     const ftlLines: string[] = [];
 
-    // Add generation timestamp and description
-    const timestamp = new Date().toISOString();
-    ftlLines.push(`### Generated on ${timestamp}`);
     ftlLines.push(`### FTL file for CMS localization`);
     ftlLines.push('');
 
@@ -444,6 +455,7 @@ export class CMSLocalization {
 
       // Try to get the current file content to get the SHA
       let fileSha: string | undefined;
+      let committedContent: string | undefined;
       try {
         const { data: fileData } = await this.octokit.repos.getContent({
           owner: github.owner,
@@ -452,9 +464,10 @@ export class CMSLocalization {
           ref: pr.head.ref,
         });
 
-        // If file exists, get its SHA
+        // If file exists, get its SHA and content
         if (fileData && !Array.isArray(fileData)) {
           fileSha = (fileData as any).sha;
+          committedContent = decodeFileContent(fileData);
         }
       } catch (fileError) {
         // File doesn't exist, that's okay - we'll create it
@@ -462,6 +475,15 @@ export class CMSLocalization {
           path: filePath,
           branch: pr.head.ref,
         });
+      }
+
+      if (committedContent === ftlContent) {
+        this.log.info('cms.integrations.github.pr.unchanged', {
+          prNumber,
+          fileName,
+          branch: pr.head.ref,
+        });
+        return;
       }
 
       // Create or update the file
@@ -517,37 +539,30 @@ export class CMSLocalization {
       const { github } = this.config.cmsl10n;
       const fileName = 'cms.ftl';
 
-      // Create new branch
-      const branchName = `cms-localization-${Date.now()}`;
-
-      // Get the latest commit SHA
+      // The file read and the new branch share this SHA, so a push to the base
+      // branch mid-run cannot make them disagree.
       const { data: refData } = await this.octokit.git.getRef({
         owner: github.owner,
         repo: github.repo,
         ref: `heads/${github.branch}`,
       });
+      const baseSha = refData.object.sha;
 
-      // Create new branch
-      await this.octokit.git.createRef({
-        owner: github.owner,
-        repo: github.repo,
-        ref: `refs/heads/${branchName}`,
-        sha: refData.object.sha,
-      });
-
-      // Check if file exists in the base branch to get its SHA
+      // Check if file exists at that commit to get its SHA and content
       let fileSha: string | undefined;
+      let committedContent: string | undefined;
       try {
         const { data: fileData } = await this.octokit.repos.getContent({
           owner: github.owner,
           repo: github.repo,
           path: `locales/en/${fileName}`,
-          ref: github.branch,
+          ref: baseSha,
         });
 
-        // If file exists, get its SHA
+        // If file exists, get its SHA and content
         if (fileData && !Array.isArray(fileData)) {
           fileSha = (fileData as any).sha;
+          committedContent = decodeFileContent(fileData);
         }
       } catch (fileError) {
         // File doesn't exist in base branch, that's okay - we'll create it
@@ -556,6 +571,25 @@ export class CMSLocalization {
           branch: github.branch,
         });
       }
+
+      // Check before creating the branch so a no-op run leaves no stray branch.
+      if (committedContent === ftlContent) {
+        this.log.info('cms.integrations.github.pr.unchanged', {
+          fileName,
+          branch: github.branch,
+        });
+        return;
+      }
+
+      // Create new branch
+      const branchName = `cms-localization-${Date.now()}`;
+
+      await this.octokit.git.createRef({
+        owner: github.owner,
+        repo: github.repo,
+        ref: `refs/heads/${branchName}`,
+        sha: baseSha,
+      });
 
       // Create the file in the new branch
       await this.octokit.repos.createOrUpdateFileContents({


### PR DESCRIPTION
## Because

- Every accepted `entry.publish` webhook opened or updated a PR in `mozilla/fxa-cms-l10n`, even when no string changed. The whole diff was the generation timestamp.
- `strapiToFtl` wrote `### Generated on <ISO timestamp>` into `cms.ftl`, so the generated file never matched the committed one. Neither `createGitHubPR` nor `updateExistingPR` compared content before it wrote the file.
- Reviewers learn to skim these PRs, so a real l10n change can slip past.
- `createGitHubPR` read the file SHA from the base branch by name, then resolved the branch tip in a separate call. A push between the two calls made them describe different trees, and the write then failed with a SHA conflict.

## This pull request

- Removes the `### Generated on` header from `strapiToFtl`, so the output is deterministic.
- Compares the generated FTL with the committed file in `createGitHubPR` and `updateExistingPR`, and returns early when they match.
- Runs that comparison before `git.createRef`, so a skipped run leaves no stray branch.
- Resolves the base tip once as `baseSha`, pins `repos.getContent` to `ref: baseSha`, and creates the new branch from the same SHA.
- Logs `cms.integrations.github.pr.unchanged` on a skipped run, and adds tests for the unchanged path, the changed path, and the shared base SHA.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14385

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `createGitHubPR` in `localization.ts`.
- Suggested review order: `localization.ts`, then `localization.spec.ts`.
- Risky or complex parts: the order of `getRef`, `getContent`, and the unchanged short-circuit. A no-op run now makes one extra `getRef` call, because the read has to be pinned to a commit.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

- `npx jest packages/fxa-auth-server/lib/routes/utils/cms/localization.spec.ts`: 48 passed, 0 failed.
- `updateExistingPR` reads and writes the same branch and never calls `getRef`, so it does not have the cross-SHA problem. It is unchanged.
- The `fileNotFoundInBase` log still names the base branch rather than the pinned SHA. Left alone to keep this round narrow.
