### PR TITLE
task(passkey): Implement POST /passkey/wraps

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.wrap.repository.ts
+++ b/libs/accounts/passkey/src/lib/passkey.wrap.repository.ts
@@ -27,7 +27,7 @@ import { base64urlToBuffer } from './passkey.repository';
  * the same widths at the API boundary; this is the last layer that can
  * still refuse the write.
  */
-const V1_WIDTHS = {
+export const V1_WIDTHS = {
   pkR: 133,
   prfWrappedSkR: 82,
   keyWrapIv: 12,

--- a/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
@@ -176,6 +176,47 @@ const PASSKEYS_API_DOCS = {
       `,
     ],
   },
+
+  /**
+   * Swagger/OpenAPI documentation for `POST /passkey/wraps`.
+   *
+   * Stores the wrap envelope that lets a passkey unlock `kB` without a password.
+   */
+  PASSKEY_WRAPS_POST: {
+    ...TAGS_PASSKEYS,
+    description: '/passkey/wraps',
+    notes: [
+      dedent`
+        🔒 Authenticated with session token (verified)
+
+        Stores the wrap envelope for one passkey. The envelope is produced entirely
+        on the client: \`kB\` is sealed with HPKE to a per-wrap recipient key, whose
+        private half is encrypted under a key derived from the credential's WebAuthn
+        PRF output. The server stores all five fields uninterpreted and never sees
+        \`kB\`, the private key, or the PRF output.
+
+        The credential must belong to the authenticated account.
+
+        **Request body:**
+        - \`credentialId\` (string, required) — base64url credential ID
+        - \`pkR\` (string, required) — base64url, 133 bytes
+        - \`prfWrappedSkR\` (string, required) — base64url, 82 bytes
+        - \`keyWrapIv\` (string, required) — base64url, 12 bytes
+        - \`hpkeEncapsulatedSecret\` (string, required) — base64url, 133 bytes
+        - \`hpkeSealedKb\` (string, required) — base64url, 48 bytes
+
+        **Response:** \`{ created: boolean }\` — false when an identical wrap was
+        already stored.
+
+        **Errors:**
+        - \`404\` errno 224 — no such passkey for this account
+        - \`409\` errno 235 — a different wrap already exists for this credential
+
+        **Security events:** \`account.passkey.wrap_created\` on a new wrap;
+        \`account.passkey.wrap_creation_failure\` on any failure to store one.
+      `,
+    ],
+  },
 };
 
 export default PASSKEYS_API_DOCS;

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -254,6 +254,9 @@ module.exports = function (
     mailer
   );
 
