### PR TITLE
fix(oauth): fail prompt=none step-up instead of challenging

### DIFF
--- a/packages/functional-tests/tests/oauth/stepUpAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/stepUpAuth.spec.ts
@@ -255,6 +255,33 @@ test.describe('severity-2', () => {
       expect(after.acr).toBe('AAL2');
       expect(typeof after.auth_time).toBe('number');
     });
+
+    test('returns unmet_authentication_requirements when prompt=none forbids the challenge', async ({
+      target,
+      pages: { page, relier, signin },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await relier.goto();
+      await relier.clickEmailFirst();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      expect(await relier.isLoggedIn()).toBe(true);
+      expect((await relier.getAuthStatus()).acr).toBe('AAL1');
+
+      // 123Done merges query params over its route defaults. Runs outside local
+      // too: the per-client allowlist is only consulted when email or login_hint
+      // is present, and /api/step_up sends neither.
+      await page.goto(`${target.relierUrl}/api/step_up?prompt=none`);
+
+      // Wait on the error param, not the path — a successful redirect also
+      // lands on /api/oauth.
+      await page.waitForURL(/error=unmet_authentication_requirements/);
+      const params = new URL(page.url()).searchParams;
+      expect(params.get('error')).toBe('unmet_authentication_requirements');
+      expect(params.get('state')).toBeTruthy();
+    });
   });
 });
 

--- a/packages/fxa-auth-server/docs/swagger/oauth-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/oauth-api.ts
@@ -19,8 +19,26 @@ const OAUTH_AUTHORIZATION_POST = {
       Authorize a new OAuth client connection to the user's account, returning a short-lived authentication code that the client can exchange for access tokens at the OAuth token endpoint.
 
       This route behaves like the oauth-server /authorization endpoint except that it is authenticated directly with a sessionToken.
+
+      ### Step-up authentication (RFC 9470)
+
+      An RP can request a higher authentication level with \`acr_values=AAL2\`, and can bound its freshness with \`max_age\`. The two are independent and each is optional; a session failing either one is rejected here with \`errno: 170\`.
+
+      The hosted sign-in UI resolves that with a second-factor challenge. Where it cannot — the RP sent \`prompt=none\` — it redirects to the registered \`redirect_uri\` with \`error=unmet_authentication_requirements\` instead. That redirect comes from the UI, never from this endpoint.
     `,
   ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 170\` - Requested \`acr_values\` or \`max_age\` could not be satisfied.
+          `,
+        },
+      },
+    },
+  },
 };
 
 const OAUTH_DESTROY_POST = {

--- a/packages/fxa-auth-server/lib/oauth/grant.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/grant.spec.ts
@@ -367,6 +367,36 @@ describe('generateTokens', () => {
     ]);
   });
 
+  // No token is minted for a rejected request, so RFC 9470 section 5 reduces to:
+  // acr tracks the achieved aal, never the requested acr_values.
+  it('reflects the achieved aal in the id_token acr claim', async () => {
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
+    requestedGrant.aal = 2;
+    const result = await generateTokens(requestedGrant);
+
+    const jwt = decodeJWT(result.id_token);
+    expect(jwt.claims.acr).toBe('AAL2');
+    expect(jwt.claims['fxa-aal']).toBe(2);
+  });
+
+  it('reports the lower level in acr when the session only reached AAL1', async () => {
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
+    requestedGrant.aal = 1;
+    const result = await generateTokens(requestedGrant);
+
+    const jwt = decodeJWT(result.id_token);
+    expect(jwt.claims.acr).toBe('AAL1');
+  });
+
+  it('omits acr when the grant carries no aal', async () => {
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
+    delete requestedGrant.aal;
+    const result = await generateTokens(requestedGrant);
+
+    const jwt = decodeJWT(result.id_token);
+    expect(jwt.claims.acr).toBeUndefined();
+  });
+
   it('propagates auth_time (seconds) in id_token claims without re-dividing', async () => {
     requestedGrant.scope = ScopeSet.fromArray(['openid']);
     // authAt is already seconds since the epoch; auth_time must equal it, not

--- a/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
+++ b/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
@@ -138,6 +138,13 @@ export const OAUTH_ERRORS: Record<string, AuthError> = {
     message: 'Invalid id_token_hint',
     response_error_code: 'invalid_request',
   },
+  // 1100, not the next slot above: error-utils resolves AuthUiErrorNos first
+  // and it already occupies 1001-1067, so those render the wrong banner copy.
+  UNMET_AUTHENTICATION_REQUIREMENTS: {
+    errno: 1100,
+    message: 'Requested authentication level could not be satisfied',
+    response_error_code: 'unmet_authentication_requirements',
+  },
 };
 
 export class OAuthError extends Error {

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
@@ -551,5 +551,51 @@ describe('models/integrations/oauth-relier', function () {
     });
   });
 
