### PR TITLE
test(passkey): add PRF output support to the virtual authenticator

### DIFF
--- a/libs/accounts/passkey/src/index.ts
+++ b/libs/accounts/passkey/src/index.ts
@@ -27,4 +27,6 @@ export * from './lib/passkey.config';
 export * from './lib/passkey.provider';
 export * from './lib/passkey.challenge.manager';
 export * from './lib/webauthn-adapter';
-export * from './lib/virtual-authenticator';
+
+// The virtual authenticator is deliberately absent — import it from
+// `@fxa/accounts/passkey/testing`.

--- a/libs/accounts/passkey/src/lib/virtual-authenticator.spec.ts
+++ b/libs/accounts/passkey/src/lib/virtual-authenticator.spec.ts
@@ -1,0 +1,193 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  derivePrfOutput,
+  VirtualAuthenticator,
+  type VirtualCeremonyExtensions,
+  type VirtualCredential,
+} from './virtual-authenticator';
+
+const TEST_RP_ID = 'accounts.firefox.com';
+const TEST_ORIGIN = 'https://accounts.firefox.com';
+const TEST_CHALLENGE = Buffer.alloc(32, 0xbb).toString('base64url');
+// base64url of "test-prf-salt" — the dev-config PRF salt, not the production one.
+const TEST_PRF_SALT = 'dGVzdC1wcmYtc2FsdA';
+// base64url of "other-prf-salt".
+const OTHER_PRF_SALT = 'b3RoZXItcHJmLXNhbHQ';
+
+const CEREMONY = {
+  challenge: TEST_CHALLENGE,
+  origin: TEST_ORIGIN,
+  rpId: TEST_RP_ID,
+};
+
+const PRF_REQUESTED: VirtualCeremonyExtensions = {
+  prf: { eval: { first: TEST_PRF_SALT } },
+};
+
+type PrfOutput = {
+  enabled?: boolean;
+  results?: { first?: string };
+};
+
+function prfOutput(extensionResults: unknown): PrfOutput | undefined {
+  return (extensionResults as { prf?: PrfOutput }).prf;
+}
+
+function assertionPrf(
+  cred: VirtualCredential,
+  extensions?: VirtualCeremonyExtensions
+) {
+  return prfOutput(
+    VirtualAuthenticator.createAssertionResponse(cred, {
+      ...CEREMONY,
+      extensions,
+    }).clientExtensionResults
+  );
+}
+
+function attestationPrf(
+  cred: VirtualCredential,
+  extensions?: VirtualCeremonyExtensions
+) {
+  return prfOutput(
+    VirtualAuthenticator.createAttestationResponse(cred, {
+      ...CEREMONY,
+      extensions,
+    }).clientExtensionResults
+  );
+}
+
+function expectedOutput(cred: VirtualCredential, salt: string) {
+  return derivePrfOutput(cred, salt).toString('base64url');
+}
+
+describe('VirtualAuthenticator PRF outputs', () => {
+  let cred: VirtualCredential;
+
+  beforeEach(() => {
+    cred = VirtualAuthenticator.createCredential();
+  });
+
+  describe('when the ceremony does not request PRF', () => {
+    it('reports no prf output on an assertion', () => {
+      const response = VirtualAuthenticator.createAssertionResponse(
+        cred,
+        CEREMONY
+      );
+      expect(response.clientExtensionResults).toEqual({});
+    });
+
+    it('reports no prf output on an attestation', () => {
+      const response = VirtualAuthenticator.createAttestationResponse(
+        cred,
+        CEREMONY
+      );
+      expect(response.clientExtensionResults).toEqual({});
+    });
+
+    it('reports no prf output when extensions omit prf', () => {
+      const response = VirtualAuthenticator.createAssertionResponse(cred, {
+        ...CEREMONY,
+        extensions: {},
+      });
+      expect(response.clientExtensionResults).toEqual({});
+    });
+  });
+
+  describe('registration', () => {
+    it('reports PRF capability without an output', () => {
+      expect(attestationPrf(cred, PRF_REQUESTED)).toEqual({ enabled: true });
+    });
+
+    it('reports PRF capability when no salt was supplied', () => {
+      expect(attestationPrf(cred, { prf: {} })).toEqual({ enabled: true });
+    });
+  });
+
+  describe('authentication', () => {
+    it('returns the derived output for the evaluated salt', () => {
+      expect(assertionPrf(cred, PRF_REQUESTED)).toEqual({
+        results: { first: expectedOutput(cred, TEST_PRF_SALT) },
+      });
+    });
+
+    it('omits the capability flag, which is a registration-time output', () => {
+      expect(assertionPrf(cred, PRF_REQUESTED)).not.toHaveProperty('enabled');
+    });
+
+    it('returns no output when the eval carries no salt', () => {
+      // Malformed per spec, but easy for a test to construct, so a missing
+      // salt has to yield no output rather than throwing.
+      const response = VirtualAuthenticator.createAssertionResponse(cred, {
+        ...CEREMONY,
+        extensions: {
+          prf: { eval: {} },
+        } as unknown as VirtualCeremonyExtensions,
+      });
+      expect(response.clientExtensionResults).toEqual({});
+    });
+
+    it('returns no output when no salt was supplied', () => {
+      const response = VirtualAuthenticator.createAssertionResponse(cred, {
+        ...CEREMONY,
+        extensions: { prf: {} },
+      });
+      expect(response.clientExtensionResults).toEqual({});
+    });
+
+    it('returns the same output for repeated assertions', () => {
+      // Pinned to a value so two absent outputs can't pass vacuously; the
+      // sign-count bump between calls is what's under test.
+      const expected = {
+        results: { first: expectedOutput(cred, TEST_PRF_SALT) },
+      };
+      expect(assertionPrf(cred, PRF_REQUESTED)).toEqual(expected);
+      expect(assertionPrf(cred, PRF_REQUESTED)).toEqual(expected);
+    });
+
+    it('returns distinct outputs for distinct credentials', () => {
+      const other = VirtualAuthenticator.createCredential();
+      expect(assertionPrf(cred, PRF_REQUESTED)?.results?.first).not.toEqual(
+        assertionPrf(other, PRF_REQUESTED)?.results?.first
+      );
+    });
+  });
+
+  describe('derivation', () => {
+    it('derives a 32-byte output', () => {
+      expect(derivePrfOutput(cred, TEST_PRF_SALT)).toHaveLength(32);
+    });
+
+    it('returns distinct outputs for distinct salts', () => {
+      expect(derivePrfOutput(cred, TEST_PRF_SALT)).not.toEqual(
+        derivePrfOutput(cred, OTHER_PRF_SALT)
+      );
+    });
+  });
+  describe('when the authenticator cannot evaluate a PRF', () => {
+    let unsupported: VirtualCredential;
+
+    beforeEach(() => {
+      unsupported = VirtualAuthenticator.createCredential({
+        prfSupported: false,
+      });
+    });
+
+    it('reports the capability as false at registration', () => {
+      expect(attestationPrf(unsupported, PRF_REQUESTED)).toEqual({
+        enabled: false,
+      });
+    });
+
+    it('returns no output at assertion', () => {
+      const response = VirtualAuthenticator.createAssertionResponse(
+        unsupported,
+        { ...CEREMONY, extensions: PRF_REQUESTED }
+      );
+      expect(response.clientExtensionResults).toEqual({});
+    });
+  });
+});

