### PR TITLE
test(functional-tests): add end-to-end v2 pairing coverage

### DIFF
--- a/packages/functional-tests/lib/android-supplicant.ts
+++ b/packages/functional-tests/lib/android-supplicant.ts
@@ -35,6 +35,17 @@
 import { execFileSync } from 'child_process';
 import { writeFileSync } from 'fs';
 
+/**
+ * Single-quote a value for the device-side shell that `adb shell` invokes.
+ * Closes the quote, inserts an escaped quote, and reopens: the standard
+ * `'\''` idiom, so the value cannot break out and run as a command.
+ */
+function shellQuote(value: string): string {
+  // Close the quote, add an escaped quote, reopen: the standard '\'' idiom.
+  const escapedQuote = "'\\''";
+  return "'" + value.split("'").join(escapedQuote) + "'";
+}
+
 const DEBUG = !!process.env.ANDROID_PAIRING_DEBUG;
 const debug = (msg: string) =>
   DEBUG && console.log(`[android-supplicant] ${msg}`);
@@ -68,6 +79,8 @@ const KEY_PAIRING_URL = 'pref_key_sync_debug_pairing_url';
 interface UiNode {
   text: string;
   desc: string;
+  /** Empty for GeckoView web content; set for native Android widgets. */
+  resourceId: string;
   cx: number;
   cy: number;
 }
