### PR TITLE
task(fxa-settings): Support pairing QR scanning when firefox is not the default

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -112,6 +112,7 @@ const settingsConfig = {
     pairRoutes: config.get('showReactApp.pairRoutes'),
   },
   pairing: {
+    browserBuild: config.get('pairing.browser_build'),
     clients: config.get('pairing.clients'),
     serverBaseUri: config.get('pairing.server_base_uri'),
     version: config.get('pairing.version'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -779,6 +779,12 @@ const conf = (module.exports = convict({
     },
   },
   pairing: {
+    browser_build: {
+      default: 'firefox',
+      doc: 'Android package suffix (org.mozilla.<build>) the pairing deep link is pinned to. "fenix" targets pre-release builds.',
+      env: 'PAIRING_BROWSER_BUILD',
+      format: ['firefox', 'fenix'],
+    },
     clients: {
       default: [
         '3c49430b43dfba77', // Reference browser

--- a/packages/fxa-settings/src/components/ContinueInFirefox/en.ftl
+++ b/packages/fxa-settings/src/components/ContinueInFirefox/en.ftl
@@ -1,0 +1,13 @@
+## ContinueInFirefox component - Part of the desktop-to-mobile pairing flow
+## Shown when the pairing QR code is opened in a browser other than Firefox.
+## It hands the pairing link to the Firefox app, and offers the app store when
+## Firefox is not installed on the device.
+
+pair-continue-in-firefox-heading = Continue in { -brand-firefox }
+pair-continue-in-firefox-description = Pairing happens in { -brand-firefox }. Open it to finish connecting this device.
+# Opens the Firefox app on this device
+pair-continue-in-firefox-button = Continue in { -brand-firefox }
+# Shown while waiting for the Firefox app to take over
+pair-continue-in-firefox-opening = Opening { -brand-firefox }
+# Sends the user to the App Store or Play Store to install Firefox
+pair-continue-in-firefox-get-firefox-link = Don’t have { -brand-firefox }? Get it now

--- a/packages/fxa-settings/src/components/ContinueInFirefox/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ContinueInFirefox/index.stories.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import { ContinueInFirefox } from '.';
+import { MOCK_ANDROID_PLAN, Subject } from './mocks';
+
+export default {
+  title: 'Components/ContinueInFirefox',
+  component: ContinueInFirefox,
+  decorators: [withLocalization],
+} as Meta;
+
+// iOS requires the user to tap, so the CTA is the whole story.
+export const Ios = () => <Subject />;
+
+// Android auto-navigates on mount, so the card starts as a spinner and only
+// reveals the CTA if the intent silently no-ops.
+export const AndroidAutoAttempting = () => <Subject plan={MOCK_ANDROID_PLAN} />;
+
+// The auto-attempt was already spent, or storage is unavailable.
+export const AndroidManual = () => (
+  <Subject plan={{ ...MOCK_ANDROID_PLAN, autoAttempt: false }} />
+);

--- a/packages/fxa-settings/src/components/ContinueInFirefox/index.test.tsx
+++ b/packages/fxa-settings/src/components/ContinueInFirefox/index.test.tsx
@@ -1,0 +1,243 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { STORE_FALLBACK_TIMEOUT_MS } from '../../lib/pairing/store-fallback';
+import {
+  HANDOFF_ATTEMPT_KEY_PREFIX,
+  planPairingHandoff,
+} from '../../lib/pairing/handoff';
+import { Devices } from '../../lib/utilities';
+import { MOCK_ANDROID_PLAN, MOCK_IOS_PLAN, Subject } from './mocks';
+
+function createStorage(seed: Record<string, string> = {}) {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: jest.fn((key: string) => values.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}
+
+describe('ContinueInFirefox', () => {
+  it('renders every message with text matching the Fluent bundle', async () => {
+    const bundle: FluentBundle = await getFtlBundle('settings');
+    renderWithLocalizationProvider(<Subject storage={createStorage()} />);
+
+    const messages = screen
+      .getAllByTestId('ftlmsg-mock')
+      // The jest SVG stub renders the file name as the element's text, so image
+      // messages can never match. Covered by components/images/index.test.tsx.
+      .filter((el) => !el.textContent?.endsWith('.svg'));
+
+    expect(messages.length).toBeGreaterThan(0);
+    messages.forEach((el) => testL10n(el, bundle));
+  });
+
+  describe('on iOS', () => {
+    // Finding 1: WebKit only honours a top-level, user-initiated navigation, so
+    // the deep link must be the anchor's href. A regression to a
+    // <button onClick={navigate}> breaks iOS silently.
+    it('puts the deep link in the CTA href rather than a click handler', () => {
+      renderWithLocalizationProvider(<Subject storage={createStorage()} />);
+
+      expect(
+        screen.getByRole('link', { name: 'Continue in Firefox' })
+      ).toHaveAttribute('href', MOCK_IOS_PLAN.deepLink);
+    });
+
+    it('does not navigate from script when the CTA is tapped', async () => {
+      const assign = jest.fn();
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(
+        <Subject assign={assign} storage={createStorage()} />
+      );
+
+      await user.click(
+        screen.getByRole('link', { name: 'Continue in Firefox' })
+      );
+
+      expect(assign).not.toHaveBeenCalled();
+    });
+
+    it('shows a spinner once the hand-off is under way', async () => {
+      const user = userEvent.setup();
+      renderWithLocalizationProvider(<Subject storage={createStorage()} />);
+
+      await user.click(
+        screen.getByRole('link', { name: 'Continue in Firefox' })
+      );
+
+      expect(screen.getByText('Opening Firefox…')).toBeInTheDocument();
+    });
+
+    it('offers the App Store as an escape hatch', () => {
+      renderWithLocalizationProvider(<Subject storage={createStorage()} />);
+
+      expect(
+        screen.getByRole('link', { name: 'Don’t have Firefox? Get it now' })
+      ).toHaveAttribute('href', MOCK_IOS_PLAN.storeUrl);
+    });
+
+    it('does not auto-navigate on mount', () => {
+      const assign = jest.fn();
+      renderWithLocalizationProvider(
+        <Subject assign={assign} storage={createStorage()} />
+      );
+
+      expect(assign).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on Android', () => {
+    it('hands off on mount without waiting for a tap', () => {
+      const assign = jest.fn();
+      renderWithLocalizationProvider(
+        <Subject
+          plan={MOCK_ANDROID_PLAN}
+          assign={assign}
+          storage={createStorage()}
+        />
+      );
+
+      expect(assign).toHaveBeenCalledWith(MOCK_ANDROID_PLAN.deepLink);
+      expect(assign).toHaveBeenCalledTimes(1);
+    });
+
+    it('spends the one-shot token so a Play Store round trip cannot loop', () => {
+      const storage = createStorage();
+      renderWithLocalizationProvider(
+        <Subject plan={MOCK_ANDROID_PLAN} storage={storage} />
+      );
+
+      expect(storage.setItem).toHaveBeenCalledWith(
+        `${HANDOFF_ATTEMPT_KEY_PREFIX}${MOCK_ANDROID_PLAN.target}`,
+        '1'
+      );
+    });
+
+    // The two halves of the loop guard are written in different modules, so
+    // this exercises both: the key this component spends must be the key
+    // planPairingHandoff reads back. Keyed apart, Back from the Play Store
+    // re-fires the intent and bounces the user straight out again.
+    it('stops the next page load from auto-attempting the same target', () => {
+      const storage = createStorage();
+      const args = {
+        device: Devices.OTHER_ANDROID,
+        targetUrl: MOCK_ANDROID_PLAN.target,
+        storeLinks: {
+          ios: MOCK_IOS_PLAN.storeUrl,
+          android: MOCK_ANDROID_PLAN.storeUrl,
+        },
+        storage,
+        build: 'firefox' as const,
+      };
+      expect(planPairingHandoff(args)).toEqual(
+        expect.objectContaining({ autoAttempt: true })
+      );
+
+      renderWithLocalizationProvider(
+        <Subject plan={MOCK_ANDROID_PLAN} storage={storage} />
+      );
+
+      expect(planPairingHandoff(args)).toEqual(
+        expect.objectContaining({ autoAttempt: false })
+      );
+    });
+
+    it('hides the CTA while the auto hand-off is in flight', () => {
+      renderWithLocalizationProvider(
+        <Subject plan={MOCK_ANDROID_PLAN} storage={createStorage()} />
+      );
+
+      expect(
+        screen.queryByRole('link', { name: 'Continue in Firefox' })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('Opening Firefox…')).toBeInTheDocument();
+    });
+
+    // In an in-app WebView the intent silently no-ops, which would otherwise
+    // strand the user on the spinner forever.
+    it('reveals the CTA when the intent silently no-ops', async () => {
+      jest.useFakeTimers();
+      try {
+        renderWithLocalizationProvider(
+          <Subject plan={MOCK_ANDROID_PLAN} storage={createStorage()} />
+        );
+
+        jest.advanceTimersByTime(STORE_FALLBACK_TIMEOUT_MS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole('link', { name: 'Continue in Firefox' })
+          ).toBeInTheDocument()
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    // The reveal timer is UI-only. If it navigated it would race
+    // S.browser_fallback_url, which is already sending the user to the store.
+    it('does not navigate a second time when the CTA is revealed', () => {
+      jest.useFakeTimers();
+      try {
+        const assign = jest.fn();
+        renderWithLocalizationProvider(
+          <Subject
+            plan={MOCK_ANDROID_PLAN}
+            assign={assign}
+            storage={createStorage()}
+          />
+        );
+
+        jest.advanceTimersByTime(STORE_FALLBACK_TIMEOUT_MS * 3);
+
+        expect(assign).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('renders the CTA immediately when the token is already spent', () => {
+      const assign = jest.fn();
+      renderWithLocalizationProvider(
+        <Subject
+          plan={{ ...MOCK_ANDROID_PLAN, autoAttempt: false }}
+          assign={assign}
+          storage={createStorage()}
+        />
+      );
+
+      expect(
+        screen.getByRole('link', { name: 'Continue in Firefox' })
+      ).toBeInTheDocument();
+      expect(assign).not.toHaveBeenCalled();
+    });
+
+    // A getItem that works alongside a setItem that throws would otherwise
+    // re-attempt on every load.
+    it('does not navigate when the token cannot be written', () => {
+      const assign = jest.fn();
+      const storage = createStorage();
+      storage.setItem.mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+      renderWithLocalizationProvider(
+        <Subject plan={MOCK_ANDROID_PLAN} assign={assign} storage={storage} />
+      );
+
+      expect(assign).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('link', { name: 'Continue in Firefox' })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/ContinueInFirefox/index.tsx
+++ b/packages/fxa-settings/src/components/ContinueInFirefox/index.tsx
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import AppLayout from '../AppLayout';
+import { FirefoxWordmarkImage, SyncDevicesImage } from '../images';
+import {
+  AttemptStorage,
+  claimAutoAttempt,
+  getAttemptStorage,
+  HandoffPlan,
+} from '../../lib/pairing/handoff';
+import {
+  armStoreFallback,
+  STORE_FALLBACK_TIMEOUT_MS,
+} from '../../lib/pairing/store-fallback';
+
+export type ContinueInFirefoxProps = {
+  /**
+   * How to reach the Firefox app from here. `planPairingHandoff` decides this;
+   * a `none` plan never reaches this component.
+   */
+  plan: Exclude<HandoffPlan, { kind: 'none' }>;
+  /**
+   * Navigation sink, injected so tests can observe the hand-off without a real
+   * page load. Defaults to `window.location.assign`.
+   *
+   * assign(), not replace(): Back returns to this card, so a user who cancelled
+   * an "Open in Firefox?" confirmation can retry. See `store-fallback`.
+   */
+  assign?: (url: string) => void;
+  storage?: AttemptStorage;
+};
+
+/**
+ * Shown when a pairing QR is opened in a browser that is not Firefox. It hands
+ * the pairing URL to the Firefox app, and sends the user to the app store when
+ * the app is not installed.
+ *
+ * The two platforms need genuinely different mechanics, and the reasons are
+ * recorded in `lib/pairing/store-fallback.ts` (iOS) and `lib/pairing/handoff.ts`
+ * (Android). In short: iOS needs the tap itself to be the navigation and has no
+ * API that reports a failed launch, so the store fallback is inferred; Android
+ * can navigate from script and carries its own store fallback inside the intent.
+ */
+export const ContinueInFirefox = ({
+  plan,
+  assign = (url: string) => window.location.assign(url),
+  storage = getAttemptStorage(),
+}: ContinueInFirefoxProps) => {
+  const isAndroid = plan.kind === 'android';
+  const willAutoAttempt = plan.kind === 'android' && plan.autoAttempt;
+
+  const [attempting, setAttempting] = useState(willAutoAttempt);
+  // Android auto-attempts on mount, so the CTA starts hidden and is revealed
+  // only if that silently fails.
+  const [ctaRevealed, setCtaRevealed] = useState(!willAutoAttempt);
+
+  // Holds the teardown for the in-flight iOS watch so we can clean up on unmount.
+  const teardownRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => teardownRef.current?.(), []);
+
+  useEffect(() => {
+    if (!willAutoAttempt) {
+      return;
+    }
+    // Navigate only once the one-shot token is actually ours, or Back from the
+    // Play Store loops. `plan.target` is the same key `planPairingHandoff`
+    // checked to set `autoAttempt`.
+    if (!claimAutoAttempt(plan.target, storage)) {
+      setCtaRevealed(true);
+      setAttempting(false);
+      return;
+    }
+    assign(plan.deepLink);
+
+    // WebView backstop: if the intent silently no-ops, reveal the manual CTA
+    // rather than spinning forever. State only — never a navigation, so it
+    // cannot race S.browser_fallback_url, which unloads us first when it works.
+    const revealTimer = window.setTimeout(
+      () => setCtaRevealed(true),
+      STORE_FALLBACK_TIMEOUT_MS
+    );
+    return () => window.clearTimeout(revealTimer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // The tap on the anchor below performs the hand-off itself — deliberately no
+  // preventDefault() and no JS navigation, since the native top-level
+  // navigation is what iOS requires and routing it through JS risks losing the
+  // user activation. This only arms the fallback.
+  const onAttempt = () => {
+    setAttempting(true);
+    // Android's intent:// carries its own store fallback via
+    // S.browser_fallback_url, so it needs no JS watchdog.
+    if (isAndroid) {
+      return;
+    }
+    teardownRef.current?.();
+    teardownRef.current = armStoreFallback({
+      onFallback: () => assign(plan.storeUrl),
+    });
+  };
+
+  return (
+    <AppLayout>
+      <div className="flex flex-col items-center text-center">
+        <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+
+        <SyncDevicesImage className="mt-10 h-[120px] w-auto" />
+
+        <FtlMsg id="pair-continue-in-firefox-heading">
+          <h1 className="card-header mt-4">Continue in Firefox</h1>
+        </FtlMsg>
+        <FtlMsg id="pair-continue-in-firefox-description">
+          <p className="mt-1 text-base">
+            Pairing happens in Firefox. Open it to finish connecting this
+            device.
+          </p>
+        </FtlMsg>
+
+        {ctaRevealed && (
+          /* The deep link lives in `href` so the tap is a top-level,
+             user-initiated navigation — the only form iOS honours. */
+          <FtlMsg id="pair-continue-in-firefox-button">
+            <a
+              href={plan.deepLink}
+              onClick={onAttempt}
+              className="cta-primary cta-xl mt-6 w-full"
+            >
+              Continue in Firefox
+            </a>
+          </FtlMsg>
+        )}
+
+        {attempting && (
+          <p className="mt-6 flex items-center justify-center gap-2 text-base">
+            <LoadingSpinner imageClassName="w-4 h-4 animate-spin" />
+            <FtlMsg id="pair-continue-in-firefox-opening">
+              <span>Opening Firefox…</span>
+            </FtlMsg>
+          </p>
+        )}
+
+        {/* Escape hatch, not the primary path — both platforms redirect to the
+            store on their own. It covers the residual cases: an iOS version
+            where the error alert happens to fire visibilitychange, and an
+            Android auto-attempt that was spent, blocked, or swallowed by a
+            WebView so S.browser_fallback_url never ran. */}
+        <FtlMsg id="pair-continue-in-firefox-get-firefox-link">
+          <a href={plan.storeUrl} className="link-blue mt-4 text-sm">
+            Don’t have Firefox? Get it now
+          </a>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default ContinueInFirefox;

--- a/packages/fxa-settings/src/components/ContinueInFirefox/mocks.tsx
+++ b/packages/fxa-settings/src/components/ContinueInFirefox/mocks.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ContinueInFirefox, ContinueInFirefoxProps } from '.';
+import { HandoffPlan } from '../../lib/pairing/handoff';
+
+export const MOCK_TARGET =
+  'https://accounts.firefox.com/pair#channel_id=chan-1&channel_key=key-1&v=2';
+
+export const MOCK_IOS_PLAN: Extract<HandoffPlan, { kind: 'ios' }> = {
+  kind: 'ios',
+  deepLink: `firefox://open-url?url=${encodeURIComponent(MOCK_TARGET)}`,
+  storeUrl: 'https://apps.apple.com/app/firefox/id989804926',
+};
+
+export const MOCK_ANDROID_PLAN: Extract<HandoffPlan, { kind: 'android' }> = {
+  kind: 'android',
+  deepLink:
+    'intent://accounts.firefox.com/pair#Intent;scheme=https;package=org.mozilla.firefox;end',
+  storeUrl: 'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
+  target: MOCK_TARGET,
+  autoAttempt: true,
+};
+
+export const Subject = ({
+  plan = MOCK_IOS_PLAN,
+  assign = () => {},
+  storage,
+}: Partial<ContinueInFirefoxProps> = {}) => (
+  <ContinueInFirefox {...{ plan, assign, storage }} />
+);

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -96,7 +96,6 @@ export type FxAStatusResponse = {
   };
   clientId?: string;
   signedInUser?: SignedInUser;
-
 };
 
 export type SignedInUser = {

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -96,6 +96,7 @@ export interface Config {
     pairRoutes: boolean;
   };
   pairing: {
+    browserBuild: 'firefox' | 'fenix';
     clients: string[];
     serverBaseUri: string;
     version: number;
@@ -221,6 +222,7 @@ export function getDefault() {
       pairRoutes: false,
     },
     pairing: {
+      browserBuild: 'firefox',
       clients: [],
       serverBaseUri: 'wss://channelserver.services.mozilla.com',
       version: 1,

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { renderHook } from '@testing-library/react-hooks';
-import { useFxAStatus } from '.';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { PAIRING_FXA_STATUS_TIMEOUT_MS, useFxAStatus } from '.';
 import { Constants } from '../../constants';
 import firefox from '../../channels/firefox';
 import { IntegrationType, isProbablyFirefox } from '../../../models';
@@ -248,7 +248,7 @@ describe('useFxAStatus', () => {
     });
 
     it('returns the hasSyncKeys when browser reports true', async () => {
-      mockCapabilities({ engines: [], hasSyncKeys:true });
+      mockCapabilities({ engines: [], hasSyncKeys: true });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useFxAStatus(integration)
@@ -259,7 +259,7 @@ describe('useFxAStatus', () => {
     });
 
     it('returns the hasSyncKeys when browser reports false', async () => {
-      mockCapabilities({ engines: [], hasSyncKeys:false });
+      mockCapabilities({ engines: [], hasSyncKeys: false });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useFxAStatus(integration)
@@ -368,6 +368,118 @@ describe('useFxAStatus', () => {
 
       renderHook(() => useFxAStatus(integration));
       expect(firefox.fxaStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fxaStatusState', () => {
+    const pairingIntegration = {
+      type: IntegrationType.PairingSupplicant,
+      isSync: () => false,
+      isFirefoxNonSync: () => false,
+      isPairing: () => true,
+    };
+    const syncIntegration = {
+      type: IntegrationType.SyncDesktopV3,
+      isSync: () => true,
+      isFirefoxNonSync: () => false,
+      isPairing: () => false,
+    };
+
+    it('settles on unanswered without asking a browser that is not Firefox', () => {
+      (isProbablyFirefox as jest.Mock).mockImplementation(() => false);
+
+      const { result } = renderHook(() => useFxAStatus(pairingIntegration));
+
+      expect(result.current.fxaStatusState).toBe('unanswered');
+      expect(firefox.fxaStatus).not.toHaveBeenCalled();
+    });
+
+    it('reports answered once the browser replies', async () => {
+      (firefox.fxaStatus as jest.Mock).mockResolvedValue({
+        capabilities: { engines: [], pairing: true, pairingVersion: 2 },
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useFxAStatus(pairingIntegration)
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.fxaStatusState).toBe('answered');
+    });
+
+    describe('when the browser looks like Firefox but never answers', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+        // Never settles — an in-app WebView or a spoofed user agent.
+        (firefox.fxaStatus as jest.Mock).mockReturnValue(new Promise(() => {}));
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it('stays pending until the deadline passes', () => {
+        const { result } = renderHook(() => useFxAStatus(pairingIntegration));
+
+        act(() => {
+          jest.advanceTimersByTime(PAIRING_FXA_STATUS_TIMEOUT_MS - 1);
+        });
+
+        expect(result.current.fxaStatusState).toBe('pending');
+      });
+
+      it('settles on unanswered with the defaults once the deadline passes', () => {
+        const { result } = renderHook(() => useFxAStatus(pairingIntegration));
+
+        act(() => {
+          jest.advanceTimersByTime(PAIRING_FXA_STATUS_TIMEOUT_MS);
+        });
+
+        expect(result.current.fxaStatusState).toBe('unanswered');
+        expect(result.current.fxaStatus?.capabilities.pairingVersion).toBe(1);
+      });
+
+      // The deadline must never cost a real Firefox its capabilities, which is
+      // why it lives here rather than as a race inside firefox.fxaStatus().
+      it('lets a reply that lands after the deadline win', async () => {
+        let reply: (value: unknown) => void = () => {};
+        (firefox.fxaStatus as jest.Mock).mockReturnValue(
+          new Promise((resolve) => {
+            reply = resolve;
+          })
+        );
+
+        const { result, waitForNextUpdate } = renderHook(() =>
+          useFxAStatus(pairingIntegration)
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(PAIRING_FXA_STATUS_TIMEOUT_MS);
+        });
+        expect(result.current.fxaStatusState).toBe('unanswered');
+
+        reply({
+          capabilities: { engines: [], pairing: true, pairingVersion: 2 },
+        });
+        await waitForNextUpdate();
+
+        expect(result.current.fxaStatusState).toBe('answered');
+        expect(result.current.fxaStatus?.capabilities.pairingVersion).toBe(2);
+      });
+
+      // Only pairing blocks the page on the reply, so only pairing pays a
+      // deadline. Everywhere else a discarded reply would be a regression.
+      it('never schedules a deadline for a non-pairing sync flow', () => {
+        const { result } = renderHook(() => useFxAStatus(syncIntegration));
+
+        expect(jest.getTimerCount()).toBe(0);
+
+        act(() => {
+          jest.advanceTimersByTime(PAIRING_FXA_STATUS_TIMEOUT_MS * 10);
+        });
+
+        expect(result.current.fxaStatusState).toBe('pending');
+      });
     });
   });
 });

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
@@ -26,6 +26,10 @@ type FxAStatusIntegration = Pick<
 
 type SyncEngineConfigs = typeof syncEngineConfigs | undefined;
 
+export type FxAStatusState = 'pending' | 'unanswered' | 'answered';
+
+export const PAIRING_FXA_STATUS_TIMEOUT_MS = 500;
+
 /**
  * `pairing` is optional in the fxa_status response, and very old versions of
  * Firefox iOS omit `capabilities` entirely. Normalizing here means callers can
@@ -72,6 +76,8 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
   // Undefined until the browser answers, so callers can tell "not yet known"
   // from "settled, no pairing" rather than routing on an unresolved default.
   const [fxaStatus, setFxaStatus] = useState<FxAStatusResponse>();
+  const [fxaStatusState, setFxaStatusState] =
+    useState<FxAStatusState>('pending');
 
   useEffect(() => {
     // This sends a web channel message to the browser to prompt a response
@@ -95,6 +101,9 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
           ...status?.capabilities,
         };
 
+        // Unconditional, and deliberately not guarded on the current state: a
+        // reply that arrives after the deadline below must still win, so a slow
+        // but genuine Firefox is never left on the fabricated defaults.
         setFxaStatus({
           ...status,
           capabilities: {
@@ -105,6 +114,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
               DEFAULT_PAIRING_CAPABILITIES.pairingVersion,
           },
         });
+        setFxaStatusState('answered');
 
         if (!webChannelEngines && capabilities.engines) {
           // choose_what_to_sync may be disabled for mobile sync, see:
@@ -139,6 +149,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
       // No fxa_status is coming, so settle on the defaults rather than leaving
       // callers waiting on a reply that will never arrive.
       setFxaStatus(DEFAULT_FXA_STATUS);
+      setFxaStatusState('unanswered');
     }
   }, [
     isSync,
@@ -149,6 +160,28 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
     webChannelEngines,
     integration,
   ]);
+
+  // Give up waiting on a browser that looks like Firefox but never answers —
+  // an in-app WebView, or a spoofed user agent. Pairing only: see
+  // PAIRING_FXA_STATUS_TIMEOUT_MS.
+  //
+  // Keyed on the pending state rather than on "did we send the message", so the
+  // timer exists only while a reply is genuinely outstanding: when we never
+  // asked, the effect above has already settled on 'unanswered' and this clears
+  // itself. A reply that lands after the deadline still wins, because the effect
+  // above sets both values unconditionally.
+  useEffect(() => {
+    if (!isPairing || fxaStatusState !== 'pending') {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setFxaStatus((current) => current ?? DEFAULT_FXA_STATUS);
+      setFxaStatusState((current) =>
+        current === 'pending' ? 'unanswered' : current
+      );
+    }, PAIRING_FXA_STATUS_TIMEOUT_MS);
+    return () => window.clearTimeout(timer);
+  }, [isPairing, fxaStatusState]);
 
   useEffect(() => {
     if (webChannelEngines) {
@@ -203,6 +236,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
     supportsKeysOptionalLogin,
     supportsCanLinkAccountUid,
     fxaStatus,
+    fxaStatusState,
   };
 }
 

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getSyncEngineIds, syncEngineConfigs } from '../../sync-engines';
-import type { UseFxAStatusResult } from '.';
+import type { FxAStatusState, UseFxAStatusResult } from '.';
 
 export function mockUseFxAStatus({
   pairingEnabled = true,
@@ -11,12 +11,16 @@ export function mockUseFxAStatus({
   offeredSyncEnginesOverride,
   supportsKeysOptionalLogin = false,
   supportsCanLinkAccountUid,
+  // Defaults to a browser that replied, since that is what most callers assume.
+  // Pass 'unanswered' for a browser with no WebChannel.
+  fxaStatusState = 'answered',
 }: {
   pairingEnabled?: boolean;
   pairingVersion?: number;
   offeredSyncEnginesOverride?: ReturnType<typeof getSyncEngineIds>;
   supportsKeysOptionalLogin?: boolean;
   supportsCanLinkAccountUid?: boolean | undefined;
+  fxaStatusState?: FxAStatusState;
 } = {}) {
   const offeredSyncEngineConfigs = syncEngineConfigs;
   const offeredSyncEngines =
@@ -41,6 +45,7 @@ export function mockUseFxAStatus({
     selectedEnginesForGlean,
     supportsKeysOptionalLogin,
     supportsCanLinkAccountUid,
+    fxaStatusState,
     fxaStatus: {
       capabilities: {
         engines: [],

--- a/packages/fxa-settings/src/lib/pairing/handoff.test.ts
+++ b/packages/fxa-settings/src/lib/pairing/handoff.test.ts
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Devices } from '../utilities';
+import {
+  claimAutoAttempt,
+  HANDOFF_ATTEMPT_KEY_PREFIX,
+  planPairingHandoff,
+  shouldAutoAttempt,
+  StoreLinks,
+} from './handoff';
+
+const MOCK_TARGET =
+  'https://accounts.firefox.com/pair#channel_id=chan-1&channel_key=key-1&v=2';
+const MOCK_OTHER_TARGET =
+  'https://accounts.firefox.com/pair#channel_id=chan-2&channel_key=key-2&v=2';
+const MOCK_KEY = `${HANDOFF_ATTEMPT_KEY_PREFIX}${MOCK_TARGET}`;
+const MOCK_STORE_LINKS: StoreLinks = {
+  ios: 'https://apps.apple.com/app/firefox/id989804926',
+  android: 'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
+};
+
+/** In-memory stand-in for sessionStorage, per test. */
+function createStorage(seed: Record<string, string> = {}) {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: jest.fn((key: string) => values.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+    values,
+  };
+}
+
+const plan = (device: Devices, storage = createStorage()) =>
+  planPairingHandoff({
+    device,
+    targetUrl: MOCK_TARGET,
+    storeLinks: MOCK_STORE_LINKS,
+    storage,
+    build: 'firefox'
+  });
+
+describe('planPairingHandoff', () => {
+  // Inside Firefox there is nothing to hand off to and `firefox://` is a no-op;
+  // on desktop there is no app to open.
+  it.each([
+    Devices.FIREFOX_ANDROID,
+    Devices.FIREFOX_DESKTOP,
+    Devices.FIREFOX_IOS,
+    Devices.OTHER,
+  ])('plans no hand-off for %s', (device) => {
+    expect(plan(device)).toEqual({ kind: 'none' });
+  });
+
+  it('plans no hand-off when there is no target to hand off', () => {
+    expect(
+      planPairingHandoff({
+        device: Devices.OTHER_IOS,
+        targetUrl: '',
+        storeLinks: MOCK_STORE_LINKS,
+        build: 'firefox'
+      })
+    ).toEqual({ kind: 'none' });
+  });
+
+  describe('on a non-Firefox iOS browser', () => {
+    it('opens the target through the Firefox custom scheme', () => {
+      expect(plan(Devices.OTHER_IOS)).toEqual({
+        kind: 'ios',
+        deepLink: `firefox://open-url?url=${encodeURIComponent(MOCK_TARGET)}`,
+        storeUrl: MOCK_STORE_LINKS.ios,
+      });
+    });
+
+    // The fragment carries the pairing channel; losing it in transit would open
+    // Firefox on a /pair page with nothing to pair.
+    it('percent-encodes the target so its fragment survives', () => {
+      const { deepLink } = plan(Devices.OTHER_IOS) as { deepLink: string };
+      const url = new URL(deepLink.replace('firefox://', 'https://'));
+      expect(url.searchParams.get('url')).toBe(MOCK_TARGET);
+    });
+  });
+
+  describe('on a non-Firefox Android browser', () => {
+    it('pins the intent to the Firefox package and carries a store fallback', () => {
+      expect(plan(Devices.OTHER_ANDROID)).toEqual({
+        kind: 'android',
+        deepLink:
+          'intent://accounts.firefox.com/pair#channel_id=chan-1&channel_key=key-1&v=2' +
+          '#Intent;scheme=https;package=org.mozilla.firefox' +
+          `;S.browser_fallback_url=${encodeURIComponent(
+            MOCK_STORE_LINKS.android
+          )};end`,
+        storeUrl: MOCK_STORE_LINKS.android,
+        target: MOCK_TARGET,
+        autoAttempt: true,
+      });
+    });
+
+    // `;` separates intent extras, so an unencoded store URL would terminate the
+    // extra early and let the rest of the URL become extras of its own.
+    it('encodes a store URL containing & and ; into a single extra', () => {
+      const storeLinks = {
+        ...MOCK_STORE_LINKS,
+        android: 'https://play.google.com/store?id=firefox&hl=en;end',
+      };
+      const { deepLink } = planPairingHandoff({
+        device: Devices.OTHER_ANDROID,
+        targetUrl: MOCK_TARGET,
+        storeLinks,
+        storage: createStorage(),
+        build: 'firefox'
+      }) as { deepLink: string };
+
+      expect(deepLink).toContain(
+        `;S.browser_fallback_url=${encodeURIComponent(storeLinks.android)};end`
+      );
+      // The encoded fallback plus the trailing terminator, and nothing more.
+      expect(deepLink.split(';end').length - 1).toBe(1);
+    });
+
+    it('does not auto-attempt once the token for this target is spent', () => {
+      expect(
+        plan(Devices.OTHER_ANDROID, createStorage({ [MOCK_KEY]: '1' }))
+      ).toEqual(expect.objectContaining({ autoAttempt: false }));
+    });
+  });
+});
+
+describe('shouldAutoAttempt', () => {
+  it('auto-attempts when no attempt has been recorded', () => {
+    expect(
+      shouldAutoAttempt({ target: MOCK_TARGET, storage: createStorage() })
+    ).toBe(true);
+  });
+
+  it('does not auto-attempt when this target was already attempted', () => {
+    const storage = createStorage({ [MOCK_KEY]: '1' });
+    expect(shouldAutoAttempt({ target: MOCK_TARGET, storage })).toBe(false);
+  });
+
+  it('auto-attempts for a different target than the one already attempted', () => {
+    const storage = createStorage({ [MOCK_KEY]: '1' });
+    expect(shouldAutoAttempt({ target: MOCK_OTHER_TARGET, storage })).toBe(
+      true
+    );
+  });
+
+  // Without a spent-token record we cannot stop a Play Store bounce loop, so
+  // the manual CTA is the safe way to fail.
+  it('does not auto-attempt when storage is unavailable', () => {
+    expect(shouldAutoAttempt({ target: MOCK_TARGET })).toBe(false);
+  });
+
+  it('does not auto-attempt when reading storage throws', () => {
+    const storage = createStorage();
+    storage.getItem.mockImplementation(() => {
+      throw new DOMException('SecurityError');
+    });
+    expect(shouldAutoAttempt({ target: MOCK_TARGET, storage })).toBe(false);
+  });
+});
+
+describe('claimAutoAttempt', () => {
+  it('records the attempt against the target key', () => {
+    const storage = createStorage();
+    claimAutoAttempt(MOCK_TARGET, storage);
+    expect(storage.setItem).toHaveBeenCalledWith(MOCK_KEY, '1');
+  });
+
+  it('returns true when the attempt was recorded', () => {
+    expect(claimAutoAttempt(MOCK_TARGET, createStorage())).toBe(true);
+  });
+
+  it('makes a second shouldAutoAttempt for the same target return false', () => {
+    const storage = createStorage();
+    claimAutoAttempt(MOCK_TARGET, storage);
+    expect(shouldAutoAttempt({ target: MOCK_TARGET, storage })).toBe(false);
+  });
+
+  // A getItem that works alongside a setItem that throws would otherwise
+  // re-attempt forever.
+  it('returns false when writing throws, so the caller does not navigate', () => {
+    const storage = createStorage();
+    storage.setItem.mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    expect(claimAutoAttempt(MOCK_TARGET, storage)).toBe(false);
+  });
+
+  it('returns false when storage is unavailable', () => {
+    expect(claimAutoAttempt(MOCK_TARGET, undefined)).toBe(false);
+  });
+});

--- a/packages/fxa-settings/src/lib/pairing/handoff.ts
+++ b/packages/fxa-settings/src/lib/pairing/handoff.ts
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Deciding how to hand a pairing URL off to the Firefox app when the browser
+ * that scanned the QR is not Firefox. Ported from the FXA-13863 proof of
+ * concept, whose on-device findings are recorded here and in `store-fallback`.
+ *
+ * Android finding — the extra "continue with Firefox" tap is an iOS tax, so
+ * Android does not pay it:
+ *
+ * Chromium follows a top-level `intent://` navigation made from page script
+ * with no user-activation bit required, and the intent carries its own store
+ * fallback in `S.browser_fallback_url`, so there is nothing for a JS watchdog
+ * to infer. Making the user tap "Continue with Firefox" on Android therefore
+ * buys nothing — they already acted, by scanning the QR. We fire the deep link
+ * from a mount effect on Android and keep the happy path at zero taps.
+ *
+ * Two things auto-navigation forces us to handle, which a manual tap did not:
+ *
+ *   a. The Play Store round-trip becomes a loop risk. Back from the store
+ *      returns to the page in the same tab; if Chrome reloads it rather than
+ *      restoring from the back/forward cache, an unguarded effect re-fires the
+ *      intent and bounces the user straight back out. `shouldAutoAttempt` /
+ *      `claimAutoAttempt` spend a one-shot token in sessionStorage, which
+ *      survives both a reload and the native-app round-trip. No token (storage
+ *      unavailable, or already spent) means render the manual CTA instead.
+ *
+ *   b. In an in-app WebView (Gmail, Facebook) `intent://` silently no-ops
+ *      unless the host app implements shouldOverrideUrlLoading, which would
+ *      strand the user on a spinner forever. A UI-only timer reveals the manual
+ *      CTA — it never navigates, so it cannot race the store fallback.
+ *
+ * Still outstanding on Android: the "Choose activity" chooser. Chrome strips an
+ * explicit `component` from intent:// for security, so we cannot force a direct
+ * launch that way. The real no-chooser mechanism is verified Android App Links
+ * (https + assetlinks.json + app autoVerify), which is app-side work.
+ */
+
+import { Devices } from '../utilities';
+
+export const HANDOFF_ATTEMPT_KEY_PREFIX = 'fxa_pairing_';
+
+/** Storage surface we need — lets tests pass a stub, including a throwing one. */
+export type AttemptStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+export type StoreLinks = { ios: string; android: string };
+
+export enum BrowserBuild {
+  FIREFOX = 'firefox',
+  FIREFOX_NIGHTLY = 'fenix',
+}
+
+/**
+ * How this device should be handed off to Firefox, or `none` when there is
+ * nothing to hand off to. Modelled as a discriminated union so the caller
+ * cannot render an iOS card with an Android intent in it.
+ */
+export type HandoffPlan =
+  | { kind: 'none' }
+  | { kind: 'ios'; deepLink: string; storeUrl: string }
+  | {
+      kind: 'android';
+      deepLink: string;
+      storeUrl: string;
+      /**
+       * The URL being handed off, carried so the caller spends the one-shot
+       * token under the same key `shouldAutoAttempt` checked. Keying on the
+       * target rather than the deep link keeps the identity stable if the
+       * store URL ever changes underneath us.
+       */
+      target: string;
+      /**
+       * Whether this page load owns the one-shot auto-navigation. False once
+       * the token is spent, or when there is no storage to spend it in.
+       */
+      autoAttempt: boolean;
+    };
+
+const attemptKey = (target: string) => `${HANDOFF_ATTEMPT_KEY_PREFIX}${target}`;
+
+/**
+ * `window.sessionStorage` is a getter that itself throws in some sandboxed
+ * WebViews, so even reaching it needs a guard.
+ */
+export function getAttemptStorage(): AttemptStorage | undefined {
+  try {
+    return typeof window !== 'undefined' ? window.sessionStorage : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read-only: is this page load allowed to hand off without waiting for a tap?
+ * No usable storage counts as "no", because without a spent-token record we
+ * cannot stop a Play Store bounce loop, and the manual CTA is the safe way to
+ * fail.
+ */
+export function shouldAutoAttempt({
+  target,
+  storage,
+}: {
+  target: string;
+  storage?: AttemptStorage;
+}): boolean {
+  if (!storage) {
+    return false;
+  }
+  try {
+    return storage.getItem(attemptKey(target)) === null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Spend the one-shot token. Returns whether we now own the attempt — callers
+ * must navigate only on `true`, since a `getItem` that works alongside a
+ * `setItem` that throws would otherwise re-attempt forever.
+ */
+export function claimAutoAttempt(
+  target: string,
+  storage?: AttemptStorage
+): boolean {
+  try {
+    storage?.setItem(attemptKey(target), '1');
+    return storage !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Package-pinned intent that opens `target` in Firefox, with a built-in store
+ * fallback for when it is not installed.
+ */
+function buildAndroidDeepLink(target: string, storeUrl: string, build: 'firefox' | 'fenix'): string {
+  const scheme = target.startsWith('http://') ? 'http' : 'https';
+  const withoutScheme = target.replace(/^https?:\/\//, '');
+  return (
+    `intent://${withoutScheme}#Intent` +
+    `;scheme=${scheme}` +
+    `;package=org.mozilla.${build}` +
+    `;S.browser_fallback_url=${encodeURIComponent(storeUrl)}` +
+    `;end`
+  );
+}
+
+function buildIosDeepLink(target: string): string {
+  return `firefox://open-url?url=${encodeURIComponent(target)}`;
+}
+
+/**
+ * Decide how — or whether — to hand `targetUrl` to the Firefox app.
+ *
+ * Only a non-Firefox phone gets a plan. Inside Firefox there is nothing to hand
+ * off to and `firefox://` is a no-op, and on desktop there is no app to open,
+ * so both fall through to `none` and the caller keeps its existing behaviour.
+ */
+export function planPairingHandoff({
+  device,
+  targetUrl,
+  storeLinks,
+  storage,
+  build
+}: {
+  device: Devices;
+  targetUrl: string;
+  storeLinks: StoreLinks;
+  storage?: AttemptStorage;
+  build: 'firefox' | 'fenix'
+}): HandoffPlan {
+  if (!targetUrl) {
+    return { kind: 'none' };
+  }
+
+  switch (device) {
+    case Devices.OTHER_IOS:
+      return {
+        kind: 'ios',
+        deepLink: buildIosDeepLink(targetUrl),
+        storeUrl: storeLinks.ios,
+      };
+    case Devices.OTHER_ANDROID:
+      return {
+        kind: 'android',
+        deepLink: buildAndroidDeepLink(targetUrl, storeLinks.android, build),
+        storeUrl: storeLinks.android,
+        target: targetUrl,
+        autoAttempt: shouldAutoAttempt({ target: targetUrl, storage }),
+      };
+    default:
+      return { kind: 'none' };
+  }
+}

--- a/packages/fxa-settings/src/lib/pairing/pair-url.test.ts
+++ b/packages/fxa-settings/src/lib/pairing/pair-url.test.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { buildPairUrl, parsePairingHash, PairingChannelInfo } from './pair-url';
+
+const MOCK_ORIGIN = 'https://accounts.firefox.com';
+const MOCK_CHANNEL: PairingChannelInfo = {
+  channelId: 'c0ffee0000000000000000000000beef',
+  channelKey: 'Zm9vYmFyLWJheg_qux-123',
+  version: '2',
+};
+
+describe('parsePairingHash', () => {
+  it('reads the channel out of an authority QR hash', () => {
+    expect(
+      parsePairingHash('#channel_id=chan-1&channel_key=key-1&v=2')
+    ).toEqual({ channelId: 'chan-1', channelKey: 'key-1', version: '2' });
+  });
+
+  it('accepts a hash without the leading #', () => {
+    expect(parsePairingHash('channel_id=chan-1&channel_key=key-1&v=2')).toEqual(
+      { channelId: 'chan-1', channelKey: 'key-1', version: '2' }
+    );
+  });
+
+  it.each([
+    ['an empty hash', ''],
+    ['an absent hash', undefined],
+    ['no version', '#channel_id=chan-1&channel_key=key-1'],
+    ['version 1', '#channel_id=chan-1&channel_key=key-1&v=1'],
+    // Half a channel cannot be opened, so it is no hand-off rather than a
+    // broken one.
+    ['no channel_key', '#channel_id=chan-1&v=2'],
+    ['no channel_id', '#channel_key=key-1&v=2'],
+    ['an empty channel_key', '#channel_id=chan-1&channel_key=&v=2'],
+  ])('returns undefined for %s', (_label, hash) => {
+    expect(parsePairingHash(hash)).toBeUndefined();
+  });
+
+  // Each of these characters is load-bearing somewhere downstream — `;` and `#`
+  // in the Android intent grammar, `/` and the space in the URL the deep link
+  // wraps — so they get named cases rather than a loop.
+  describe('rejects a channel carrying a character the deep link cannot survive', () => {
+    it.each([
+      { name: 'a semicolon, which separates Android intent extras', char: ';' },
+      { name: 'a hash, which opens the intent extras block', char: '#' },
+      { name: 'a slash', char: '/' },
+      { name: 'a space', char: ' ' },
+      { name: 'an ampersand', char: '&' },
+    ])('$name in the channel key', ({ char }) => {
+      const hash = `#channel_id=chan-1&channel_key=${encodeURIComponent(
+        `key-1${char}end`
+      )}&v=2`;
+      expect(parsePairingHash(hash)).toBeUndefined();
+    });
+
+    it('a semicolon in the channel id', () => {
+      expect(
+        parsePairingHash('#channel_id=chan-1%3Bend&channel_key=key-1&v=2')
+      ).toBeUndefined();
+    });
+  });
+
+  it('rejects a channel key longer than 128 characters', () => {
+    const key = 'a'.repeat(129);
+    expect(
+      parsePairingHash(`#channel_id=chan-1&channel_key=${key}&v=2`)
+    ).toBeUndefined();
+  });
+
+  it('accepts a channel key of exactly 128 characters', () => {
+    const key = 'a'.repeat(128);
+    expect(
+      parsePairingHash(`#channel_id=chan-1&channel_key=${key}&v=2`)
+    ).toEqual({ channelId: 'chan-1', channelKey: key, version: '2' });
+  });
+});
+
+describe('buildPairUrl', () => {
+  it('builds the URL the authority encodes into its QR code', () => {
+    expect(buildPairUrl(MOCK_CHANNEL, MOCK_ORIGIN)).toBe(
+      `${MOCK_ORIGIN}/pair` +
+        `#channel_id=${MOCK_CHANNEL.channelId}` +
+        `&channel_key=${MOCK_CHANNEL.channelKey}` +
+        `&v=2`
+    );
+  });
+
+  it('defaults to the current origin', () => {
+    expect(buildPairUrl(MOCK_CHANNEL)).toBe(
+      buildPairUrl(MOCK_CHANNEL, window.location.origin)
+    );
+  });
+
+  // The QR the authority shows and the deep link the supplicant hands to
+  // Firefox are the same string. If these two ever disagree, pairing breaks
+  // only on a real device, with a real scan.
+  it('round-trips through parsePairingHash', () => {
+    const url = new URL(buildPairUrl(MOCK_CHANNEL, MOCK_ORIGIN));
+    expect(parsePairingHash(url.hash)).toEqual(MOCK_CHANNEL);
+  });
+});

--- a/packages/fxa-settings/src/lib/pairing/pair-url.ts
+++ b/packages/fxa-settings/src/lib/pairing/pair-url.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * The pairing channel URL, in both directions: the authority builds one into
+ * its QR code, and the supplicant reads it back out of the URL it was opened
+ * with. Both live here so the two can never drift — a mismatch between the
+ * string we encode and the string we parse only shows up on a real device,
+ * with a scanned QR, which is the most expensive place to find a bug.
+ */
+
+/**
+ * The pairing channel the authority encodes into its QR code.
+ */
+export type PairingChannelInfo = {
+  channelId: string;
+  channelKey: string;
+  version: '1' | '2';
+};
+
+/**
+ * Both halves of the channel are base64url, the same shape content-server's
+ * `Vat.channelId()` / `Vat.channelKey()` accept.
+ */
+const BASE64URL = /^[A-Za-z0-9-_]+$/;
+
+/** Comfortably above a real channel id or key, well below any useful payload. */
+const MAX_CHANNEL_VALUE_LENGTH = 128;
+
+/**
+ * The hash arrives from a scanned QR code, so it is attacker-supplied, and it is
+ * interpolated raw into the Android `intent://...#Intent;...;end` deep link in
+ * `handoff.ts`. A `;` or `#` would close the URL and open a new intent extra,
+ * letting a crafted QR override `package` or `S.browser_fallback_url` and send
+ * the user to an app or store page of its choosing. Allowlisting base64url
+ * rejects those, and every other character the deep link cannot carry, without
+ * having to enumerate them.
+ */
+function isSafeChannelValue(value: string): boolean {
+  return value.length <= MAX_CHANNEL_VALUE_LENGTH && BASE64URL.test(value);
+}
+
+/**
+ * Read a v2 pairing channel out of a URL hash, as produced by the authority's
+ * QR code: `/pair#channel_id=...&channel_key=...&v=2`. The channel lives in the
+ * hash rather than the query string so the key is never sent to the server.
+ *
+ * Returns undefined unless the hash names version 2 and carries both halves of
+ * the channel, each well-formed — half a channel cannot be opened, and a
+ * malformed one cannot be trusted, so both are treated as no hand-off at all
+ * rather than as a broken one.
+ */
+export function parsePairingHash(
+  hash?: string
+): PairingChannelInfo | undefined {
+  const params = new URLSearchParams((hash ?? '').replace(/^#/, ''));
+
+  if (params.get('v') !== '2') {
+    return undefined;
+  }
+
+  const channelId = params.get('channel_id');
+  const channelKey = params.get('channel_key');
+  if (!channelId || !channelKey) {
+    return undefined;
+  }
+  if (!isSafeChannelValue(channelId) || !isSafeChannelValue(channelKey)) {
+    return undefined;
+  }
+
+  return { channelId, channelKey, version: '2' };
+}
+
+/**
+ * The URL the authority puts in its QR code, and the URL the supplicant deep
+ * links back into Firefox with. `origin` is injectable for tests; it defaults
+ * to the current one.
+ */
+export function buildPairUrl(
+  { channelId, channelKey, version }: PairingChannelInfo,
+  origin: string = window.location.origin
+): string {
+  return (
+    `${origin}/pair` +
+    `#channel_id=${channelId}` +
+    `&channel_key=${channelKey}` +
+    `&v=${version}`
+  );
+}

--- a/packages/fxa-settings/src/lib/pairing/store-fallback.test.ts
+++ b/packages/fxa-settings/src/lib/pairing/store-fallback.test.ts
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * These tests assert how we react to a sequence of events, not that iOS
+ * produces that sequence — the latter is device behaviour a jsdom test cannot
+ * honestly assert. The sequences below are the ones recorded on-device in the
+ * module's header comment.
+ */
+
+import {
+  armStoreFallback,
+  STORE_FALLBACK_GRACE_MS,
+  STORE_FALLBACK_TIMEOUT_MS,
+} from './store-fallback';
+
+/**
+ * A stand-in for window/document that lets a test drive the exact event order
+ * iOS produces, and inspect listener bookkeeping.
+ */
+function createHost() {
+  const listeners = new Map<string, Set<EventListener>>();
+  let visibility: DocumentVisibilityState = 'visible';
+
+  const add = (type: string, fn: EventListener) => {
+    const set = listeners.get(type) ?? new Set();
+    set.add(fn);
+    listeners.set(type, set);
+  };
+  const remove = (type: string, fn: EventListener) => {
+    listeners.get(type)?.delete(fn);
+  };
+
+  const target = {
+    addEventListener: jest.fn(add),
+    removeEventListener: jest.fn(remove),
+    setTimeout: ((fn: () => void, ms?: number) =>
+      setTimeout(fn, ms)) as unknown as Window['setTimeout'],
+    clearTimeout: ((id?: number) =>
+      clearTimeout(id)) as unknown as Window['clearTimeout'],
+  };
+
+  const doc = {
+    addEventListener: jest.fn(add),
+    removeEventListener: jest.fn(remove),
+    get hidden() {
+      return visibility === 'hidden';
+    },
+    get visibilityState() {
+      return visibility;
+    },
+  } as unknown as Document;
+
+  return {
+    win: target,
+    doc,
+    listenerCount: () =>
+      [...listeners.values()].reduce((total, set) => total + set.size, 0),
+    setVisibility(next: DocumentVisibilityState) {
+      visibility = next;
+    },
+    fire(type: string) {
+      [...(listeners.get(type) ?? [])].forEach((fn) =>
+        fn(new Event(type) as Event)
+      );
+    },
+  };
+}
+
+function arm(host: ReturnType<typeof createHost>, onFallback: jest.Mock) {
+  return armStoreFallback({ onFallback, win: host.win, doc: host.doc });
+}
+
+describe('armStoreFallback', () => {
+  let host: ReturnType<typeof createHost>;
+  let onFallback: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    host = createHost();
+    onFallback = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // The scheme no-ops with no dialog at all, so there is no blur/focus pair to
+  // key off and the backstop timer owns the decision.
+  it('falls back when the scheme no-ops silently', () => {
+    arm(host, onFallback);
+
+    jest.advanceTimersByTime(STORE_FALLBACK_TIMEOUT_MS);
+
+    expect(onFallback).toHaveBeenCalledTimes(1);
+  });
+
+  // The highest-value case: a dialog is on screen and the user is slow to tap
+  // "Open". A bare timer would send them to the store mid-dialog.
+  it('does not fall back on the backstop timer once a dialog has appeared', () => {
+    arm(host, onFallback);
+
+    host.fire('blur');
+    jest.advanceTimersByTime(STORE_FALLBACK_TIMEOUT_MS);
+
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  // not installed: blur ("address is invalid") -> focus (tapped OK) -> nothing.
+  it('falls back when focus returns and nothing follows it', () => {
+    arm(host, onFallback);
+
+    host.fire('blur');
+    host.fire('focus');
+    jest.advanceTimersByTime(STORE_FALLBACK_GRACE_MS);
+
+    expect(onFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fall back while the grace window is still open', () => {
+    arm(host, onFallback);
+
+    host.fire('blur');
+    host.fire('focus');
+    jest.advanceTimersByTime(STORE_FALLBACK_GRACE_MS - 1);
+
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  // installed: focus comes back BEFORE Safari is backgrounded, so each of these
+  // three signals arrives after the grace window has already opened.
+  describe('when the app takes the foreground after focus returns', () => {
+    it('cancels the fallback on visibilitychange to hidden', () => {
+      arm(host, onFallback);
+
+      host.fire('blur');
+      host.fire('focus');
+      host.setVisibility('hidden');
+      host.fire('visibilitychange');
+      jest.advanceTimersByTime(STORE_FALLBACK_GRACE_MS);
+
+      expect(onFallback).not.toHaveBeenCalled();
+    });
+
+    it('cancels the fallback on pagehide', () => {
+      arm(host, onFallback);
+
+      host.fire('blur');
+      host.fire('focus');
+      host.fire('pagehide');
+      jest.advanceTimersByTime(STORE_FALLBACK_GRACE_MS);
+
+      expect(onFallback).not.toHaveBeenCalled();
+    });
+
+    // Holds together on any iOS version where visibilitychange does not fire
+    // for an app switch.
+    it('cancels the fallback on a second blur', () => {
+      arm(host, onFallback);
+
+      host.fire('blur');
+      host.fire('focus');
+      host.fire('blur');
+      jest.advanceTimersByTime(STORE_FALLBACK_GRACE_MS);
+
+      expect(onFallback).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not fall back while the page is not visible', () => {
+    arm(host, onFallback);
+
+    host.setVisibility('hidden');
+    jest.advanceTimersByTime(STORE_FALLBACK_TIMEOUT_MS);
+
+    expect(onFallback).toHaveBeenCalledTimes(0);
+  });
+
+  it('falls back only once', () => {
+    arm(host, onFallback);
+
+    jest.advanceTimersByTime(STORE_FALLBACK_TIMEOUT_MS);
+    host.fire('blur');
+    host.fire('focus');
+    jest.advanceTimersByTime(STORE_FALLBACK_GRACE_MS);
+
+    expect(onFallback).toHaveBeenCalledTimes(1);
+  });
+
+  describe('teardown', () => {
+    it('removes every listener it added', () => {
+      const teardown = arm(host, onFallback);
+      expect(host.listenerCount()).toBe(4);
+
+      teardown();
+
+      expect(host.listenerCount()).toBe(0);
+    });
+
+    it('stops the backstop timer from firing', () => {
+      const teardown = arm(host, onFallback);
+
+      teardown();
+      jest.advanceTimersByTime(STORE_FALLBACK_TIMEOUT_MS);
+
+      expect(onFallback).not.toHaveBeenCalled();
+    });
+
+    it('stops an open grace window from firing', () => {
+      const teardown = arm(host, onFallback);
+
+      host.fire('blur');
+      host.fire('focus');
+      teardown();
+      jest.advanceTimersByTime(STORE_FALLBACK_GRACE_MS);
+
+      expect(onFallback).not.toHaveBeenCalled();
+    });
+
+    it('is safe to call twice', () => {
+      const teardown = arm(host, onFallback);
+
+      teardown();
+      expect(() => teardown()).not.toThrow();
+    });
+  });
+});

--- a/packages/fxa-settings/src/lib/pairing/store-fallback.ts
+++ b/packages/fxa-settings/src/lib/pairing/store-fallback.ts
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Inferring "the Firefox deep link did not resolve" on iOS, so the caller can
+ * send the user to the App Store. Ported from the FXA-13863 proof of concept.
+ * The findings below constrain the whole shape of this file:
+ *
+ * 1. The app hand-off MUST be a top-level, user-initiated navigation. WebKit
+ *    ignores external-scheme navigations made from a subframe, so a hidden
+ *    iframe never launches anything on iOS — and a store-fallback timer then
+ *    fires and sends users who *have* Firefox to the App Store. The deep link
+ *    therefore belongs in a CTA's `href`, so the tap itself is the navigation;
+ *    this module only watches what happens afterwards.
+ *
+ * 2. The "address is invalid" alert cannot be suppressed with a custom scheme.
+ *    When Firefox isn't installed, `firefox://` raises it, and no API reports
+ *    it. Universal Links are the only alert-free mechanism, and they don't work
+ *    yet: we serve accounts.firefox.com's apple-app-site-association claiming
+ *    `/pair` and `/pair/*` (see
+ *    fxa-content-server/server/lib/routes/get-apple-app-site-association.js),
+ *    but Universal Links are a two-sided handshake and Firefox iOS ships
+ *    `com.apple.developer.associated-domains` as an EMPTY array. Until the app
+ *    adds `applinks:accounts.firefox.com` (FXA-13732), our AASA entries are inert.
+ *
+ * 3. The store fallback is therefore inferred, not detected: we treat "the page
+ *    never went hidden" as "the app never opened". The trap is that iOS hands
+ *    focus back to the page when the "Open in Firefox?" dialog is confirmed, a
+ *    beat BEFORE it backgrounds Safari — so regained focus can only *start* a
+ *    grace window, never trigger the fallback.
+ *
+ *    Known limitation: a *cancelled* "Open in Firefox?" confirmation is
+ *    genuinely indistinguishable from the error alert — both are blur → focus
+ *    with nothing following — so cancelling sends a user who *has* Firefox to
+ *    the App Store. That is why the caller should navigate with assign() and
+ *    not replace(): Back returns to the interstitial so they can retry.
+ */
+
+/** Backstop for a *silent* failure — no dialog, no launch. */
+export const STORE_FALLBACK_TIMEOUT_MS = 2000;
+/**
+ * How long the app switch gets to win after focus comes back. Tapping "Open" on
+ * iOS's "Open in Firefox?" dialog hands focus back to the page BEFORE Safari is
+ * backgrounded, so focus alone must never trigger the fallback.
+ */
+export const STORE_FALLBACK_GRACE_MS = 1000;
+
+type TimerWindow = Pick<
+  Window,
+  'addEventListener' | 'removeEventListener' | 'setTimeout' | 'clearTimeout'
+>;
+
+/**
+ * Watch for the deep link failing and call `onFallback` when it does.
+ *
+ * There is no API that reports "the custom scheme didn't resolve", so we infer
+ * it. The subtlety that makes this hard: iOS dismisses BOTH native dialogs the
+ * same way as far as the page can see.
+ *
+ *   not installed:  tap -> blur ("address is invalid") -> focus (tapped OK)
+ *                   -> nothing else ever happens.
+ *   installed:      tap -> blur ("Open in Firefox?") -> focus (tapped Open!)
+ *                   -> *then* Safari is backgrounded -> blur + hidden.
+ *
+ * So regained focus is NOT the decision point — it arrives on the happy path
+ * too, before iOS has backgrounded us. Redirecting there sent people who tapped
+ * "Open" to the App Store. Instead focus only opens a `grace` window, and any of
+ * hidden/pagehide/a second blur cancels it. Nothing left to cancel it by the
+ * time the window closes means the launch really did fail.
+ *
+ * `win`/`doc` are injectable so the decision is testable; the event ordering
+ * itself is device behaviour a jsdom test cannot honestly assert.
+ *
+ * @returns a teardown that removes every listener and clears every timer.
+ */
+export function armStoreFallback({
+  onFallback,
+  timeoutMs = STORE_FALLBACK_TIMEOUT_MS,
+  graceMs = STORE_FALLBACK_GRACE_MS,
+  win = window,
+  doc = document,
+}: {
+  onFallback: () => void;
+  timeoutMs?: number;
+  graceMs?: number;
+  win?: TimerWindow;
+  doc?: Document;
+}): () => void {
+  let appOpened = false;
+  let sawBlur = false;
+  let sawFocus = false;
+  let graceTimer = 0;
+  let torndown = false;
+
+  const fallback = () => {
+    if (appOpened || doc.visibilityState !== 'visible') {
+      return;
+    }
+    teardown();
+    onFallback();
+  };
+
+  // Definitive "the app opened" signals — a real background or teardown.
+  const onHidden = () => {
+    if (doc.hidden) {
+      appOpened = true;
+      win.clearTimeout(graceTimer);
+    }
+  };
+  const onLeave = () => {
+    appOpened = true;
+    win.clearTimeout(graceTimer);
+  };
+
+  const onBlur = () => {
+    win.clearTimeout(graceTimer);
+    // A blur *after* we had already regained focus is the app taking the
+    // foreground on its second act — the dialog was confirmed and the launch is
+    // under way. Treat it as opened, so this still holds together on any iOS
+    // version where visibilitychange does not fire for an app switch.
+    if (sawFocus) {
+      appOpened = true;
+    }
+    sawBlur = true;
+  };
+
+  const onFocus = () => {
+    if (appOpened) {
+      return;
+    }
+    sawFocus = true;
+    win.clearTimeout(graceTimer);
+    graceTimer = win.setTimeout(fallback, graceMs);
+  };
+
+  doc.addEventListener('visibilitychange', onHidden);
+  win.addEventListener('pagehide', onLeave);
+  win.addEventListener('blur', onBlur);
+  win.addEventListener('focus', onFocus);
+
+  // Backstop for a silent failure: the scheme no-ops with no dialog at all, so
+  // there is no blur/focus pair to key off. Deliberately gated on `!sawBlur` —
+  // if a dialog did appear, the blur/focus machinery owns the decision, and
+  // firing here could redirect while that dialog is still on screen, which is
+  // what a bare timer does to anyone slow to tap "Open".
+  const timer = win.setTimeout(() => {
+    if (!sawBlur) {
+      fallback();
+    }
+  }, timeoutMs);
+
+  function teardown() {
+    if (torndown) {
+      return;
+    }
+    torndown = true;
+    doc.removeEventListener('visibilitychange', onHidden);
+    win.removeEventListener('pagehide', onLeave);
+    win.removeEventListener('blur', onBlur);
+    win.removeEventListener('focus', onFocus);
+    win.clearTimeout(timer);
+    win.clearTimeout(graceTimer);
+  }
+
+  return teardown;
+}

--- a/packages/fxa-settings/src/models/integrations/pairing-authority-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-authority-integration.ts
@@ -28,6 +28,7 @@ import {
   validateSupplicantRequest,
 } from './pairing-request-validation';
 import * as Sentry from '@sentry/browser';
+import { buildPairUrl } from '../../lib/pairing/pair-url';
 
 const PAIR_HEARTBEAT_INTERVAL = 1000;
 
@@ -125,12 +126,13 @@ export class PairingAuthorityIntegration extends OAuthWebIntegration {
     if (!this._channel?.channelId || !this._channel?.channelKey) {
       throw new Error('Cannot build a pair URL before the channel is created.');
     }
-    return (
-      `${window.location.origin}/pair` +
-      `#channel_id=${this._channel.channelId}` +
-      `&channel_key=${this._channel.channelKey}` +
-      `&v=${v}`
-    );
+    // Shared with the supplicant's deep link back into Firefox, so the URL we
+    // encode and the URL we hand off can never disagree.
+    return buildPairUrl({
+      channelId: this._channel.channelId,
+      channelKey: this._channel.channelKey,
+      version: v,
+    });
   }
 
   async createChannel(): Promise<void> {

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
@@ -30,6 +30,7 @@ export function mockFxAStatus({
     selectedEnginesForGlean: {},
     supportsKeysOptionalLogin: false,
     supportsCanLinkAccountUid: undefined,
+    fxaStatusState: 'answered',
     fxaStatus: {
       capabilities: {
         engines: [],

--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -12,11 +12,12 @@ import firefox from '../../../lib/channels/firefox';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import { MOCK_ERROR } from './mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
-import Pair, { parsePairingHash, viewName } from '.';
+import Pair, { viewName } from '.';
 import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { getDefault } from '../../../lib/config';
 import { PAIR_GLEAN_REASONS } from 'fxa-shared/metrics/glean/pair-reasons';
 import { Integration } from '../../../models';
+import { parsePairingHash } from '../../../lib/pairing/pair-url';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -712,5 +713,129 @@ describe('parseV2PairingHash', () => {
     ['an empty channel_key', '#channel_id=chan-1&channel_key=&v=2'],
   ])('returns undefined for %s', (_label, hash) => {
     expect(parsePairingHash(hash)).toBeUndefined();
+  });
+
+  // A phone that scans the pairing QR with its system camera opens this page in
+  // its default browser, which is often not Firefox. Those browsers never answer
+  // fxa_status, so the page hands the pairing URL to the Firefox app instead of
+  // dead-ending on /pair/unsupported.
+  describe('hand-off when the browser never answers fxa_status', () => {
+    const V2_HASH = '#channel_id=chan-1&channel_key=key-1&v=2';
+    const IOS_SAFARI =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 ' +
+      '(KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+    const ANDROID_CHROME =
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+      'Chrome/124.0.0.0 Mobile Safari/537.36';
+    const DESKTOP_CHROME =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+    const FIREFOX_ANDROID =
+      'Mozilla/5.0 (Android 14; Mobile; rv:124.0) Gecko/124.0 Firefox/124.0';
+
+    const setUserAgent = (value: string) =>
+      Object.defineProperty(navigator, 'userAgent', {
+        value,
+        configurable: true,
+      });
+
+    const unansweredProps = {
+      fxaStatusResult: mockUseFxAStatus({ fxaStatusState: 'unanswered' }),
+    };
+
+    const v2AppContext = () => {
+      const config = getDefault();
+      config.pairing.version = 2;
+      return mockAppContext({ config } as Parameters<typeof mockAppContext>[0]);
+    };
+
+    beforeEach(() => {
+      mockLocationHash = V2_HASH;
+    });
+
+    it.each([
+      ['iOS Safari', IOS_SAFARI],
+      ['Android Chrome', ANDROID_CHROME],
+    ])('offers to continue in Firefox on %s', async (_label, ua) => {
+      setUserAgent(ua);
+      renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+
+      expect(
+        await screen.findByRole('heading', { name: 'Continue in Firefox' })
+      ).toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    // The channel key is what the deep link exists to carry; without it Firefox
+    // opens on a /pair page with nothing to pair.
+    it('hands Firefox the pairing URL the QR encoded', async () => {
+      setUserAgent(IOS_SAFARI);
+      renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+
+      const cta = await screen.findByRole('link', {
+        name: 'Continue in Firefox',
+      });
+      const target = new URL(
+        decodeURIComponent(
+          cta.getAttribute('href')!.replace('firefox://open-url?url=', '')
+        )
+      );
+      expect(target.pathname).toBe('/pair');
+      expect(target.hash).toBe(V2_HASH);
+    });
+
+    // There is no Firefox app to hand off to on desktop.
+    it('sends a non-Firefox desktop browser to /pair/unsupported', async () => {
+      setUserAgent(DESKTOP_CHROME);
+      renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+
+      // The hash rides along, which is what lets /pair/unsupported recognise a
+      // system-camera scan.
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(`/pair/unsupported${V2_HASH}`)
+      );
+      expect(
+        screen.queryByRole('heading', { name: 'Continue in Firefox' })
+      ).not.toBeInTheDocument();
+    });
+
+    // firefox:// inside Firefox is a no-op, so a hand-off here would strand the
+    // user rather than help them.
+    it('does not offer the hand-off inside Firefox for Android', async () => {
+      setUserAgent(FIREFOX_ANDROID);
+      renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+      expect(
+        screen.queryByRole('heading', { name: 'Continue in Firefox' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not offer the hand-off when the URL carries no pairing channel', async () => {
+      mockLocationHash = '';
+      setUserAgent(IOS_SAFARI);
+      renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+      expect(
+        screen.queryByRole('heading', { name: 'Continue in Firefox' })
+      ).not.toBeInTheDocument();
+    });
+
+    // A browser that answered is telling us something; only silence means the
+    // WebChannel is absent.
+    it('does not offer the hand-off when the browser answered with v1', async () => {
+      setUserAgent(IOS_SAFARI);
+      renderWithRouter(
+        <Pair fxaStatusResult={mockUseFxAStatus({ pairingVersion: 1 })} />,
+        {},
+        v2AppContext()
+      );
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+      expect(
+        screen.queryByRole('heading', { name: 'Continue in Firefox' })
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -36,8 +36,17 @@ import mobileFirefoxIcon from './mobile-ff.svg';
 import mobileDownloadIcon from './mobile-download.svg';
 import {
   buildPairingDownloadUrl,
+  detectDevice,
+  Devices,
   isSendTabEntrypoint,
 } from '../../../lib/utilities';
+import { buildPairUrl, parsePairingHash } from '../../../lib/pairing/pair-url';
+import {
+  getAttemptStorage,
+  HandoffPlan,
+  planPairingHandoff,
+} from '../../../lib/pairing/handoff';
+import ContinueInFirefox from '../../../components/ContinueInFirefox';
 import type { PairOrigin } from '../../Signin/utils';
 import type { SigninLocationState } from '../../Signin/interfaces';
 import type { Integration } from '../../../models';
@@ -69,33 +78,7 @@ export type PairingChannelInfo = {
   version: '1'|'2';
 };
 
-/**
- * Read a v2 pairing channel out of a URL hash, as produced by the authority's
- * QR code: `/pair#channel_id=...&channel_key=...&v=2`. The channel lives in the
- * hash rather than the query string so the key is never sent to the server.
- *
- * Returns undefined unless the hash names version 2 and carries both halves of
- * the channel — half a channel cannot be opened, so it is treated as no hand-off
- * at all rather than as a broken one.
- */
-export function parsePairingHash(
-  hash?: string
-): PairingChannelInfo | undefined {
-  const params = new URLSearchParams((hash ?? '').replace(/^#/, ''));
 
-  if (params.get('v') !== '2') {
-    return undefined;
-  }
-
-  const version = params.get('v') === '2' ? '2':'1';
-  const channelId = params.get('channel_id');
-  const channelKey = params.get('channel_key');
-  if (!channelId || !channelKey) {
-    return undefined;
-  }
-
-  return { channelId, channelKey, version };
-}
 
 type MobileChoice = 'has-mobile' | 'needs-mobile';
 
@@ -160,11 +143,78 @@ const Pair = ({
     [location.hash]
   );
 
+  const device = detectDevice();
+  const isFirefoxDesktop = device === Devices.FIREFOX_DESKTOP;
+
+  // A phone that scanned the QR with its system camera opens this page in
+  // whatever browser it defaults to, which is might not be Firefox.
+  // When the browser never answered fxa_status there is no WebChannel here to
+  // carry the flow, so we will hand the pairing URL to the Firefox app instead,
+  // falling back to the app store when it is not installed.
+  //
+  // Read-only, so it is safe to evaluate during render; the auto-attempt token
+  // is only spent by ContinueInFirefox.
+  const handoffPlan: HandoffPlan = useMemo(
+    () => {
+      if (pairingChannelInfo && fxaStatusResult.fxaStatusState === 'unanswered') {
+        return planPairingHandoff({
+            device,
+            targetUrl: buildPairUrl(pairingChannelInfo),
+            storeLinks: config.mobileStoreLinks,
+            storage: getAttemptStorage(),
+            build: config.pairing.browserBuild,
+          })
+      }
+
+      // This indicates no handoff is needed. and we can continue as normal.
+      return { kind: 'none' }
+    }, [pairingChannelInfo, fxaStatusResult.fxaStatusState, device, config]
+  );
 
   useEffect(() => {
-    const ua = navigator.userAgent;
-    const isFirefoxDesktop =
-      /Firefox/i.test(ua) && !/FxiOS/i.test(ua) && !/Android/i.test(ua);
+    // This is a signal that the initial fxa_status message is still pending.
+    // Don't move forwards with other evaluations until we have a definitive
+    // answer here. 'unanswered' is a definitive answer: no reply is coming.
+    if (fxaStatusResult.fxaStatusState === 'pending') {
+      return;
+    }
+
+    // Handled by rendering the hand-off card below. It must be checked before
+    // the !isFirefoxDesktop branch, which would otherwise send every mobile
+    // browser to /pair/unsupported.
+    if (handoffPlan.kind !== 'none') {
+      return;
+    }
+
+    // Switch on pairing version 2! Both FxA and Firefox have to signal that it
+    // is enabled, same gate as ConnectAnotherDevice.
+    const pairingVersion = fxaStatusResult.fxaStatus?.capabilities.pairingVersion;
+
+    if (
+      config.pairing.version === 2 &&
+      pairingVersion &&
+      pairingVersion === 2 &&
+      pairingChannelInfo?.version === '2'
+    ) {
+      navigateWithQuery(
+        '/pair/supplicant/connect_this_device',
+        { state: pairingChannelInfo },
+        false
+      );
+      return;
+    }
+
+    if (
+      isFirefoxDesktop &&
+      config.pairing.version === 2 &&
+      pairingVersion &&
+      pairingVersion === 2
+    ) {
+      // Full reload: `useIntegration` is not keyed on location, so only a
+      // fresh page load rebuilds it as a PairingAuthorityIntegration.
+      hardNavigate('/pair/authority/scan_qr', {}, true);
+      return;
+    }
 
     // This is a signal that the initial fxa_status message is still pending.
     // Don't move forwards with other evaluations until we have a definitive
@@ -175,7 +225,6 @@ const Pair = ({
 
     // Switch on pairing version 2! Both FxA and Firefox have to signal that it
     // is enabled, same gate as ConnectAnotherDevice.
-    const { pairingVersion } = fxaStatusResult.fxaStatus.capabilities;
     if(
       config.pairing.version === 2 &&
       pairingVersion && pairingVersion === 2 &&
@@ -252,7 +301,7 @@ const Pair = ({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pairingChannelInfo, fxaStatusResult, navigateWithQuery]);
+  }, [pairingChannelInfo, fxaStatusResult, handoffPlan, navigateWithQuery]);
 
   // Banner variant is driven by router state from getSyncNavigate.
   const { origin: pairOrigin } = (location.state ?? {}) as Pick<
@@ -333,7 +382,11 @@ const Pair = ({
     openPairPreferences();
   }, [openPairPreferences]);
 
-  if (bootstrapping || !fxaStatusResult.fxaStatus) {
+  if (handoffPlan.kind !== 'none') {
+    return <ContinueInFirefox plan={handoffPlan} />;
+  }
+
+  if (bootstrapping || fxaStatusResult.fxaStatusState === 'pending') {
     return <LoadingSpinner fullScreen />;
   }
 


### PR DESCRIPTION
## Because

- It's not uncommon for a Firefox pairing QR to be scanned, and then open in a browser other than Firefox. This happens when:
  - Firefox is not configured as the default browser.
  - Firefox is simply not installed.

## This pull request

- Detects when pair page is opened by a browser other than firefox.
- Falls back to trying to open Firefox via a deep link
- If the deep link fails, falls back to opening the app store 

## Issue that this pull request solves

Closes: FXA-13866

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- You'll want to target android (or iOS) at your local stack. 
- Next make a browser other than firefox your default browser
- On a desktop Firefox version that supports pairing version 2 (156 and on):
  - Sign in to sync
  - Choose 'add another device' from syncs menu, so you can see the v2 pairing URL.
- Scan this code with your native camera.
- On Android:
  - Observe that you'll get the app switcher dialog. 
  - Select the firefox icon
  - Observe that Firefox opens pointing at the pair page
- On iOS
  - Observer that you'll see a button that says continue with firefox.
  - Click it!
  - Observe that firefox opens
  

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note, typically one would do this with app links or universal links; however, the fact that Firefox is a browser puts us in an unusual spot, since a universal link cannot override the OS's system setting for default browser. As a result we have this taken this deeplink based approach.

Note, on iOS a deep link can only be opened from a user button click, so we a user must click the 'Continue with Firefox' button in order to open a deep link into Firefox.
