### PR TITLE
chore(auth-server): remove browserid route, config, and docs

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -175,8 +175,7 @@
   },
   "oauthServer": {
     "browserid": {
-      "issuer": "localhost:9000",
-      "verificationUrl": "http://localhost:5050/v2"
+      "issuer": "localhost:9000"
     },
     "contentUrl": "http://localhost:3030/oauth/",
     "clientManagement": {

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1295,17 +1295,6 @@ const convictConf = convict({
         env: 'ISSUER',
         default: 'api.accounts.firefox.com',
       },
-      maxSockets: {
-        doc: 'The maximum number of connections that the pool can use at once.',
-        env: 'BROWSERID_MAX_SOCKETS',
-        default: 10,
-      },
-      verificationUrl: {
-        doc: 'URL to the remote verifier we will use for fxa-assertions',
-        format: 'url',
-        env: 'VERIFICATION_URL',
-        default: 'https://verifier.accounts.firefox.com/v2',
-      },
     },
     clients: {
       doc: 'Some pre-defined clients that will be inserted into the DB',

--- a/packages/fxa-auth-server/docs/swagger/misc-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/misc-api.ts
@@ -51,18 +51,6 @@ const SUPPORT_TICKET_POST = {
   ],
 };
 
-const WELLKNOWN_BROWSERID_GET = {
-  ...TAGS_MISC,
-  description: '/.well-known/browserid',
-  notes: [
-    dedent`
-      Verifies a user is who they say they are using [BrowserID](https://hacks.mozilla.org/2011/07/introducing-browserid-easier-and-safer-authentication-on-the-web/).
-
-      It has been deprecated in newer version of Firefox desktop, though some clients still use it.
-    `,
-  ],
-};
-
 const WELLKNOWN_PUBLIC_KEYS = {
   ...TAGS_MISC,
   description: '/.well-known/public-keys',
@@ -99,7 +87,6 @@ const API_DOCS = {
   NEWSLETTERS_POST,
   OAUTH_ID_TOKEN_VERIFY_POST,
   SUPPORT_TICKET_POST,
-  WELLKNOWN_BROWSERID_GET,
   WELLKNOWN_PUBLIC_KEYS,
 };
 

--- a/packages/fxa-auth-server/docs/swagger/oauth-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/oauth-api.ts
@@ -18,7 +18,7 @@ const OAUTH_AUTHORIZATION_POST = {
 
       Authorize a new OAuth client connection to the user's account, returning a short-lived authentication code that the client can exchange for access tokens at the OAuth token endpoint.
 
-      This route behaves like the oauth-server /authorization endpoint except that it is authenticated directly with a sessionToken rather than with a BrowserID assertion.
+      This route behaves like the oauth-server /authorization endpoint except that it is authenticated directly with a sessionToken.
     `,
   ],
 };
@@ -82,7 +82,7 @@ const OAUTH_TOKEN_POST = {
         - \`grant_type=refresh_token\`: A refresh token issued by a previous call to this endpoint.
         - \`grant_type=fxa-credentials\`: Directly grant tokens using an FxA sessionToken.
 
-      This is the "token endpoint" as defined in RFC6749, and behaves like the [oauth-server /token endpoint](#tag/OAuth-Server-API-Overview/operation/postToken) except that the \`fxa-credentials\` grant can be authenticated directly with a sessionToken rather than with a BrowserID assertion.
+      This is the "token endpoint" as defined in RFC6749, and behaves like the [oauth-server /token endpoint](#tag/OAuth-Server-API-Overview/operation/postToken) except that the \`fxa-credentials\` grant can be authenticated directly with a sessionToken.
     `,
   ],
   plugins: {

--- a/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
+++ b/packages/fxa-auth-server/docs/swagger/shared/descriptions.ts
@@ -194,8 +194,6 @@ const DESCRIPTIONS = {
   promotionPercentOff:
     'Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a $100 invoice $50 instead.',
   providerUid: 'The user id associated with a particular third party provider.',
-  publicKey:
-    'The key to sign (run bin/generate-keypair from [**browserid-crypto**](https://github.com/mozilla/browserid-crypto)).',
   pushPayload:
     'Push payload, validated against [**pushpayloads.schema.json**](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/pushpayloads.schema.json).',
   reason:

--- a/packages/fxa-auth-server/lib/oauth/assertion.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/assertion.spec.ts
@@ -157,7 +157,8 @@ describe('JWT verifyAssertion', () => {
 
   it('should reject JWTs with missing `lastAuthAt` claim', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { 'fxa-lastAuthAt': _removed, ...claimsWithoutLastAuth } = GOOD_CLAIMS;
+    const { 'fxa-lastAuthAt': _removed, ...claimsWithoutLastAuth } =
+      GOOD_CLAIMS;
     const assertion = await makeJWT(claimsWithoutLastAuth);
     await expect(verifyAssertion(assertion)).rejects.toHaveProperty(
       'errno',

--- a/packages/fxa-auth-server/lib/routes/idp.js
+++ b/packages/fxa-auth-server/lib/routes/idp.js
@@ -4,59 +4,15 @@
 
 'use strict';
 
-const BN = require('bn.js');
-
 const MISC_DOCS = require('../../docs/swagger/misc-api').default;
 
-function b64toDec(str) {
-  const n = new BN(Buffer.from(str, 'base64'));
-  return n.toString(10);
-}
-
-function toDec(str) {
-  return /^[0-9]+$/.test(str) ? str : b64toDec(str);
-}
-
-function browseridFormat(keys) {
-  const primary = keys[0];
-  return {
-    'public-key': {
-      kid: primary.jwk.kid,
-      'fxa-createdAt': primary.jwk['fxa-createdAt'],
-      algorithm: primary.jwk.algorithm,
-      n: toDec(primary.jwk.n),
-      e: toDec(primary.jwk.e),
-    },
-    authentication: '/.well-known/browserid/nonexistent.html',
-    provisioning: '/.well-known/browserid/nonexistent.html',
-    keys: keys,
-  };
-}
-
-module.exports = function (log, serverPublicKeys) {
+module.exports = function (serverPublicKeys) {
   const keys = [serverPublicKeys.primary];
   if (serverPublicKeys.secondary) {
     keys.push(serverPublicKeys.secondary);
   }
 
-  const browserid = browseridFormat(keys);
-
   const routes = [
-    {
-      method: 'GET',
-      path: '/.well-known/browserid',
-      options: {
-        ...MISC_DOCS.WELLKNOWN_BROWSERID_GET,
-        cache: {
-          privacy: 'public',
-          expiresIn: 10000,
-        },
-      },
-      handler: async function (request) {
-        log.begin('browserid', request);
-        return browserid;
-      },
-    },
     {
       method: 'GET',
       path: '/.well-known/public-keys',

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -56,7 +56,7 @@ module.exports = function (
   );
   // The routing modules themselves.
   const defaults = require('./defaults')(log, config, db);
-  const idp = require('./idp')(log, serverPublicKeys);
+  const idp = require('./idp')(serverPublicKeys);
   const grant = require('../oauth/grant');
   const oauthRawDB = require('../oauth/db');
   grant.setStripeHelper(stripeHelper);

--- a/packages/fxa-auth-server/test/lib/oauth-test.json
+++ b/packages/fxa-auth-server/test/lib/oauth-test.json
@@ -1,8 +1,7 @@
 {
   "oauthServer": {
     "browserid": {
-      "issuer": "localhost:9000",
-      "verificationUrl": "http://localhost:5050/v2"
+      "issuer": "localhost:9000"
     },
     "clientManagement": {
       "enabled": true

--- a/packages/fxa-auth-server/test/load/loadtests.py
+++ b/packages/fxa-auth-server/test/load/loadtests.py
@@ -33,7 +33,7 @@ from loads import TestCase
 #        * 5% of flows will generate some random bytes
 #    * 3% of tests exercise the password reset flow
 #    * 1% of tests exercise are the password change flow
-#    * 1% of are simple requests for the browserid support document
+#    * 1% of are simple requests for the public keys document
 
 PERCENT_TEST_LOGIN = 95
 PERCENT_TEST_RESET = 3
@@ -308,7 +308,7 @@ class LoadTest(TestCase):
 
     def test_support_doc_flow(self):
         base_url = self.server_url[:-3]
-        self.session.get(base_url + "/.well-known/browserid")
+        self.session.get(base_url + "/.well-known/public-keys")
 
     def _get_code_from_email(self, emailAcct, header):
         # Due to possible race conditions, and previous test runs

--- a/packages/fxa-auth-server/test/remote/base_path.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/base_path.in.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  getSharedTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 import pkg from '../../package.json';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -40,13 +43,11 @@ describe.each(testVersions)(
 
     it('.well-known did not move', async () => {
       const res = await fetch(
-        `http://localhost:${serverPort}/.well-known/browserid`
+        `http://localhost:${serverPort}/.well-known/public-keys`
       );
       expect(res.status).toBe(200);
       const json = await res.json();
-      expect(json.authentication).toBe(
-        '/.well-known/browserid/nonexistent.html'
-      );
+      expect(json.keys.length).toBeGreaterThan(0);
     });
 
     it('"/" returns valid version information', async () => {

--- a/packages/fxa-auth-server/test/remote/misc_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/misc_tests.in.spec.ts
@@ -246,26 +246,6 @@ describe.each(testVersions)(
       expect(x.data.length).toBe(64);
     });
 
-    it('fetch /.well-known/browserid support document', async () => {
-      const client = new Client(server.publicUrl, testOptions);
-      const doc = await client.api.doRequest(
-        'GET',
-        server.publicUrl + '/.well-known/browserid'
-      );
-      expect(Object.prototype.hasOwnProperty.call(doc, 'public-key')).toBe(
-        true
-      );
-      expect(/^[0-9]+$/.test(doc['public-key'].n)).toBe(true);
-      expect(/^[0-9]+$/.test(doc['public-key'].e)).toBe(true);
-      expect(Object.prototype.hasOwnProperty.call(doc, 'authentication')).toBe(
-        true
-      );
-      expect(Object.prototype.hasOwnProperty.call(doc, 'provisioning')).toBe(
-        true
-      );
-      expect(doc.keys.length).toBe(1);
-    });
-
     it('ignores fail on hawk payload mismatch', async () => {
       const email = server.uniqueEmail();
       const password = 'allyourbasearebelongtous';

--- a/packages/fxa-auth-server/test/remote/sign_key_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/sign_key_tests.in.spec.ts
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import path from 'path';
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 
 const superagent = require('superagent');
 
@@ -22,15 +25,11 @@ afterAll(async () => {
 });
 
 describe('#integration - remote sign key', () => {
-  it('.well-known/browserid has keys', async () => {
+  it('.well-known/public-keys serves the primary and old keys', async () => {
     const res = await superagent.get(
-      `${server.publicUrl}/.well-known/browserid`
+      `${server.publicUrl}/.well-known/public-keys`
     );
     expect(res.statusCode).toBe(200);
-    const json = res.body;
-    expect(json.authentication).toBe(
-      '/.well-known/browserid/nonexistent.html'
-    );
-    expect(json.keys.length).toBe(2);
+    expect(res.body.keys.length).toBe(2);
   });
 });

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -1169,9 +1169,7 @@ const conf = (module.exports = convict({
   },
 }));
 
-// At the time this file is required, we'll determine the "process name" for this proc
-// if we can determine what type of process it is (browserid or verifier) based
-// on the path, we'll use that, otherwise we'll name it 'ephemeral'.
+// Name this process after the script that started it.
 conf.set('process_type', path.basename(process.argv[1], '.js'));
 
 // Always send CSP headers in development mode
@@ -1215,7 +1213,6 @@ if (!conf.has('static_resource_url')) {
   conf.set('static_resource_url', conf.get('public_url'));
 }
 
-// For ops consistency with Browserid, we support HTTP_PROXY
 // special handling of HTTP_PROXY env var
 if (process.env.HTTP_PROXY) {
   const p = process.env.HTTP_PROXY.split(':');


### PR DESCRIPTION
## Because

- BrowserID was retired in FXA-2715, but 42 references across 20 files stayed behind, including a live `/.well-known/browserid` route and the config that fed it.
- The reporter confirmed on the ticket that the route has no consumers, which unblocks retiring it.

## This pull request

- Removes the `GET /.well-known/browserid` route and the code that only served it: `browseridFormat`, `toDec`, `b64toDec`, and the `bn.js` require in `idp.js`. `GET /.well-known/public-keys` stays.
- Changes the `idp.js` export to take `(serverPublicKeys)` and updates the call site in `lib/routes/index.js`.
- Deletes the dead config keys `maxSockets` (`BROWSERID_MAX_SOCKETS`) and `verificationUrl` (`VERIFICATION_URL`). Nothing in the repo reads either one.
- Drops `WELLKNOWN_BROWSERID_GET` from the swagger docs, plus the orphaned `publicKey` description left over from the removed `/certificate/sign` route.
- Deletes the two remote tests that asserted on the browserid document, and points `base_path`, `sign_key_tests`, and the load test at `/.well-known/public-keys`.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13791

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/routes/idp.js` for what survives, its call site in `lib/routes/index.js`, and `config/index.ts` for the two deleted keys.
- Suggested review order: `idp.js`, then `lib/routes/index.js`, then `config/index.ts` and `dev.json`, then docs and tests.
- Risky or complex parts: the route removal is the only behaviour change. The rest is dead code and docs.

## Screenshots (Optional)

Not applicable. There is no user interface change.

## Other information (Optional)

`oauthServer.browserid.issuer` is kept, at your request. The ticket asks to remove all browserid references, so this PR deliberately stops short of that: one config key name survives. Flagging it here so nobody reads the ticket as done and then trips over the key. An earlier revision of this PR renamed it to `oauthServer.assertionIssuer`. That rename is reverted, so no config path moves.

"There are no consumers" is true for the route. It is not true for two other things the same sentence would sweep away, so neither is touched here:

1. `lib/oauth/assertion.js` has five live consumers across the OAuth routes. It is already JWT only, and its only tie to browserid was the config key it read. It is not deleted, and its verification logic is unchanged.
2. `lib/routes/idp.js` served two routes. Only `/.well-known/browserid` is browserid. `/.well-known/public-keys` stays, because retiring it is a separate decision nobody has made.

No deployment change. The `ISSUER` env var binding does not move, and the JSON key it overrides is the same one as before. The two deleted keys have no readers, so an environment that still sets `BROWSERID_MAX_SOCKETS` or `VERIFICATION_URL` keeps booting; `convict` validates with `allowed: 'warn'` and ignores env vars with no schema entry.

`/.well-known/browserid` was a public discovery endpoint and now returns 404. That is the decision recorded on the ticket, not an accident, but it is worth watching for 404s on that path after deploy.

The three tests are handled two different ways on purpose. The misc_tests case is deleted, because its subject was the browserid document itself. The `base_path` and `sign_key_tests` cases are pointed at `/.well-known/public-keys` instead, because their subjects are base path placement and secondary key loading. Browserid was only the probe there, and deleting them would drop coverage that has nothing to do with this ticket.

Three references stay in the tree on purpose:

- `_dev/docker/sync/sync-for-fxa/config/local.toml` keeps its `tokenserver.fxa_browserid_*` keys. That namespace belongs to tokenserver and is not FxA's to rename.
- `config/index.ts:1194` keeps the words "retired BrowserID `/certificate/sign` flow". It explains why `oldSyncClientIds` exists, and cutting the word makes the doc string meaningless.
- `docs/adr/0045` keeps its `browserid-verifier` line. It is one row of a dated commit count survey, and editing it would falsify a historical record.

One follow up. `bn.js` was the last direct import in the repo, so `bn.js` and `@types/bn.js` in the root `package.json` are now orphaned. Removing them needs a `yarn.lock` refresh in the same commit, because CI installs with `--immutable`. That is separable from this change, so it is left out.

Local runs: `jest --selectProjects unit` for `fxa-auth-server` gives 3799 passed, 0 failed. `nx lint fxa-auth-server` exits 0, and `tsc --noEmit` adds no new errors. The `test/remote/*.in.spec.ts` files need a running auth server, so they were not run locally. CI covers them. Functional tests were not run.