--- a/libs/accounts/passkey/src/lib/virtual-authenticator.ts
+++ b/libs/accounts/passkey/src/lib/virtual-authenticator.ts
@@ -12,6 +12,7 @@
 
 import {
   createHash,
+  createHmac,
   createSign,
   generateKeyPairSync,
   randomBytes,
@@ -20,6 +21,8 @@ import {
 import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
+  AuthenticationExtensionsClientInputs,
+  AuthenticationExtensionsClientOutputs,
 } from '@simplewebauthn/server';
 
 // ---------------------------------------------------------------------------
@@ -72,6 +75,144 @@ export interface VirtualCredential {
   privateKey: KeyObject;
   publicKey: KeyObject;
   signCount: number;
+  /**
+   * Whether this authenticator can evaluate a PRF. False models a working
+   * authenticator with no `hmac-secret` support: `prf.enabled: false` and never
+   * an output, so the relying party must fall back to a password.
+   */
+  prfSupported: boolean;
+}
+
+/**
+ * PRF eval salt, base64url-encoded as the server issues it. The spec allows a
+ * `second` salt; FxA only ever sends `first`, so it isn't modelled.
+ */
+export interface PrfEvalInputJSON {
+  first: string;
+}
+
+/**
+ * Client extension inputs for a ceremony, in the base64url JSON shape the
+ * server issues — pass the server's `options.extensions` straight through.
+ */
+export interface VirtualCeremonyExtensions {
+  prf?: {
+    eval?: PrfEvalInputJSON;
+  };
+}
+
+export interface CeremonyInput {
+  challenge: string;
+  origin: string;
+  rpId: string;
+  /**
+   * Client extension inputs; takes the server's `options.extensions` directly.
+   * Extensions other than `prf` are ignored, as an authenticator ignores ones
+   * it doesn't implement.
+   */
+  extensions?: VirtualCeremonyExtensions & AuthenticationExtensionsClientInputs;
+}
+
+/** Per-ceremony knobs shared by both response builders. */
+export interface CeremonyOpts {
+  /** Clear the UV flag (default: UV performed). */
+  userVerified?: boolean;
+}
+
+/** The `prf` client extension output, absent from SimpleWebAuthn's types. */
+interface PrfExtensionOutputs {
+  prf?: {
+    enabled?: boolean;
+    results?: { first: string };
+  };
+}
+
+const PRF_SECRET_DOMAIN = 'fxa-virtual-authenticator-prf';
+
+/**
+ * Domain-separation prefix a real client prepends before hashing the RP's salt
+ * into the value the authenticator evaluates.
+ */
+const PRF_INPUT_PREFIX = Buffer.concat([
+  Buffer.from('WebAuthn PRF', 'utf8'),
+  Buffer.from([0x00]),
+]);
+
+/**
+ * Stand-in for the per-credential secret a real authenticator keeps for the
+ * CTAP `hmac-secret` extension. Derived from the private key so the same
+ * credential always yields the same PRF outputs, and two credentials never
+ * collide.
+ *
+ * Not keyed on UV state, unlike CTAP 2.1: FxA requires UV at both ceremonies
+ * and rejects a no-UV assertion server-side, so there is no reachable no-UV
+ * output to model. Revisit if a flow ever requests `userVerification:
+ * 'preferred'`, which is what would make a no-UV assertion reachable.
+ */
+function prfSecret(cred: VirtualCredential): Buffer {
+  return createHash('sha256')
+    .update(PRF_SECRET_DOMAIN)
+    .update(cred.privateKey.export({ format: 'der', type: 'pkcs8' }))
+    .digest();
+}
+
+/**
+ * Derive the PRF output a virtual credential produces for a salt. Test-only:
+ * deterministic per credential and salt, which is what makes wrap round-trip
+ * assertions possible, but not the derivation a real authenticator performs.
+ *
+ * The salt is hashed under the `WebAuthn PRF` prefix first, as a real client
+ * does — that step is also what guarantees the authenticator sees the 32 bytes
+ * CTAP requires, whatever length salt the server sent.
+ *
+ * @param cred - the credential evaluating the PRF
+ * @param salt - base64url eval salt, as sent by the server
+ * @returns the 32-byte output
+ */
+export function derivePrfOutput(cred: VirtualCredential, salt: string): Buffer {
+  const input = createHash('sha256')
+    .update(PRF_INPUT_PREFIX)
+    .update(Buffer.from(salt, 'base64url'))
+    .digest();
+  return createHmac('sha256', prfSecret(cred)).update(input).digest();
+}
+
+/**
+ * `prf` output for a registration ceremony. Returns `{}` unless the ceremony
+ * requested PRF, so ceremonies that don't ask see no change.
+ */
+function registrationPrfOutput(
+  cred: VirtualCredential,
+  input: CeremonyInput
+): AuthenticationExtensionsClientOutputs & PrfExtensionOutputs {
+  if (!input.extensions?.prf) {
+    return {};
+  }
+  // Capability only: a CTAP2 device yields secrets at assertion, not here.
+  return { prf: { enabled: cred.prfSupported } };
+}
+
+/**
+ * `prf` output for an assertion: the evaluated results only. `enabled` is a
+ * registration-time output — a real client does not repeat it here, and code
+ * that reads it at sign-in would be reading something production never sends.
+ */
+function assertionPrfOutput(
+  cred: VirtualCredential,
+  input: CeremonyInput
+): AuthenticationExtensionsClientOutputs & PrfExtensionOutputs {
+  const evalInput = input.extensions?.prf?.eval;
+  if (!evalInput?.first || !cred.prfSupported) {
+    return {};
+  }
+
+  return {
+    prf: {
+      results: {
+        first: derivePrfOutput(cred, evalInput.first).toString('base64url'),
+      },
+    },
+  };
 }
 
 /**
@@ -81,19 +222,34 @@ export interface VirtualCredential {
  * attestation and assertion responses for use in tests.
  */
 export class VirtualAuthenticator {
-  /** Create a fresh ES256 credential with a random 32-byte ID. */
-  static createCredential(): VirtualCredential {
+  /**
+   * Create a fresh ES256 credential with a random 32-byte ID. Pass
+   * `prfSupported: false` for an authenticator that cannot evaluate a PRF.
+   */
+  static createCredential(
+    opts: { prfSupported?: boolean } = {}
+  ): VirtualCredential {
     const { privateKey, publicKey } = generateKeyPairSync('ec', {
       namedCurve: 'P-256',
     });
-    return { id: randomBytes(32), privateKey, publicKey, signCount: 0 };
+    return {
+      id: randomBytes(32),
+      privateKey,
+      publicKey,
+      signCount: 0,
+      prfSupported: opts.prfSupported !== false,
+    };
   }
 
-  /** Build a "none"-format attestation response; pass `userVerified: false` to clear the UV flag (default true). */
+  /**
+   * Build a "none"-format attestation response; pass `userVerified: false` to
+   * clear the UV flag (default true). Pass `input.extensions` to request PRF,
+   * which reports `prf.enabled` — the capability flag the server records.
+   */
   static createAttestationResponse(
     cred: VirtualCredential,
-    input: { challenge: string; origin: string; rpId: string },
-    opts: { userVerified?: boolean } = {}
+    input: CeremonyInput,
+    opts: CeremonyOpts = {}
   ): RegistrationResponseJSON {
     const jwk = cred.publicKey.export({ format: 'jwk' });
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -110,8 +266,10 @@ export class VirtualAuthenticator {
     ]);
 
     const rpIdHash = createHash('sha256').update(input.rpId).digest();
-    const uvFlag = opts.userVerified === false ? 0x00 : 0x04;
-    const flags = Buffer.from([0x41 | uvFlag]); // UP + AT (+ UV unless suppressed)
+    // UP + AT (+ UV unless suppressed)
+    const flags = Buffer.from([
+      0x41 | (opts.userVerified !== false ? 0x04 : 0x00),
+    ]);
     const signCountBuf = Buffer.alloc(4);
     const credIdLen = Buffer.alloc(2);
     credIdLen.writeUInt16BE(cred.id.length, 0);
@@ -149,22 +307,28 @@ export class VirtualAuthenticator {
         transports: ['internal'],
       },
       type: 'public-key',
-      clientExtensionResults: {},
+      clientExtensionResults: registrationPrfOutput(cred, input),
       authenticatorAttachment: 'platform',
     };
   }
 
-  /** Build a signed assertion response; pass `userVerified: false` to clear the UV flag (default true). */
+  /**
+   * Build a signed assertion response; pass `userVerified: false` to clear the
+   * UV flag (default true). Pass `input.extensions` to request PRF, which
+   * yields the deterministic `prf.results` output that wraps `kB`.
+   */
   static createAssertionResponse(
     cred: VirtualCredential,
-    input: { challenge: string; origin: string; rpId: string },
-    opts: { userVerified?: boolean } = {}
+    input: CeremonyInput,
+    opts: CeremonyOpts = {}
   ): AuthenticationResponseJSON {
     cred.signCount++;
 
     const rpIdHash = createHash('sha256').update(input.rpId).digest();
-    const uvFlag = opts.userVerified === false ? 0x00 : 0x04;
-    const flags = Buffer.from([0x01 | uvFlag]); // UP (+ UV unless suppressed)
+    // UP (+ UV unless suppressed)
+    const flags = Buffer.from([
+      0x01 | (opts.userVerified !== false ? 0x04 : 0x00),
+    ]);
     const signCountBuf = Buffer.alloc(4);
     signCountBuf.writeUInt32BE(cred.signCount, 0);
 
@@ -192,7 +356,7 @@ export class VirtualAuthenticator {
         signature: signature.toString('base64url'),
       },
       type: 'public-key',
-      clientExtensionResults: {},
+      clientExtensionResults: assertionPrfOutput(cred, input),
     };
   }
 }

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -288,10 +288,16 @@ describe('verifyWebauthnRegistrationResponse', () => {
   });
 
   it('records prfEnabled when the browser reports PRF support', async () => {
+    // A config that actually requests PRF, so the ceremony carries the eval
+    // salt and the authenticator reports the capability on its own.
+    const prfConfig = testConfig({
+      requestPrfAtRegistration: true,
+      prfSalt: TEST_PRF_SALT,
+    });
     const cred = VirtualAuthenticator.createCredential();
     const challenge = randomBytes(32).toString('base64url');
 
-    const options = await generateWebauthnRegistrationOptions(config, {
+    const options = await generateWebauthnRegistrationOptions(prfConfig, {
       uid: Buffer.alloc(16, 0xaa).toString('hex'),
       email: 'test@example.com',
       challenge,
@@ -301,20 +307,46 @@ describe('verifyWebauthnRegistrationResponse', () => {
       challenge: options.challenge,
       origin: TEST_ORIGIN,
       rpId: TEST_RP_ID,
+      extensions: options.extensions,
     });
-    // prf.enabled is a WebAuthn Level 3 client-extension output the browser
-    // sets; the virtual authenticator leaves clientExtensionResults empty, so
-    // attach it here. (Field absent from SimpleWebAuthn's output type.)
-    (attestation.clientExtensionResults as { prf?: { enabled: boolean } }).prf =
-      { enabled: true };
 
-    const result = await verifyWebauthnRegistrationResponse(config, {
+    const result = await verifyWebauthnRegistrationResponse(prfConfig, {
       response: attestation,
       challenge,
     });
 
     expect(result.verified).toBe(true);
     expect(result.data?.prfEnabled).toBe(true);
+  });
+
+  it('records prfEnabled as false when the authenticator cannot do PRF', async () => {
+    const prfConfig = testConfig({
+      requestPrfAtRegistration: true,
+      prfSalt: TEST_PRF_SALT,
+    });
+    const cred = VirtualAuthenticator.createCredential({ prfSupported: false });
+    const challenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnRegistrationOptions(prfConfig, {
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
+      email: 'test@example.com',
+      challenge,
+    });
+
+    const attestation = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: TEST_RP_ID,
+      extensions: options.extensions,
+    });
+
+    const result = await verifyWebauthnRegistrationResponse(prfConfig, {
+      response: attestation,
+      challenge,
+    });
+
+    expect(result.verified).toBe(true);
+    expect(result.data?.prfEnabled).toBe(false);
   });
 
   it('rejects a mismatched challenge', async () => {

--- a/libs/accounts/passkey/src/testing.ts
+++ b/libs/accounts/passkey/src/testing.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Test-only helpers for `@fxa/accounts/passkey`.
+ *
+ * Kept out of the package's main entry point so production code doesn't reach a
+ * fake authenticator by accident — in particular `derivePrfOutput`, which looks
+ * like a key-derivation function and is not one. The path mapping is global and
+ * this file still compiles into the build, so the split is a guard rail rather
+ * than a barrier.
+ */
+export * from './lib/virtual-authenticator';

--- a/packages/functional-tests/lib/passkeyPolyfill.ts
+++ b/packages/functional-tests/lib/passkeyPolyfill.ts
@@ -3,13 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { Page } from '@playwright/test';
-// Import the virtual-authenticator module directly rather than through the
-// `@fxa/accounts/passkey` barrel — the barrel re-exports NestJS-decorated
-// services whose parameter decorators Playwright's Babel loader cannot parse.
+// The testing entry point rather than the `@fxa/accounts/passkey` barrel: the
+// barrel re-exports NestJS-decorated services whose parameter decorators
+// Playwright's Babel loader cannot parse.
 import {
   VirtualAuthenticator,
+  type VirtualCeremonyExtensions,
   type VirtualCredential,
-} from '../../../libs/accounts/passkey/src/lib/virtual-authenticator';
+} from '@fxa/accounts/passkey/testing';
 import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
@@ -44,6 +45,14 @@ const WEBAUTHN_DOM_EXCEPTION_NAMES = [
   'UnknownError',
 ];
 
+export type PasskeyPolyfillOpts = {
+  /**
+   * Pass `false` to mint credentials from an authenticator that cannot evaluate
+   * a PRF, so the relying party's password-required fallback can be exercised.
+   */
+  prfSupported?: boolean;
+};
+
 type Mode = 'pending' | 'success' | 'cancel' | 'corrupt';
 type Trigger = () => Promise<void>;
 type PostCheck = () => Promise<void>;
@@ -54,11 +63,13 @@ type CreationOptions = {
   challenge: string;
   rp?: { id?: string };
   allowCredentials?: Array<{ id: string }>;
+  extensions?: VirtualCeremonyExtensions;
 };
 type RequestOptions = {
   challenge: string;
   rpId?: string;
   allowCredentials?: Array<{ id: string }>;
+  extensions?: VirtualCeremonyExtensions;
 };
 
 /**
@@ -67,7 +78,7 @@ type RequestOptions = {
  * Unlike the previous CDP-based approach (Chromium only), this patches
  * `window.PublicKeyCredential` and `navigator.credentials.{create,get}` via
  * `page.addInitScript`, delegating the cryptographic work to the Node-side
- * VirtualAuthenticator from `@fxa/accounts/passkey`. The resulting attestation
+ * VirtualAuthenticator from `@fxa/accounts/passkey/testing`. The resulting attestation
  * and assertion responses are cryptographically valid, so the auth-server
  * `verifyRegistration/AuthenticationResponse` checks pass end-to-end.
  *
@@ -81,9 +92,17 @@ type RequestOptions = {
  */
 export class PasskeyPolyfill {
   private credentials: VirtualCredential[] = [];
+  private readonly prfSupported: boolean;
   private mode: Mode = 'pending';
   private onCredentialAdded?: () => void;
   private installed = false;
+
+  /**
+   * @param opts - see {@link PasskeyPolyfillOpts}
+   */
+  constructor(opts: PasskeyPolyfillOpts = {}) {
+    this.prfSupported = opts.prfSupported !== false;
+  }
 
   /**
    * Install the polyfill on the given Playwright page. Exposes the Node-side
@@ -216,7 +235,9 @@ export class PasskeyPolyfill {
   ): Promise<RegistrationResponseJSON> {
     await this.waitForReleasableMode();
 
-    const cred = VirtualAuthenticator.createCredential();
+    const cred = VirtualAuthenticator.createCredential({
+      prfSupported: this.prfSupported,
+    });
     this.credentials.push(cred);
 
     const rpId = options.rp?.id ?? new URL(origin).hostname;
@@ -224,6 +245,7 @@ export class PasskeyPolyfill {
       challenge: options.challenge,
       origin,
       rpId,
+      extensions: options.extensions,
     });
 
     this.onCredentialAdded?.();
@@ -249,6 +271,7 @@ export class PasskeyPolyfill {
       challenge: options.challenge,
       origin,
       rpId,
+      extensions: options.extensions,
     });
 
     if (this.mode === 'corrupt') {
@@ -345,6 +368,29 @@ const BROWSER_POLYFILL = `(() => {
       }
       return bufToB64url(v);
     }
+    // Native PRF eval inputs are BufferSources; Node speaks the base64url JSON
+    // shape the server issues, so re-encode them on the way out.
+    function serializePrfValues(values) {
+      return { first: reqB64url(values.first, 'prf eval first') };
+    }
+    function serializeExtensions(ext) {
+      if (!ext) return undefined;
+      if (!ext.prf) return ext;
+      const prf = {};
+      if (ext.prf.eval) prf.eval = serializePrfValues(ext.prf.eval);
+      return Object.assign({}, ext, { prf: prf });
+    }
+    // A real browser surfaces PRF outputs as ArrayBuffers, and the app relies on
+    // that (binary outputs drop out when the credential is JSON-stringified for
+    // the server). Node sends them base64url, so decode here.
+    function decodeExtensionResults(results) {
+      const prf = results && results.prf;
+      if (!prf || !prf.results) return results;
+      const decoded = { first: b64urlToBuf(prf.results.first) };
+      return Object.assign({}, results, {
+        prf: Object.assign({}, prf, { results: decoded }),
+      });
+    }
 
     class FakePublicKeyCredential {
       constructor(json) {
@@ -368,7 +414,9 @@ const BROWSER_POLYFILL = `(() => {
             userHandle: r.userHandle ? b64urlToBuf(r.userHandle) : null,
           };
         }
-        this._clientExtensionResults = json.clientExtensionResults || {};
+        this._clientExtensionResults = decodeExtensionResults(
+          json.clientExtensionResults || {}
+        );
       }
       static isUserVerifyingPlatformAuthenticatorAvailable() {
         return Promise.resolve(true);
@@ -444,6 +492,7 @@ const BROWSER_POLYFILL = `(() => {
         const json = await invoke('__fxaPasskeyCreate', {
           challenge: reqB64url(pk.challenge, 'create challenge'),
           rp: pk.rp,
+          extensions: serializeExtensions(pk.extensions),
         });
         return new FakePublicKeyCredential(json);
       },
@@ -455,6 +504,7 @@ const BROWSER_POLYFILL = `(() => {
           allowCredentials: (pk.allowCredentials || []).map((c) => ({
             id: reqB64url(c.id, 'allowCredentials id'),
           })),
+          extensions: serializeExtensions(pk.extensions),
         });
         return new FakePublicKeyCredential(json);
       },

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -28,6 +28,9 @@
   "nx": {
     "tags": [
       "scope:functional-test"
+    ],
+    "implicitDependencies": [
+      "accounts-passkey"
     ]
   }
 }

--- a/packages/functional-tests/tests/unit/passkeyPolyfillPrf.spec.ts
+++ b/packages/functional-tests/tests/unit/passkeyPolyfillPrf.spec.ts
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Covers the one part of the passkey polyfill a Jest test cannot reach: the
+ * browser-side shim, which lives in a template string and converts PRF eval
+ * salts and outputs across the page/Node boundary. Everything else about the
+ * PRF path is unit-tested in `libs/accounts/passkey`.
+ *
+ * Deliberately minimal — once the wrap flow has functional tests of its own,
+ * they exercise this seam through real app code and these become redundant.
+ *
+ * The page is served by route interception, so no FxA service is needed.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { derivePrfOutput } from '@fxa/accounts/passkey/testing';
+
+import { PasskeyPolyfill } from '../../lib/passkeyPolyfill';
+
+// base64url of "test-prf-salt" — the dev-config PRF salt, not the production one.
+const TEST_PRF_SALT = 'dGVzdC1wcmYtc2FsdA';
+const SALT_BYTES = [...Buffer.from(TEST_PRF_SALT, 'base64url')];
+const RP_ID = 'passkey-polyfill.test';
+const PAGE_URL = `http://${RP_ID}/`;
+const PRF_OUTPUT_BYTES = 32;
+
+/** Structural stand-in for the DOM's PublicKeyCredential. */
+type PrfCredential = {
+  getClientExtensionResults(): {
+    prf?: { enabled?: boolean; results?: { first: ArrayBuffer } };
+  };
+};
+type GetOptions = Parameters<typeof navigator.credentials.get>[0];
+/** The DOM's client extension inputs, named without a DOM identifier. */
+type Extensions = NonNullable<
+  NonNullable<NonNullable<GetOptions>['publicKey']>['extensions']
+>;
+
+type PageArgs = { salt: number[]; rpId: string };
+
+/** Registration run in page context; reports the capability it was told. */
+const createInPage = async ({ salt, rpId }: PageArgs) => {
+  const credential = (await navigator.credentials.create({
+    publicKey: {
+      challenge: new Uint8Array(32),
+      rp: { id: rpId, name: rpId },
+      user: {
+        id: new Uint8Array(16),
+        name: 'polyfill@example.com',
+        displayName: 'polyfill@example.com',
+      },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      extensions: {
+        prf: { eval: { first: new Uint8Array(salt) } },
+      } as Extensions,
+    },
+  })) as unknown as PrfCredential;
+
+  return { enabled: credential.getClientExtensionResults().prf?.enabled };
+};
+
+/** Assertion run in page context; reports the PRF output as the page sees it. */
+const getInPage = async ({ salt, rpId }: PageArgs) => {
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      challenge: new Uint8Array(32),
+      rpId,
+      extensions: {
+        prf: { eval: { first: new Uint8Array(salt) } },
+      } as Extensions,
+    },
+  })) as unknown as PrfCredential;
+
+  const results = credential.getClientExtensionResults().prf?.results;
+  if (!results) {
+    return { hasOutput: false };
+  }
+  return {
+    hasOutput: true,
+    isArrayBuffer: results.first instanceof ArrayBuffer,
+    byteLength: results.first.byteLength,
+    first: btoa(String.fromCharCode(...new Uint8Array(results.first)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, ''),
+  };
+};
+
+/** Serve a blank page on a routable origin and install the polyfill on it. */
+async function installOn(
+  page: Parameters<PasskeyPolyfill['install']>[0],
+  polyfill: PasskeyPolyfill
+) {
+  await page.route(`${PAGE_URL}**`, (route) =>
+    route.fulfill({ contentType: 'text/html', body: '<html></html>' })
+  );
+  await page.goto(PAGE_URL);
+  await polyfill.install(page);
+}
+
+test.describe('passkey polyfill PRF seam', () => {
+  test('round-trips an eval salt to an ArrayBuffer output in page context', async ({
+    page,
+  }) => {
+    const polyfill = new PasskeyPolyfill();
+    await installOn(page, polyfill);
+    await polyfill.success(async () => {
+      await page.evaluate(createInPage, { salt: SALT_BYTES, rpId: RP_ID });
+    });
+    const [credential] = polyfill.getCredentialObjects();
+
+    let assertion: Awaited<ReturnType<typeof getInPage>> | undefined;
+    await polyfill.assertion(async () => {
+      assertion = await page.evaluate(getInPage, {
+        salt: SALT_BYTES,
+        rpId: RP_ID,
+      });
+    });
+
+    expect(assertion).toEqual({
+      hasOutput: true,
+      isArrayBuffer: true,
+      byteLength: PRF_OUTPUT_BYTES,
+      first: derivePrfOutput(credential, TEST_PRF_SALT).toString('base64url'),
+    });
+  });
+
+  test('surfaces no output when the authenticator has no PRF support', async ({
+    page,
+  }) => {
+    const polyfill = new PasskeyPolyfill({ prfSupported: false });
+    await installOn(page, polyfill);
+
+    let registration: Awaited<ReturnType<typeof createInPage>> | undefined;
+    await polyfill.success(async () => {
+      registration = await page.evaluate(createInPage, {
+        salt: SALT_BYTES,
+        rpId: RP_ID,
+      });
+    });
+
+    // `enabled: false` only reaches page code if the eval request crossed the
+    // boundary, so the absent assertion output below is attributable to the
+    // authenticator rather than to broken extension forwarding.
+    expect(registration).toEqual({ enabled: false });
+
+    let assertion: Awaited<ReturnType<typeof getInPage>> | undefined;
+    await polyfill.assertion(async () => {
+      assertion = await page.evaluate(getInPage, {
+        salt: SALT_BYTES,
+        rpId: RP_ID,
+      });
+    });
+
+    expect(assertion).toEqual({ hasOutput: false });
+  });
+});

--- a/packages/fxa-auth-server/jest.config.js
+++ b/packages/fxa-auth-server/jest.config.js
@@ -27,6 +27,10 @@ const base = {
     '^@fxa/free-access-program$':
       '<rootDir>/../../libs/free-access-program/src',
     '^@fxa/shared/(.*)$': '<rootDir>/../../libs/shared/$1/src',
+    // Secondary entry points must precede the greedy pattern below, which would
+    // otherwise map them to `libs/accounts/<pkg>/<entry>/src`.
+    '^@fxa/accounts/passkey/testing$':
+      '<rootDir>/../../libs/accounts/passkey/src/testing',
     '^@fxa/accounts/(.*)$': '<rootDir>/../../libs/accounts/$1/src',
     '^@fxa/payments/(.*)$': '<rootDir>/../../libs/payments/$1/src',
     '^@fxa/profile/(.*)$': '<rootDir>/../../libs/profile/$1/src',

--- a/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
@@ -10,9 +10,11 @@ import {
   PasskeyService,
   PasskeyChallengeManager,
   PasskeyManager,
+} from '@fxa/accounts/passkey';
+import {
   VirtualAuthenticator,
   VirtualCredential,
-} from '@fxa/accounts/passkey';
+} from '@fxa/accounts/passkey/testing';
 import Config from '../../config';
 import {
   createTestServer,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,6 +36,9 @@
       "@fxa/accounts/errors": ["./libs/accounts/errors/src/index.ts"],
       "@fxa/accounts/oauth": ["./libs/accounts/oauth/src/index.ts"],
       "@fxa/accounts/passkey": ["./libs/accounts/passkey/src/index.ts"],
+      "@fxa/accounts/passkey/testing": [
+        "./libs/accounts/passkey/src/testing.ts"
+      ],
       "@fxa/accounts/rate-limit": ["./libs/accounts/rate-limit/src/index.ts"],
       "@fxa/accounts/recovery-phone": [
         "./libs/accounts/recovery-phone/src/index.ts"


### PR DESCRIPTION
## Because

- Nothing in the test stack could produce a PRF output, so the `kB` wrap work in this epic could not be tested above the unit layer.
- Two consumers were blocked on it: auth-server integration tests, and functional tests whose polyfill delegates its crypto to this authenticator.

## This pull request

- Returns a deterministic per-credential PRF output at assertion, keyed on the eval salt the server sent.
- Reports `prf.enabled` at registration, the capability flag the server records.
- Models an authenticator with no PRF support via `prfSupported: false`, for the password-fallback path.
- Surfaces the output to page code through the Playwright polyfill as an `ArrayBuffer`.
- Drives the adapter spec's two `prfEnabled` cases through the real path, retiring its hand-patched `clientExtensionResults`.
- Moves the virtual authenticator behind a new `@fxa/accounts/passkey/testing` entry point.

## Issue that this pull request solves

Closes: FXA-14268

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `libs/accounts/passkey/src/lib/virtual-authenticator.ts`
- Suggested review order: `a4fdafaa35` (entry point) → authenticator → polyfill
- Risky or complex parts: all test-only; `derivePrfOutput` is deterministic by construction and is not a real KDF

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