@@ -164,6 +177,20 @@ export class AndroidSupplicant {
   }
 
   /**
+   * Wipe all app data so pairing starts from a signed-out, first-run state.
+   *
+   * `forceStop` only kills the process; the FxA account in `shared_prefs`
+   * survives it, and a Fenix that already has an account takes a re-auth web
+   * flow instead of the pairing flow. Call this before `ensureReady`, which
+   * re-grants the permissions and rewrites the server override that
+   * `pm clear` removes.
+   */
+  resetToColdState(): void {
+    this.adb(['shell', 'pm', 'clear', this.pkg]);
+    debug('Cleared app data; supplicant is in a cold, signed-out state');
+  }
+
+  /**
    * Verify a device is attached and the Fenix debug build is installed. Grants
    * camera/notification permissions and points the FxA server override at the
    * given content server. Cold-starts once so the prefs files exist.
@@ -200,9 +227,11 @@ export class AndroidSupplicant {
     }
 
     // Launch once so the prefs files are created, then stop before editing.
+    this.adb(['logcat', '-c']);
     this.launchHome();
     await this.waitForProcess(30_000);
     await sleep(3_000);
+    await this.assertSignedOut();
     this.forceStop();
 
     this.setPrefString(
@@ -211,6 +240,44 @@ export class AndroidSupplicant {
       contentServerUrl
     );
     debug(`FxA server override set to ${contentServerUrl}`);
+  }
+
+  /**
+   * Fail now if the app still holds an account.
+   *
+   * A Fenix with leftover credentials answers a scanned pairing URL with a
+   * re-auth web flow instead of pairing, so the authority sits waiting for a
+   * `pair:supp:request` that never arrives and the run dies a minute later on
+   * an unrelated timeout. The account state machine names the state on startup,
+   * so read it and say what is actually wrong.
+   */
+  private async assertSignedOut(timeoutMs = 30_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let lastState = '';
+
+    do {
+      // The last state wins: the machine reports Initialize before settling.
+      const states = this.dumpLogcat().match(/FxaState\$(\w+)/g) ?? [];
+      lastState = states.length ? states[states.length - 1] : '';
+
+      if (lastState.endsWith('$Disconnected')) {
+        return;
+      }
+      if (lastState.endsWith('$AuthIssues') || lastState.endsWith('$Connected')) {
+        throw new Error(
+          `${this.pkg} still holds an account (${lastState}). ` +
+            'A signed-in supplicant takes a re-auth flow instead of pairing. ' +
+            `Run \`adb shell pm clear ${this.pkg}\` and retry.`
+        );
+      }
+      await sleep(1_000);
+    } while (Date.now() < deadline);
+
+    // Never reported a state. Nothing here proves an account exists, so let the
+    // flow proceed rather than failing a run for a missing log line.
+    debug(
+      `Could not read the account state${lastState ? ` (last saw ${lastState})` : ''}; continuing`
+    );
   }
 
   /**
@@ -247,6 +314,45 @@ export class AndroidSupplicant {
   }
 
   /**
+   * Open the pairing URL as a normal tab, the way a native QR scan does on a
+   * v2 device: `VIEW <pair url>` with no OAuth params in the URL. The page then
+   * asks the browser for them over the web channel (`fxaccounts:pair_oauth_start`).
+   *
+   * The Sync Debug hook takes the other branch - app-services runs OAuth-start
+   * itself and hands the page a URL that already carries the params - so this
+   * is the path that exercises the v2 web-channel command. The web channel is
+   * live in normal tabs: `FxaWebChannelIntegration` is installed by
+   * `BaseBrowserFragment`, the parent of both the browser and custom-tab
+   * fragments.
+   *
+   * Returns the pairing URL as seen in logcat once the tab has loaded it.
+   */
+  async openPairingUrl(
+    pairingUrl: string,
+    timeoutMs = 60_000
+  ): Promise<string> {
+    this.forceStop();
+    this.adb(['logcat', '-c']);
+    // `adb shell` re-tokenizes argv on the device, and the URL carries `#` and
+    // `&`, so it has to travel as one quoted string or the device shell
+    // truncates it. Escape it rather than interpolating it raw: a quote in the
+    // value would otherwise close the quoting and run as a device-side command.
+    this.adb([
+      'shell',
+      `am start -a android.intent.action.VIEW -d ${shellQuote(pairingUrl)} ${this.pkg}`,
+    ]);
+    await this.waitForProcess(30_000);
+    await sleep(6_000); // first-run init before dialogs are dismissable
+    this.dismissBlockingDialogs();
+
+    const line = await this.waitForLog(/url=[^,]*\/pair(\?|#|,|\s)/, timeoutMs);
+    debug(
+      `Supplicant opened the pairing URL in a normal tab: ${line.slice(0, 120)}`
+    );
+    return line;
+  }
+
+  /**
    * Wait until the supplicant custom tab has loaded its pairing page and is
    * connecting to the channel. Distinguishes the real pairing flow (/pair/supp
    * or a pairing authorization URL) from the FXA-13611 email fallback that a
@@ -272,12 +378,15 @@ export class AndroidSupplicant {
    * authority approves the new device, then the supplicant confirms here.
    * (uiautomator can read GeckoView web content.)
    */
-  async confirmPairing(timeoutMs = 45_000): Promise<void> {
+  async confirmPairing(
+    timeoutMs = 45_000,
+    // v1 uses "Confirm"/"Confirm pairing"; the v2 supplicant card uses "Connect".
+    re = /^Confirm pairing$|^Confirm$/i
+  ): Promise<void> {
     // The confirm button lives in GeckoView web content, read via uiautomator's
     // accessibility tree — which GeckoView populates lazily, so a dump can miss
     // it transiently. Poll, and periodically nudge the page with a tiny scroll
     // to force the a11y tree to repopulate.
-    const re = /^Confirm pairing$|^Confirm$/i;
     const deadline = Date.now() + timeoutMs;
     let attempt = 0;
     while (Date.now() < deadline) {
@@ -418,10 +527,15 @@ export class AndroidSupplicant {
     ];
     for (let pass = 0; pass < 3; pass++) {
       const nodes = this.dumpUi();
-      const hit = nodes.find((n) => dismissers.some((re) => re.test(n.text)));
+      // Native widgets only. uiautomator also reads GeckoView web content, and
+      // the v2 supplicant card has its own Cancel button - tapping that would
+      // close the pairing channel and abort the flow on both sides.
+      const hit = nodes.find(
+        (n) => n.resourceId && dismissers.some((re) => re.test(n.text))
+      );
       if (!hit) return;
       this.tap(hit.cx, hit.cy);
-      debug(`Dismissed dialog button: ${hit.text}`);
+      debug(`Dismissed dialog button: ${hit.text} (${hit.resourceId})`);
     }
   }
 
@@ -471,14 +585,34 @@ export class AndroidSupplicant {
       const tag = m[0];
       const text = attr(tag, 'text');
       const desc = attr(tag, 'content-desc');
+      const resourceId = attr(tag, 'resource-id');
       const bounds = attr(tag, 'bounds');
       const b = bounds.match(/\[(\d+),(\d+)\]\[(\d+),(\d+)\]/);
       if (!b) continue;
       const cx = Math.floor((Number(b[1]) + Number(b[3])) / 2);
       const cy = Math.floor((Number(b[2]) + Number(b[4])) / 2);
-      nodes.push({ text, desc, cx, cy });
+      nodes.push({ text, desc, resourceId, cx, cy });
     }
     return nodes;
+  }
+
+  /**
+   * Wait for text to appear in the supplicant's own UI.
+   *
+   * The authority reaching sync_success only proves the authority's half. This
+   * reads the phone's screen, so a supplicant that registered the device but
+   * then landed on an error card is still caught.
+   */
+  async waitForText(re: RegExp, timeoutMs = 45_000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    do {
+      const nodes = this.dumpUi();
+      if (nodes.some((n) => re.test(n.text) || re.test(n.desc))) {
+        return true;
+      }
+      await sleep(2_000);
+    } while (Date.now() < deadline);
+    return false;
   }
 
   private async waitForLog(re: RegExp, timeoutMs: number): Promise<string> {

--- a/packages/functional-tests/lib/firefox-binary.ts
+++ b/packages/functional-tests/lib/firefox-binary.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Resolves the desktop Firefox that pairing tests drive over Marionette.
+ *
+ * The v2 chrome commands ship in Nightly, so the v2 specs need it. Playwright
+ * launches only its own build and never comes through here.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { firefox } from 'playwright';
+
+/** Default install locations for Firefox Nightly, by platform. */
+const NIGHTLY_PATHS: Record<string, string[]> = {
+  darwin: [
+    '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
+    path.join(
+      os.homedir(),
+      'Applications/Firefox Nightly.app/Contents/MacOS/firefox'
+    ),
+  ],
+  linux: [
+    '/usr/bin/firefox-nightly',
+    '/usr/local/bin/firefox-nightly',
+    '/opt/firefox-nightly/firefox',
+    path.join(os.homedir(), 'firefox-nightly/firefox'),
+  ],
+  win32: [
+    'C:\\Program Files\\Firefox Nightly\\firefox.exe',
+    'C:\\Program Files (x86)\\Firefox Nightly\\firefox.exe',
+  ],
+};
+
+function findFirefoxNightly(): string | undefined {
+  return (NIGHTLY_PATHS[process.platform] || []).find((p) => fs.existsSync(p));
+}
+
+/** A v2-capable Firefox, or undefined. FIREFOX_BINARY wins, so a local build works. */
+export function findV2AuthorityBinary(): string | undefined {
+  return process.env.FIREFOX_BINARY || findFirefoxNightly();
+}
+
+/** Binary for the `marionetteAuthority` fixture. The v1 specs run on either. */
+export function resolveAuthorityBinary(): string {
+  return findV2AuthorityBinary() || firefox.executablePath();
+}

--- a/packages/functional-tests/lib/fixtures/pairing.ts
+++ b/packages/functional-tests/lib/fixtures/pairing.ts
@@ -10,63 +10,123 @@
  * (desktop) side of the pairing flow.
  */
 
-import { firefox } from 'playwright';
+import { resolveAuthorityBinary } from '../firefox-binary';
 import { MarionetteFirefox } from '../marionette-firefox';
+import { BaseTarget } from '../targets/base';
 import { test as standardTest, TestOptions } from './standard';
 
 export type PairingTestOptions = TestOptions & {
   marionetteAuthority: MarionetteFirefox;
+  /**
+   * A second real Firefox for the supplicant half. The v2 supplicant runs real
+   * web-channel commands (pair_oauth_start, oauth_login), so it cannot be a
+   * Playwright page; its profile is fresh, hence signed out.
+   *
+   * Both roles get `identity.fxaccounts.pairing.version: 2` from `buildPrefs`
+   * in `lib/marionette-firefox.ts`, which is what lets chrome accept the v2
+   * commands at all.
+   */
+  marionetteSupplicant: MarionetteFirefox;
 };
+
+/**
+ * Marionette ports, two per worker so the roles cannot collide at any worker
+ * count. A collision would not be silent: `MarionetteFirefox.launch` kills
+ * whatever already holds the port.
+ */
+function marionettePortFor(role: PairingRole, parallelIndex: number): number {
+  const raw = process.env.MARIONETTE_PORT || '2828';
+  const basePort = Number(raw);
+  if (!Number.isInteger(basePort)) {
+    throw new Error(`Invalid MARIONETTE_PORT: ${raw}`);
+  }
+  const port = basePort + parallelIndex * 2 + (role === 'supplicant' ? 1 : 0);
+  if (port < 1024 || port > 65535) {
+    throw new Error(
+      `Marionette port out of range for worker ${parallelIndex}: ${port}`
+    );
+  }
+  return port;
+}
+
+type PairingRole = 'authority' | 'supplicant';
+
+/**
+ * Launch one Marionette-driven Firefox for a pairing role.
+ *
+ * Shared by both fixtures so the two roles cannot drift — notably the CI WAF
+ * bypass, which a supplicant hitting a protected target needs just as much as
+ * the authority does.
+ */
+async function launchPairingFirefox(
+  role: PairingRole,
+  target: BaseTarget,
+  channelServerUri: string,
+  parallelIndex: number
+): Promise<MarionetteFirefox> {
+  const firefox = await MarionetteFirefox.launch({
+    firefoxBinary: resolveAuthorityBinary(),
+    marionettePort: marionettePortFor(role, parallelIndex),
+    channelServerUri,
+    target: target.name,
+    context: 'oauth_webchannel_v1',
+    headless: process.env.MARIONETTE_HEADLESS !== 'false',
+  });
+
+  // In CI, inject WAF bypass header into all Firefox HTTP requests
+  const wafToken = process.env.CI_WAF_TOKEN;
+  if (process.env.CI && wafToken) {
+    await firefox.client.setContext('chrome');
+    await firefox.client.executeScript(
+      `
+      const token = arguments[0];
+      Services.obs.addObserver({
+        observe(subject) {
+          subject.QueryInterface(Ci.nsIHttpChannel);
+          subject.setRequestHeader("fxa-ci", token, false);
+        }
+      }, "http-on-modify-request");
+      `,
+      { sandbox: 'system', args: [wafToken] }
+    );
+  }
+
+  return firefox;
+}
+
+/** Resolved once per worker: both roles talk to the same channel server. */
+async function resolveChannelServerUri(contentServerUrl: string) {
+  return (
+    process.env.CHANNEL_SERVER_URI ||
+    (await fetchChannelServerUri(contentServerUrl))
+  );
+}
 
 export const test = standardTest.extend<PairingTestOptions>({
   marionetteAuthority: async ({ target }, use, testInfo) => {
-    // Use Playwright's bundled Firefox by default — it's already downloaded
-    // in CI and locally. Override with FIREFOX_BINARY env if needed.
-    const firefoxBinary =
-      process.env.FIREFOX_BINARY || firefox.executablePath();
-    const channelServerUri =
-      process.env.CHANNEL_SERVER_URI ||
-      (await fetchChannelServerUri(target.contentServerUrl));
-    const basePort = parseInt(process.env.MARIONETTE_PORT || '2828', 10);
-    if (isNaN(basePort)) {
-      throw new Error(
-        `Invalid MARIONETTE_PORT: ${process.env.MARIONETTE_PORT}`
-      );
-    }
-    // Offset port by parallelIndex so parallel workers don't collide
-    const marionettePort = basePort + testInfo.parallelIndex;
-    const headless = process.env.MARIONETTE_HEADLESS !== 'false';
-
-    const authority = await MarionetteFirefox.launch({
-      firefoxBinary,
-      marionettePort,
-      channelServerUri,
-      target: target.name,
-      context: 'oauth_webchannel_v1',
-      headless,
-    });
-
-    // In CI, inject WAF bypass header into all Firefox HTTP requests
-    const wafToken = process.env.CI_WAF_TOKEN;
-    if (process.env.CI && wafToken) {
-      await authority.client.setContext('chrome');
-      await authority.client.executeScript(
-        `
-        const token = arguments[0];
-        Services.obs.addObserver({
-          observe(subject) {
-            subject.QueryInterface(Ci.nsIHttpChannel);
-            subject.setRequestHeader("fxa-ci", token, false);
-          }
-        }, "http-on-modify-request");
-        `,
-        { sandbox: 'system', args: [wafToken] }
-      );
-    }
+    const authority = await launchPairingFirefox(
+      'authority',
+      target,
+      await resolveChannelServerUri(target.contentServerUrl),
+      testInfo.parallelIndex
+    );
 
     await use(authority);
 
     await authority.close();
+  },
+
+  marionetteSupplicant: async ({ target }, use, testInfo) => {
+    const supplicant = await launchPairingFirefox(
+      'supplicant',
+      target,
+      await resolveChannelServerUri(target.contentServerUrl),
+      testInfo.parallelIndex
+    );
+
+    await use(supplicant);
+
+    await supplicant.close();
   },
 });
 

--- a/packages/functional-tests/lib/marionette-firefox.ts
+++ b/packages/functional-tests/lib/marionette-firefox.ts
@@ -98,10 +98,18 @@ export class MarionetteFirefox {
       args.push('--headless');
     }
 
+    // Diagnostic: set MARIONETTE_LOG to capture the authority's stdout (content
+    // console.log, via devtools.console.stdout.content) to a file.
+    const logPath = process.env.MARIONETTE_LOG;
     const proc = spawn(firefoxBinary, args, {
-      stdio: 'ignore',
+      stdio: logPath ? ['ignore', 'pipe', 'pipe'] : 'ignore',
       detached: false,
     });
+    if (logPath && proc.stdout && proc.stderr) {
+      const ws = fs.createWriteStream(logPath, { flags: 'a' });
+      proc.stdout.pipe(ws);
+      proc.stderr.pipe(ws);
+    }
 
     try {
       // Wait for Marionette port to become available
@@ -216,9 +224,18 @@ function buildPrefs(
     // Auto-handle unexpected dialogs (dismiss by default)
     'marionette.prefs.recommended': true,
 
-    // Pairing
+    // Pairing. version=2 lets chrome accept the v2 pair_oauth_start /
+    // pair_oauth_finish web-channel commands (gated by _ensurePairingEnabled).
     'identity.fxaccounts.pairing.enabled': true,
+    'identity.fxaccounts.pairing.version': 2,
     'identity.fxaccounts.remote.pairing.uri': channelServerUri,
+
+    // Diagnostic: route content console.log to the process stdout so the
+    // authority's [pair2] logs can be captured (see MARIONETTE_LOG).
+    'devtools.console.stdout.content': true,
+    // Diagnostic: FxAccounts chrome logs (pairing + oauth) to dump/stdout.
+    'identity.fxaccounts.loglevel': 'Trace',
+    'identity.fxaccounts.log.appender.dump': 'Trace',
 
     // Browser chrome — suppress UI that interferes with automation
     'datareporting.policy.dataSubmissionEnabled': false,

--- a/packages/functional-tests/lib/marionette.ts
+++ b/packages/functional-tests/lib/marionette.ts
@@ -366,12 +366,14 @@ export class MarionetteClient {
   }
 
   /**
-   * Take a screenshot of the current page.
-   * Returns the screenshot as a base64-encoded PNG string.
+   * Screenshot a single element, returned as a base64-encoded PNG.
+   *
+   * Scoped to the element rather than the viewport so the caller gets just
+   * that node's pixels, which is what an image decoder needs.
    */
-  async takeScreenshot(): Promise<string> {
+  async screenshotElement(elementId: string): Promise<string> {
     const result = await this.sendCommandWithRetry('WebDriver:TakeScreenshot', {
-      full: true,
+      id: elementId,
     });
     return this.extractValue(result) as string;
   }

--- a/packages/functional-tests/lib/pairing-constants.ts
+++ b/packages/functional-tests/lib/pairing-constants.ts
@@ -19,9 +19,39 @@ export const TIMEOUTS = {
   SIGNED_IN_CHECK: 15_000,
   SUPPLICANT_ALLOW: 30_000,
   AUTHORITY_COMPLETE: 15_000,
+  // A v2 handshake step spans a channel-server round trip between two separate
+  // browsers, so it needs more headroom than a same-browser navigation.
+  PAIR_V2_HANDSHAKE: 45_000,
   POLL_INTERVAL: 500,
   POLL_INTERVAL_MAX: 2_000,
 } as const;
+
+// ---- v2 pairing (FXA-12855) ----
+// The v2 flow moves the authority into FxA web content. These constants cover
+// the v2 routes and QR URL format; v1 constants above are unchanged.
+//
+// Route source of truth is App/index.tsx (code takes precedence over the ticket
+// prose, which uses "/pair2/..." and "approve_sign_in").
+export const PAIR_V2_ROUTES = {
+  AUTHORITY_SCAN_QR: '/pair/authority/scan_qr',
+  AUTHORITY_APPROVE_SIGNIN: '/pair/authority/approve_signin',
+  AUTHORITY_CONTINUE_ON_MOBILE: '/pair/authority/continue_on_mobile',
+  AUTHORITY_SYNC_SUCCESS: '/pair/authority/sync_success',
+  AUTHORITY_TIMEOUT_AND_CANCEL: '/pair/authority/timeout_and_cancel',
+  SUPPLICANT_APPROVE_SIGNIN: '/pair/supplicant/approve_signin',
+  SUPPLICANT_CONNECT_THIS_DEVICE: '/pair/supplicant/connect_this_device',
+  SUPPLICANT_READY_TO_SCAN: '/pair/supplicant/ready_to_scan',
+  SUPPLICANT_SYNC_SUCCESS: '/pair/supplicant/sync_success',
+  SUPPLICANT_TIMEOUT_AND_CANCEL: '/pair/supplicant/timeout_and_cancel',
+} as const;
+
+// v2 QR URL format, confirmed by FXA-13868 AC:
+//   https://<host>/pair#channel_id=<id>&channel_key=<key>&v=2
+// i.e. the v1 fragment plus the v2 marker.
+export const PAIR_V2_URL_MARKER = 'v=2';
+
+/** Browser pref that decides the pairing version Firefox reports and accepts. */
+export const PAIRING_VERSION_PREF = 'identity.fxaccounts.pairing.version';
 
 export const SELECTORS = {
   EMAIL_INPUT: [

--- a/packages/functional-tests/lib/pairing-helpers.ts
+++ b/packages/functional-tests/lib/pairing-helpers.ts
@@ -13,8 +13,11 @@
  * characters (e.g. em dashes), causing parse failures.
  */
 
+import { writeFileSync } from 'fs';
 import crypto from 'crypto';
-import { Browser, expect, Page } from '@playwright/test';
+import jsQR from 'jsqr';
+import UPNG from 'upng-js';
+import { Browser, expect, Page, TestInfo } from '@playwright/test';
 import { ConfigPage } from '../pages/config';
 import { BaseTarget } from './targets/base';
 import { MarionetteClient } from './marionette';
@@ -22,6 +25,7 @@ import {
   PAIRING_CLIENT_ID,
   PAIRING_REDIRECT_URI,
   PAIRING_SCOPE,
+  PAIRING_VERSION_PREF,
   SELECTORS,
   TIMEOUTS,
 } from './pairing-constants';
@@ -74,7 +78,8 @@ export async function isPairRoutesReact(
 async function pollUntil<T>(
   check: () => Promise<T | undefined>,
   timeoutMs: number,
-  label: string
+  // A thunk lets the caller include state it only knows after the last poll.
+  label: string | (() => string)
 ): Promise<T> {
   const start = Date.now();
   let interval: number = TIMEOUTS.POLL_INTERVAL;
@@ -92,7 +97,8 @@ async function pollUntil<T>(
   }
 
   const suffix = lastError ? ` Last error: ${lastError.message}` : '';
-  throw new Error(`${label} after ${timeoutMs}ms.${suffix}`);
+  const text = typeof label === 'function' ? label() : label;
+  throw new Error(`${text} after ${timeoutMs}ms.${suffix}`);
 }
 
 /**
@@ -103,13 +109,15 @@ export async function waitForUrlContaining(
   substring: string,
   timeoutMs: number = TIMEOUTS.AUTHORITY_COMPLETE
 ): Promise<string> {
+  let lastUrl = '';
   return pollUntil(
     async () => {
-      const url = await client.getUrl();
-      return url.includes(substring) ? url : undefined;
+      lastUrl = await client.getUrl();
+      return lastUrl.includes(substring) ? lastUrl : undefined;
     },
     timeoutMs,
-    `URL did not contain "${substring}"`
+    // The URL it stalled on is the first thing you need when this fails.
+    () => `URL did not contain "${substring}" (last seen: ${lastUrl})`
   );
 }
 
@@ -151,10 +159,14 @@ export async function waitForSignedInState(
 /**
  * Sign in to FxA Sync via the content server web UI using Marionette.
  *
- * Uses Firefox's internal beginOAuthFlow() to generate PKCE + keys_jwk
- * and register the OAuth flow, then signs in through the content server UI.
- * After sign-in, Firefox processes the fxaccounts:oauth_login WebChannel
- * message and completes the key exchange automatically.
+ * Drives /pair, which asks Firefox for the OAuth params over the web channel
+ * and redirects to the sign-in form carrying them, then fills that form. After
+ * sign-in, Firefox processes the fxaccounts:oauth_login WebChannel message and
+ * completes the key exchange automatically.
+ *
+ * Every step runs in content, so Marionette is only the remoting protocol here.
+ * Playwright cannot replace it while the authority must be a custom Firefox
+ * build: Playwright drives its own Juggler-patched builds only.
  */
 export async function signInAuthorityViaMarionette(
   client: MarionetteClient,
@@ -164,61 +176,13 @@ export async function signInAuthorityViaMarionette(
   totpSecret?: string,
   useReact = false
 ): Promise<void> {
-  // Use Firefox's internal beginOAuthFlow() to generate PKCE + keys_jwk
-  // and register the OAuth flow so Firefox can complete the key exchange
-  // when the content server sends fxaccounts:oauth_login via WebChannel.
-  // Requires Playwright's bundled Firefox (125+).
-  await client.setContext('chrome');
-  const oauthResult = await client.executeAsyncScript(
-    `
-    const [resolve] = arguments;
-    (async () => {
-      try {
-        const { getFxAccountsSingleton } = ChromeUtils.importESModule(
-          "resource://gre/modules/FxAccounts.sys.mjs"
-        );
-        const fxAccounts = getFxAccountsSingleton();
-        const scopes = ["profile", "https://identity.mozilla.com/apps/oldsync"];
-        const result = await fxAccounts._internal.beginOAuthFlow(scopes);
-        resolve(JSON.stringify({ success: true, ...result }));
-      } catch (e) {
-        resolve(JSON.stringify({
-          success: false,
-          error: e.message,
-          stack: (e.stack || "").substring(0, 500),
-        }));
-      }
-    })();
-    `,
-    { sandbox: 'system', timeoutMs: TIMEOUTS.ASYNC_SCRIPT }
-  );
-
-  if (typeof oauthResult !== 'string') {
-    throw new Error(
-      `Expected string from beginOAuthFlow, got ${typeof oauthResult}`
-    );
-  }
-  const oauthData = JSON.parse(oauthResult);
-  if (!oauthData.success) {
-    throw new Error(`beginOAuthFlow failed: ${oauthData.error}`);
-  }
-
-  // Build the sign-in URL from the OAuth params Firefox generated
-  const params = new URLSearchParams({
-    context: 'oauth_webchannel_v1',
-    entrypoint: 'fxa_discoverability_native',
-    action: 'email',
-    service: 'sync',
-    client_id: oauthData.client_id,
-    scope: oauthData.scope || PAIRING_SCOPE,
-    state: oauthData.state,
-    code_challenge: oauthData.code_challenge,
-    code_challenge_method: oauthData.code_challenge_method || 'S256',
-    keys_jwk: oauthData.keys_jwk,
-    access_type: 'offline',
-    response_type: 'code',
-  });
-  const signinUrl = `${contentServerUrl}/?${params}${useReact ? '&showReactApp=true' : ''}`;
+  // Navigating to /pair is enough to start a Sync sign-in: the page sends
+  // fxaccounts:oauth_flow_begin over the web channel, Firefox answers with the
+  // OAuth params, and the page redirects to the sign-in form already carrying
+  // them. Building that URL here from a chrome-context beginOAuthFlow() call
+  // duplicated what the page does, and was the only part of this flow that
+  // needed chrome privileges.
+  const signinUrl = `${contentServerUrl}/pair${useReact ? '?showReactApp=true' : ''}`;
 
   try {
     await client.setContext('content');
@@ -473,6 +437,81 @@ export function extractChannelId(pairUrl: string): string {
 }
 
 /**
+ * Drive a signed-in Marionette authority through the v2 entrypoint to the
+ * scan_qr page and return the encoded pairing URL from the rendered QR.
+ *
+ * v2 has no chrome-side pairing flow (contrast v1 `startPairingFlow`, which calls
+ * `FxAccountsPairingFlow.start()`). The authority mints the channel in web
+ * content on `/pair/authority/scan_qr` (FXA-13868) and encodes it into the QR.
+ * The test screenshots that QR and decodes it, so it reads the same value a
+ * user's phone would, not one the page reports about itself.
+ *
+ * CONTRACT: scan_qr must render the code inside `data-testid="pairing-qr"`, and
+ * that element must include the quiet zone around the code. Decoding fails
+ * without the quiet zone.
+ *
+ * Requires an eligible entrypoint (Sync context + a pairing entrypoint), so the
+ * caller passes the same query string the real Firefox menu entrypoint sends.
+ */
+export async function startPairingFlowV2(
+  client: MarionetteClient,
+  contentServerUrl: string,
+  eligibleEntrypointQs: string
+): Promise<string> {
+  await client.setContext('content');
+  await client.navigate(
+    `${contentServerUrl}/connect_another_device?${eligibleEntrypointQs}&v=2`
+  );
+  await waitForUrlContaining(client, '/pair/authority/scan_qr');
+
+  // Decode the QR the page actually renders, rather than reading the value
+  // out of a test-only attribute. A side channel would still agree with the
+  // page when the rendered code encodes something else, which is the one
+  // thing this card can get wrong.
+  //
+  // Shoot the wrapper, not the svg inside it: the wrapper carries the quiet
+  // zone the QR spec requires, and jsQR cannot find the finder patterns
+  // without it.
+  return pollUntil(
+    async () => {
+      const el = await client
+        .findElement('css selector', '[data-testid="pairing-qr"]')
+        .catch(() => undefined);
+      if (!el) return undefined;
+      const png = Buffer.from(await client.screenshotElement(el), 'base64');
+      const img = UPNG.decode(png);
+      const decoded = jsQR(
+        new Uint8ClampedArray(UPNG.toRGBA8(img)[0]),
+        img.width,
+        img.height
+      );
+      return decoded?.data.includes('channel_id=') ? decoded.data : undefined;
+    },
+    TIMEOUTS.ASYNC_SCRIPT,
+    'scan_qr did not render a decodable v2 pairing QR'
+  );
+}
+
+/**
+ * Extract channel_id from a v2 pairing QR URL, asserting the v=2 marker is
+ * present. Use this over {@link extractChannelId} when the test must prove the
+ * QR is a v2 QR and not a v1 one.
+ */
+export function extractChannelIdV2(pairUrl: string): string {
+  const hash = pairUrl.split('#')[1];
+  if (!hash) throw new Error('No fragment in v2 pair URL');
+
+  const params = new URLSearchParams(hash);
+  if (params.get('v') !== '2') {
+    throw new Error(`v2 pair URL missing v=2 marker: ${hash}`);
+  }
+  const channelId = params.get('channel_id');
+  if (!channelId) throw new Error('No channel_id in v2 pair URL');
+
+  return channelId;
+}
+
+/**
  * Build the authority OAuth URL that navigates the authority to the
  * pairing approval page.
  *
@@ -660,33 +699,6 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Take a screenshot of the authority browser via Marionette and write it
- * to the artifacts directory for debugging. Only writes when PAIRING_DEBUG=1.
- */
-export async function screenshotAuthority(
-  client: MarionetteClient,
-  prefix: string,
-  step: string
-): Promise<void> {
-  if (!process.env.PAIRING_DEBUG) {
-    return;
-  }
-  try {
-    const fs = await import('fs');
-    const path = await import('path');
-    const base64 = await client.takeScreenshot();
-    const dir = path.join(process.cwd(), '..', '..', 'artifacts', 'functional');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, `${prefix}-${step}.png`),
-      Buffer.from(base64, 'base64')
-    );
-  } catch {
-    // best-effort
-  }
-}
-
-/**
  * Verify the /pair index choice screen renders correctly after sign-in.
  *
  * The authority should already be on /pair after signInAuthorityViaMarionette.
@@ -818,4 +830,210 @@ export async function completeSupplicantApproval(
     TIMEOUTS.AUTHORITY_COMPLETE
   );
   expect(finalAuthUrl).not.toContain('pair/failure');
+}
+
+/**
+ * Set the pairing version pref in the running browser.
+ *
+ * `FxAccountsWebChannel` reads this through `defineLazyPreferenceGetter`, which
+ * observes changes, so flipping it at runtime takes effect on the next command
+ * and there is no need for a second browser with different prefs.
+ */
+export async function setPairingVersion(
+  client: MarionetteClient,
+  version: number
+): Promise<void> {
+  await client.setContext('chrome');
+  await client.executeScript(
+    `Services.prefs.setIntPref(arguments[0], arguments[1]);`,
+    { sandbox: 'system', args: [PAIRING_VERSION_PREF, version] }
+  );
+}
+
+/**
+ * Read `config.pairing.version` as the content server serves it.
+ *
+ * The value comes from convict (`PAIRING_VERSION`) and is baked into the page
+ * at server boot, so a test cannot change it. Tests that need version 2 read
+ * it to decide whether to run. Uses a real page for the same WAF reason as
+ * `isPairRoutesReact`; defaults to 1 when the config omits the value.
+ */
+export async function getServedPairingVersion(
+  browser: Browser,
+  target: BaseTarget
+): Promise<number> {
+  const extraHTTPHeaders: Record<string, string> = {};
+  target.ciHeader?.forEach((value, key) => {
+    extraHTTPHeaders[key] = value;
+  });
+  const context = await browser.newContext({ extraHTTPHeaders });
+  const page = await context.newPage();
+  try {
+    const config = await new ConfigPage(page, target).getConfig();
+    return config?.pairing?.version ?? 1;
+  } finally {
+    await context.close();
+  }
+}
+
+/**
+ * Pref the supplicant shim records the captured oauth_login payload in, so a
+ * later Marionette call can read it back out of chrome.
+ */
+const CAPTURED_OAUTH_LOGIN_PREF = 'fxa.functional-tests.captured-oauth-login';
+
+/**
+ * A Fenix user agent, so a borrowed desktop Firefox reports the mobile client it
+ * is standing in for.
+ */
+const FENIX_USER_AGENT =
+  'Mozilla/5.0 (Android 13; Mobile; rv:140.0) Gecko/140.0 Firefox/140.0';
+
+/**
+ * Present the supplicant browser as Fenix.
+ *
+ * A scanned QR carries no query, so the supplicant derives its client id from
+ * the User-Agent. Left as desktop it reports the Firefox Desktop id, which the
+ * server's `pairing.clients` allowlist excludes, and the authority rejects the
+ * request on arrival.
+ *
+ * Declaring it through the UA rather than a `client_id` query param is
+ * deliberate: `onConnect` navigates with a plain `navigate()`, which drops the
+ * query, and losing `client_id` mid-flow makes `useClientInfoState` recompute
+ * and `useIntegration` rebuild the integration — taking the live channel and the
+ * authority's metadata with it. The UA survives the navigation, so the flow
+ * behaves like the real mobile supplicant it stands for.
+ */
+export async function setSupplicantUserAgent(
+  client: MarionetteClient,
+  userAgent = FENIX_USER_AGENT
+): Promise<void> {
+  await client.setContext('chrome');
+  await client.executeScript(
+    `Services.prefs.setStringPref("general.useragent.override", arguments[0]);`,
+    { sandbox: 'system', args: [userAgent] }
+  );
+}
+
+/**
+ * Make a desktop Firefox usable as a v2 pairing supplicant.
+ *
+ * Desktop chrome implements the pairing *authority* only: its `oauth_login`
+ * handler reads `uid`/`sessionToken` off the existing account and completes the
+ * flow with them, so on an account-less supplicant it throws
+ * "null has no properties" and the browser never signs in. Everything else the
+ * supplicant needs is real, so replace just that one handler: capture the code
+ * and state the authority granted, and let the page finish.
+ *
+ * Leaves `pair_oauth_start`, the channel, and the authority's
+ * `pair_oauth_finish` untouched, so the handshake under test is the real one.
+ */
+export async function mockSupplicantOAuthLogin(
+  client: MarionetteClient
+): Promise<void> {
+  await client.setContext('chrome');
+  await client.executeScript(
+    `
+    const pref = arguments[0];
+    const { FxAccountsWebChannelHelpers } = ChromeUtils.importESModule(
+      "resource://gre/modules/FxAccountsWebChannel.sys.mjs"
+    );
+    Services.prefs.setStringPref(pref, "");
+    FxAccountsWebChannelHelpers.prototype.oauthLogin = async function (data) {
+      Services.prefs.setStringPref(pref, JSON.stringify(data || {}));
+    };
+    `,
+    { sandbox: 'system', args: [CAPTURED_OAUTH_LOGIN_PREF] }
+  );
+}
+
+/** What the supplicant's chrome received on `oauth_login`. */
+export type CapturedOAuthLogin = {
+  code?: string;
+  state?: string;
+  action?: string;
+};
+
+/**
+ * Read back what the supplicant's chrome received on `oauth_login`, polling
+ * because the page sends it without waiting for a reply.
+ */
+export async function readCapturedOAuthLogin(
+  client: MarionetteClient,
+  timeoutMs = 30_000
+): Promise<CapturedOAuthLogin | undefined> {
+  await client.setContext('chrome');
+
+  const deadline = Date.now() + timeoutMs;
+  do {
+    // The shim leaves the pref empty until the message arrives. Anything other
+    // than a non-empty string means the read itself failed, so keep polling
+    // rather than parsing it: `String(null)` would be a truthy "null".
+    let raw: unknown;
+    try {
+      raw = await client.executeScript(
+        `return Services.prefs.getStringPref(arguments[0], "");`,
+        { sandbox: 'system', args: [CAPTURED_OAUTH_LOGIN_PREF] }
+      );
+    } catch {
+      // Transient Marionette error, e.g. mid-navigation. Poll again.
+      raw = undefined;
+    }
+    if (typeof raw === 'string' && raw) {
+      return JSON.parse(raw) as CapturedOAuthLogin;
+    }
+    await sleep(1_000);
+  } while (Date.now() < deadline);
+  return undefined;
+}
+
+/**
+ * Mask the pairing channel key.
+ *
+ * `channel_key` is the shared secret for the channel: whoever has it plus the
+ * channel id can join as a supplicant. CI keeps failure artifacts far longer
+ * than the channel lives, so it must not travel into one.
+ */
+export function redactChannelKey(text: string): string {
+  return text.replace(/(channel_key=)[^&\s]+/g, '$1<redacted>');
+}
+
+/**
+ * Attach the browser's URL and a screenshot of its page body when a test fails.
+ */
+export async function attachAuthorityDiagnostics(
+  client: MarionetteClient,
+  testInfo: TestInfo,
+  // Names the attachments, so a test driving both halves over Marionette does
+  // not have the second browser overwrite the first one's files.
+  role: 'authority' | 'supplicant' = 'authority'
+): Promise<void> {
+  // A skipped test has no failure to explain, and its browsers are still blank.
+  if (testInfo.status === 'skipped') {
+    return;
+  }
+  if (testInfo.status === testInfo.expectedStatus) {
+    return;
+  }
+
+  const save = async (name: string, body: string | Buffer, type: string) => {
+    const file = testInfo.outputPath(name);
+    writeFileSync(file, body);
+    await testInfo.attach(name, { path: file, contentType: type });
+  };
+
+  try {
+    await client.setContext('content');
+    await save(
+      `${role}-url.txt`,
+      redactChannelKey(await client.getUrl()),
+      'text/plain'
+    );
+
+    const body = await client.findElement('css selector', 'body');
+    const png = Buffer.from(await client.screenshotElement(body), 'base64');
+    await save(`${role}-page.png`, png, 'image/png');
+  } catch {
+    // Diagnostics must never mask the real failure.
+  }
 }

--- a/packages/functional-tests/tests/pairing/CLAUDE.md
+++ b/packages/functional-tests/tests/pairing/CLAUDE.md
@@ -10,7 +10,7 @@ the same ground framed for developers doing manual, by-hand device testing.)
 Pairing connects a signed-in desktop Firefox (the **authority**) to a mobile
 Firefox (the **supplicant**) over a short-lived channel. The specs drive both
 sides: a Marionette-controlled desktop Firefox as the authority, and a real
-mobile app as the supplicant.
+mobile app or a Playwright page as the supplicant.
 
 - `pairingFlowAndroid.spec.ts` + `lib/android-supplicant.ts` (adb-driven Fenix).
 - `pairingFlowiOS.spec.ts` (Simulator + XCUITest-driven Firefox iOS).
@@ -31,9 +31,12 @@ mobile app's FxA-server override.
 mza` for a faster core subset). Needs Docker; `yarn start infrastructure` if it
   isn't up. Provides content-server :3030, auth-server :9000; Fenix/iOS client
   ids are registered in `packages/fxa-auth-server/config/dev.json`.
-- **Playwright's Firefox** (the authority): pulled by `yarn install` in
-  `packages/functional-tests`; if missing, `npx playwright install firefox`.
-  Override the binary with `FIREFOX_BINARY`.
+- **The authority browser** (Marionette): the v1 specs run on Playwright's
+  bundled Firefox, pulled by `yarn install`. The **v2** specs need **Firefox
+  Nightly**, because the v2 chrome commands ship there; they skip without it.
+  Install it from https://www.mozilla.org/firefox/channel/desktop/#nightly.
+  `lib/firefox-binary.ts` finds it at the default install path and falls back to
+  the bundled build. Override with `FIREFOX_BINARY`.
 - **Android:** a booted emulator/device (`adb devices` lists it) with a Fenix
   debug build that has the Sync Debug pairing hook (`org.mozilla.fenix.debug`;
   hook landed in Bug 2053454, so a current debug build already has it). Build +

--- a/packages/functional-tests/tests/pairing/pairChoice.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairChoice.spec.ts
@@ -3,7 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FirefoxCommand } from '../../lib/channels';
-import { test, expect } from '../../lib/fixtures/standard';
+import { Page, expect } from '../../lib/fixtures/standard';
+import { test } from '../../lib/fixtures/pairing';
+import { findV2AuthorityBinary } from '../../lib/firefox-binary';
+import { MarionetteClient } from '../../lib/marionette';
+import { PAIR_V2_ROUTES, SELECTORS } from '../../lib/pairing-constants';
+import {
+  findElementBySelectors,
+  getServedPairingVersion,
+  setPairingVersion,
+  signInAuthorityViaMarionette,
+  waitForUrlContaining,
+} from '../../lib/pairing-helpers';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { SettingsPage } from '../../pages/settings';
+import { SigninPage } from '../../pages/signin';
+
+// What the Firefox app-menu entry sends; /connect_another_device requires an
+// eligible entrypoint to consider pairing at all.
+const ELIGIBLE_ENTRYPOINT_QS =
+  'context=oauth_webchannel_v1&entrypoint=fxa_app_menu';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Pair entry flow', () => {
@@ -67,5 +86,138 @@ test.describe('severity-2 #smoke', () => {
       await settings.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       await settings.checkWebChannelMessage(FirefoxCommand.OAuthFlowBegin);
     });
+
+    /**
+     * Settings "Connect a device" is the other way into pairing. The CTA is
+     * gated to desktop Firefox (isFirefox && !isMobile).
+     *
+     * Note: the link currently targets /pair (v1). Carrying `?v=2` when the v2
+     * pref is on is FXA-14289 / FXA-13869 work not yet wired into this link;
+     * when it lands, extend this to assert the v2 target.
+     */
+    test('Settings "Connect a device" launches the pair flow', async ({
+      target,
+      page,
+      pages: { signin, settings },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
+
+      await settings.goto();
+
+      // The CTA is gated to desktop Firefox; the functional-test browser qualifies.
+      const connectDevice = page.locator(
+        '[data-glean-id="account_pref_connect_device_submit"]'
+      );
+      await expect(connectDevice).toBeVisible();
+      await expect(connectDevice).toHaveAttribute('href', /\/pair/);
+
+      await connectDevice.click();
+      await page.waitForURL(/\/pair(\?|#|$)/);
+    });
+  });
+
+  /**
+   * The authority enters v2 only when FxA and the browser agree, via
+   * `capabilities.pairingVersion` in the fxa_status reply. Playwright's own
+   * build omits it and reads as v1, so these need Marionette on Nightly.
+   *
+   * No URL here carries `v=2`: the supplicant hand-off has no such override, so
+   * negotiation is the only way into the v2 flow.
+   */
+  test.describe.serial('v2 pairing version negotiation', () => {
+    let servedVersion = 1;
+
+    // Baked in at server boot, so a test cannot change it.
+    test.beforeAll(async ({ browser, target }) => {
+      servedVersion = await getServedPairingVersion(browser, target);
+    });
+
+    test.beforeEach(() => {
+      test.skip(
+        !findV2AuthorityBinary(),
+        'Firefox Nightly not found — install it, or set FIREFOX_BINARY to a v2-capable build'
+      );
+      test.skip(
+        servedVersion !== 2,
+        `Needs the stack to serve config.pairing.version=2 (serving ${servedVersion})`
+      );
+    });
+
+    async function signInAtVersion(
+      client: MarionetteClient,
+      contentServerUrl: string,
+      version: number,
+          credentials: Pick<Credentials, 'email' | 'password'>
+    ) {
+      await setPairingVersion(client, version);
+      await signInAuthorityViaMarionette(
+        client,
+        contentServerUrl,
+        credentials.email,
+        credentials.password
+      );
+      // Sign-in ends on a chrome-context check, and navigate() needs content.
+      await client.setContext('content');
+    }
+
+    // Each authority entry negotiates separately. /pair is where Settings
+    // "Connect a device" and the post-signin handoffs land.
+    for (const entry of ['/connect_another_device', '/pair']) {
+      test(`a v2 browser skips the choice screen on ${entry}`, async ({
+        target,
+        testAccountTracker,
+        marionetteAuthority,
+      }) => {
+        const client = marionetteAuthority.client;
+        const credentials = await testAccountTracker.signUp();
+        await signInAtVersion(client, target.contentServerUrl, 2, credentials);
+
+        await client.navigate(
+          `${target.contentServerUrl}${entry}?${ELIGIBLE_ENTRYPOINT_QS}`
+        );
+
+        const url = await waitForUrlContaining(
+          client,
+          PAIR_V2_ROUTES.AUTHORITY_SCAN_QR
+        );
+        // Reached on capability alone; nothing here asked for v2.
+        expect(url).not.toContain('v=2');
+      });
+    }
+
+    // Without this, a branch that always fired would pass the two above.
+    test('a v1 browser still gets the choice screen', async ({
+      target,
+      testAccountTracker,
+      marionetteAuthority,
+    }) => {
+      const client = marionetteAuthority.client;
+      const credentials = await testAccountTracker.signUp();
+      await signInAtVersion(client, target.contentServerUrl, 1, credentials);
+
+      await client.navigate(
+        `${target.contentServerUrl}/connect_another_device?${ELIGIBLE_ENTRYPOINT_QS}`
+      );
+
+      // Renders only once negotiation finishes, so this waits for the URL check.
+      await findElementBySelectors(client, SELECTORS.PAIR_RADIO_HAS_MOBILE);
+      expect(await client.getUrl()).not.toContain('/pair/authority');
+    });
   });
 });
+
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  settings: SettingsPage,
+  signin: SigninPage,
+  credentials: Credentials
+): Promise<void> {
+  await page.goto(target.contentServerUrl);
+  await signin.fillOutEmailFirstForm(credentials.email);
+  await signin.fillOutPasswordForm(credentials.password);
+  await page.waitForURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
+}

--- a/packages/functional-tests/tests/pairing/pairingFlow.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlow.spec.ts
@@ -31,6 +31,7 @@ import { MarionetteClient } from '../../lib/marionette';
 import { SELECTORS, TIMEOUTS } from '../../lib/pairing-constants';
 import {
   signInAuthorityViaMarionette,
+  setPairingVersion,
   getSignedInUser,
   startPairingFlow,
   buildSupplicantUrl,
@@ -112,6 +113,10 @@ test.describe('severity-2 #smoke', () => {
       marionetteAuthority,
     }) => {
       const client = marionetteAuthority.client;
+      // /pair negotiates into the v2 flow when FxA and the browser both report
+      // version 2, which this stack does. Opt the browser down so this spec
+      // still exercises v1.
+      await setPairingVersion(client, 1);
 
       const credentials = await test.step('Create test account', async () => {
         return await testAccountTracker.signUp();
@@ -184,6 +189,10 @@ test.describe('severity-2 #smoke', () => {
       marionetteAuthority,
     }) => {
       const client = marionetteAuthority.client;
+      // /pair negotiates into the v2 flow when FxA and the browser both report
+      // version 2, which this stack does. Opt the browser down so this spec
+      // still exercises v1.
+      await setPairingVersion(client, 1);
 
       const { credentials, secret } =
         await test.step('Create test account with TOTP', async () => {

--- a/packages/functional-tests/tests/pairing/pairingFlowV2.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowV2.spec.ts
@@ -1,0 +1,325 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * v2 pairing end to end, desktop to desktop: the happy path and the
+ * supplicant-cancel path.
+ *
+ * Both halves are real Firefox Nightly instances driven over Marionette. The
+ * authority runs the real chrome fxaccounts:pair_oauth_finish and the supplicant
+ * the real fxaccounts:pair_oauth_start, so the PKCE material, the channel and
+ * the granted code are all genuine.
+ *
+ * Two things are stood in for, both because desktop Firefox is a pairing
+ * *authority* only and this spec borrows it as a supplicant. Nothing that the
+ * FxA flow itself owns is faked.
+ *
+ * 1. The supplicant's User-Agent, set to Fenix. A scanned QR carries no query, so
+ *    the supplicant derives its client id from the UA, and a desktop UA yields
+ *    the Firefox Desktop id. That id is a native client but is not in the
+ *    server's `pairing.clients` allowlist, so `validateSupplicantRequest`
+ *    rejects the request on arrival — correctly: Firefox mints the code *for
+ *    that client*, so the allowlist is what stops a code carrying the account's
+ *    Sync keys reaching an unintended one. The UA is the stand-in rather than a
+ *    `client_id` query param because `onConnect` navigates with a plain
+ *    `navigate()`, which drops the query; losing `client_id` mid-flow rebuilds
+ *    the integration and discards the live channel.
+ *
+ * 2. The supplicant's `oauth_login` handler, replaced with a recorder. Chrome's
+ *    real handler completes the flow with the signed-in account's session token,
+ *    which an account-less supplicant does not have, so it throws and the browser
+ *    never signs in. Recording the message instead lets the test assert on the
+ *    code the authority actually granted.
+ *
+ * What stays real: the channel, the supplicant's `pair_oauth_start` and its PKCE
+ * and ECDH material, the authority's `pair_oauth_finish` and the code it mints,
+ * every pairing-channel message, and all of the FxA routing on both sides. The
+ * real mobile supplicant path is covered by `pairingFlowV2Android.spec.ts`.
+ *
+ * Prerequisites: FXA stack started with PAIRING_VERSION=2, Firefox Nightly (or
+ * FIREFOX_BINARY at a v2-capable build), and network to the channel server. The
+ * authority reaches scan_qr through the ?v=2 escape hatch on
+ * /connect_another_device; the supplicant hand-off on /pair has no such hatch,
+ * so the server config is what opens the supplicant half. Skips without
+ * Nightly, so it does not run in CI.
+ *
+ * Both cases share the same topology and setup, so they live together rather
+ * than in a second spec that would launch its own pair of browsers.
+ */
+
+import { findV2AuthorityBinary } from '../../lib/firefox-binary';
+import { test, expect } from '../../lib/fixtures/pairing';
+import { MarionetteClient } from '../../lib/marionette';
+import { PAIR_V2_ROUTES, TIMEOUTS } from '../../lib/pairing-constants';
+import {
+  signInAuthorityViaMarionette,
+  getSignedInUser,
+  startPairingFlowV2,
+  waitForUrlContaining,
+  attachAuthorityDiagnostics,
+  mockSupplicantOAuthLogin,
+  readCapturedOAuthLogin,
+  setSupplicantUserAgent,
+  sleep,
+} from '../../lib/pairing-helpers';
+
+const ELIGIBLE_ENTRYPOINT_QS =
+  'context=oauth_webchannel_v1&entrypoint=fxa_app_menu';
+
+// Set PAIRING_WATCH_MS (e.g. 4000) to pause on each page so the flow is
+// watchable in headed mode. Default 0 keeps normal runs fast.
+const WATCH_MS = parseInt(process.env.PAIRING_WATCH_MS || '0', 10);
+
+// Two real browsers, an OAuth sign-in and a full channel handshake.
+test.setTimeout(240_000);
+
+/**
+ * Click once the button is present and enabled.
+ *
+ * The supplicant's buttons render `disabled` until the authority's metadata
+ * arrives, and Marionette does not error when told to click a disabled button —
+ * it silently does nothing, and the test then fails later at an unrelated wait.
+ */
+async function clickByTestId(client: MarionetteClient, testId: string) {
+  const selector = `[data-testid="${testId}"]`;
+  const deadline = Date.now() + TIMEOUTS.ELEMENT_FIND;
+  let lastError = '';
+
+  do {
+    try {
+      const el = await client.findElement('css selector', selector);
+      if ((await client.getElementAttribute(el, 'disabled')) === null) {
+        await client.clickElement(el);
+        return;
+      }
+      lastError = 'still disabled';
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    await sleep(500);
+  } while (Date.now() < deadline);
+
+  throw new Error(`Could not click ${selector}: ${lastError}`);
+}
+
+test.describe('severity-2 #smoke', () => {
+  test.describe.serial('v2 pairing flow', () => {
+    test.beforeEach(() => {
+      test.skip(
+        !findV2AuthorityBinary(),
+        'Firefox Nightly not found — install it, or set FIREFOX_BINARY to a v2-capable build'
+      );
+    });
+
+    // Both cases need the supplicant to report the mobile client it stands for,
+    // before it opens anything.
+    test.beforeEach(async ({ marionetteSupplicant }) => {
+      await setSupplicantUserAgent(marionetteSupplicant.client);
+    });
+
+    // Both browsers run under Marionette, so Playwright's own failure artifacts
+    // capture nothing from either. Attach each one's URL and page.
+    //
+    // Taking the browsers from the test body rather than as hook parameters is
+    // deliberate: a hook that destructures a fixture forces Playwright to build
+    // it, which on the skip path above would launch two browsers for a test
+    // that never runs.
+    let clients: { authority: MarionetteClient; supplicant: MarionetteClient };
+
+    test.afterEach(async ({}, testInfo) => {
+      if (!clients) return;
+      await attachAuthorityDiagnostics(clients.authority, testInfo, 'authority');
+      await attachAuthorityDiagnostics(
+        clients.supplicant,
+        testInfo,
+        'supplicant'
+      );
+      clients = undefined as never;
+    });
+
+    test('happy path: both sides complete the handshake and the supplicant is granted a code', async ({
+      target,
+      testAccountTracker,
+      marionetteAuthority,
+      marionetteSupplicant,
+    }) => {
+      const authority = marionetteAuthority.client;
+      const supplicant = marionetteSupplicant.client;
+      clients = { authority, supplicant };
+
+      await test.step('Authority signs in', async () => {
+        const creds = await testAccountTracker.signUp();
+        await signInAuthorityViaMarionette(
+          authority,
+          target.contentServerUrl,
+          creds.email,
+          creds.password
+        );
+        expect((await getSignedInUser(authority)).signedIn).toBe(true);
+      });
+
+      const pairUrl = await test.step('Authority mints the v2 QR', async () => {
+        const url = await startPairingFlowV2(
+          authority,
+          target.contentServerUrl,
+          ELIGIBLE_ENTRYPOINT_QS
+        );
+        expect(url).toContain('channel_id=');
+        expect(url).toContain('v=2');
+        await sleep(WATCH_MS); // authority: QR on screen
+        return url;
+      });
+
+      await test.step('Supplicant opens the scanned QR', async () => {
+        await mockSupplicantOAuthLogin(supplicant);
+        // Exactly the URL the QR encodes — a scan hands the browser no more
+        // than this, so the flow has to work from the fragment alone.
+        await supplicant.setContext('content');
+        await supplicant.navigate(pairUrl);
+        // /pair#..v=2 forwards straight to the confirmation card, which opens
+        // the channel and then waits there for the authority's metadata.
+        await waitForUrlContaining(
+          supplicant,
+          PAIR_V2_ROUTES.SUPPLICANT_CONNECT_THIS_DEVICE,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+        await sleep(WATCH_MS); // supplicant: connect this device
+      });
+
+      await test.step('Authority waits on the supplicant', async () => {
+        // The request arriving on the channel moves the authority off scan_qr.
+        await waitForUrlContaining(
+          authority,
+          PAIR_V2_ROUTES.AUTHORITY_CONTINUE_ON_MOBILE,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+        await sleep(WATCH_MS); // authority: continue on mobile
+      });
+
+      await test.step('Supplicant confirms', async () => {
+        // Enabled only once the authority's metadata has populated the card, so
+        // clicking it also proves the metadata arrived.
+        await clickByTestId(supplicant, 'pair2-supp-connect-btn');
+        await waitForUrlContaining(
+          supplicant,
+          PAIR_V2_ROUTES.SUPPLICANT_APPROVE_SIGNIN,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+        await sleep(WATCH_MS); // supplicant: approve sign-in
+      });
+
+      await test.step('Authority approves', async () => {
+        await waitForUrlContaining(
+          authority,
+          PAIR_V2_ROUTES.AUTHORITY_APPROVE_SIGNIN,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+        await sleep(WATCH_MS); // authority: approve sign-in
+        await clickByTestId(authority, 'pair2-auth-approve-btn');
+      });
+
+      await test.step('Both sides reach sync success', async () => {
+        await waitForUrlContaining(
+          supplicant,
+          PAIR_V2_ROUTES.SUPPLICANT_SYNC_SUCCESS,
+          60_000
+        );
+        await waitForUrlContaining(
+          authority,
+          PAIR_V2_ROUTES.AUTHORITY_SYNC_SUCCESS,
+          60_000
+        );
+        await sleep(WATCH_MS); // both: sync success
+      });
+
+      await test.step('Supplicant chrome receives the granted OAuth code', async () => {
+        // The page reaching sync_success only proves it sent oauth_login, which
+        // it does without waiting for a reply. This proves what it sent: the
+        // code the authority actually granted over the channel.
+        const login = await readCapturedOAuthLogin(supplicant);
+        expect(login, 'supplicant should have sent oauth_login').toBeTruthy();
+        expect(login?.action).toBe('pairing');
+        // Same shape the supplicant integration validates before accepting it.
+        expect(login?.code).toMatch(/^[a-fA-F0-9]{64}$/);
+        expect(login?.state).toBeTruthy();
+      });
+    });
+
+    test('supplicant cancels: both sides end on timeout_and_cancel, no code granted', async ({
+      target,
+      testAccountTracker,
+      marionetteAuthority,
+      marionetteSupplicant,
+    }) => {
+      const authority = marionetteAuthority.client;
+      const supplicant = marionetteSupplicant.client;
+      clients = { authority, supplicant };
+
+      await test.step('Authority signs in', async () => {
+        const creds = await testAccountTracker.signUp();
+        await signInAuthorityViaMarionette(
+          authority,
+          target.contentServerUrl,
+          creds.email,
+          creds.password
+        );
+        expect((await getSignedInUser(authority)).signedIn).toBe(true);
+      });
+
+      const pairUrl = await test.step('Authority mints the v2 QR', async () => {
+        const url = await startPairingFlowV2(
+          authority,
+          target.contentServerUrl,
+          ELIGIBLE_ENTRYPOINT_QS
+        );
+        expect(url).toContain('v=2');
+        return url;
+      });
+
+      await test.step('Supplicant reaches connect_this_device', async () => {
+        // Records any oauth_login, so the final step can prove none arrived.
+        await mockSupplicantOAuthLogin(supplicant);
+        await supplicant.setContext('content');
+        await supplicant.navigate(pairUrl);
+        await waitForUrlContaining(
+          supplicant,
+          PAIR_V2_ROUTES.SUPPLICANT_CONNECT_THIS_DEVICE,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+        // The authority received the request and is waiting on the supplicant.
+        await waitForUrlContaining(
+          authority,
+          PAIR_V2_ROUTES.AUTHORITY_CONTINUE_ON_MOBILE,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+      });
+
+      await test.step('Supplicant cancels', async () => {
+        await clickByTestId(supplicant, 'pair2-supp-cancel-btn');
+        await waitForUrlContaining(
+          supplicant,
+          PAIR_V2_ROUTES.SUPPLICANT_TIMEOUT_AND_CANCEL,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+      });
+
+      await test.step('Authority is sent to timeout_and_cancel', async () => {
+        await waitForUrlContaining(
+          authority,
+          PAIR_V2_ROUTES.AUTHORITY_TIMEOUT_AND_CANCEL,
+          TIMEOUTS.PAIR_V2_HANDSHAKE
+        );
+      });
+
+      await test.step('Supplicant is never granted an OAuth code', async () => {
+        // The device list cannot tell us anything here: this desktop supplicant
+        // never completes oauth_login either way, so no device is registered
+        // whether the user cancels or not. What cancelling must prevent is the
+        // authority granting a code at all, and the recorder can see that.
+        const login = await readCapturedOAuthLogin(supplicant, 5_000);
+        expect(login, 'a cancelled pairing must not grant a code').toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/functional-tests/tests/pairing/pairingFlowV2Android.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowV2Android.spec.ts
@@ -1,0 +1,304 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * v2 pairing flow, Android supplicant (FXA-12855 / FXA-13870).
+ *
+ * The real-device counterpart of `pairingFlowV2.spec.ts`: the authority is a
+ * real Firefox Nightly (Marionette) running the FxA-owned v2 authority flow, and
+ * the supplicant is a real Fenix on an Android emulator, driven over adb via
+ * `AndroidSupplicant` (the same driver the v1 `pairingFlowAndroid.spec.ts` uses).
+ *
+ *   Authority (Marionette, Nightly)          Supplicant (Android / Fenix)
+ *   ------------------------------------     ----------------------------
+ *   1. sign in, open /connect_another_device?v=2 -> scan_qr (real channel + QR)
+ *                                            2. adb injects the v2 QR URL into
+ *                                               the Sync Debug hook, begins pairing
+ *   3. on pair:supp:request -> continue_on_mobile
+ *                                            4. tap "Connect" (connect_this_device)
+ *   5. on pair:supp:authorize -> approve_signin
+ *   6. tap "Yes, approve sign-in"
+ *   7. pair_oauth_finish -> sync_success
+ *                                            8. OAuth completes -> device registered
+ *
+ * Gated behind ANDROID_PAIRING_V2_ENABLED and skipped by default: it needs an
+ * emulator running a Fenix build with the v2 web-channel commands. This is the
+ * only run against a real browser supplicant; pairingFlowV2.spec.ts covers the
+ * same authority side and additionally verifies the Sync scoped keys.
+ *
+ * Prerequisites: the FXA stack started with PAIRING_VERSION=2, a booted Android
+ * emulator with a v2-capable Fenix debug build, `yarn adb-reverse`, and the
+ * webchannel-localhost manifest patch (see docs/pairing/README.md). Set
+ * ANDROID_PAIRING_V2_ENABLED=1 to run; the authority needs Firefox Nightly, or
+ * FIREFOX_BINARY at a v2-capable build.
+ */
+
+import { writeFileSync } from 'fs';
+import { findV2AuthorityBinary } from '../../lib/firefox-binary';
+import { test, expect } from '../../lib/fixtures/pairing';
+import { MarionetteClient } from '../../lib/marionette';
+import { PAIR_V2_ROUTES } from '../../lib/pairing-constants';
+import {
+  signInAuthorityViaMarionette,
+  startPairingFlowV2,
+  extractChannelIdV2,
+  waitForUrlContaining,
+  redactChannelKey,
+} from '../../lib/pairing-helpers';
+import { AndroidSupplicant } from '../../lib/android-supplicant';
+
+const ELIGIBLE_ENTRYPOINT_QS =
+  'context=oauth_webchannel_v1&entrypoint=fxa_app_menu';
+
+/**
+ * Match the paired Android supplicant only.
+ *
+ * The authority is a signed-in Firefox on the same account, so a pattern that
+ * also matched a desktop device name would let this succeed before Android ever
+ * registers.
+ */
+function isMobileDevice(d: { type?: string; name?: string }): boolean {
+  return d.type === 'mobile' || /Android|Fenix/i.test(d.name || '');
+}
+
+type PairedDevice = { id: string; name?: string; type?: string };
+
+async function pollForMobileDevice(
+  authClient: { deviceList: (token: string) => Promise<PairedDevice[]> },
+  sessionToken: string,
+  timeoutMs: number
+): Promise<PairedDevice | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const devices = await authClient.deviceList(sessionToken);
+    const found = devices.find(isMobileDevice);
+    if (found) return found;
+    await new Promise((r) => setTimeout(r, 3_000));
+  } while (Date.now() < deadline);
+  return undefined;
+}
+
+async function clickByTestId(client: MarionetteClient, testId: string) {
+  const el = await client.findElement(
+    'css selector',
+    `[data-testid="${testId}"]`
+  );
+  await client.clickElement(el);
+}
+
+// Set PAIRING_WATCH_MS (e.g. 4000) to pause between steps so the flow is
+// watchable in headed mode. Default 0 keeps normal runs fast.
+const WATCH_MS = parseInt(process.env.PAIRING_WATCH_MS || '0', 10);
+const watch = () =>
+  WATCH_MS ? new Promise((r) => setTimeout(r, WATCH_MS)) : Promise.resolve();
+
+// Emulator cold start + UI nav + channel handshake + OAuth round trip.
+test.setTimeout(300_000);
+
+test.describe.serial('v2 Android pairing flow', () => {
+  test.describe.configure({ retries: 0 });
+
+  let supplicant: AndroidSupplicant | undefined;
+
+  test.beforeEach(async ({}, testInfo) => {
+    if (!process.env.ANDROID_PAIRING_V2_ENABLED) {
+      testInfo.skip(
+        true,
+        'Set ANDROID_PAIRING_V2_ENABLED=1 (needs a booted emulator running a Fenix debug build)'
+      );
+    }
+    if (!findV2AuthorityBinary()) {
+      testInfo.skip(
+        true,
+        'Firefox Nightly not found — install it, or set FIREFOX_BINARY to a v2-capable build'
+      );
+    }
+    supplicant = new AndroidSupplicant();
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    // `beforeEach` skips before assigning the supplicant when a prerequisite is
+    // missing, and teardown still runs; touching it there would turn a clean
+    // skip into an error.
+    if (!supplicant) return;
+    if (testInfo.status !== testInfo.expectedStatus) {
+      try {
+        const shot = testInfo.outputPath('android-v2-supplicant.png');
+        supplicant.screenshot(shot);
+        await testInfo.attach('android-v2-supplicant.png', {
+          path: shot,
+          contentType: 'image/png',
+        });
+        await testInfo.attach('android-v2-logcat.txt', {
+          body: redactChannelKey(supplicant.dumpLogcat()),
+          contentType: 'text/plain',
+        });
+      } catch {
+        /* best-effort diagnostics */
+      }
+    }
+    supplicant.forceStop();
+    // Each test's guard must reflect that test, not the previous one's.
+    supplicant = undefined;
+  });
+
+  test('authority mints v2 QR and Android supplicant completes pairing', async ({
+    target,
+    testAccountTracker,
+    marionetteAuthority,
+  }, testInfo) => {
+    const authority = marionetteAuthority.client;
+    // `supplicant` is optional so teardown can tell "never assigned" from
+    // "assigned"; the body runs only after beforeEach set it.
+    const fenix = supplicant as AndroidSupplicant;
+
+    const credentials = await test.step('Authority signs in', async () => {
+      const creds = await testAccountTracker.signUp();
+      await signInAuthorityViaMarionette(
+        authority,
+        target.contentServerUrl,
+        creds.email,
+        creds.password
+      );
+      // signInAuthorityViaMarionette already blocks until Firefox reports the
+      // signed-in state, so re-asserting it here only repeats that check.
+      return creds;
+    });
+
+    // Prepare the supplicant before minting the (short-lived) channel. The
+    // reset must come first: a Fenix that still has an account from an earlier
+    // run takes a re-auth web flow instead of pairing, so the authority waits
+    // for a `pair:supp:request` that never arrives.
+    await test.step('Prepare Android supplicant', async () => {
+      fenix.resetToColdState();
+      await fenix.ensureReady(target.contentServerUrl);
+    });
+
+    const { pairUrl, channelId } =
+      await test.step('Authority mints the v2 QR', async () => {
+        const url = await startPairingFlowV2(
+          authority,
+          target.contentServerUrl,
+          ELIGIBLE_ENTRYPOINT_QS
+        );
+        expect(url).toContain('v=2');
+        return { pairUrl: url, channelId: extractChannelIdV2(url) };
+      });
+
+    await test.step('Android supplicant opens the QR URL', async () => {
+      // A v2 device scans the QR with the native camera, so the URL arrives as
+      // a plain VIEW intent and opens in a normal tab. The page then asks the
+      // browser for the OAuth params over `fxaccounts:pair_oauth_start`.
+      const seenUrl = await fenix.openPairingUrl(pairUrl);
+      expect(seenUrl).toContain(channelId);
+      await fenix.waitForSupplicantOnChannel(45_000);
+    });
+
+    await test.step('Authority waits on the supplicant', async () => {
+      // The request arriving on the channel moves the authority off scan_qr.
+      await waitForUrlContaining(
+        authority,
+        PAIR_V2_ROUTES.AUTHORITY_CONTINUE_ON_MOBILE,
+        45_000
+      );
+    });
+
+    await test.step('Android supplicant confirms', async () => {
+      // The v2 connect_this_device card's CTA reads "Connect". It is enabled
+      // only once the authority's metadata has populated the card.
+      await fenix.confirmPairing(45_000, /^Connect$/i);
+    });
+
+    await test.step('Authority approves the request', async () => {
+      await waitForUrlContaining(
+        authority,
+        PAIR_V2_ROUTES.AUTHORITY_APPROVE_SIGNIN,
+        45_000
+      );
+      await clickByTestId(authority, 'pair2-auth-approve-btn');
+    });
+
+    await test.step('Both sides reach sync success', async () => {
+      await waitForUrlContaining(
+        authority,
+        PAIR_V2_ROUTES.AUTHORITY_SYNC_SUCCESS,
+        60_000
+      );
+      // Read the phone's own screen too: a supplicant that registered the
+      // device and then landed on an error card would otherwise pass.
+      expect(
+        await fenix.waitForText(/Your device is connected/i, 60_000),
+        'supplicant should show the sync success card'
+      ).toBe(true);
+    });
+
+    const device =
+      await test.step('Android device is registered on the account', async () => {
+        const found = await pollForMobileDevice(
+          target.authClient,
+          credentials.sessionToken as string,
+          45_000
+        );
+        expect(found).toBeTruthy();
+        return found;
+      });
+
+    await test.step('Connected Services lists the Android device', async () => {
+      // The API check above proves registration; this proves the authority's
+      // own Settings UI surfaces the newly paired device to the user.
+      await authority.navigate(`${target.contentServerUrl}/settings/clients`);
+      await waitForUrlContaining(authority, '/settings/clients', 30_000);
+
+      const deviceName = device?.name;
+      expect(
+        deviceName,
+        'registered device should have a name to look for'
+      ).toBeTruthy();
+      const row = await pollUntilElement(
+        authority,
+        `//*[contains(text(), ${xpathLiteral(deviceName as string)})]`,
+        30_000
+      );
+      expect(
+        row,
+        `"${deviceName}" not listed in Connected Services`
+      ).toBeTruthy();
+
+      const body = await authority.findElement('css selector', 'body');
+      const shot = testInfo.outputPath('authority-connected-services.png');
+      writeFileSync(
+        shot,
+        Buffer.from(await authority.screenshotElement(body), 'base64')
+      );
+      await testInfo.attach('authority-connected-services.png', {
+        path: shot,
+        contentType: 'image/png',
+      });
+      await watch();
+    });
+  });
+});
+
+/** Poll for an element so the Settings list has time to load its services. */
+async function pollUntilElement(
+  client: MarionetteClient,
+  xpath: string,
+  timeoutMs: number
+): Promise<string | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    try {
+      return await client.findElement('xpath', xpath);
+    } catch {
+      await new Promise((r) => setTimeout(r, 2_000));
+    }
+  } while (Date.now() < deadline);
+  return undefined;
+}
+
+/** Quote a value for use inside an XPath expression. */
+function xpathLiteral(value: string): string {
+  if (!value.includes("'")) return `'${value}'`;
+  return `concat('${value.split("'").join(`', "'", '`)}')`;
+}

--- a/packages/functional-tests/tests/pairing/pairingFlowiOS.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowiOS.spec.ts
@@ -42,7 +42,6 @@ import {
   buildAuthorityOAuthUrl,
   extractChannelId,
   findElementBySelectors,
-  screenshotAuthority,
   isPairRoutesReact,
   waitForUrlContaining,
   captureDiagnostics,
@@ -283,7 +282,6 @@ test.describe.serial('iOS pairing flow', () => {
         const user = await getSignedInUser(client);
         expect(user.signedIn).toBe(true);
         expect(user.email).toBe(credentials.email);
-        await screenshotAuthority(client, 'iOS', '1-signed-in');
         return user;
       });
 
@@ -341,7 +339,6 @@ test.describe.serial('iOS pairing flow', () => {
       await sleep(3_000);
       const { url: preApproveUrl } = await captureDiagnostics(client);
       debug(`Authority URL before approve: ${preApproveUrl}`);
-      await screenshotAuthority(client, 'iOS', '2-auth-approve');
 
       // Dump the page HTML to help debug missing buttons
       try {
@@ -381,7 +378,6 @@ test.describe.serial('iOS pairing flow', () => {
       );
       await client.clickElement(approveBtn);
       debug('Authority approved pairing');
-      await screenshotAuthority(client, 'iOS', '3-auth-approved');
     });
 
     // 5. Wait for authority to reach completion page
@@ -396,7 +392,6 @@ test.describe.serial('iOS pairing flow', () => {
       );
       expect(finalUrl).not.toContain('pair/failure');
       debug(`Authority completed at: ${finalUrl}`);
-      await screenshotAuthority(client, 'iOS', '4-auth-complete');
     });
 
     // 6. Wait for iOS XCUITest to finish
@@ -501,7 +496,6 @@ test.describe.serial('iOS pairing flow', () => {
       // Wait for the approve button to confirm the page loaded
       await findElementBySelectors(client, SELECTORS.AUTHORITY_APPROVE, 30_000);
       debug('Authority approval page loaded');
-      await screenshotAuthority(client, 'iOS-cancel', '1-auth-approve');
     });
 
     // Wait for iOS XCUITest to finish (supplicant taps Cancel)

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ApproveSignIn/index.tsx
@@ -59,6 +59,7 @@ const ApproveSignIn = ({
       <FtlMsg id="pair2-authority-approve-sign-in-confirm-button">
         <button
           type="button"
+          data-testid="pair2-auth-approve-btn"
           onClick={onApprove}
           className="cta-primary cta-xl mt-6 w-full"
         >

--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.tsx
@@ -66,7 +66,9 @@ const ScanQR = ({ qrCodeValue }: ScanQRProps) => {
                 size and drift out of the phone as the card resizes. `QRCode`'s
                 own `p-4` stays a fixed quiet zone, which only ever grows in
                 proportion as the card narrows. */}
-            <div className="w-[41%]">
+            {/* `data-testid` scopes the functional tests' screenshot to the
+                quiet zone as well as the code, which a QR decoder needs. */}
+            <div className="w-[41%]" data-testid="pairing-qr">
               <QRCode
                 value={qrCodeValue ?? ''}
                 loading={!qrCodeValue}

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/index.tsx
@@ -63,6 +63,7 @@ export const ApproveSignIn = ({ remoteMetadata, onCancel }: ApproveSignInProps) 
       <FtlMsg id="pair2-supplicant-approve-sign-in-cancel-button">
         <button
           type="button"
+          data-testid="pair2-supp-cancel-btn"
           onClick={onCancel}
           className="link-dark-grey"
         >

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/index.tsx
@@ -72,6 +72,7 @@ export const ConnectThisDevice = ({
       <FtlMsg id="pair2-supplicant-connect-this-device-connect-button">
         <button
           type="button"
+          data-testid="pair2-supp-connect-btn"
           onClick={onConnect}
           disabled={awaitingRemoteMetadata}
           className="cta-primary cta-xl mt-6 w-full"
@@ -82,6 +83,7 @@ export const ConnectThisDevice = ({
       <FtlMsg id="pair2-supplicant-connect-this-device-cancel-button">
         <button
           type="button"
+          data-testid="pair2-supp-cancel-btn"
           onClick={onCancel}
           disabled={awaitingRemoteMetadata}
           className="link-dark-grey"


### PR DESCRIPTION
## Because

- The v2 pairing flow shipped with no end-to-end coverage, so nothing exercised a real authority and supplicant against each other.

## This pull request

- Adds `pairingFlowV2Android.spec.ts`: a Marionette-driven desktop authority paired with a real Fenix supplicant over adb, with nothing stubbed. Gated behind `ANDROID_PAIRING_V2_ENABLED`.
- Adds `pairingFlowV2.spec.ts`: both halves over Marionette, covering the happy path and supplicant cancel.
- Adds `marionetteSupplicant` to `fixtures/pairing.ts` and `firefox-binary.ts`, which resolves Firefox Nightly for the v2 web-channel commands.
- Extends `pairChoice.spec.ts` with v2 version negotiation, and `pairing-helpers.ts` with the v2 QR decode and supplicant stand-ins.
- Adds four `data-testid` hooks to the `Pair2` supplicant and authority cards.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13870

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information

**How to test:**
1. `PAIRING_VERSION=2 yarn start mza`, and install Firefox Nightly.
2. `npx playwright test tests/pairing/pairingFlowV2.spec.ts --project=local`
3. For the Android spec: boot an emulator with a Fenix debug build, `yarn adb-reverse`, then rerun with `ANDROID_PAIRING_V2_ENABLED=1`.

Local results: `pairingFlowV2` + `pairingFlowV2Android`: 3 passed, 0 failed. `pairChoice` v2 negotiation: 3 passed, 0 failed.