+  describe('getRedirectWithErrorUrl', () => {
+    function getIntegration(params: Record<string, unknown>) {
+      const integration = new OAuthWebIntegration(
+        new GenericData({ scope: 'profile', ...params }),
+        new GenericData({ scope: 'profile' }),
+        {
+          scopedKeysEnabled: true,
+          scopedKeysValidation: {},
+          isPromptNoneEnabled: true,
+          isPromptNoneEnabledClientIds: [],
+        }
+      );
+      // The registered URI the server handed back, not the RP-supplied param.
+      integration.clientInfo = { redirectUri: 'https://amo.test/oauth' } as any;
+      return integration;
+    }
+
+    it('returns the RFC 9470 error code and echoes state', () => {
+      const integration = getIntegration({ state: 'rp-state-123' });
+
+      const url = new URL(
+        integration.getRedirectWithErrorUrl(
+          new OAuthError('UNMET_AUTHENTICATION_REQUIREMENTS')
+        )
+      );
+
+      expect(url.origin + url.pathname).toBe('https://amo.test/oauth');
+      expect(url.searchParams.get('error')).toBe(
+        'unmet_authentication_requirements'
+      );
+      expect(url.searchParams.get('state')).toBe('rp-state-123');
+    });
+
+    it('falls back to the errno when the error carries no OAuth code', () => {
+      const integration = getIntegration({ state: 'rp-state-123' });
+
+      const url = new URL(
+        integration.getRedirectWithErrorUrl(OAUTH_ERRORS.TRY_AGAIN)
+      );
+
+      expect(url.searchParams.get('error')).toBe(
+        String(OAUTH_ERRORS.TRY_AGAIN.errno)
+      );
+    });
+  });
+
   // TODO: OAuth Relier Model Test Coverage
 });

--- a/packages/fxa-settings/src/pages/Authorization/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.test.tsx
@@ -6,7 +6,7 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 import { screen, waitFor } from '@testing-library/react';
 import AuthorizationContainer from './container';
 import { Config } from '../../lib/config';
-import { OAUTH_ERRORS } from '../../lib/oauth/oauth-errors';
+import { OAUTH_ERRORS, OAuthError } from '../../lib/oauth/oauth-errors';
 import { Integration } from '../../models';
 import AuthClient from 'fxa-auth-client/browser';
 import VerificationMethods from '../../constants/verification-methods';
@@ -187,6 +187,39 @@ describe('AuthorizationContainer', () => {
         'https://mozilla.com/error'
       );
     });
