### PR TITLE
fix(l10n): stop requesting en-US ftl files we never deploy

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/email-helpers.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-helpers.spec.ts
@@ -34,7 +34,8 @@ describe('EmailHelpers', () => {
 
       expect(result.time).toEqual('8:30:45 PM (UTC)');
       expect(result.date).toEqual('Monday, Jan 15, 2024');
-      expect(result.acceptLanguage).toEqual('en-US');
+      // en-US is not a supported locale, so negotiation resolves it to en.
+      expect(result.acceptLanguage).toEqual('en');
       expect(result.timeZone).toEqual('Etc/UTC');
     });
 

--- a/libs/shared/l10n/src/lib/l10n.utils.spec.ts
+++ b/libs/shared/l10n/src/lib/l10n.utils.spec.ts
@@ -29,12 +29,7 @@ describe('l10n.utils', () => {
 
   describe('l10n/parseAcceptLanguage:', () => {
     it('returns default', () => {
-      expect(parseAcceptLanguage('en')).toEqual([
-        'en',
-        'en-US',
-        'en-GB',
-        'en-CA',
-      ]);
+      expect(parseAcceptLanguage('en')).toEqual(['en', 'en-GB', 'en-CA']);
     });
 
     it('handles empty case', () => {
@@ -60,7 +55,6 @@ describe('l10n.utils', () => {
     it('parses several with expected output', () => {
       expect(parseAcceptLanguage('en, de, es, ru')).toEqual([
         'en',
-        'en-US',
         'en-GB',
         'en-CA',
         'de',
@@ -89,7 +83,6 @@ describe('l10n.utils', () => {
             'es-MX',
             'it',
             'en',
-            'en-US',
             'en-GB',
             'en-CA',
           ]
@@ -99,7 +92,6 @@ describe('l10n.utils', () => {
       it('applies correctly with dialects', () => {
         expect(parseAcceptLanguage('de-DE, en-US;q=0.7, en;q=0.3')).toEqual([
           'de',
-          'en-US',
           'en',
           'en-GB',
           'en-CA',
@@ -109,12 +101,7 @@ describe('l10n.utils', () => {
 
     describe('dialect (region) options', () => {
       it('handles en-*', () => {
-        expect(parseAcceptLanguage('en-CA')).toEqual([
-          'en-CA',
-          'en',
-          'en-US',
-          'en-GB',
-        ]);
+        expect(parseAcceptLanguage('en-CA')).toEqual(['en-CA', 'en', 'en-GB']);
       });
 
       it('includes all options and always contains default language (en)', () => {
@@ -142,7 +129,6 @@ describe('l10n.utils', () => {
 
       it('gives "en" higher priority than second locale when first locale is en-*', () => {
         expect(parseAcceptLanguage('en-US, de')).toEqual([
-          'en-US',
           'en',
           'en-GB',
           'en-CA',
@@ -150,20 +136,18 @@ describe('l10n.utils', () => {
         ]);
       });
 
+      it('resolves en-US to en', () => {
+        expect(parseAcceptLanguage('en-US')).toEqual(['en', 'en-GB', 'en-CA']);
+      });
+
       it('handles alias to en-GB', () => {
-        expect(parseAcceptLanguage('en-NZ')).toEqual([
-          'en-GB',
-          'en',
-          'en-US',
-          'en-CA',
-        ]);
+        expect(parseAcceptLanguage('en-NZ')).toEqual(['en-GB', 'en', 'en-CA']);
       });
 
       it('handles multiple languages with en-GB alias', () => {
         expect(parseAcceptLanguage('en-NZ, en-GB, en-MY')).toEqual([
           'en-GB',
           'en',
-          'en-US',
           'en-CA',
         ]);
       });
@@ -294,7 +278,11 @@ describe('l10n.utils', () => {
     });
 
     it('resolves region', () => {
-      expect(determineLocale('en-US')).toEqual('en-US');
+      expect(determineLocale('en-CA')).toEqual('en-CA');
+    });
+
+    it('resolves en-US to en', () => {
+      expect(determineLocale('en-US')).toEqual('en');
     });
 
     it('defaults to base langauge', () => {
@@ -306,7 +294,7 @@ describe('l10n.utils', () => {
     });
 
     it('ignores case', () => {
-      expect(determineLocale('En-uS')).toEqual('en-US');
+      expect(determineLocale('En-cA')).toEqual('en-CA');
     });
 
     it('ignores case and determines correct priority', () => {

--- a/libs/shared/l10n/src/lib/supported-languages.json
+++ b/libs/shared/l10n/src/lib/supported-languages.json
@@ -9,7 +9,6 @@
   "en",
   "en-GB",
   "en-CA",
-  "en-US",
   "es",
   "es-AR",
   "es-CL",

--- a/libs/shared/l10n/src/lib/supported-languages.spec.ts
+++ b/libs/shared/l10n/src/lib/supported-languages.spec.ts
@@ -17,4 +17,9 @@ describe('l10n/supportedLanguages:', () => {
     expect(supportedLanguages.indexOf('fr')).toBeGreaterThanOrEqual(0);
     expect(supportedLanguages.indexOf('pt')).toBeGreaterThanOrEqual(0);
   });
+
+  // If negotiation returns en-US, the localizer fetches an ftl that 404s.
+  it('excludes en-US, which has no translations folder', () => {
+    expect(supportedLanguages).not.toContain('en-US');
+  });
 });

--- a/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
@@ -15,7 +15,7 @@ import fetchMock from 'fetch-mock';
 import AppLocalizationProvider from './AppLocalizationProvider';
 
 describe('<AppLocalizationProvider/>', () => {
-  const locales = ['en-GB', 'en-US', 'es-ES'];
+  const locales = ['en-GB', 'en-CA', 'es-ES'];
   const bundles = ['greetings', 'farewells'];
   const reportError = () => {};
   function waitUntilTranslated() {
@@ -30,15 +30,15 @@ describe('<AppLocalizationProvider/>', () => {
       '/static-asset-manifest.json',
       `
       {
-        "/locales/en-US/greetings.ftl": "/locales/en-US/greetings.ftl",
-        "/locales/en-US/farewells.ftl": "/locales/en-US/farewells.ftl",
+        "/locales/en-CA/greetings.ftl": "/locales/en-CA/greetings.ftl",
+        "/locales/en-CA/farewells.ftl": "/locales/en-CA/farewells.ftl",
         "/locales/es-ES/greetings.ftl": "/locales/es-ES/greetings.ftl",
         "/locales/en-GB/greetings.ftl": "/locales/en-GB/greetings.ftl",
       }
       `
     );
-    fetchMock.get('/locales/en-US/greetings.ftl', 'hello = Hello\n');
-    fetchMock.get('/locales/en-US/farewells.ftl', 'goodbye = Goodbye\n');
+    fetchMock.get('/locales/en-CA/greetings.ftl', 'hello = Hello\n');
+    fetchMock.get('/locales/en-CA/farewells.ftl', 'goodbye = Goodbye\n');
     fetchMock.get('/locales/es-ES/greetings.ftl', 'hello = Hola\n');
     fetchMock.get('/locales/en-GB/greetings.ftl', 'hello = Hello { $amount }');
     fetchMock.get('*', { throws: new Error() });
@@ -58,11 +58,11 @@ describe('<AppLocalizationProvider/>', () => {
     cleanup();
   });
 
-  it('translate to en-US', async () => {
+  it('translate to en-CA', async () => {
     const { getByTestId } = render(
       <AppLocalizationProvider
         bundles={bundles}
-        userLocales={['en-US']}
+        userLocales={['en-CA']}
         reportError={reportError}
       >
         <main data-testid="result">
@@ -99,7 +99,7 @@ describe('<AppLocalizationProvider/>', () => {
     );
     await waitUntilTranslated();
 
-    // Ensure we fall back to en-US if our locale is missing that string.
+    // Ensure we leave the string untranslated if our locale is missing it.
     expect(getByTestId('result')).toHaveTextContent('Holauntranslated');
   });
 
@@ -122,7 +122,7 @@ describe('<AppLocalizationProvider/>', () => {
     );
     await waitUntilTranslated();
 
-    // Ensure we fall back to en-US strings if we don't have translations for
+    // Ensure we leave strings untranslated if we don't have translations for
     // any of the userLocales.
     expect(getByTestId('result')).toHaveTextContent('untranslated');
   });

--- a/packages/fxa-settings/src/models/contexts/NimbusContext.test.tsx
+++ b/packages/fxa-settings/src/models/contexts/NimbusContext.test.tsx
@@ -64,7 +64,7 @@ describe('NimbusContext', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDynamicLocalization.mockReturnValue({
-      currentLocale: 'en-US',
+      currentLocale: 'en-CA',
       switchLanguage: jest.fn(),
       clearLanguagePreference: jest.fn(),
       isLoading: false,
@@ -195,13 +195,29 @@ describe('NimbusContext', () => {
 
       expect(mockInitializeNimbus).toHaveBeenCalledWith('test-user-id', false, {
         language: 'en',
-        region: 'us',
+        region: 'ca',
       });
 
       await screen.findByTestId('experiments');
       expect(screen.getByTestId('experiments')).toHaveTextContent(
         'has-experiments'
       );
+    });
+
+    it('sends no region when the locale negotiates down to en', async () => {
+      mockUseDynamicLocalization.mockReturnValue({
+        currentLocale: 'en-US',
+        switchLanguage: jest.fn(),
+        clearLanguagePreference: jest.fn(),
+        isLoading: false,
+      });
+
+      renderWithProviders();
+
+      expect(mockInitializeNimbus).toHaveBeenCalledWith('test-user-id', false, {
+        language: 'en',
+        region: undefined,
+      });
     });
 
     it('handles API response with lowercase features', async () => {
@@ -255,7 +271,7 @@ describe('NimbusContext', () => {
         expect(mockInitializeNimbus).toHaveBeenCalledWith(
           'test-user-id',
           true,
-          { language: 'en', region: 'us' }
+          { language: 'en', region: 'ca' }
         );
       });
     });
@@ -272,7 +288,7 @@ describe('NimbusContext', () => {
         expect(mockInitializeNimbus).toHaveBeenCalledWith(
           'test-user-id',
           true,
-          { language: 'en', region: 'us' }
+          { language: 'en', region: 'ca' }
         );
       });
     });


### PR DESCRIPTION
## Because

- `supported-languages.json` lists `en-US`, but the l10n repo only ships `en`, `en-CA` and `en-GB`. Every page load asked for `.../en-US/main.ftl` and got a 404, so the request could never be a cache hit.
- Negotiation made that unavoidable. `en-US` matched itself, and a plain `en` header expanded to every `en-*` entry in the list, which pulled `en-US` in too.

## This pull request

- Drops `en-US` from `supported-languages.json`. Fluent strips the region and resolves `en-US` to `en`, so we serve the English bundle we actually deploy.
- Adds a case to `supported-languages.spec.ts` that keeps `en-US` out of the list. JSON holds no comments, so the test carries the reason.
- Adds `parseAcceptLanguage` and `determineLocale` cases for `en-US`, and updates the existing expectations in `l10n.utils.spec.ts`.
- Moves the `en-US` fixtures in `AppLocalizationProvider.test.tsx` and `NimbusContext.test.tsx` to `en-CA`, a locale we do deploy.
- Adds a `NimbusContext` case for the region change described below.

I picked removal over an `EN_GB_LOCALES`-style alias. An alias fixes the `en-US` header but not the `en` header, which still expands to `en-US` through the available-range match, so the 404 would stay.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10363

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `libs/shared/l10n/src/lib/supported-languages.json` is the whole fix. The rest follows from it.
- Suggested review order: the JSON, then `l10n.utils.spec.ts`, then the two consumer tests.
- Risky or complex parts: two behaviour changes ride along.
  - `NimbusContext` derives its Nimbus targeting region from the negotiated locale. An `en-US` user used to send `region: "us"` and now sends no region. If any experiment targets US, that needs a follow-up ticket. There is a test for the new behaviour, but I did not widen this PR to change it.
  - The `fxa-settings` language switcher builds its option list from the same JSON, so "English (US)" drops off it. Those users get the `en` strings they were already served after the 404.

## Screenshots (Optional)

## Other information (Optional)

Local runs: `shared-l10n` 89 passed, `fxa-react` 106 passed, `accounts-email-renderer` 122 passed, `fxa-settings` locale tests 38 passed, all with 0 failures. `nx lint` is clean for the four projects.

`LOCALE_MAPPINGS` in `packages/fxa-settings/src/lib/locales.ts` still holds an `en-US` entry. The switcher filters that map by the supported list, so the entry is now unreachable. I left it alone rather than touch a file this ticket does not need.
