### PR TITLE
chore: allow BLEnder to dismiss confident high-severity not-affected alerts

### DIFF
--- a/.blender/blender.yml
+++ b/.blender/blender.yml
@@ -7,6 +7,9 @@ install_command: "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --immutable --
 investigate:
   enabled: true
   dismiss_unaffected: true
+  # Dismiss confident (high) not-affected alerts up to high severity.
+  dismiss_min_confidence: high
+  dismiss_max_severity: high
   max_claude_turns: 100
   max_budget_usd: 6.00
 


### PR DESCRIPTION
## What
Sets in `.blender/blender.yml`:
- `investigate.dismiss_max_severity: high` — raise the auto-dismiss ceiling from the default `medium` to `high`
- `investigate.dismiss_min_confidence: high` — explicit confidence floor (also the default)

## Why
BLEnder currently leaves high-severity not-affected alerts open because it couldn't auto-dismiss. With the confidence floor as the safety rail, it can now dismiss the ones it assesses **not-affected at high confidence**. Criticals still require a human.

Enables mozilla/blender#145 + #147 (FXA-14410, FXA-14411).

## Rollout
Once merged, BLEnder will need its investigated tags cleared for the high/critical alerts to re-scan them.