### PR TITLE
fix(auth-server): do not await push sends in three routes

### DIFF
--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -544,16 +544,12 @@ module.exports = (
         }
 
         if (deviceArray.length !== 0) {
-          try {
-            await push.sendPush(uid, deviceArray, endpointAction, pushOptions);
-          } catch (err) {
-            // push may fail due to not found devices or a bad push action
-            // log the error but still respond with a 200
-            log.error('Account.devicesNotify', {
-              uid: uid,
-              error: err,
-            });
-          }
+          // Fire and forget. A send can take minutes; the route responds 200 regardless.
+          push
+            .sendPush(uid, deviceArray, endpointAction, pushOptions)
+            .catch((err) =>
+              log.error('Account.devicesNotify', { uid, error: err })
+            );
         }
 
         // Emit a metrics event for when a user sends tabs between devices.

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.spec.ts
@@ -569,6 +569,43 @@ describe('/account/devices/notify', () => {
     });
   });
 
+  it('responds before the push send settles and logs its rejection', async () => {
+    mockRequest.payload = {
+      to: ['bogusid1', 'bogusid2'],
+      TTL: 60,
+      payload: pushPayload,
+    };
+
+    const pushError = new Error('push failed');
+    let rejectPush: (err: Error) => void = () => {};
+    const pushSend = new Promise((_, reject) => {
+      rejectPush = reject;
+    });
+    const log = createMock<AuthLogger>();
+    const route = getRoute(
+      makeRoutes({
+        config: { deviceNotificationsEnabled: true },
+        customs: { checkAuthenticated: () => Promise.resolve() },
+        log,
+        push: mocks.mockPush({ sendPush: () => pushSend }),
+      }),
+      '/account/devices/notify'
+    );
+
+    // The send is still pending here. An awaited send would hang this test.
+    await runTest(route, mockRequest, (response) => {
+      expect(JSON.stringify(response)).toBe('{}');
+    });
+
+    rejectPush(pushError);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(log.error).toHaveBeenCalledWith('Account.devicesNotify', {
+      uid,
+      error: pushError,
+    });
+  });
+
   it('can send account verification message with empty payload', () => {
     mockRequest.payload = {
       to: 'all',

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -948,7 +948,15 @@ module.exports = (
         if (device) {
           const devices = await request.app.devices;
           const otherDevices = devices.filter((d) => d.id !== device.id);
-          await push.notifyDeviceConnected(uid, otherDevices, device.name);
+          // Fire and forget. A send can take minutes, so do not block the response.
+          push
+            .notifyDeviceConnected(uid, otherDevices, device.name)
+            .catch((err) =>
+              log.error('Account.RecoveryEmailVerify.notifyDeviceConnected', {
+                err,
+                uid,
+              })
+            );
         }
 
         // If the account is already verified, the link may have been
@@ -995,7 +1003,15 @@ module.exports = (
 
               request.emitMetricsEvent('account.confirmed', { uid });
               const devices = await request.app.devices;
-              await push.notifyAccountUpdated(uid, devices, 'accountConfirm');
+              // Fire and forget. A send can take minutes, so do not block the response.
+              push
+                .notifyAccountUpdated(uid, devices, 'accountConfirm')
+                .catch((err) =>
+                  log.error('account.signin.confirm.notifyAccountUpdated', {
+                    err,
+                    uid,
+                  })
+                );
             }
           } catch (err) {
             if (

--- a/packages/fxa-auth-server/lib/routes/emails.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/emails.spec.ts
@@ -975,6 +975,89 @@ describe('/recovery_email/verify_code', () => {
         expect(notifyArgs[2]).toBe('accountConfirm');
       });
     });
+
+    describe('the push send is not awaited', () => {
+      const pushError = new Error('push failed');
+
+      // The route responds before the push send settles, so give the
+      // rejection handler a turn before asserting on the log.
+      const flushRejectionHandler = () =>
+        new Promise((resolve) => setImmediate(resolve));
+
+      // These tests own their db, log and push mocks so that the mocks
+      // shared by the rest of this describe keep their state.
+      const makeDb = (dbOverrides: any = {}) =>
+        mocks.mockDB({
+          email: TEST_EMAIL,
+          emailCode: Buffer.from(mockRequest.payload.code, 'hex'),
+          emailVerified: true,
+          uid,
+          ...dbOverrides,
+        });
+
+      const setup = (push: any, db: any) => {
+        const log = createMock<AuthLogger>();
+        const route = getRoute(
+          makeRoutes({
+            config: {},
+            customs: mockCustoms,
+            db,
+            log,
+            mailer: mockMailer,
+            push,
+            verificationReminders,
+          }),
+          '/recovery_email/verify_code'
+        );
+        return { log, route };
+      };
+
+      it('logs a rejected notifyDeviceConnected and still returns an empty body', async () => {
+        const db = makeDb();
+        db.deviceFromTokenVerificationId = jest.fn().mockResolvedValue({
+          name: 'my device',
+          id: '123456789',
+          type: 'desktop',
+        });
+        const { log, route } = setup(
+          mocks.mockPush({
+            notifyDeviceConnected: () => Promise.reject(pushError),
+          }),
+          db
+        );
+
+        await runTest(route, mockRequest, (response: any) => {
+          expect(JSON.stringify(response)).toBe('{}');
+        });
+        await flushRejectionHandler();
+
+        expect(log.error).toHaveBeenCalledWith(
+          'Account.RecoveryEmailVerify.notifyDeviceConnected',
+          { err: pushError, uid }
+        );
+      });
+
+      it('logs a rejected notifyAccountUpdated and still returns an empty body', async () => {
+        // An emailCode that differs from the submitted code makes this a
+        // sign-in confirmation rather than an account verification.
+        const { log, route } = setup(
+          mocks.mockPush({
+            notifyAccountUpdated: () => Promise.reject(pushError),
+          }),
+          makeDb({ emailCode: Buffer.from('f'.repeat(32), 'hex') })
+        );
+
+        await runTest(route, mockRequest, (response: any) => {
+          expect(JSON.stringify(response)).toBe('{}');
+        });
+        await flushRejectionHandler();
+
+        expect(log.error).toHaveBeenCalledWith(
+          'account.signin.confirm.notifyAccountUpdated',
+          { err: pushError, uid }
+        );
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Because

- Routes that send a push notification show 1-3 minute timeouts in Grafana. A push send can take a minute or longer while it contacts APNS, and the client waits on it.
- `notifyAccountUpdated` sat inside the `try` of `accountAndTokenVerification`, whose `catch` rethrows. A push failure could turn a successful sign-in confirmation into a 500 after the database write had already committed.

## This pull request

- Drops the `await` on `push.sendPush` in `devices-and-sessions.js`, and on `push.notifyDeviceConnected` and `push.notifyAccountUpdated` in `emails.js`.
- Adds a `.catch()` that logs at each of the three sites. `push.js` rethrows per-device send errors, so a bare floating promise would become an unhandled rejection.
- Adds a test per site. The `devices-and-sessions` test holds the send pending, so an accidental re-`await` hangs the test instead of passing.
- Leaves `notifyCommandReceived` awaited. That route returns `notified` and `notifyError` in its response body, so the push result is part of the API contract.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-5807

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/routes/emails.js` and `lib/routes/devices-and-sessions.js`
- Suggested review order: the two route files, then their specs
- Risky or complex parts: the `notifyAccountUpdated` site. A push failure there no longer fails the request, so the caller now gets a 200 where it used to get a 500.

## Screenshots (Optional)

No user interface change.

## Other information (Optional)

- `npx jest --selectProjects unit --findRelatedTests` over the four files: 220 passed, 0 failed. `npx nx lint fxa-auth-server`: exit 0.
- The repo has other un-awaited push sends (`routes/account.ts`, `routes/password.ts`, `routes/utils/signup.js`, `lib/devices.js`, and `emails.js` `notifyProfileUpdated`) that carry no `.catch()`. They look like the same latent unhandled-rejection risk, but this change leaves them alone to stay narrow.
- Functional tests were not run for this change.
