### PR TITLE
fix(auth-server): report the real Joi error for response validation

### DIFF
--- a/packages/fxa-auth-server/lib/server.in.spec.ts
+++ b/packages/fxa-auth-server/lib/server.in.spec.ts
@@ -4,11 +4,18 @@
 
 import { Account } from 'fxa-shared/db/models/auth/account';
 import { createMock } from '@golevelup/ts-jest';
+import Joi from 'joi';
 import { AuthLogger } from './types';
 
-const mockReportValidationError = jest.fn();
-jest.mock('fxa-shared/sentry/report-validation-error', () => ({
-  reportValidationError: mockReportValidationError,
+const mockScope = {
+  setContext: jest.fn(),
+  setFingerprint: jest.fn(),
+};
+const mockCaptureMessage = jest.fn();
+jest.mock('@sentry/node', () => ({
+  ...jest.requireActual('@sentry/node'),
+  withScope: jest.fn((cb: (scope: unknown) => void) => cb(mockScope)),
+  captureMessage: mockCaptureMessage,
 }));
 
 const EndpointError = require('poolee/lib/error')(require('util').inherits);
@@ -16,6 +23,7 @@ const { AppError: error } = require('@fxa/accounts/errors');
 const knownIpLocation = require('../test/known-ip-location');
 const mocks = require('../test/mocks');
 const server = require('./server');
+const oauthValidators = require('./oauth/validators');
 
 const glean = mocks.mockGlean();
 const customs = mocks.mockCustoms();
@@ -71,38 +79,123 @@ describe('lib/server', () => {
   });
 
   describe('logValidationError', () => {
-    const msg = 'Invalid response payload';
-    const response = {
-      __proto__: {
-        name: 'ValidationError',
-      },
-      message: msg,
-      stack: 'ValidationError: "[0].plan_id" is required',
-    };
+    // 64 characters clears the token branch's length check, so both branches
+    // reach their pattern and report `string.pattern.base` on the same path.
+    const LEAKY_TOKEN = 'leaky-token-user@example.com'.padEnd(64, 'z');
+    const LEAKY_EMAIL = 'leaky@example.com';
+    const HEX_PATTERN = '^(?:[0-9a-f]{2})+$';
+    const JWT_PATTERN =
+      '^([a-zA-Z0-9\\-_]+)\\.([a-zA-Z0-9\\-_]+)\\.([a-zA-Z0-9\\-_]+)$';
+    const mockLog = { error: jest.fn() };
 
-    afterEach(() => {
-      mockReportValidationError.mockClear();
-    });
+    // Mirrors the shape that produced FXA-AUTH-2ST: an outer alternatives()
+    // whose accessToken is itself an alternatives(), so Joi collapses the real
+    // cause twice and the top level reports only `alternatives.match`. The
+    // accessToken validator is the production one, so the patterns are real.
+    const validate = (payload: any) =>
+      Joi.alternatives(
+        Joi.object({
+          accessToken: oauthValidators.accessToken,
+          email: Joi.string().email(),
+        }),
+        Joi.object({ code: Joi.string() })
+      ).validate(payload).error;
+
+    const tokenFailure = () =>
+      validate({ accessToken: LEAKY_TOKEN, email: LEAKY_EMAIL });
 
     it('logs a validation error', () => {
-      const mockLog = {
-        error: (op: string, err: any) => {
-          expect(op).toBe('server.ValidationError');
-          expect(err.message).toBe(msg);
-        },
-      };
+      const response = tokenFailure();
       server._logValidationError(response, mockLog);
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'server.ValidationError',
+        response
+      );
     });
 
-    it('reports a validation error to Sentry', () => {
-      const mockLog = {
-        error: () => {},
-      };
+    it('reports the failing field and constraint to Sentry', () => {
+      server._logValidationError(tokenFailure(), mockLog);
+      expect(mockScope.setContext).toHaveBeenCalledWith('validationError', {
+        details: [
+          {
+            path: 'accessToken',
+            type: 'object.unknown',
+            constraint: '',
+            message: '"accessToken" is not allowed',
+          },
+          {
+            path: 'accessToken',
+            type: 'string.pattern.base',
+            constraint: HEX_PATTERN,
+            message: `"accessToken" with value "<redacted>" fails to match the required pattern: /${HEX_PATTERN}/`,
+          },
+          {
+            path: 'accessToken',
+            type: 'string.pattern.base',
+            constraint: JWT_PATTERN,
+            message: `"accessToken" with value "<redacted>" fails to match the required pattern: /${JWT_PATTERN}/`,
+          },
+        ],
+      });
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'Response validation failed: accessToken (object.unknown), accessToken (string.pattern.base), accessToken (string.pattern.base)',
+        'error'
+      );
+    });
+
+    it('fingerprints on the flattened path, type and constraint', () => {
+      server._logValidationError(tokenFailure(), mockLog);
+      expect(mockScope.setFingerprint).toHaveBeenCalledWith([
+        'response-validation',
+        'accessToken:object.unknown:',
+        `accessToken:string.pattern.base:${HEX_PATTERN}`,
+        `accessToken:string.pattern.base:${JWT_PATTERN}`,
+      ]);
+    });
+
+    it('gives a failure on a different field a different fingerprint', () => {
+      server._logValidationError(
+        validate({ accessToken: 'f'.repeat(64), email: 'not-an-email' }),
+        mockLog
+      );
+      expect(mockScope.setFingerprint).toHaveBeenCalledWith([
+        'response-validation',
+        'accessToken:object.unknown:',
+        'email:string.email:',
+      ]);
+    });
+
+    it('gives the same failure at two array indexes one fingerprint', () => {
+      const response = Joi.array()
+        .items(Joi.object({ plan_id: Joi.string().required() }))
+        .validate([{}, {}], { abortEarly: false }).error;
       server._logValidationError(response, mockLog);
-      expect(mockReportValidationError).toHaveBeenCalledTimes(1);
-      expect(mockReportValidationError).toHaveBeenCalledWith(
-        response.stack,
-        response
+      expect(mockScope.setFingerprint).toHaveBeenCalledWith([
+        'response-validation',
+        '*.plan_id:any.required:',
+      ]);
+    });
+
+    it('reports no values from the response payload', () => {
+      server._logValidationError(tokenFailure(), mockLog);
+      const reported = JSON.stringify([
+        mockScope.setContext.mock.calls,
+        mockScope.setFingerprint.mock.calls,
+        mockCaptureMessage.mock.calls,
+      ]);
+      expect(reported).not.toContain(LEAKY_TOKEN);
+      expect(reported).not.toContain(LEAKY_EMAIL);
+    });
+
+    it('reports a validation error that carries no details', () => {
+      server._logValidationError({ details: undefined }, mockLog);
+      expect(mockScope.setContext).toHaveBeenCalledWith('validationError', {
+        details: [],
+      });
+      expect(mockScope.setFingerprint).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'Response validation failed',
+        'error'
       );
     });
   });

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -22,9 +22,6 @@ const { resolveClientTags } = require('./metrics/client-tags');
 const { swaggerOptions } = require('../docs/swagger/swagger-options');
 const { Account } = require('fxa-shared/db/models/auth');
 const { determineLocale } = require('../../../libs/shared/l10n/src');
-const {
-  reportValidationError,
-} = require('fxa-shared/sentry/report-validation-error');
 const { logErrorWithGlean } = require('./metrics/glean');
 const { retryAfterHeaderValue } = require('@fxa/accounts/errors');
 const mfa = require('./routes/auth-schemes/mfa');
@@ -48,9 +45,76 @@ function trimLocale(header) {
   return str.trim();
 }
 
+// Only Joi's `string.pattern.*` messages embed the failing value, which in a
+// response payload is user data. They render it quoted, so redact that form
+// rather than every occurrence, which would shred a message on a short value.
+function redactValue(message, value) {
+  if (typeof value !== 'string' || value === '') {
+    return message;
+  }
+  return message.replaceAll(`"${value}"`, '"<redacted>"');
+}
+
+// Joi collapses a nested `alternatives()` failure into a single
+// `alternatives.match` and hides the real cause under `context.details`. Walk
+// down to the leaves so the failing field and its constraint survive.
+function flattenValidationDetails(details) {
+  const leaves = new Map();
+  const walk = (list) => {
+    for (const detail of list || []) {
+      const nested = detail.context?.details;
+      if (nested?.length) {
+        walk(nested);
+        continue;
+      }
+      // Array indexes are data, not schema. Collapse them so the same failure
+      // at items 0 and 3 groups as one Sentry issue instead of two.
+      const path = (detail.path || [])
+        .map((segment) => (typeof segment === 'number' ? '*' : segment))
+        .join('.');
+      // Path and type alone collide: an alternatives() of two string patterns
+      // reports `string.pattern.base` twice on the same path. The pattern is
+      // schema, not response data, so it is safe to report and stable.
+      const constraint = detail.context?.regex?.source ?? '';
+      leaves.set(`${path}:${detail.type}:${constraint}`, {
+        path,
+        type: detail.type,
+        constraint,
+        message: redactValue(detail.message, detail.context?.value),
+      });
+    }
+  };
+  walk(details);
+  // Plain codepoint order, not localeCompare: two hosts on different ICU
+  // collations must not fingerprint the same failure two ways.
+  return [...leaves.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([, leaf]) => leaf);
+}
+
 function logValidationError(response, log) {
   log.error('server.ValidationError', response);
-  reportValidationError(response.stack, response);
+
+  const details = flattenValidationDetails(response.details);
+  const summary = details
+    .map((d) => `${d.path || '<root>'} (${d.type})`)
+    .join(', ');
+  const message = details.length
+    ? `Response validation failed: ${summary}`
+    : 'Response validation failed';
+
+  Sentry.withScope((scope) => {
+    scope.setContext('validationError', { details });
+    if (details.length) {
+      // Group on the field and the constraint, not on the collapsed top-level
+      // message, which is identical for every alternatives() mismatch.
+      scope.setFingerprint([
+        'response-validation',
+        ...details.map((d) => `${d.path}:${d.type}:${d.constraint}`),
+      ]);
+    }
+    Sentry.captureMessage(message, 'error');
+  });
 }
 
 function logEndpointErrors(response, log) {


### PR DESCRIPTION
## Because

- `flattenValidationDetails` keyed its dedup map on path and Joi type alone. Two different constraints on one path overwrote each other.
- `accessToken` is an `alternatives()` of two string patterns, so both branches report `string.pattern.base` on the same path. Only the second one survived, and the fingerprint could not tell a hex-token failure from a JWT failure.
- So the grouping problem this PR set out to fix came back one level down.

## This pull request

- Adds a `constraint` field to each flattened leaf, taken from `detail.context.regex.source`.
- Keys the dedup map and the Sentry fingerprint on `path:type:constraint`, so the two patterns stay apart.
- Builds the spec fixture from the production `accessToken` validator in `lib/oauth/validators.js`, so the test covers the real colliding patterns.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14395

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `flattenValidationDetails` in `packages/fxa-auth-server/lib/server.js`.
- Suggested review order: `server.js`, then `server.in.spec.ts`.
- Risky or complex parts: none. `failAction` and `redactValue` have zero diff, and the array-index collapse still groups `items[0]` and `items[3]` as one entry.

## Screenshots (Optional)

## Other information (Optional)

- The review suggested `?? detail.context?.name` as a second fallback. I left it out. In Joi, `name` appears only on `string.pattern.name`, and that context always carries `regex` too (`joi/lib/types/string.js:571`), so the branch never runs. I will add it back if you want it as a guard.
- Limit constraints can still collide, for example `string.max(3)` against `string.max(5)` on one path. `context.limit` is the obvious discriminator, but it can be a `Joi.ref()` that resolves from the response payload, which would put a value in Sentry. That needs its own ticket.
- Local runs: `npx jest packages/fxa-auth-server/lib/server.in.spec.ts`: 63 passed, 0 failed. `npx nx lint fxa-auth-server`: clean.