+  const { passkeyWrapsRoutes } = require('./passkey-wraps');
+  const passkeyWraps = passkeyWrapsRoutes(customs, db, config, log);
+
   const { passwordlessRoutes } = require('./passwordless');
   const passwordless = passwordlessRoutes(
     log,
@@ -294,7 +297,8 @@ module.exports = function (
     cms,
     geo,
     mfa,
-    passkeys
+    passkeys,
+    passkeyWraps
   );
 
   function optionallyIgnoreTrace(fn) {

--- a/packages/fxa-auth-server/lib/routes/passkey-wraps.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkey-wraps.spec.ts
@@ -1,0 +1,279 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Schema } from 'joi';
+import { Container } from 'typedi';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { PasskeyService, V1_WIDTHS } from '@fxa/accounts/passkey';
+import type { Customs, DB } from './passkeys';
+import { AuthLogger } from '../types';
+import { AppError, ERRNO } from '@fxa/accounts/errors';
+import { recordSecurityEvent } from './utils/security-event';
+import { passkeyWrapsRoutes } from './passkey-wraps';
+import { ConfigType } from '../../config';
+
+jest.mock('./utils/security-event', () => ({
+  recordSecurityEvent: jest.fn(),
+}));
+
+const UID = 'f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6';
+const TEST_EMAIL = 'test@example.com';
+const CREDENTIAL_ID = Buffer.from('credential-id-xyz').toString('base64url');
+
+/**
+ * A field value of exactly the right width, distinct per field.
+ */
+const field = (bytes: number, fill: number) =>
+  Buffer.alloc(bytes, fill).toString('base64url');
+
+const validEnvelope = () => ({
+  pkR: field(V1_WIDTHS.pkR, 0x04),
+  prfWrappedSkR: field(V1_WIDTHS.prfWrappedSkR, 0x11),
+  keyWrapIv: field(V1_WIDTHS.keyWrapIv, 0x22),
+  hpkeEncapsulatedSecret: field(V1_WIDTHS.hpkeEncapsulatedSecret, 0x33),
+  hpkeSealedKb: field(V1_WIDTHS.hpkeSealedKb, 0x44),
+});
+
+const validPayload = (overrides: Record<string, unknown> = {}) => ({
+  credentialId: CREDENTIAL_ID,
+  ...validEnvelope(),
+  ...overrides,
+});
+
+const config = {
+  passkeys: { enabled: true, passwordlessSyncEnabled: true },
+} as unknown as ConfigType;
+
+const disabledConfig = {
+  passkeys: { enabled: true, passwordlessSyncEnabled: false },
+} as unknown as ConfigType;
+
+describe('passkey wraps routes', () => {
+  let log: DeepMocked<AuthLogger>;
+  let db: DeepMocked<DB>;
+  let customs: DeepMocked<Customs>;
+  let service: DeepMocked<PasskeyService>;
+
+  const buildRoute = (cfg: ConfigType = config) =>
+    passkeyWrapsRoutes(customs, db, cfg, log).find(
+      (r) => r.path === '/passkey/wraps' && r.method === 'POST'
+    ) as any;
+
+  async function run(payload: Record<string, unknown> = validPayload()) {
+    const route = buildRoute();
+    const request = {
+      headers: { 'user-agent': 'test-agent' },
+      auth: { credentials: { uid: UID, id: 'session-token-id' } },
+      payload,
+      app: {
+        clientAddress: '127.0.0.1',
+        geo: { location: { country: 'United States', countryCode: 'US' } },
+      },
+    };
+    return route.handler(request);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    log = createMock<AuthLogger>();
+    db = createMock<DB>();
+    db.account.mockResolvedValue({
+      primaryEmail: { email: TEST_EMAIL },
+    } as Awaited<ReturnType<DB['account']>>);
+    customs = createMock<Customs>();
+    service = createMock<PasskeyService>();
+    service.storePasskeyWrap.mockResolvedValue('created');
+    Container.set(PasskeyService, service);
+  });
+
+  afterEach(() => {
+    Container.reset();
+  });
+
+  describe('POST /passkey/wraps', () => {
+    it('stores the envelope and reports it as created', async () => {
+      const result = await run();
+
+      expect(result).toEqual({ created: true });
+      expect(service.storePasskeyWrap).toHaveBeenCalledWith(
+        UID,
+        CREDENTIAL_ID,
+        {
+          pkR: Buffer.alloc(V1_WIDTHS.pkR, 0x04),
+          prfWrappedSkR: Buffer.alloc(V1_WIDTHS.prfWrappedSkR, 0x11),
+          keyWrapIv: Buffer.alloc(V1_WIDTHS.keyWrapIv, 0x22),
+          hpkeEncapsulatedSecret: Buffer.alloc(
+            V1_WIDTHS.hpkeEncapsulatedSecret,
+            0x33
+          ),
+          hpkeSealedKb: Buffer.alloc(V1_WIDTHS.hpkeSealedKb, 0x44),
+        },
+        expect.any(Number)
+      );
+    });
+
+    it('records a wrap_created event on a new wrap', async () => {
+      await run();
+
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.wrap_created',
+        expect.objectContaining({ db, request: expect.any(Object) })
+      );
+    });
+
+    // Returned bare rather than through the toolkit, so Hapi's default 200
+    // applies; only the 201 needs an explicit code.
+    it('reports an unchanged wrap without re-emitting the event', async () => {
+      service.storePasskeyWrap.mockResolvedValue('unchanged');
+
+      const result = await run();
+
+      expect(result).toEqual({ created: false });
+      expect(recordSecurityEvent).not.toHaveBeenCalledWith(
+        'account.passkey.wrap_created',
+        expect.anything()
+      );
+    });
+
+    it('rate-limits against the current primary email', async () => {
+      await run();
+
+      expect(customs.checkAuthenticated).toHaveBeenCalledWith(
+        expect.any(Object),
+        UID,
+        TEST_EMAIL,
+        'passkeyWrapsCreate'
+      );
+    });
+
+    // The handler does not branch on the error, so one case covers the rethrow.
+    // Which errno belongs to which cause is PasskeyService's contract and is
+    // tested there.
+    it('propagates a store failure with its errno intact', async () => {
+      service.storePasskeyWrap.mockRejectedValue(
+        AppError.passkeyWrapConflict()
+      );
+
+      await expect(run()).rejects.toMatchObject({
+        errno: ERRNO.PASSKEY_WRAP_CONFLICT,
+      });
+    });
+
+    // One event for every cause, matching the other passkey routes. Which cause
+    // it was lives in statsd, emitted by PasskeyService.wrapFailure.
+    it('records a wrap_creation_failure event when the store throws', async () => {
+      service.storePasskeyWrap.mockRejectedValue(new Error('db is down'));
+
+      await expect(run()).rejects.toThrow('db is down');
+
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.wrap_creation_failure',
+        expect.objectContaining({ db, request: expect.any(Object) })
+      );
+    });
+
+    it('surfaces the store error even when the audit write fails', async () => {
+      service.storePasskeyWrap.mockRejectedValue(
+        AppError.passkeyWrapConflict()
+      );
+      (recordSecurityEvent as jest.Mock).mockRejectedValueOnce(
+        new Error('audit write failed')
+      );
+
+      await expect(run()).rejects.toMatchObject({
+        errno: ERRNO.PASSKEY_WRAP_CONFLICT,
+      });
+    });
+
+    it('propagates a customs rejection without writing', async () => {
+      customs.checkAuthenticated.mockRejectedValue(AppError.tooManyRequests(1));
+
+      await expect(run()).rejects.toThrow();
+      expect(service.storePasskeyWrap).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('route configuration', () => {
+    it('accepts only a verified session token', () => {
+      expect(buildRoute().options.auth).toEqual({
+        strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
+        payload: false,
+      });
+    });
+
+    it('gates on the passwordless sync flag', () => {
+      expect(buildRoute().options.pre[0].method()).toBe(true);
+    });
+
+    it('refuses to serve when the passwordless sync flag is off', () => {
+      const routes = passkeyWrapsRoutes(
+        customs,
+        db as any,
+        disabledConfig,
+        log
+      );
+      const route = routes.find(
+        (r) => r.path === '/passkey/wraps' && r.method === 'POST'
+      ) as any;
+
+      expect(() => route.options.pre[0].method()).toThrow();
+    });
+  });
+
+  describe('payload validation', () => {
+    let schema: Schema;
+
+    beforeEach(() => {
+      schema = buildRoute().options.validate.payload;
+    });
+
+    it('accepts a well-formed payload', () => {
+      expect(schema.validate(validPayload()).error).toBeUndefined();
+    });
+
+    it.each(Object.keys(V1_WIDTHS))(
+      'rejects %s one byte short and one byte long',
+      (name) => {
+        const bytes = V1_WIDTHS[name as keyof typeof V1_WIDTHS];
+
+        expect(
+          schema.validate(validPayload({ [name]: field(bytes - 1, 0x01) }))
+            .error
+        ).toBeDefined();
+        expect(
+          schema.validate(validPayload({ [name]: field(bytes + 1, 0x01) }))
+            .error
+        ).toBeDefined();
+      }
+    );
+
+    it.each(['credentialId', ...Object.keys(V1_WIDTHS)])(
+      'requires %s',
+      (name) => {
+        const payload = validPayload();
+        delete (payload as Record<string, unknown>)[name];
+
+        expect(schema.validate(payload).error).toBeDefined();
+      }
+    );
+
+    it('rejects standard base64 in place of base64url', () => {
+      expect(
+        schema.validate(validPayload({ keyWrapIv: 'AAAA/AAAAAAAAAA+' })).error
+      ).toBeDefined();
+    });
+
+    it('strips an unknown field rather than rejecting it', () => {
+      // The server validates with `stripUnknown: true` (lib/server.js), so an
+      // unknown key never reaches the handler and never 400s. Asserting joi's
+      // default here would document behaviour production does not have.
+      const { error, value } = schema.validate(validPayload({ notAField: 1 }), {
+        stripUnknown: true,
+      });
+
+      expect(error).toBeUndefined();
+      expect(value).not.toHaveProperty('notAField');
+    });
+  });
+});

--- a/packages/fxa-auth-server/lib/routes/passkey-wraps.ts
+++ b/packages/fxa-auth-server/lib/routes/passkey-wraps.ts
@@ -1,0 +1,195 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as isA from 'joi';
+import { Container } from 'typedi';
+import {
+  PasskeyService,
+  V1_WIDTHS,
+  type NewPasskeyWrapData,
+} from '@fxa/accounts/passkey';
+import { AuthRequest } from '../types';
+import { ConfigType } from '../../config';
+import { isPasskeyPasswordlessSyncEnabled } from '../passkey-utils';
+import { recordSecurityEvent } from './utils/security-event';
+import type { SecurityEventNames } from 'fxa-shared/db/models/auth/security-event';
+import { reportSentryError } from '../sentry';
+import { base64urlCredentialId, base64urlString } from './passkeys';
+import type { Customs, DB } from './passkeys';
+import PASSKEYS_API_DOCS from '../../docs/swagger/passkeys-api';
+
+/**
+ * A base64url string of exactly `bytes` decoded bytes. Every v1 width has one
+ * legal character count, so the length is the whole check.
+ */
+const base64urlBytes = (bytes: number) => {
+  const chars = Math.ceil((bytes * 4) / 3);
+  return base64urlString(chars).length(chars);
+};
+
+/**
+ * One required field per envelope width, built from the widths themselves so a
+ * v2 field cannot reach the handler unvalidated.
+ */
+const envelopeSchema = Object.fromEntries(
+  Object.entries(V1_WIDTHS).map(([name, bytes]) => [
+    name,
+    base64urlBytes(bytes).required(),
+  ])
+);
+
+/**
+ * The stored wrap as it arrives on the wire: the same fields, base64url-encoded
+ * rather than binary. Keyed off the stored shape, so a new field cannot be
+ * added without a payload entry.
+ */
+type WrapPayload = Record<keyof NewPasskeyWrapData, string>;
+
+/**
+ * Handlers for the passkey wrap endpoints. The envelopes that let a passkey
+ * unlock `kB`.
+ */
+export class PasskeyWrapsHandler {
+  constructor(
+    private readonly service: PasskeyService,
+    private readonly db: DB,
+    private readonly customs: Customs
+  ) {}
+
+  /**
+   * Handles `POST /passkey/wraps`.
+   *
+   * Creates the wrap for a credential that has none. There is no update path,
+   * so a stale wrap is resolved by deleting the passkey and re-enrolling.
+   *
+   * Takes a verified session, as passkey rename does. Registering and deleting
+   * a credential take the `mfa:passkey` scope; this writes against a credential
+   * that already cleared that bar, and a wrap is inert without its PRF output.
+   *
+   * @returns `{ created: boolean }` — false when an identical wrap was already
+   *   stored.
+   */
+  async createPasskeyWrap(request: AuthRequest) {
+    const { uid } = request.auth.credentials as { uid: string };
+    const payload = request.payload as WrapPayload;
+    const { credentialId } = payload;
+
+    const account = await this.db.account(uid);
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      account.primaryEmail.email,
+      'passkeyWrapsCreate'
+    );
+
+    let result: 'created' | 'unchanged';
+    try {
+      result = await this.service.storePasskeyWrap(
+        uid,
+        credentialId,
+        {
+          pkR: Buffer.from(payload.pkR, 'base64url'),
+          prfWrappedSkR: Buffer.from(payload.prfWrappedSkR, 'base64url'),
+          keyWrapIv: Buffer.from(payload.keyWrapIv, 'base64url'),
+          hpkeEncapsulatedSecret: Buffer.from(
+            payload.hpkeEncapsulatedSecret,
+            'base64url'
+          ),
+          hpkeSealedKb: Buffer.from(payload.hpkeSealedKb, 'base64url'),
+        },
+        Date.now()
+      );
+    } catch (err) {
+      await this.recordEvent(request, 'account.passkey.wrap_creation_failure');
+      throw err;
+    }
+
+    if (result === 'unchanged') {
+      return { created: false };
+    }
+
+    // Guarded like the failure path: the row is already committed, so a failed
+    // audit write must not turn a stored wrap into a 500 the client retries —
+    // the retry answers `created: false` and the event is never emitted at all.
+    await this.recordEvent(request, 'account.passkey.wrap_created');
+
+    return { created: true };
+  }
+
+  /**
+   * Records a security event without letting its failure escape.
+   *
+   * On the failure path this runs on the way out of a `throw` and must not
+   * replace the error that caused it; on the success path the row is already
+   * committed. Reported to Sentry so an audit-write outage is not silent.
+   */
+  private async recordEvent(request: AuthRequest, name: SecurityEventNames) {
+    try {
+      await recordSecurityEvent(name, {
+        db: this.db,
+        request,
+      });
+    } catch (err) {
+      reportSentryError(err, request);
+    }
+  }
+}
+
+/**
+ * Builds the passkey wrap routes.
+ *
+ * Gated on `passkeys.passwordlessSyncEnabled` rather than the management flag.
+ */
+export const passkeyWrapsRoutes = (
+  customs: Customs,
+  db: DB,
+  config: ConfigType,
+  log: any
+) => {
+  const passwordlessSyncEnabledCheck = () =>
+    isPasskeyPasswordlessSyncEnabled(config);
+
+  if (!Container.has(PasskeyService)) {
+    throw new Error(
+      'Could not register passkey wrap routes. PasskeyService not registered with DI.'
+    );
+  }
+  const handler = new PasskeyWrapsHandler(
+    Container.get(PasskeyService),
+    db,
+    customs
+  );
+
+  return [
+    {
+      method: 'POST',
+      path: '/passkey/wraps',
+      options: {
+        ...PASSKEYS_API_DOCS.PASSKEY_WRAPS_POST,
+        pre: [{ method: passwordlessSyncEnabledCheck }],
+        auth: {
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
+          payload: false,
+        },
+        validate: {
+          payload: isA.object({
+            credentialId: base64urlCredentialId().required(),
+            ...envelopeSchema,
+          }),
+        },
+        response: {
+          schema: isA.object({
+            created: isA.boolean().required(),
+          }),
+        },
+      },
+      handler: function (request: AuthRequest) {
+        log.begin('passkey.wraps.create', request);
+        return handler.createPasskeyWrap(request);
+      },
+    },
+  ];
+};
+
+export default passkeyWrapsRoutes;

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -33,9 +33,9 @@ import { reportSentryError } from '../sentry';
 // matches the WebAuthn L2 ceiling (1023 bytes → 1364 base64url chars),
 // aligning with `passkeys.credentialId VARBINARY(1023)`.
 const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
-const base64urlString = (maxLen: number) =>
+export const base64urlString = (maxLen: number) =>
   isA.string().max(maxLen).regex(BASE64URL_PATTERN);
-const base64urlCredentialId = () => base64urlString(1364);
+export const base64urlCredentialId = () => base64urlString(1364);
 const base64urlChallenge = () => base64urlString(64);
 
 // Mirrors `AAGUID_RE` in libs/accounts/passkey, which rejects the same
@@ -57,7 +57,7 @@ export const passkeyResponseSchema = isA.object({
 });
 
 /** Subset of the Customs service used by passkey routes. */
-interface Customs {
+export interface Customs {
   /**
    * Enforces rate-limiting for an authenticated action.
    * Throws an AppError if the user or IP is throttled.
@@ -76,7 +76,7 @@ interface Customs {
 }
 
 /** Subset of the database used by passkey routes. */
-interface DB {
+export interface DB {
   /** Fetches the account record for the given UID. */
   account(uid: string): Promise<{
     uid: string;

--- a/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
@@ -1,0 +1,263 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Container } from 'typedi';
+import Redis from 'ioredis';
+import { setupAccountDatabase } from '@fxa/shared/db/mysql/account';
+import {
+  PasskeyChallengeManager,
+  PasskeyConfig,
+  PasskeyManager,
+  PasskeyService,
+  V1_WIDTHS,
+  VirtualAuthenticator,
+} from '@fxa/accounts/passkey';
+import { ERRNO } from '@fxa/accounts/errors';
+import Config from '../../config';
+
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
+
+const Client = require('../client')();
+
+const password = 'pssssst';
+
+let server: TestServerInstance;
+let redis: Redis.Redis | undefined;
+let db: Awaited<ReturnType<typeof setupAccountDatabase>> | undefined;
+let passkeyManager: PasskeyManager;
+let passkeyRpId: string;
+let passkeyOrigin: string;
+
+/**
+ * A field value of the right width, varied so a swap is visible.
+ */
+const field = (bytes: number, fill: number) =>
+  Buffer.alloc(bytes, fill).toString('base64url');
+
+const envelope = (fill = 0x11) => ({
+  pkR: field(V1_WIDTHS.pkR, 0x04),
+  prfWrappedSkR: field(V1_WIDTHS.prfWrappedSkR, fill),
+  keyWrapIv: field(V1_WIDTHS.keyWrapIv, fill),
+  hpkeEncapsulatedSecret: field(V1_WIDTHS.hpkeEncapsulatedSecret, 0x04),
+  hpkeSealedKb: field(V1_WIDTHS.hpkeSealedKb, fill),
+});
+
+beforeAll(async () => {
+  redis = new Redis({ host: 'localhost' });
+  const mockStatsD = { increment: jest.fn() };
+  const mockLog = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+  };
+  const config = Config.getProperties();
+  db = await setupAccountDatabase(config.database.mysql.auth);
+
+  const passkeyConfig = new PasskeyConfig(config.passkeys as PasskeyConfig);
+  passkeyRpId = passkeyConfig.rpId;
+  passkeyOrigin = passkeyConfig.allowedOrigins[0];
+
+  passkeyManager = new PasskeyManager(
+    db,
+    passkeyConfig,
+    mockStatsD as any,
+    mockLog as any
+  );
+  const challengeManager = new PasskeyChallengeManager(
+    redis,
+    passkeyConfig,
+    mockLog as any,
+    mockStatsD as any
+  );
+  Container.set(
+    PasskeyService,
+    new PasskeyService(
+      passkeyManager,
+      challengeManager,
+      passkeyConfig,
+      mockStatsD as any,
+      mockLog as any
+    )
+  );
+
+  server = await createTestServer({
+    configOverrides: {
+      securityHistory: { ipProfiling: {} },
+      signinConfirmation: { skipForNewAccounts: { enabled: false } },
+      mfa: { enabled: true, actions: ['passkey'] },
+      passkeys: {
+        enabled: true,
+        registrationEnabled: true,
+        authenticationEnabled: true,
+        passwordlessSyncEnabled: true,
+      },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+  await redis?.quit();
+  await db?.destroy();
+  Container.remove(PasskeyService);
+});
+
+describe('#integration - remote passkey wrap storage', () => {
+  let client: any;
+  let credentialId: string;
+
+  /**
+   * Registers a passkey through the real MFA + WebAuthn flow.
+   */
+  async function registerPasskey(): Promise<string> {
+    await client.api.doRequest(
+      'POST',
+      `${client.api.baseURL}/mfa/otp/request`,
+      await client.api.Token.SessionToken.fromHex(client.sessionToken),
+      { action: 'passkey' }
+    );
+    const code = await server.mailbox.waitForMfaCode(client.email);
+    const { accessToken } = await client.api.doRequest(
+      'POST',
+      `${client.api.baseURL}/mfa/otp/verify`,
+      await client.api.Token.SessionToken.fromHex(client.sessionToken),
+      { action: 'passkey', code }
+    );
+
+    const options = await client.api.doRequestWithBearerToken(
+      'POST',
+      `${client.api.baseURL}/passkey/registration/start`,
+      accessToken,
+      {}
+    );
+    const cred = VirtualAuthenticator.createCredential();
+    const response = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: passkeyOrigin,
+      rpId: passkeyRpId,
+    });
+    const registered = await client.api.doRequestWithBearerToken(
+      'POST',
+      `${client.api.baseURL}/passkey/registration/finish`,
+      accessToken,
+      { response, challenge: options.challenge }
+    );
+
+    return registered.credentialId;
+  }
+
+  /** POSTs a wrap. */
+  async function storeWrap(payload: Record<string, unknown>) {
+    return client.api.doRequest(
+      'POST',
+      `${client.api.baseURL}/passkey/wraps`,
+      await client.api.Token.SessionToken.fromHex(client.sessionToken),
+      payload
+    );
+  }
+
+  async function storeCurrentWrap(overrides: Record<string, unknown> = {}) {
+    return storeWrap({ credentialId, ...envelope(), ...overrides });
+  }
+
+  beforeEach(async () => {
+    client = await Client.createAndVerify(
+      server.publicUrl,
+      server.uniqueEmail(),
+      password,
+      server.mailbox,
+      { version: 'V2' }
+    );
+    credentialId = await registerPasskey();
+  });
+
+  it('stores the envelope and records a security event', async () => {
+    const result = await storeCurrentWrap();
+
+    expect(result).toEqual({ created: true });
+
+    const stored = await passkeyManager.findPasskeyWrap(
+      client.uid,
+      credentialId
+    );
+    expect(stored?.hpkeSealedKb).toEqual(
+      Buffer.alloc(V1_WIDTHS.hpkeSealedKb, 0x11)
+    );
+
+    const events = await client.securityEvents();
+    expect(events.map((e: any) => e.name)).toContain(
+      'account.passkey.wrap_created'
+    );
+  });
+
+  it('reports an identical repeat as unchanged', async () => {
+    await storeCurrentWrap();
+
+    const repeat = await storeCurrentWrap();
+
+    expect(repeat).toEqual({ created: false });
+    const events = await client.securityEvents();
+    expect(
+      events.filter((e: any) => e.name === 'account.passkey.wrap_created')
+    ).toHaveLength(1);
+  });
+
+  it('rejects a different envelope and leaves the stored one intact', async () => {
+    await storeCurrentWrap();
+
+    await expect(storeCurrentWrap(envelope(0x99))).rejects.toMatchObject({
+      code: 409,
+      errno: ERRNO.PASSKEY_WRAP_CONFLICT,
+    });
+
+    const stored = await passkeyManager.findPasskeyWrap(
+      client.uid,
+      credentialId
+    );
+    expect(stored?.hpkeSealedKb).toEqual(
+      Buffer.alloc(V1_WIDTHS.hpkeSealedKb, 0x11)
+    );
+  });
+
+  it('rejects a malformed envelope at the route boundary', async () => {
+    await expect(
+      storeCurrentWrap({
+        // One byte short of the fixed v1 width.
+        keyWrapIv: field(V1_WIDTHS.keyWrapIv - 1, 0x22),
+      })
+    ).rejects.toMatchObject({ code: 400 });
+
+    const stored = await passkeyManager.findPasskeyWrap(
+      client.uid,
+      credentialId
+    );
+    expect(stored).toBeUndefined();
+  });
+
+  it('rejects a credential the account does not own', async () => {
+    await expect(
+      storeCurrentWrap({
+        credentialId: Buffer.from('someone-elses-cred').toString('base64url'),
+      })
+    ).rejects.toMatchObject({
+      code: 404,
+      errno: ERRNO.PASSKEY_NOT_FOUND,
+    });
+  });
+
+  it('requires a session token', async () => {
+    await expect(
+      client.api.doRequestWithBearerToken(
+        'POST',
+        `${client.api.baseURL}/passkey/wraps`,
+        'invalid-token',
+        { credentialId, ...envelope() }
+      )
+    ).rejects.toMatchObject({ code: 401 });
+  });
+});


### PR DESCRIPTION
## Because

- Passwordless Sync needs somewhere to store the envelope that lets a passkey unlock `kB` without a password.
- A wrap is create-only: rotating `kB` invalidates it, so a stale one is replaced by deleting the passkey and re-enrolling, never by an update.

## This pull request

- Adds `POST /passkey/wraps`, one envelope per credential, behind a verified session token and the `passwordlessSyncEnabled` flag.
- Pins each of the five envelope fields to its one legal v1 width, which the fixed-width `BINARY` columns would otherwise zero-pad on a short one.
- Reports `created: false` on an identical repeat and 409s a different one, since there is no update path.
- Records `wrap_created` / `wrap_creation_failure` through a guarded helper, so an audit write cannot 500 a committed wrap or mask the error that preceded it.

## Issue that this pull request solves

Closes: FXA-13142

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/lib/routes/passkey-wraps.ts`
- Suggested review order: route → swagger notes → unit spec → integration spec
- Risky or complex parts: the auth tier. This takes a verified session, as passkey rename does, rather than the `mfa:passkey` scope registration and deletion take. Reasoning is in the handler JSDoc — the credential already cleared that bar at registration, and a wrap is inert without its PRF output.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Supersedes the verification-proof design in #21114 (closed). 
- The rate-limit config update will happen in a separate ticket
- Returning an existing wrap from `authentication/finish`, gated on `wraps.createdAt` being newer than the account's `keysChangedAt`, is scoped to the GET ticket.