+  });
+
+  it('redirects to the RP with unmet_authentication_requirements when step-up cannot be satisfied', async () => {
+    mockHandleNavigation.mockResolvedValue({
+      error: new OAuthError('UNMET_AUTHENTICATION_REQUIREMENTS'),
+    });
+
+    const getRedirectWithErrorUrl = jest
+      .fn()
+      .mockReturnValue(
+        'https://amo.test/oauth?error=unmet_authentication_requirements'
+      );
+    const mockIntegration = {
+      data: {},
+      wantsPromptNone: jest.fn().mockReturnValue(true),
+      returnOnError: jest.fn().mockReturnValue(true),
+      getRedirectWithErrorUrl,
+      validatePromptNoneRequest: jest.fn().mockResolvedValue(undefined),
+      getClientId: jest.fn().mockReturnValue('some-client-id'),
+    };
+
+    render(mockIntegration);
+
+    await waitFor(() => {
+      expect(ReactUtilsModule.hardNavigate).toHaveBeenCalledWith(
+        'https://amo.test/oauth?error=unmet_authentication_requirements'
+      );
+    });
+    expect(getRedirectWithErrorUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        response_error_code: 'unmet_authentication_requirements',
+      })
+    );
   });
 
   it('navigates to /oauth if cached signed in returns PROMPT_NONE_NOT_SIGNED_IN error', async () => {

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -121,6 +121,10 @@ const AuthorizationContainer = ({
           finishOAuthFlowHandler,
           queryParams: location.search,
           authClient,
+          canRelayPromptNoneError:
+            isOAuthWebIntegration(integration) &&
+            integration.wantsPromptNone() &&
+            integration.returnOnError(),
         };
 
         const { error: navError } = await handleNavigation(navigationOptions);

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -300,6 +300,12 @@ export interface NavigationOptions {
   // session was established. Drives the /pair `choice_view` reason.
   passwordCreationReason?: PasswordCreationReason;
   accountHasTotp?: boolean;
+  // Set only by the Authorization container, and only when the RP accepts error
+  // redirects. It is the one caller that relays a returned error to the RP; the
+  // rest render errors in-FxA, and with return_on_error=false even this one
+  // does. Failing the request in those cases would dead-end the user instead of
+  // letting the interactive fallback complete the flow.
+  canRelayPromptNoneError?: boolean;
   authClient: Pick<AuthClient, 'sessionResendVerifyCode'>;
 }
 

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -27,6 +27,8 @@ import * as ReactUtils from 'fxa-react/lib/utils';
 import firefox from '../../lib/channels/firefox';
 import config from '../../lib/config';
 import { OAuthNativeServices } from '@fxa/accounts/oauth';
+import { OAUTH_ERRORS, OAuthError } from '../../lib/oauth';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
@@ -792,6 +794,152 @@ describe('Signin utils', () => {
           undefined,
           true
         );
+      });
+
+      describe('prompt=none', () => {
+        const buildPromptNoneOptions = (
+          overrides: Partial<NavigationOptions> = {}
+        ) => {
+          const integration = createMockSigninOAuthIntegration();
+          integration.wantsTwoStepAuthentication = jest
+            .fn()
+            .mockReturnValue(true);
+          return createBaseNavigationOptions({
+            integration,
+            queryParams: '?client_id=abc',
+            canRelayPromptNoneError: true,
+            ...overrides,
+          });
+        };
+
+        it('fails the request instead of challenging when the server reports errno 170', async () => {
+          const finishOAuthFlowHandler = jest.fn().mockResolvedValue({
+            error: AuthUiErrors.INSUFFICIENT_ACR_VALUES,
+          });
+          const navigationOptions = buildPromptNoneOptions({
+            // Has TOTP, so the enrolment divert is skipped and the grant
+            // attempt is what surfaces the unmet level.
+            accountHasTotp: true,
+            finishOAuthFlowHandler,
+          });
+
+          const result = await handleNavigation(navigationOptions);
+
+          expect(finishOAuthFlowHandler).toHaveBeenCalledTimes(1);
+          expect(result.error).toBeInstanceOf(OAuthError);
+          expect(result.error).toEqual(
+            expect.objectContaining({
+              errno: OAUTH_ERRORS.UNMET_AUTHENTICATION_REQUIREMENTS.errno,
+              response_error_code: 'unmet_authentication_requirements',
+            })
+          );
+          expect(mockNavigate).not.toHaveBeenCalled();
+          expect(hardNavigateSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not reclassify an unverified session as an unmet level', async () => {
+          // Same errno branch, different meaning — interaction_required, not an
+          // unmet level. Pins that it is not mislabelled (FXA-14408).
+          const finishOAuthFlowHandler = jest.fn().mockResolvedValue({
+            error: AuthUiErrors.UNVERIFIED_SESSION,
+          });
+          const navigationOptions = buildPromptNoneOptions({
+            accountHasTotp: true,
+            finishOAuthFlowHandler,
+          });
+
+          const result = await handleNavigation(navigationOptions);
+
+          expect(result.error).toBeUndefined();
+          expect(mockNavigate).toHaveBeenCalledWith(
+            '/signin_token_code?client_id=abc',
+            expect.objectContaining({ replace: true })
+          );
+        });
+
+        it('still diverts to enrolment when the account has no TOTP', async () => {
+          // The server is authoritative: a passkey session is already
+          // fxa-aal>=2, so it would grant what a client-side check would refuse.
+          const finishOAuthFlowHandler = jest.fn();
+          const navigationOptions = buildPromptNoneOptions({
+            accountHasTotp: false,
+            finishOAuthFlowHandler,
+          });
+
+          const result = await handleNavigation(navigationOptions);
+
+          expect(result.error).toBeUndefined();
+          expect(mockNavigate).toHaveBeenCalledWith(
+            '/inline_totp_setup?client_id=abc',
+            expect.objectContaining({ replace: true })
+          );
+        });
+
+        it('does not fail the request when the RP opted out of error redirects', async () => {
+          // return_on_error=false means the container renders in-FxA rather than
+          // redirecting, so failing here would dead-end the user instead of
+          // letting enrolment complete the flow.
+          const finishOAuthFlowHandler = jest.fn().mockResolvedValue({
+            error: AuthUiErrors.INSUFFICIENT_ACR_VALUES,
+          });
+          const navigationOptions = buildPromptNoneOptions({
+            accountHasTotp: true,
+            canRelayPromptNoneError: false,
+            finishOAuthFlowHandler,
+          });
+
+          const result = await handleNavigation(navigationOptions);
+
+          expect(result.error).toBeUndefined();
+          expect(mockNavigate).toHaveBeenCalledWith(
+            '/inline_totp_setup?client_id=abc',
+            expect.objectContaining({ replace: true })
+          );
+        });
+
+        it('does not fail the request for callers that cannot relay it to the RP', async () => {
+          const finishOAuthFlowHandler = jest.fn().mockResolvedValue({
+            error: AuthUiErrors.INSUFFICIENT_ACR_VALUES,
+          });
+          const navigationOptions = buildPromptNoneOptions({
+            accountHasTotp: true,
+            canRelayPromptNoneError: false,
+            finishOAuthFlowHandler,
+          });
+
+          const result = await handleNavigation(navigationOptions);
+
+          expect(result.error).toBeUndefined();
+          expect(mockNavigate).toHaveBeenCalledWith(
+            '/inline_totp_setup?client_id=abc',
+            expect.objectContaining({ replace: true })
+          );
+        });
+
+        it('still challenges interactively when prompt=none was not requested', async () => {
+          const integration = createMockSigninOAuthIntegration();
+          integration.wantsTwoStepAuthentication = jest
+            .fn()
+            .mockReturnValue(true);
+          const finishOAuthFlowHandler = jest.fn().mockResolvedValue({
+            error: AuthUiErrors.INSUFFICIENT_ACR_VALUES,
+          });
+
+          const navigationOptions = createBaseNavigationOptions({
+            integration,
+            queryParams: '?client_id=abc',
+            accountHasTotp: true,
+            finishOAuthFlowHandler,
+          });
+
+          const result = await handleNavigation(navigationOptions);
+
+          expect(result.error).toBeUndefined();
+          expect(mockNavigate).toHaveBeenCalledWith(
+            '/inline_totp_setup?client_id=abc',
+            expect.objectContaining({ replace: true })
+          );
+        });
       });
 
       it('returns a Settings-originated AAL upgrade to /settings', async () => {

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -24,7 +24,7 @@ import { useNavigateWithQuery } from '../../lib/hooks';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { currentAccount, discardSessionToken } from '../../lib/cache';
 import firefox from '../../lib/channels/firefox';
-import { AuthError } from '../../lib/oauth';
+import { AuthError, OAuthError } from '../../lib/oauth';
 import GleanMetrics from '../../lib/glean';
 import { OAuthData } from '../../lib/oauth/hooks';
 import AuthenticationMethods from '../../constants/authentication-methods';
@@ -723,6 +723,18 @@ const getOAuthNavigationTarget = async (
       error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno
     ) {
       GleanMetrics.login.error({ event: { reason: error.message } });
+
+      // Every destination below is interactive, which prompt=none forbids. On
+      // the caller's flag, not the integration: prompt=none can outlive the
+      // authorization route in the query string, and the RP may have opted out
+      // of error redirects. Errno 170 only — an unverified session is
+      // interaction_required, not an unmet level (FXA-14408).
+      if (
+        error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno &&
+        navigationOptions.canRelayPromptNoneError
+      ) {
+        return { error: new OAuthError('UNMET_AUTHENTICATION_REQUIREMENTS') };
+      }
 
       const to = (() => {
         // If the user doesn't have totp, and encountered an unverified_session error, send them


### PR DESCRIPTION
## Because

- RFC 9470 section 5 requires the authorization request to fail with `unmet_authentication_requirements` when the requested authentication level cannot be reached. FxA had no such path.
- A `prompt=none` step-up request routed the user to an interactive 2FA page, which the parameter forbids, and the RP was never told its request failed.

## This pull request

- Adds `UNMET_AUTHENTICATION_REQUIREMENTS` to `OAUTH_ERRORS`, carrying `response_error_code: 'unmet_authentication_requirements'`.
- Fails `prompt=none` step-up requests in `getOAuthNavigationTarget` instead of routing to an interactive challenge, on errno 170 only.
- Gates that on a new `isPromptNoneRequest` navigation option set only by the Authorization container, the one caller that relays a returned error to the RP.
- Documents errno 170 and the step-up parameters on `POST /oauth/authorization`.
- Pins that the id_token `acr` claim reflects the achieved AAL.

## Issue that this pull request solves

Closes: FXA-12860

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the `prompt=none` short-circuit in `packages/fxa-settings/src/pages/Signin/utils.ts`, and where `isPromptNoneRequest` is set in `packages/fxa-settings/src/pages/Authorization/container.tsx`.
- Suggested review order: `Signin/utils.ts` → `Authorization/container.tsx` → tests.
- Risky or complex parts: the gate is on the caller's flag rather than `integration.wantsPromptNone()`, because `prompt=none` can outlive the authorization route in the query string. Every other `handleNavigation` caller renders errors in-FxA, so returning one to them would dead-end the user instead of completing enrolment.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Scoped to `prompt=none`. The ticket also describes returning this error when a user declines to enrol a second factor, which is **not** in this PR:

- Inline TOTP setup is handled upstream — #21097 rescoped its MFA guard to the enrolment step, so dismissing it returns to the intro screen rather than leaving the flow. That is an in-flow back action, not a decline.
- Recovery setup was implemented and then removed. `MfaGuardCore` only renders its modal when the `mfa:2fa` JWT is absent, and that JWT is already minted during TOTP setup — so `onDismiss` there is reachable only via a stale-JWT re-prompt mid-enrolment, where treating it as a decline would discard a confirmed phone number and generated backup codes.
- Abandoning an interactive 2FA challenge (`/signin_totp_code`, `/signin_token_code`) still dead-ends without notifying the RP. Those surfaces have no decline control and none was added.

The decline half wants its own ticket with UX input. FXA-14408 covers the adjacent `prompt=none` gap for unverified sessions, where `interaction_required` is the correct code rather than `unmet_authentication_requirements`.
