### PR TITLE
chore(customs): add a build-fast target so yarn start mza skips tsc

### DIFF
--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-customs-server",
   "bugs": "https://github.com/mozilla/fxa/issues/",
   "scripts": {
+    "build-fast": "exit 0",
     "clean": "rimraf dist",
     "outdated": "npm outdated --depth 0 || exit 0",
     "start": "pm2 start pm2.config.js",


### PR DESCRIPTION
Stacked on #21118 so the head branch carries `.github/skills/fxa-risk-score` while the diff is ordinary code.

## Why

`build-fast` is opt-in per project. Nx's `^build-fast` edge only builds a dependency that declares the target and never falls back to `build`, so `fxa-customs-server` was skipped by `yarn start mza`. It has no `build` script to skip, so the target is a no-op.

## Test plan

- `yarn start mza` reaches customs-server without a tsc step.

---

Draft, and partly a probe: checking whether Copilot code review picks up the agent skill from the head branch when the diff is not the skill itself. Do not merge before #21118.