### PR TITLE
fix(auth-server): raise the routes jwt bound to 2048 and define idToken

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -124,7 +124,6 @@ module.exports.hexString = isA.string().regex(HEX_STRING);
 module.exports.uid = module.exports.hexString.length(32);
 module.exports.clientId = module.exports.hexString.length(16);
 module.exports.clientSecret = module.exports.hexString;
-module.exports.idToken = module.exports.jwt;
 module.exports.reasonForAccountDeletion = isA
   .string()
   .valid(...Object.values(ReasonForDeletion));
@@ -162,11 +161,14 @@ module.exports.jwe = isA
     /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/
   );
 
+// lib/oauth/validators.js has a separate jwt validator; keep the bounds in sync.
 module.exports.jwt = isA
   .string()
-  .max(1024)
+  .max(2048)
   // JWT format: 'header.payload.signature'
   .regex(/^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)$/);
+
+module.exports.idToken = module.exports.jwt;
 
 module.exports.accessToken = isA
   .alternatives()

--- a/packages/fxa-auth-server/lib/routes/validators.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/validators.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const isA = require('joi');
 const validators = require('./validators');
 const plan1 = require('../../test/local/payments/fixtures/stripe/plan1.json');
 const validProductMetadata = plan1.product.metadata;
@@ -851,6 +852,55 @@ describe('lib/routes/validators:', () => {
       { value: '12345', label: 'more than 4 digits' },
     ])('rejects $label', ({ value }) => {
       expect(validators.maskedPhoneNumber.validate(value).error).toBeDefined();
+    });
+  });
+
+  describe('jwt:', () => {
+    // Shaped like a real Google id_token: a base64url header and an RS256
+    // signature, with the payload making up the rest.
+    const HEADER_LENGTH = 75;
+    const SIGNATURE_LENGTH = 342;
+    const jwtOfLength = (length: number) =>
+      [
+        'h'.repeat(HEADER_LENGTH),
+        'p'.repeat(length - HEADER_LENGTH - SIGNATURE_LENGTH - 2),
+        's'.repeat(SIGNATURE_LENGTH),
+      ].join('.');
+
+    // A Google id_token passes 1024 characters once the name, picture and hd
+    // claims are long, which the previous bound rejected as a 400 on sign-in.
+    it('accepts a 1500 character token', () => {
+      expect(validators.jwt.validate(jwtOfLength(1500)).error).toBeUndefined();
+    });
+
+    it('accepts a token at the 2048 character bound', () => {
+      expect(validators.jwt.validate(jwtOfLength(2048)).error).toBeUndefined();
+    });
+
+    it('rejects a token longer than 2048 characters', () => {
+      expect(validators.jwt.validate(jwtOfLength(2049)).error).toBeDefined();
+    });
+
+    it('rejects a string that is not JWT shaped', () => {
+      expect(validators.jwt.validate('not.a@token').error).toBeDefined();
+    });
+
+    // thirdPartyIdToken is the route that a long Google id_token failed on.
+    it('accepts a 1500 character token as thirdPartyIdToken', () => {
+      expect(
+        validators.thirdPartyIdToken.validate(jwtOfLength(1500)).error
+      ).toBeUndefined();
+    });
+
+    // idToken aliases jwt. It was assigned before jwt, so the export was undefined.
+    it('exports idToken as a Joi schema', () => {
+      expect(isA.isSchema(validators.idToken)).toBe(true);
+    });
+
+    it('accepts a 1500 character token as idToken', () => {
+      expect(
+        validators.idToken.validate(jwtOfLength(1500)).error
+      ).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Because

- `lib/routes/validators.js` caps `jwt` at 1024 characters. A Google `id_token` can exceed that when the `name`, `picture` and `hd` claims are long. The request then fails validation and the client gets a 400 on a sign-in that should have worked.
- FXA-14391 raised the sibling validator in `lib/oauth/validators.js` to 2048 but left this one behind, so the two bounds diverged.
- `module.exports.idToken = module.exports.jwt` ran 38 lines before `jwt` was assigned, so the export was always `undefined`. Nothing reads it today and Joi does not complain, which makes it a trap for whoever wires it up next.

## This pull request

- Raises the `jwt` bound in `lib/routes/validators.js` from 1024 to 2048, matching `lib/oauth/validators.js`.
- Adds a comment at that validator noting the second `jwt` validator, since the two look shared and are not.
- Moves the `idToken` assignment below `jwt` so the export is a real schema.
- Adds a `jwt:` block to `validators.spec.ts` covering the 1500, 2048 and 2049 character cases, a non-JWT string, and the `thirdPartyIdToken` and `idToken` aliases.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14398

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/lib/routes/validators.js`. The widened `jwt` backs `thirdPartyIdToken` (`validators.js:663`, read by the linked-account login route at `linked-accounts.ts:718`) and the `/account/finish_setup` token.
- Suggested review order: the two-line source change, then the new tests.
- Risky or complex parts: none. The regex is anchored with flat character classes, so the larger bound adds no ReDoS risk. `idToken` still has no consumers; it is kept rather than deleted because the ticket asks for a test that it is a Joi schema, which a deleted export cannot have.

## Screenshots (Optional)

Not applicable. No user interface change.

## Other information (Optional)

- The ticket also asks for a Sentry check for existing `thirdPartyIdToken` validation failures. That is outstanding. This VM has no Sentry access, so whether the 1024 bound is a live production bug or only a latent one is unconfirmed.
- The ticket cites `linked-accounts.ts:745` as the `thirdPartyIdToken` consumer. On `main` it is `linked-accounts.ts:718`.
- Local results: `jest --selectProjects unit` in `fxa-auth-server`: 3799 passed, 0 failed. `nx lint fxa-auth-server`: clean.
- Out of scope on purpose: consolidating the two `jwt` validators onto one bound. That widens a two-line fix into a refactor of validators that gate auth routes.
