### PR TITLE
feat(pairing): configurable iOS scheme and v2 iOS E2E coverage

### DIFF
--- a/packages/functional-tests/lib/ios-supplicant.ts
+++ b/packages/functional-tests/lib/ios-supplicant.ts
@@ -1,0 +1,377 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Simulator-driven Firefox iOS supplicant for the v2 pairing E2E test.
+ *
+ * This is deliberately thinner than `AndroidSupplicant`. adb ships uiautomator, so the Android
+ * driver can read the screen and tap from outside the app; `simctl` has no equivalent, so the
+ * taps and the in-webview assertions live in the XCUITest (`XCUITests/PairingTests`) instead.
+ * What stays here is everything that can be driven from outside: the build check, the app
+ * lifecycle, delivering the pairing URL, and collecting diagnostics.
+ *
+ * Delivering the URL uses the app's own custom scheme rather than a QR scan or a universal
+ * link. A simulator has no camera, and firefox-ios claims no `applinks` entitlement, so an
+ * https pairing URL opens Safari. `firefox://open-url?url=...` reaches the real
+ * `RouteBuilder` -> `FxAPairingURLParser` -> `.fxaPairing` path that a scanned v2 QR takes.
+ *
+ * Set PAIRING_DEBUG=1 for verbose logging.
+ */
+
+import { execFileSync, spawn, ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const DEBUG = !!process.env.PAIRING_DEBUG;
+const debug = (msg: string) => DEBUG && console.log(`[ios-supplicant] ${msg}`);
+
+/** Fennec is the debug/dev build of Firefox iOS, and the one the test plan builds. */
+const DEFAULT_BUNDLE_ID = 'org.mozilla.ios.Fennec';
+/** `MOZ_INTERNAL_URL_SCHEME` for the Fennec configuration. */
+const DEFAULT_URL_SCHEME = 'fennec';
+
+export interface IOSSupplicantOptions {
+  /** Simulator to target. Defaults to whichever device is currently booted. */
+  udid?: string;
+  projectDir?: string;
+  destination?: string;
+  bundleId?: string;
+  urlScheme?: string;
+}
+
+/** Resolves `booted` to a concrete Simulator udid so the destination cannot drift. */
+function resolveBootedUdid(udid: string): string {
+  if (udid !== 'booted') return udid;
+  const out = execFileSync(
+    'xcrun',
+    ['simctl', 'list', 'devices', 'booted', '-j'],
+    {
+      encoding: 'utf8',
+    }
+  );
+  const devices = JSON.parse(out).devices as Record<
+    string,
+    Array<{ udid: string }>
+  >;
+  const first = Object.values(devices).flat()[0];
+  if (!first) throw new Error('No booted iOS Simulator found');
+  return first.udid;
+}
+
+export class IOSSupplicant {
+  private readonly udid: string;
+  private readonly projectDir: string;
+  private readonly destination: string;
+  private readonly bundleId: string;
+  private readonly urlScheme: string;
+  private xcuitest: ChildProcess | undefined;
+  private buildProductsDir: string | undefined;
+  private testStarted = false;
+  private onTestStart: (() => void) | undefined;
+
+  constructor(options: IOSSupplicantOptions = {}) {
+    this.udid = options.udid || process.env.IOS_SIMULATOR_UDID || 'booted';
+    this.projectDir =
+      options.projectDir ||
+      process.env.FIREFOX_IOS_PROJECT_DIR ||
+      path.resolve(__dirname, '../../../../firefox-ios');
+    // Target the booted Simulator by id. A hardcoded device name silently resolves to
+    // "no matching device" whenever a different model is booted, and xcodebuild then
+    // reports zero tests run rather than a failure.
+    this.destination =
+      options.destination ||
+      process.env.IOS_DESTINATION ||
+      `platform=iOS Simulator,id=${resolveBootedUdid(this.udid)}`;
+    this.bundleId =
+      options.bundleId || process.env.IOS_BUNDLE_ID || DEFAULT_BUNDLE_ID;
+    this.urlScheme = options.urlScheme || DEFAULT_URL_SCHEME;
+  }
+
+  /**
+   * Path to the prebuilt xctestrun, or undefined when the tests were never built.
+   *
+   * Scoped to the build directory Xcode derives for `projectDir`. A bare glob over every
+   * `Client-*` directory silently picks another checkout's build, so a stale one can pass
+   * while the change under test is never exercised. Set IOS_XCTESTRUN to override.
+   */
+  findXctestrun(): string | undefined {
+    if (process.env.IOS_XCTESTRUN) {
+      return fs.existsSync(process.env.IOS_XCTESTRUN)
+        ? process.env.IOS_XCTESTRUN
+        : undefined;
+    }
+    const buildDir = this.derivedDataProductsDir();
+    if (!buildDir) return undefined;
+    try {
+      const found = fs
+        .readdirSync(buildDir)
+        .filter(
+          (f) => f.includes('SyncIntegration') && f.endsWith('.xctestrun')
+        )
+        .sort();
+      return found.length ? path.join(buildDir, found[0]) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * The `Build/Products` directory Xcode uses for this project.
+   *
+   * `-showBuildSettings` is the only way to map a project path to its DerivedData hash, and
+   * it is slow, so the answer is cached for the run.
+   */
+  private derivedDataProductsDir(): string | undefined {
+    if (this.buildProductsDir !== undefined)
+      return this.buildProductsDir || undefined;
+    try {
+      const out = execFileSync(
+        'xcodebuild',
+        [
+          '-project',
+          path.join(this.projectDir, 'firefox-ios', 'Client.xcodeproj'),
+          '-scheme',
+          'Fennec',
+          '-showBuildSettings',
+          '-json',
+        ],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+      );
+      const settings = JSON.parse(out)?.[0]?.buildSettings ?? {};
+      const symroot = settings.SYMROOT as string | undefined;
+      this.buildProductsDir = symroot ?? '';
+      return symroot;
+    } catch {
+      // Cache the failure so a broken project path does not re-run this for every call.
+      this.buildProductsDir = '';
+      return undefined;
+    }
+  }
+
+  /**
+   * Reset the app to a signed-out state.
+   *
+   * A simulator that still holds an account from an earlier run takes a re-auth flow instead
+   * of pairing, so the authority waits on a request that never arrives. `PairingTests` also
+   * passes `ClearProfile`, but the runner reuses the installed app between runs.
+   */
+  resetToColdState(): void {
+    this.simctl(['terminate', this.udid, this.bundleId], {
+      allowFailure: true,
+    });
+    this.simctl(
+      ['privacy', this.udid, 'grant', 'notifications', this.bundleId],
+      {
+        allowFailure: true,
+      }
+    );
+    debug('reset simulator app state');
+  }
+
+  /**
+   * The deep link this build answers for a pairing URL. Encoded because the channel
+   * credentials live in a fragment, and a raw `#` truncates everything after it.
+   */
+  deepLinkFor(pairUrl: string): string {
+    return `${this.urlScheme}://open-url?url=${encodeURIComponent(pairUrl)}`;
+  }
+
+  /** Hand a deep link to the app. */
+  openDeepLink(deepLink: string): void {
+    this.simctl(['openurl', this.udid, deepLink]);
+    debug(`opened ${deepLink.slice(0, 60)}...`);
+  }
+
+  /**
+   * Start the XCUITest that taps through the supplicant cards.
+   *
+   * Environment reaches the sandboxed runner only through the xctestrun plist, so it is
+   * patched in rather than passed to `xcodebuild`.
+   */
+  startXCUITest(options: {
+    testMethod: string;
+    pairingUrl: string;
+    customFxAServer: string;
+    logPath?: string;
+  }): Promise<void> {
+    const xctestrun = this.findXctestrun();
+    if (!xctestrun) {
+      throw new Error(
+        'No SyncIntegrationTestPlan .xctestrun found. Build the iOS tests first:\n' +
+          `  cd ${this.projectDir}\n` +
+          '  xcodebuild build-for-testing -project firefox-ios/Client.xcodeproj -scheme Fennec ' +
+          `-testPlan SyncIntegrationTestPlan -destination '${this.destination}'`
+      );
+    }
+
+    this.patchXctestrun(xctestrun, {
+      PAIRING_URL: options.pairingUrl,
+      CUSTOM_FXA_SERVER: options.customFxAServer,
+    });
+
+    const args = [
+      'test-without-building',
+      '-xctestrun',
+      xctestrun,
+      '-destination',
+      this.destination,
+      `-only-testing:XCUITests/PairingTests/${options.testMethod}`,
+    ];
+
+    if (options.logPath) {
+      fs.mkdirSync(path.dirname(options.logPath), { recursive: true });
+      fs.writeFileSync(
+        options.logPath,
+        `xcodebuild ${args.join(' ')}\n\n`,
+        'utf8'
+      );
+    }
+
+    this.testStarted = false;
+    const proc = spawn('xcodebuild', args, {
+      cwd: this.projectDir,
+      stdio: 'pipe',
+    });
+    this.xcuitest = proc;
+
+    let output = '';
+    const capture = (chunk: Buffer) => {
+      const text = chunk.toString();
+      output += text;
+      // Neither `Test Case ... started` nor `Launch` means the app can take a URL: the
+      // first prints before setUp, and the second when the launch begins. XCUITest logs
+      // "Wait for <bundle> to idle" once the scene has settled, which is the real signal;
+      // an open delivered before it is dropped.
+      if (
+        !this.testStarted &&
+        output.includes(`Wait for ${this.bundleId} to idle`)
+      ) {
+        this.testStarted = true;
+        this.onTestStart?.();
+      }
+      if (options.logPath) fs.appendFileSync(options.logPath, text);
+      if (DEBUG) process.stdout.write(text);
+    };
+    proc.stdout?.on('data', capture);
+    proc.stderr?.on('data', capture);
+
+    return new Promise<void>((resolve, reject) => {
+      proc.on('close', (code) => {
+        this.xcuitest = undefined;
+        // "Test Suite 'Selected tests' passed" is printed even when the selection matched
+        // nothing, so a skipped or misnamed test would otherwise look like a pass. Require
+        // that a test actually ran.
+        const executed = [...output.matchAll(/Executed (\d+) tests?/g)].some(
+          (m) => Number(m[1]) > 0
+        );
+        if (!executed) {
+          reject(
+            new Error(
+              'XCUITest executed 0 tests. The selection matched nothing: check that ' +
+                `${options.testMethod} exists and is not in the test plan's skippedTests.`
+            )
+          );
+          return;
+        }
+        // xcodebuild reports 65 for infrastructure noise even when every test passed, so the
+        // summary line is the authority rather than the exit code.
+        const passed = output.includes("Test Suite 'Selected tests' passed");
+        if (code === 0 || passed) {
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `xcodebuild exited with ${code}. Last 800 chars:\n${output.slice(-800)}`
+            )
+          );
+        }
+      });
+      proc.on('error', (err) =>
+        reject(new Error(`Failed to launch xcodebuild: ${err.message}`))
+      );
+    });
+  }
+
+  /**
+   * Resolve once the app has settled under XCUITest and can receive a URL.
+   *
+   * `settleMs` is a short cushion after the idle marker, not a guess at launch time.
+   * Falls back to the timeout so a missed marker degrades rather than hanging.
+   */
+  waitForAppLaunch(timeoutMs = 120_000, settleMs = 3_000): Promise<void> {
+    const settle = () => new Promise<void>((r) => setTimeout(r, settleMs));
+    if (this.testStarted) return settle();
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        debug('idle marker not seen; delivering anyway');
+        this.onTestStart = undefined;
+        resolve();
+      }, timeoutMs);
+      this.onTestStart = () => {
+        clearTimeout(timer);
+        this.onTestStart = undefined;
+        debug(`app idle; settling ${settleMs}ms before delivery`);
+        settle().then(resolve);
+      };
+    });
+  }
+
+  /** Capture the simulator screen. Best-effort: diagnostics must never fail a test. */
+  screenshot(destPath: string): void {
+    try {
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      this.simctl(['io', this.udid, 'screenshot', destPath]);
+    } catch {
+      debug('screenshot failed');
+    }
+  }
+
+  /** Kill any XCUITest still running, then stop the app. */
+  stop(): void {
+    if (this.xcuitest && !this.xcuitest.killed) {
+      this.xcuitest.kill('SIGTERM');
+    }
+    this.xcuitest = undefined;
+    this.simctl(['terminate', this.udid, this.bundleId], {
+      allowFailure: true,
+    });
+  }
+
+  private patchXctestrun(
+    xctestrunPath: string,
+    env: Record<string, string>
+  ): void {
+    const target = 'TestConfigurations:0:TestTargets:0:EnvironmentVariables';
+    for (const [key, value] of Object.entries(env)) {
+      // Add first, then Set: PlistBuddy has no upsert, and the key may survive a prior run.
+      const add = `Add :${target}:${key} string ${JSON.stringify(value)}`;
+      const set = `Set :${target}:${key} ${JSON.stringify(value)}`;
+      try {
+        execFileSync('/usr/libexec/PlistBuddy', ['-c', add, xctestrunPath], {
+          stdio: 'pipe',
+        });
+      } catch {
+        execFileSync('/usr/libexec/PlistBuddy', ['-c', set, xctestrunPath], {
+          stdio: 'pipe',
+        });
+      }
+    }
+    debug(`patched xctestrun with ${Object.keys(env).join(', ')}`);
+  }
+
+  private simctl(
+    args: string[],
+    options: { allowFailure?: boolean } = {}
+  ): string {
+    try {
+      return execFileSync('xcrun', ['simctl', ...args], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+    } catch (err) {
+      if (options.allowFailure) return '';
+      throw err;
+    }
+  }
+}

--- a/packages/functional-tests/lib/pairing-helpers.ts
+++ b/packages/functional-tests/lib/pairing-helpers.ts
@@ -122,6 +122,29 @@ export async function waitForUrlContaining(
 }
 
 /**
+ * Poll `client.getUrl()` until it contains any one of the given substrings.
+ *
+ * Use this where the authority passes through a transient screen: a card it only shows while
+ * waiting can be gone before the next poll, so asserting on that one route alone is a race.
+ */
+export async function waitForUrlContainingAny(
+  client: MarionetteClient,
+  substrings: string[],
+  timeoutMs: number = TIMEOUTS.AUTHORITY_COMPLETE
+): Promise<string> {
+  let lastUrl = '';
+  return pollUntil(
+    async () => {
+      lastUrl = await client.getUrl();
+      return substrings.some((s) => lastUrl.includes(s)) ? lastUrl : undefined;
+    },
+    timeoutMs,
+    () =>
+      `URL did not contain any of ${substrings.join(', ')} (last seen: ${lastUrl})`
+  );
+}
+
+/**
  * Poll `client.getUrl()` until the URL differs from `previousUrl`.
  */
 export async function waitForUrlChange(
@@ -190,7 +213,6 @@ export async function signInAuthorityViaMarionette(
 
     // Wait for the email input to appear instead of a fixed sleep
     await findElementBySelectors(client, SELECTORS.EMAIL_INPUT);
-
     // Enter email — use script-based value setting for React compatibility.
     // Marionette's sendKeys doesn't always trigger React's synthetic onChange.
     await setInputValueByScript(client, SELECTORS.EMAIL_INPUT, email);
@@ -204,7 +226,6 @@ export async function signInAuthorityViaMarionette(
 
     // Wait for the password input to appear instead of a fixed sleep
     await findElementBySelectors(client, SELECTORS.PASSWORD_INPUT);
-
     // Enter password
     await setInputValueByScript(client, SELECTORS.PASSWORD_INPUT, password);
 

--- a/packages/functional-tests/lib/targets/firefoxUserPrefs.ts
+++ b/packages/functional-tests/lib/targets/firefoxUserPrefs.ts
@@ -2,13 +2,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**
+ * Host the local stack is reachable on. Must match `FXA_LOCAL_HOST` in `targets/local.ts`:
+ * the authority Firefox only speaks the FxA WebChannel to `identity.fxaccounts.remote.root`,
+ * so a supplicant reached on another host needs this to agree or the sign-in page never
+ * receives its OAuth params.
+ */
+const LOCAL_HOST = process.env.FXA_LOCAL_HOST ?? 'localhost';
+const CONTENT_ORIGIN =
+  process.env.FXA_CONTENT_ORIGIN ?? `http://${LOCAL_HOST}:3030`;
+const AUTH_ORIGIN = process.env.FXA_AUTH_ORIGIN ?? `http://${LOCAL_HOST}:9000`;
+const PROFILE_ORIGIN =
+  process.env.FXA_PROFILE_ORIGIN ?? `http://${LOCAL_HOST}:1111`;
+
+/** Host to mark trustworthy, or undefined when the origin is already one. */
+const secureContextHost = (() => {
+  try {
+    const { hostname, protocol } = new URL(CONTENT_ORIGIN);
+    if (
+      protocol === 'https:' ||
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1'
+    ) {
+      return undefined;
+    }
+    return hostname;
+  } catch {
+    return undefined;
+  }
+})();
+
 const CONFIGS = {
   local: {
-    auth: 'http://localhost:9000/v1',
-    content: 'http://localhost:3030/',
-    token: 'http://localhost:8000/token/1.0/sync/1.5',
-    oauth: 'http://localhost:9000/v1',
-    profile: 'http://localhost:1111/v1',
+    auth: `${AUTH_ORIGIN}/v1`,
+    content: `${CONTENT_ORIGIN}/`,
+    token: `http://${LOCAL_HOST}:8000/token/1.0/sync/1.5`,
+    oauth: `${AUTH_ORIGIN}/v1`,
+    profile: `${PROFILE_ORIGIN}/v1`,
   },
   stage: {
     auth: 'https://api-accounts.stage.mozaws.net/v1',
@@ -54,6 +84,15 @@ export function getFirefoxUserPrefs(
     'extensions.formautofill.creditCards.enabled': false,
     'identity.fxaccounts.auth.uri': fxaEnv.auth,
     'identity.fxaccounts.allowHttp': target === 'local',
+
+    // Firefox treats localhost as a trustworthy origin but not an arbitrary host over http,
+    // and the FxA WebChannel is refused on a non-secure context. When the local stack is
+    // reached on another host (Tailscale, LAN), mark it trustworthy so the channel works.
+    // Read off the content origin, since that is the page the channel runs on and it can be
+    // set directly through FXA_CONTENT_ORIGIN without FXA_LOCAL_HOST.
+    ...(target === 'local' && secureContextHost
+      ? { 'dom.securecontext.allowlist': secureContextHost }
+      : {}),
     'identity.fxaccounts.remote.root': fxaEnv.content,
     'identity.fxaccounts.remote.force_auth.uri':
       fxaEnv.content + `force_auth?service=sync&context=${context}`,

--- a/packages/functional-tests/lib/targets/local.ts
+++ b/packages/functional-tests/lib/targets/local.ts
@@ -9,10 +9,23 @@ import { RateLimitClient } from '../ratelimit';
 
 const RELIER_CLIENT_ID = 'dcdb5ae7add825d2';
 
+/**
+ * Host the local stack is reachable on.
+ *
+ * Defaults to localhost. Override when the supplicant is not on this machine's loopback, for
+ * example a Tailscale address so a simulator or a real device reaches the same origin the
+ * authority uses. Start the stack with matching PUBLIC_URL/FXA_URL/FXA_OAUTH_URL, or its
+ * served config will still advertise localhost.
+ */
+const LOCAL_HOST = process.env.FXA_LOCAL_HOST ?? 'localhost';
+const CONTENT_ORIGIN =
+  process.env.FXA_CONTENT_ORIGIN ?? `http://${LOCAL_HOST}:3030`;
+const AUTH_ORIGIN = process.env.FXA_AUTH_ORIGIN ?? `http://${LOCAL_HOST}:9000`;
+
 export class LocalTarget extends BaseTarget {
   static readonly target = 'local';
   readonly name: TargetName = LocalTarget.target;
-  readonly contentServerUrl = 'http://localhost:3030';
+  readonly contentServerUrl = CONTENT_ORIGIN;
   readonly paymentsNextUrl = 'http://localhost:3035';
   readonly paymentsTestOfferingId = '123donepro';
   readonly paymentsTestPriceId = 'price_1NSnz3BVqmGyQTMaIkV5wjEc';
@@ -21,7 +34,9 @@ export class LocalTarget extends BaseTarget {
   readonly rateLimitClient: RateLimitClient;
 
   constructor() {
-    super('http://localhost:9000', 'http://localhost:9001');
+    // 9001 is the auth server's admin/test port, used only by this test runner and bound to
+    // loopback, so it stays on localhost even when the supplicant reaches us on another host.
+    super(AUTH_ORIGIN, 'http://localhost:9001');
     this.rateLimitClient = new RateLimitClient();
   }
 

--- a/packages/functional-tests/tests/pairing/CLAUDE.md
+++ b/packages/functional-tests/tests/pairing/CLAUDE.md
@@ -14,9 +14,13 @@ mobile app or a Playwright page as the supplicant.
 
 - `pairingFlowAndroid.spec.ts` + `lib/android-supplicant.ts` (adb-driven Fenix).
 - `pairingFlowiOS.spec.ts` (Simulator + XCUITest-driven Firefox iOS).
+- `pairingFlowV2Android.spec.ts` (v2, adb-driven Fenix).
+- `pairingFlowV2iOS.spec.ts` + `lib/ios-supplicant.ts` (v2, Simulator + XCUITest).
 
-Both are gated behind env flags (`ANDROID_PAIRING_ENABLED` /
-`IOS_PAIRING_ENABLED`) and skip by default, including in CI. The web-only specs
+All are gated behind env flags (`ANDROID_PAIRING_ENABLED`,
+`IOS_PAIRING_ENABLED`, `ANDROID_PAIRING_V2_ENABLED`, `IOS_PAIRING_V2_ENABLED`)
+and skip by default, including in CI. The two v2 specs additionally skip on any
+target but `local`, since both halves run on this machine. The web-only specs
 (`pairingFlow.spec.ts`, `pairChoice.spec.ts`, the Backbone/negative variants)
 need no mobile device and are unaffected.
 
@@ -71,6 +75,32 @@ IOS_PAIRING_ENABLED=1 \
   npx playwright test pairingFlowiOS.spec.ts --project=local
 ```
 
+iOS v2 (needs the stack started with `PAIRING_VERSION=2` and
+`PAIRING_IOS_URL_SCHEME=fennec`):
+
+```bash
+cd packages/functional-tests
+IOS_PAIRING_V2_ENABLED=1 \
+  FIREFOX_IOS_PROJECT_DIR=<firefox-ios checkout> \
+  IOS_DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+  npx playwright test pairingFlowV2iOS.spec.ts --project=local
+```
+
+The spec runs the whole flow twice, once per delivery, so `-g` picks one:
+
+```bash
+npx playwright test pairingFlowV2iOS.spec.ts -g 'from a deep link'   # test builds the link
+npx playwright test pairingFlowV2iOS.spec.ts -g "page's own"         # page supplies the link
+```
+
+`PAIRING_IOS_URL_SCHEME` only matters to the hand-off delivery, whose link the
+`/pair` page builds from the served `pairing.iosUrlScheme`. It has to name this
+build (`fennec`) or the link points at an install that is not there. The
+deep-link delivery builds its own URL in `IOSSupplicant` and ignores the config.
+
+`IOS_DESTINATION` is optional; without it `IOSSupplicant` targets whichever
+Simulator is booted. `IOS_SIMULATOR_UDID` picks one when several are.
+
 Extra flags: `ANDROID_PAIRING_DEBUG=1` / `PAIRING_DEBUG=1` (verbose logs),
 `ANDROID_SERIAL` (target one of several attached devices).
 
@@ -122,6 +152,35 @@ The run reports `1 passed`. With `ANDROID_PAIRING_DEBUG=1` the account device
 list shows the paired mobile device as `type=mobile, commands=2`, i.e. it
 registered on the account. The authority reaching `/pair/auth/complete` (not
 `/pair/failure`) is the authoritative signal both sides completed the handshake.
+
+## How the iOS v2 driver works (and its gotchas)
+
+`IOSSupplicant` (`lib/ios-supplicant.ts`) is deliberately thinner than its Android
+counterpart. adb ships uiautomator, so `AndroidSupplicant` can read the screen and tap from
+outside the app. `simctl` has no equivalent, so on iOS the taps and the in-webview assertions
+live in `XCUITests/PairingTests/testPairingV2`, and the driver only handles the build
+check, the app lifecycle, URL delivery, and diagnostics.
+
+- **The QR is never scanned; the URL is delivered with `simctl openurl`,** because a
+  Simulator has no camera. Both deliveries use `fennec://open-url?url=...`, which goes
+  through the real `RouteBuilder` -> `FxAPairingURLParser` -> `.fxaPairing` path a scanned v2
+  QR takes. They differ only in who built the link: the test, or the `/pair` page.
+- **The hand-off delivery reads the link off the rendered page,** in an iOS-emulated browser
+  context. That covers what a constructed URL cannot: that the card renders for a non-Firefox
+  browser, and that the link names the configured `PAIRING_IOS_URL_SCHEME`.
+- **Neither delivery taps the CTA, and a Simulator cannot.** Safari there refuses to open a
+  third-party scheme, answering "the address is invalid" even though the identical URL opens
+  fine through `simctl`, the app is installed, and it registers the scheme. Verified against
+  the app: `RouteBuilder` matches host `open-url` and `FxAPairingURLParser` accepts the link,
+  so the failure is upstream of the app. The tap is only testable on a real device.
+- **`CUSTOM_FXA_SERVER` still reaches the app through the xctestrun plist,** because XCUITest
+  runs sandboxed and does not inherit host env. `UITestAppDelegate` reads it and sets the FxA
+  content-server prefs before the account manager initializes.
+- **The supplicant-side failure shows up in the xcodebuild log,** not in a Playwright
+  assertion. The spec attaches it on failure.
+- **No webchannel-localhost patch is needed.** `FxAWebViewModel` compares each message's
+  frame origin against the loaded page's scheme, host and port, and that page comes from the
+  configured content server, so pointing the app at the local stack is enough.
 
 ## How the Android driver works (and its gotchas)
 

--- a/packages/functional-tests/tests/pairing/pairingFlowV2Android.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowV2Android.spec.ts
@@ -96,6 +96,9 @@ const watch = () =>
 // Emulator cold start + UI nav + channel handshake + OAuth round trip.
 test.setTimeout(300_000);
 
+// Local only: both halves run on this machine, against the stack under test.
+test.skip(({ target }) => target.name !== 'local');
+
 test.describe.serial('v2 Android pairing flow', () => {
   test.describe.configure({ retries: 0 });
 

--- a/packages/functional-tests/tests/pairing/pairingFlowV2iOS.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowV2iOS.spec.ts
@@ -1,0 +1,410 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * v2 pairing flow, iOS supplicant.
+ *
+ * The iOS counterpart of `pairingFlowV2Android.spec.ts`: the authority is a real Firefox
+ * Nightly (Marionette) running the FxA-owned v2 authority flow, and the supplicant is Firefox
+ * iOS on a Simulator.
+ *
+ *   Authority (Marionette, Nightly)          Supplicant (iOS Simulator)
+ *   ------------------------------------     --------------------------------
+ *   1. sign in, open /connect_another_device -> scan_qr (real channel + QR)
+ *                                            2. simctl delivers the v2 QR URL over the app's
+ *                                               custom scheme; it opens as a normal tab
+ *   3. on pair:supp:request -> continue_on_mobile
+ *                                            4. XCUITest taps "Connect"
+ *   5. on pair:supp:authorize -> approve_signin
+ *   6. tap "Yes, approve sign-in"
+ *   7. pair_oauth_finish -> sync_success
+ *                                            8. OAuth completes -> device registered
+ *
+ * Two things differ from the Android spec, both forced by the platform:
+ *
+ *   - The supplicant's taps and its in-webview assertions live in the XCUITest, because
+ *     `simctl` cannot read the screen or tap the way adb's uiautomator can. On failure the
+ *     xcodebuild log is attached, since that is where the supplicant-side failure shows up.
+ *   - A Simulator has no camera, so the QR is never scanned. `simctl openurl` delivers
+ *     `fennec://open-url` instead, taking the same
+ *     `RouteBuilder` -> `FxAPairingURLParser` -> `.fxaPairing` path a scan would. The run
+ *     happens twice, differing only in who built the link. See `DELIVERIES`.
+ *
+ * The authority takes the v2 route because both sides advertise it: the stack's
+ * `pairing.version` and the browser's `identity.fxaccounts.pairing.version`, which
+ * `marionette-firefox` sets. `startPairingFlowV2` also appends `v=2`, which
+ * `ConnectAnotherDevice` honours as a deliberately temporary escape hatch -- it forces the v2
+ * route even when the capability handshake fails, so it can hide that regression here.
+ *
+ * Local target only, gated behind IOS_PAIRING_V2_ENABLED, and skipped by default in every
+ * case. Prerequisites: the FxA stack
+ * started with PAIRING_VERSION=2, a booted Simulator, a firefox-ios checkout built with
+ * `build-for-testing` for the SyncIntegrationTestPlan, and Firefox Nightly for the authority
+ * (or FIREFOX_BINARY at a v2-capable build).
+ */
+
+import { writeFileSync } from 'fs';
+import { findV2AuthorityBinary } from '../../lib/firefox-binary';
+import { Browser, devices } from '@playwright/test';
+import { test, expect } from '../../lib/fixtures/pairing';
+import { IOSSupplicant } from '../../lib/ios-supplicant';
+import { MarionetteClient } from '../../lib/marionette';
+import { PAIR_V2_ROUTES } from '../../lib/pairing-constants';
+import {
+  signInAuthorityViaMarionette,
+  startPairingFlowV2,
+  extractChannelIdV2,
+  waitForUrlContaining,
+  waitForUrlContainingAny,
+} from '../../lib/pairing-helpers';
+
+const ELIGIBLE_ENTRYPOINT_QS =
+  'context=oauth_webchannel_v1&entrypoint=fxa_app_menu';
+
+/**
+ * Match the paired iOS supplicant only.
+ *
+ * The authority is a signed-in Firefox on the same account, so a pattern that also matched a
+ * desktop device name would let this succeed before iOS ever registers.
+ */
+function isMobileDevice(d: { type?: string; name?: string }): boolean {
+  return d.type === 'mobile' || /iOS|iPhone|iPad|Fennec/i.test(d.name || '');
+}
+
+type PairedDevice = { id: string; name?: string; type?: string };
+
+async function pollForMobileDevice(
+  authClient: { deviceList: (token: string) => Promise<PairedDevice[]> },
+  sessionToken: string,
+  timeoutMs: number
+): Promise<PairedDevice | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const devices = await authClient.deviceList(sessionToken);
+    const found = devices.find(isMobileDevice);
+    if (found) return found;
+    await new Promise((r) => setTimeout(r, 3_000));
+  } while (Date.now() < deadline);
+  return undefined;
+}
+
+/**
+ * Click a control by test id, polling for it first.
+ *
+ * The authority's URL changes before React has rendered the new screen, so a single
+ * `findElement` right after the URL check races the render.
+ */
+async function clickByTestId(
+  client: MarionetteClient,
+  testId: string,
+  timeoutMs = 30_000
+) {
+  const selector = `[data-testid="${testId}"]`;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const el = await client.findElement('css selector', selector);
+      await client.clickElement(el);
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) throw err;
+      await new Promise((r) => setTimeout(r, 1_000));
+    }
+  }
+}
+
+type DeliveryContext = {
+  ios: IOSSupplicant;
+  pairUrl: string;
+  browser: Browser;
+};
+
+/**
+ * Where the deep link comes from. Both run the same XCUITest; the supplicant side is identical
+ * once the app holds the URL.
+ *
+ * Reading the link off the rendered page covers what a constructed URL cannot: that the card
+ * renders for a non-Firefox browser, and that it names the configured iOS scheme.
+ *
+ * Neither taps the CTA. A Simulator's Safari refuses to open a third-party scheme, answering
+ * "the address is invalid" while `simctl` opens the same URL fine, so that is device-only.
+ */
+const DELIVERIES = [
+  {
+    title: 'the iOS supplicant completes pairing from a deep link',
+    resolve: async ({ ios, pairUrl }: DeliveryContext) =>
+      ios.deepLinkFor(pairUrl),
+  },
+  {
+    title: "the page's own hand-off link completes pairing",
+    resolve: async ({ ios, browser, pairUrl }: DeliveryContext) => {
+      const deepLink = await readHandoffDeepLink(browser, pairUrl);
+      // Exact match, not a substring: every flavour also registers `firefox://`, so a
+      // page that ignored `PAIRING_IOS_URL_SCHEME` would still emit a link that works.
+      expect(deepLink).toBe(ios.deepLinkFor(pairUrl));
+      return deepLink;
+    },
+  },
+];
+
+/**
+ * Render `/pair` as a non-Firefox phone would and return the hand-off link it offers.
+ *
+ * The iOS descriptor makes `detectDevice` report iOS. The card renders only once `fxa_status`
+ * goes unanswered, which is a timeout rather than a reply, so it is absent on first paint.
+ */
+async function readHandoffDeepLink(
+  browser: Browser,
+  pairUrl: string
+): Promise<string> {
+  const context = await browser.newContext(devices['iPhone 13']);
+  try {
+    const page = await context.newPage();
+    await page.goto(pairUrl);
+    const cta = page
+      .locator('a[href^="fennec://"], a[href^="firefox://"]')
+      .first();
+    await cta.waitFor({ state: 'attached', timeout: 30_000 });
+    const href = await cta.getAttribute('href');
+    if (!href) {
+      throw new Error('Hand-off CTA rendered without an href');
+    }
+    return href;
+  } finally {
+    await context.close();
+  }
+}
+
+// Simulator boot + xcodebuild launch + channel handshake + OAuth round trip.
+test.setTimeout(420_000);
+
+// Local only: both halves run on this machine, against the stack under test.
+test.skip(({ target }) => target.name !== 'local');
+
+test.describe.serial('v2 iOS pairing flow', () => {
+  test.describe.configure({ retries: 0 });
+
+  let supplicant: IOSSupplicant | undefined;
+
+  test.beforeEach(async ({}, testInfo) => {
+    if (!process.env.IOS_PAIRING_V2_ENABLED) {
+      testInfo.skip(
+        true,
+        'Set IOS_PAIRING_V2_ENABLED=1 (needs a booted Simulator with a build-for-testing Firefox iOS)'
+      );
+    }
+    if (!findV2AuthorityBinary()) {
+      testInfo.skip(
+        true,
+        'Firefox Nightly not found — install it, or set FIREFOX_BINARY to a v2-capable build'
+      );
+    }
+    supplicant = new IOSSupplicant();
+    if (!supplicant.findXctestrun()) {
+      testInfo.skip(
+        true,
+        'No SyncIntegrationTestPlan .xctestrun — run xcodebuild build-for-testing first'
+      );
+    }
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    // `beforeEach` skips before assigning the supplicant when a prerequisite is missing, and
+    // teardown still runs; touching it there would turn a clean skip into an error.
+    if (!supplicant) return;
+    if (testInfo.status !== testInfo.expectedStatus) {
+      try {
+        const shot = testInfo.outputPath('ios-v2-supplicant.png');
+        supplicant.screenshot(shot);
+        await testInfo.attach('ios-v2-supplicant.png', {
+          path: shot,
+          contentType: 'image/png',
+        });
+        await testInfo.attach('ios-v2-xcodebuild.log', {
+          path: testInfo.outputPath('ios-v2-xcodebuild.log'),
+          contentType: 'text/plain',
+        });
+      } catch {
+        /* best-effort diagnostics */
+      }
+    }
+    supplicant.stop();
+    // Each test's guard must reflect that test, not the previous one's.
+    supplicant = undefined;
+  });
+
+  for (const delivery of DELIVERIES) {
+    test(`authority mints v2 QR and ${delivery.title}`, async ({
+      target,
+      testAccountTracker,
+      marionetteAuthority,
+      browser,
+    }, testInfo) => {
+      const authority = marionetteAuthority.client;
+      // `supplicant` is optional so teardown can tell "never assigned" from "assigned"; the body
+      // runs only after beforeEach set it.
+      const ios = supplicant as IOSSupplicant;
+      const xcodebuildLog = testInfo.outputPath('ios-v2-xcodebuild.log');
+
+      const credentials = await test.step('Authority signs in', async () => {
+        const creds = await testAccountTracker.signUp();
+        await signInAuthorityViaMarionette(
+          authority,
+          target.contentServerUrl,
+          creds.email,
+          creds.password
+        );
+        return creds;
+      });
+
+      // Reset before minting the short-lived channel. A Simulator that still holds an account
+      // from an earlier run takes a re-auth flow instead of pairing, so the authority would wait
+      // for a `pair:supp:request` that never arrives.
+      await test.step('Prepare iOS supplicant', async () => {
+        ios.resetToColdState();
+      });
+
+      const { pairUrl, channelId } =
+        await test.step('Authority mints the v2 QR', async () => {
+          const url = await startPairingFlowV2(
+            authority,
+            target.contentServerUrl,
+            ELIGIBLE_ENTRYPOINT_QS
+          );
+          expect(url).toContain('v=2');
+          return { pairUrl: url, channelId: extractChannelIdV2(url) };
+        });
+
+      // The XCUITest owns every supplicant-side tap and assertion, so it runs for the whole
+      // flow while the authority side advances in parallel here.
+      const xcuitest = ios.startXCUITest({
+        testMethod: 'testPairingV2',
+        pairingUrl: pairUrl,
+        customFxAServer: target.contentServerUrl,
+        logPath: xcodebuildLog,
+      });
+      // A rejection that lands while we are awaiting the authority would otherwise be an
+      // unhandled rejection; the real assertion happens in the final step.
+      const xcuitestSettled = xcuitest.catch((err: Error) => err);
+
+      await test.step('iOS supplicant opens the QR URL', async () => {
+        // Deliver only once the app has launched, or the open lands before the scene exists
+        // and is dropped. Keyed off the launch xcodebuild logs rather than a fixed sleep: a
+        // slow launch used to outlive the v2 channel, and a fast one paid the full delay.
+        const [deepLink] = await Promise.all([
+          delivery.resolve({ ios, pairUrl, browser }),
+          ios.waitForAppLaunch(),
+        ]);
+        ios.openDeepLink(deepLink);
+        expect(pairUrl).toContain(channelId);
+      });
+
+      await test.step('Authority waits on the supplicant', async () => {
+        // The request arriving on the channel moves the authority off scan_qr. Accept
+        // approve_signin too: continue_on_mobile is only shown until the supplicant approves,
+        // and on a fast run that happens before the next poll, so requiring it is a race.
+        await waitForUrlContainingAny(
+          authority,
+          [
+            PAIR_V2_ROUTES.AUTHORITY_CONTINUE_ON_MOBILE,
+            PAIR_V2_ROUTES.AUTHORITY_APPROVE_SIGNIN,
+          ],
+          90_000
+        );
+      });
+
+      await test.step('Authority approves the request', async () => {
+        // The XCUITest taps "Connect", which is what moves the authority on to approve_signin.
+        await waitForUrlContaining(
+          authority,
+          PAIR_V2_ROUTES.AUTHORITY_APPROVE_SIGNIN,
+          90_000
+        );
+        await clickByTestId(authority, 'pair2-auth-approve-btn');
+      });
+
+      await test.step('Authority reaches sync success', async () => {
+        await waitForUrlContaining(
+          authority,
+          PAIR_V2_ROUTES.AUTHORITY_SYNC_SUCCESS,
+          90_000
+        );
+      });
+
+      const device =
+        await test.step('iOS device is registered on the account', async () => {
+          const found = await pollForMobileDevice(
+            target.authClient,
+            credentials.sessionToken as string,
+            60_000
+          );
+          expect(found).toBeTruthy();
+          return found;
+        });
+
+      await test.step('Connected Services lists the iOS device', async () => {
+        // The API check above proves registration; this proves the authority's own Settings UI
+        // surfaces the newly paired device to the user.
+        await authority.navigate(`${target.contentServerUrl}/settings/clients`);
+        await waitForUrlContaining(authority, '/settings/clients', 30_000);
+
+        const deviceName = device?.name;
+        expect(
+          deviceName,
+          'registered device should have a name to look for'
+        ).toBeTruthy();
+        const row = await pollUntilElement(
+          authority,
+          `//*[contains(text(), ${xpathLiteral(deviceName as string)})]`,
+          30_000
+        );
+        expect(
+          row,
+          `"${deviceName}" not listed in Connected Services`
+        ).toBeTruthy();
+
+        const body = await authority.findElement('css selector', 'body');
+        const shot = testInfo.outputPath('authority-connected-services.png');
+        writeFileSync(
+          shot,
+          Buffer.from(await authority.screenshotElement(body), 'base64')
+        );
+        await testInfo.attach('authority-connected-services.png', {
+          path: shot,
+          contentType: 'image/png',
+        });
+      });
+
+      await test.step('iOS supplicant confirms its own success card', async () => {
+        // The supplicant's taps and card assertions live in Swift, so a failure surfaces as a
+        // rejected xcodebuild run. `afterEach` attaches the log.
+        const result = await xcuitestSettled;
+        expect(result, `${result}`).not.toBeInstanceOf(Error);
+      });
+    });
+  }
+});
+
+/** Poll for an element so the Settings list has time to load its services. */
+async function pollUntilElement(
+  client: MarionetteClient,
+  xpath: string,
+  timeoutMs: number
+): Promise<string | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    try {
+      return await client.findElement('xpath', xpath);
+    } catch {
+      await new Promise((r) => setTimeout(r, 2_000));
+    }
+  } while (Date.now() < deadline);
+  return undefined;
+}
+
+/** Quote a value for use inside an XPath expression. */
+function xpathLiteral(value: string): string {
+  if (!value.includes("'")) return `'${value}'`;
+  return `concat('${value.split("'").join(`', "'", '`)}')`;
+}

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -113,6 +113,7 @@ const settingsConfig = {
   },
   pairing: {
     browserBuild: config.get('pairing.browser_build'),
+    iosUrlScheme: config.get('pairing.ios_url_scheme'),
     clients: config.get('pairing.clients'),
     serverBaseUri: config.get('pairing.server_base_uri'),
     version: config.get('pairing.version'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -785,6 +785,12 @@ const conf = (module.exports = convict({
       env: 'PAIRING_BROWSER_BUILD',
       format: ['firefox', 'fenix'],
     },
+    ios_url_scheme: {
+      default: 'firefox',
+      doc: 'URL scheme the iOS pairing deep link opens. Every Firefox iOS flavour registers "firefox", so name a build-specific scheme to reach a local build when a release install is also present.',
+      env: 'PAIRING_IOS_URL_SCHEME',
+      format: ['firefox', 'fennec', 'firefox-beta', 'firefox-internal'],
+    },
     clients: {
       default: [
         '3c49430b43dfba77', // Reference browser

--- a/packages/fxa-dev-launcher/profile.mjs
+++ b/packages/fxa-dev-launcher/profile.mjs
@@ -1,13 +1,43 @@
 import chalk from 'chalk';
 
+// Origins for the `local` env. They default to localhost, so the usual dev flow is
+// unchanged. Override them to point at a stack reached on another host, such as a
+// Tailscale address, which is what pairing with a real phone needs: the authority must
+// mint pair URLs on the same origin the phone is configured against.
+const LOCAL_HOST = process.env.FXA_LOCAL_HOST ?? 'localhost';
+const CONTENT_ORIGIN =
+  process.env.FXA_CONTENT_ORIGIN ?? `http://${LOCAL_HOST}:3030`;
+const AUTH_ORIGIN = process.env.FXA_AUTH_ORIGIN ?? `http://${LOCAL_HOST}:9000`;
+const PROFILE_ORIGIN =
+  process.env.FXA_PROFILE_ORIGIN ?? `http://${LOCAL_HOST}:1111`;
+
+// Firefox refuses the FxA WebChannel on a non-secure context, and only localhost is
+// trustworthy by default. A stack reached on another host over http needs its hostname
+// marked, or sign-in and pairing fail with no visible cause.
+const secureContextHost = (() => {
+  try {
+    const { hostname, protocol } = new URL(CONTENT_ORIGIN);
+    if (
+      protocol === 'https:' ||
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1'
+    ) {
+      return undefined;
+    }
+    return hostname;
+  } catch {
+    return undefined;
+  }
+})();
+
 const CONFIGS = {
   local: {
-    auth: 'http://localhost:9000/v1',
-    content: 'http://localhost:3030/',
-    token: 'http://localhost:8000/1.0/sync/1.5',
-    loop: 'http://localhost:10222',
-    oauth: 'http://localhost:9000/v1',
-    profile: 'http://localhost:1111/v1',
+    auth: `${AUTH_ORIGIN}/v1`,
+    content: `${CONTENT_ORIGIN}/`,
+    token: `http://${LOCAL_HOST}:8000/1.0/sync/1.5`,
+    loop: `http://${LOCAL_HOST}:10222`,
+    oauth: `${AUTH_ORIGIN}/v1`,
+    profile: `${PROFILE_ORIGIN}/v1`,
   },
   latest: {
     auth: 'https://latest.dev.lcip.org/auth/v1',
@@ -99,6 +129,9 @@ const fxaProfile = {
   'services.sync.log.appender.dump': 'Debug',
   'identity.fxaccounts.auth.uri': fxaEnv.auth,
   'identity.fxaccounts.allowHttp': true,
+  ...(secureContextHost
+    ? { 'dom.securecontext.allowlist': secureContextHost }
+    : {}),
   'identity.fxaccounts.remote.root': fxaEnv.content,
   'identity.fxaccounts.remote.force_auth.uri':
     fxaEnv.content + 'force_auth?service=sync&context=' + FXA_DESKTOP_CONTEXT,
@@ -132,6 +165,16 @@ const fxaProfile = {
   'identity.fxaccounts.oauth.enabled':
     FXA_DESKTOP_CONTEXT === 'oauth_webchannel_v1',
 };
+
+// Opt in to the pairing v2 flow. Both the browser and the server have to advertise
+// version 2 before /pair takes the v2 route, so this pairs with PAIRING_VERSION=2 on
+// the stack. Left unset by default so existing dev flows keep v1. The v2 chrome
+// commands ship in Nightly, so point FIREFOX_BIN at a Nightly build.
+if (process.env.FXA_PAIRING_VERSION) {
+  fxaProfile['identity.fxaccounts.pairing.version'] = Number(
+    process.env.FXA_PAIRING_VERSION
+  );
+}
 
 // Configuration for local sync development
 

--- a/packages/fxa-settings/src/lib/channels/firefox.test.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.test.ts
@@ -8,8 +8,10 @@ import {
   Firefox,
   FirefoxCommand,
   buildSyncOAuthSearch,
+  DEFAULT_SEND_TIMEOUT_LENGTH_MS,
   FxAOAuthFlowBeginResponse,
   FxAStatusResponse,
+  PAIR_OAUTH_TIMEOUT_MS,
   PairOAuthFinishState,
   PairOAuthStartState,
 } from './firefox';
@@ -126,10 +128,9 @@ describe('buildSyncOAuthSearch', () => {
 });
 
 describe('Firefox pairing OAuth WebChannel methods', () => {
-  // Keep in sync with DEFAULT_SEND_TIMEOUT_LENGTH_MS in firefox.ts (not exported).
-  const SEND_TIMEOUT_MS = 500;
-  // pairOauthFinish overrides the default; it makes a web call.
-  const FINISH_TIMEOUT_MS = 10_000;
+  const SEND_TIMEOUT_MS = DEFAULT_SEND_TIMEOUT_LENGTH_MS;
+  const START_TIMEOUT_MS = PAIR_OAUTH_TIMEOUT_MS;
+  const FINISH_TIMEOUT_MS = PAIR_OAUTH_TIMEOUT_MS;
 
   const MOCK_START_RESPONSE: PairOAuthStartState = {
     state: 'mock-oauth-state',
@@ -145,7 +146,7 @@ describe('Firefox pairing OAuth WebChannel methods', () => {
     scope: 'profile',
     code_challenge: 'mock-code-challenge',
     code_challenge_method: 'mock-code-challenge-method',
-    keys_jwk: 'mock-keys-jwk'
+    keys_jwk: 'mock-keys-jwk',
   };
 
   const MOCK_FINISH_RESPONSE: PairOAuthFinishState = {
@@ -261,15 +262,16 @@ describe('Firefox pairing OAuth WebChannel methods', () => {
 
     it('resolves undefined when the browser does not respond', async () => {
       const promise = ff.pairOauthStart({});
-      jest.advanceTimersByTime(SEND_TIMEOUT_MS);
+      jest.advanceTimersByTime(START_TIMEOUT_MS);
       await expect(promise).resolves.toBeUndefined();
     });
 
+    // A cold mobile start fetches config before it can mint params; 500 ms cut that off.
     it('does not resolve before the timeout elapses', async () => {
       const onSettled = jest.fn();
       ff.pairOauthStart({}).then(onSettled);
 
-      await jest.advanceTimersByTimeAsync(SEND_TIMEOUT_MS - 1);
+      await jest.advanceTimersByTimeAsync(START_TIMEOUT_MS - 1);
       expect(onSettled).not.toHaveBeenCalled();
 
       await jest.advanceTimersByTimeAsync(1);

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Constants } from "../constants";
+import { Constants } from '../constants';
 
 export enum FirefoxCommand {
   AccountDeleted = 'fxaccounts:delete',
@@ -108,16 +108,16 @@ export type SignedInUser = {
 };
 
 export type PairOAuthStartState = {
-  state:string,
-  scope:string,
-  code_challenge: string,
-  code_challenge_method: string,
-  keys_jwk:string
-}
+  state: string;
+  scope: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  keys_jwk: string;
+};
 export type PairOAuthFinishState = {
-  state:string,
-  code:string
-}
+  state: string;
+  code: string;
+};
 
 export type FxALoginRequest = {
   email: string;
@@ -244,7 +244,11 @@ export function buildSyncOAuthSearch(
 // timeout tuned for device latency
 // max timeout of 100-200 ms would be optimal for an ultra-snappy UX, but could cause false negatives on mobile
 // compromising with 500ms for safer mobile support without being noticeably long if it times out
-const DEFAULT_SEND_TIMEOUT_LENGTH_MS = 500;
+export const DEFAULT_SEND_TIMEOUT_LENGTH_MS = 500;
+
+// Both halves of the handshake make a web call, and a cold start fetches the FxA client and
+// OpenID configuration first, which does not fit the default.
+export const PAIR_OAUTH_TIMEOUT_MS = 10_000;
 
 // Firefox for Android binds its web channel handler per tab, so the first
 // fxa_status message is routinely dropped. Retrying a handful of times recovers
@@ -654,15 +658,14 @@ export class Firefox extends EventTarget {
   }
 
   /** Requests that a pairing oauth operation begin. This is the first half of pairing dance. */
-  async pairOauthStart(msg:{
-    scopes?: string[]
-  }):Promise<PairOAuthStartState|undefined> {
-
+  async pairOauthStart(msg: {
+    scopes?: string[];
+  }): Promise<PairOAuthStartState | undefined> {
     // Default sync scopes
     if (msg.scopes == null) {
       msg.scopes = [
         Constants.OAUTH_OLDSYNC_SCOPE,
-        Constants.OAUTH_TRUSTED_PROFILE_SCOPE
+        Constants.OAUTH_TRUSTED_PROFILE_SCOPE,
       ];
     }
 
@@ -671,57 +674,71 @@ export class Firefox extends EventTarget {
       msg,
       (event) => {
         if (event?.detail?.state == null) {
-          throw new Error(`${FirefoxCommand.PairOauthStart} missing state from event.details`);
+          throw new Error(
+            `${FirefoxCommand.PairOauthStart} missing state from event.details`
+          );
         }
         if (event?.detail?.scope == null) {
-          throw new Error(`${FirefoxCommand.PairOauthStart} missing scope from event.details`);
+          throw new Error(
+            `${FirefoxCommand.PairOauthStart} missing scope from event.details`
+          );
         }
         if (event?.detail?.code_challenge == null) {
-          throw new Error(`${FirefoxCommand.PairOauthStart} missing code_challenge from event.details`);
+          throw new Error(
+            `${FirefoxCommand.PairOauthStart} missing code_challenge from event.details`
+          );
         }
         if (event?.detail?.code_challenge_method == null) {
-          throw new Error(`${FirefoxCommand.PairOauthStart} missing code_challenge_method from event.details`);
+          throw new Error(
+            `${FirefoxCommand.PairOauthStart} missing code_challenge_method from event.details`
+          );
         }
         if (event?.detail?.keys_jwk == null) {
-          throw new Error(`${FirefoxCommand.PairOauthStart} missing keys_jwk from event.details`);
+          throw new Error(
+            `${FirefoxCommand.PairOauthStart} missing keys_jwk from event.details`
+          );
         }
         return event.detail as PairOAuthStartState;
-      }
-    )
+      },
+      PAIR_OAUTH_TIMEOUT_MS
+    );
   }
 
   /** Requests that a pairing oauth operation be finished. This is the second half of pairing dance. */
-  async pairOauthFinish(msg:{
-    client_id:string,
-    state:string,
-    scope:string,
-    code_challenge:string,
-    code_challenge_method:string,
+  async pairOauthFinish(msg: {
+    client_id: string;
+    state: string;
+    scope: string;
+    code_challenge: string;
+    code_challenge_method: string;
     /**
      * The supplicant's ephemeral public JWK. Firefox only wraps scoped keys into
      * `keys_jwe` when this is present, so omitting it yields a code that grants
      * the sync scope with no sync key behind it.
      */
-    keys_jwk:string,
-  }):Promise<PairOAuthFinishState|undefined> {
+    keys_jwk: string;
+  }): Promise<PairOAuthFinishState | undefined> {
     return this._executeCommandWithResponse<PairOAuthFinishState>(
       FirefoxCommand.PairOauthFinish,
       msg,
       (event) => {
         if (event?.detail?.code == null) {
-          throw new Error(`${FirefoxCommand.PairOauthFinish} missing code from event.details`);
+          throw new Error(
+            `${FirefoxCommand.PairOauthFinish} missing code from event.details`
+          );
         }
         if (event?.detail?.state == null) {
-          throw new Error(`${FirefoxCommand.PairOauthFinish} missing state from event.details`);
+          throw new Error(
+            `${FirefoxCommand.PairOauthFinish} missing state from event.details`
+          );
         }
         if (event.detail.state !== msg.state) {
           throw new Error(`${FirefoxCommand.PairOauthFinish} invalid state!`);
-
         }
-        return event.detail as PairOAuthFinishState
+        return event.detail as PairOAuthFinishState;
       },
-      10_000 // The final handshake makes a web call. Give it some leeway.
-    )
+      PAIR_OAUTH_TIMEOUT_MS
+    );
   }
 
   /**
@@ -734,11 +751,11 @@ export class Firefox extends EventTarget {
   private async _executeCommandWithResponse<TResp>(
     cmd: FirefoxCommand,
     msg: any,
-    handleResp:(event:any) => TResp,
+    handleResp: (event: any) => TResp,
     timeout = DEFAULT_SEND_TIMEOUT_LENGTH_MS
   ) {
     let timeoutId: number;
-    let onResp:EventListenerOrEventListenerObject;
+    let onResp: EventListenerOrEventListenerObject;
     return Promise.race<undefined | TResp>([
       new Promise<undefined | TResp>((resolve, reject) => {
         onResp = (event: any) => {
@@ -755,13 +772,13 @@ export class Firefox extends EventTarget {
           // The handler might throw an error and fail fast if the data looks wrong. Handle error
           // and reject if this happens.
           try {
-            const resp = handleResp(event)
+            const resp = handleResp(event);
 
             resolve(resp);
           } catch (err) {
             reject(err);
           }
-        }
+        };
         this.addEventListener(cmd, onResp);
         requestAnimationFrame(() => {
           console.log(`[[Firefox WebChannel] ${cmd} sent msg`, msg);
@@ -775,16 +792,13 @@ export class Firefox extends EventTarget {
             `[Firefox WebChannel] ${cmd} timed out or unavailable in this browser`
           );
           if (onResp) {
-            this.removeEventListener(cmd, onResp)
+            this.removeEventListener(cmd, onResp);
           }
           resolve(undefined);
         }, timeout);
       }),
     ]);
   }
-
-
-
 
   /*
    * Sends an fxa_status and returns the signed in user if available.

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -97,6 +97,8 @@ export interface Config {
   };
   pairing: {
     browserBuild: 'firefox' | 'fenix';
+    /** iOS URL scheme the pairing hand-off opens. See `pairing.ios_url_scheme`. */
+    iosUrlScheme: string;
     clients: string[];
     serverBaseUri: string;
     version: number;
@@ -223,6 +225,7 @@ export function getDefault() {
     },
     pairing: {
       browserBuild: 'firefox',
+      iosUrlScheme: 'firefox',
       clients: [],
       serverBaseUri: 'wss://channelserver.services.mozilla.com',
       version: 1,

--- a/packages/fxa-settings/src/lib/pairing/handoff.test.ts
+++ b/packages/fxa-settings/src/lib/pairing/handoff.test.ts
@@ -39,7 +39,7 @@ const plan = (device: Devices, storage = createStorage()) =>
     targetUrl: MOCK_TARGET,
     storeLinks: MOCK_STORE_LINKS,
     storage,
-    build: 'firefox'
+    build: 'firefox',
   });
 
 describe('planPairingHandoff', () => {
@@ -60,7 +60,7 @@ describe('planPairingHandoff', () => {
         device: Devices.OTHER_IOS,
         targetUrl: '',
         storeLinks: MOCK_STORE_LINKS,
-        build: 'firefox'
+        build: 'firefox',
       })
     ).toEqual({ kind: 'none' });
   });
@@ -99,6 +99,31 @@ describe('planPairingHandoff', () => {
       });
     });
 
+    // Every Firefox iOS flavour registers `firefox`, so a release install and a
+    // local build both answer it. The scheme is the only way to pin which one.
+    it('defaults the iOS deep link to the release scheme', () => {
+      const { deepLink } = plan(Devices.OTHER_IOS) as { deepLink: string };
+
+      expect(deepLink).toBe(
+        `firefox://open-url?url=${encodeURIComponent(MOCK_TARGET)}`
+      );
+    });
+
+    it('opens a build-specific iOS scheme when one is configured', () => {
+      const { deepLink } = planPairingHandoff({
+        device: Devices.OTHER_IOS,
+        targetUrl: MOCK_TARGET,
+        storeLinks: MOCK_STORE_LINKS,
+        storage: createStorage(),
+        build: 'firefox',
+        iosScheme: 'fennec',
+      }) as { deepLink: string };
+
+      expect(deepLink).toBe(
+        `fennec://open-url?url=${encodeURIComponent(MOCK_TARGET)}`
+      );
+    });
+
     // `;` separates intent extras, so an unencoded store URL would terminate the
     // extra early and let the rest of the URL become extras of its own.
     it('encodes a store URL containing & and ; into a single extra', () => {
@@ -111,7 +136,7 @@ describe('planPairingHandoff', () => {
         targetUrl: MOCK_TARGET,
         storeLinks,
         storage: createStorage(),
-        build: 'firefox'
+        build: 'firefox',
       }) as { deepLink: string };
 
       expect(deepLink).toContain(

--- a/packages/fxa-settings/src/lib/pairing/handoff.ts
+++ b/packages/fxa-settings/src/lib/pairing/handoff.ts
@@ -136,7 +136,11 @@ export function claimAutoAttempt(
  * Package-pinned intent that opens `target` in Firefox, with a built-in store
  * fallback for when it is not installed.
  */
-function buildAndroidDeepLink(target: string, storeUrl: string, build: 'firefox' | 'fenix'): string {
+function buildAndroidDeepLink(
+  target: string,
+  storeUrl: string,
+  build: 'firefox' | 'fenix'
+): string {
   const scheme = target.startsWith('http://') ? 'http' : 'https';
   const withoutScheme = target.replace(/^https?:\/\//, '');
   return (
@@ -148,8 +152,9 @@ function buildAndroidDeepLink(target: string, storeUrl: string, build: 'firefox'
   );
 }
 
-function buildIosDeepLink(target: string): string {
-  return `firefox://open-url?url=${encodeURIComponent(target)}`;
+/** Every iOS flavour also registers `firefox`, so `scheme` is what picks a build. */
+function buildIosDeepLink(target: string, scheme: string): string {
+  return `${scheme}://open-url?url=${encodeURIComponent(target)}`;
 }
 
 /**
@@ -164,13 +169,16 @@ export function planPairingHandoff({
   targetUrl,
   storeLinks,
   storage,
-  build
+  build,
+  iosScheme = 'firefox',
 }: {
   device: Devices;
   targetUrl: string;
   storeLinks: StoreLinks;
   storage?: AttemptStorage;
-  build: 'firefox' | 'fenix'
+  build: 'firefox' | 'fenix';
+  /** iOS URL scheme to hand off to. See `buildIosDeepLink`. */
+  iosScheme?: string;
 }): HandoffPlan {
   if (!targetUrl) {
     return { kind: 'none' };
@@ -180,7 +188,7 @@ export function planPairingHandoff({
     case Devices.OTHER_IOS:
       return {
         kind: 'ios',
-        deepLink: buildIosDeepLink(targetUrl),
+        deepLink: buildIosDeepLink(targetUrl, iosScheme),
         storeUrl: storeLinks.ios,
       };
     case Devices.OTHER_ANDROID:

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -75,10 +75,8 @@ const PAIR_BANNER_FTL: Record<PairOrigin, { id: string; fallback: string }> = {
 export type PairingChannelInfo = {
   channelId: string;
   channelKey: string;
-  version: '1'|'2';
+  version: '1' | '2';
 };
-
-
 
 type MobileChoice = 'has-mobile' | 'needs-mobile';
 
@@ -101,9 +99,8 @@ const Pair = ({
   error,
   cmsInfo: cmsInfoProp,
   integration,
-  fxaStatusResult
+  fxaStatusResult,
 }: PairProps) => {
-
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedQRCodeLabel = ftlMsgResolver.getMsg(
@@ -154,22 +151,21 @@ const Pair = ({
   //
   // Read-only, so it is safe to evaluate during render; the auto-attempt token
   // is only spent by ContinueInFirefox.
-  const handoffPlan: HandoffPlan = useMemo(
-    () => {
-      if (pairingChannelInfo && fxaStatusResult.fxaStatusState === 'unanswered') {
-        return planPairingHandoff({
-            device,
-            targetUrl: buildPairUrl(pairingChannelInfo),
-            storeLinks: config.mobileStoreLinks,
-            storage: getAttemptStorage(),
-            build: config.pairing.browserBuild,
-          })
-      }
+  const handoffPlan: HandoffPlan = useMemo(() => {
+    if (pairingChannelInfo && fxaStatusResult.fxaStatusState === 'unanswered') {
+      return planPairingHandoff({
+        device,
+        targetUrl: buildPairUrl(pairingChannelInfo),
+        storeLinks: config.mobileStoreLinks,
+        storage: getAttemptStorage(),
+        build: config.pairing.browserBuild,
+        iosScheme: config.pairing.iosUrlScheme,
+      });
+    }
 
-      // This indicates no handoff is needed. and we can continue as normal.
-      return { kind: 'none' }
-    }, [pairingChannelInfo, fxaStatusResult.fxaStatusState, device, config]
-  );
+    // This indicates no handoff is needed. and we can continue as normal.
+    return { kind: 'none' };
+  }, [pairingChannelInfo, fxaStatusResult.fxaStatusState, device, config]);
 
   useEffect(() => {
     // This is a signal that the initial fxa_status message is still pending.
@@ -188,7 +184,8 @@ const Pair = ({
 
     // Switch on pairing version 2! Both FxA and Firefox have to signal that it
     // is enabled, same gate as ConnectAnotherDevice.
-    const pairingVersion = fxaStatusResult.fxaStatus?.capabilities.pairingVersion;
+    const pairingVersion =
+      fxaStatusResult.fxaStatus?.capabilities.pairingVersion;
 
     if (
       config.pairing.version === 2 &&
@@ -225,10 +222,12 @@ const Pair = ({
 
     // Switch on pairing version 2! Both FxA and Firefox have to signal that it
     // is enabled, same gate as ConnectAnotherDevice.
-    if(
+    if (
       config.pairing.version === 2 &&
-      pairingVersion && pairingVersion === 2 &&
-      pairingChannelInfo && parseInt(pairingChannelInfo?.version) === 2
+      pairingVersion &&
+      pairingVersion === 2 &&
+      pairingChannelInfo &&
+      parseInt(pairingChannelInfo?.version) === 2
     ) {
       navigateWithQuery(
         '/pair/supplicant/connect_this_device',
@@ -240,10 +239,11 @@ const Pair = ({
       return;
     }
 
-    if(
+    if (
       isFirefoxDesktop &&
       config.pairing.version === 2 &&
-      pairingVersion && pairingVersion === 2
+      pairingVersion &&
+      pairingVersion === 2
     ) {
       // Full reload: `useIntegration` is not keyed on location, so only a
       // fresh page load rebuilds it as a PairingAuthorityIntegration.


### PR DESCRIPTION
## Because

- The pairing hand-off hardcoded `firefox://`, which every Firefox iOS flavour registers, so it cannot reach a local or pre-release build when a release install is also present.
- `pair_oauth_start` used the 500 ms default WebChannel deadline. A cold mobile start fetches the FxA client and OpenID configuration first, so it timed out and failed the whole pairing.
- v2 pairing had no coverage against a real Firefox iOS supplicant.

## This pull request

- Adds a `pairing.ios_url_scheme` setting in `configuration.js` and `beta-settings.js`, surfaced as `config.pairing.iosUrlScheme`, and builds the iOS deep link from it in `handoff.ts`.
- Extracts `PAIR_OAUTH_TIMEOUT_MS` in `firefox.ts` and exports it with the send default, so `firefox.test.ts` stops copying the numbers.
- Adds `pairingFlowV2iOS.spec.ts` and `ios-supplicant.ts`: a Simulator supplicant against a Marionette authority, run twice — once with a test-built deep link, once with the link read off the rendered `/pair` page.
- Restricts the v2 iOS and Android pairing specs to the `local` target.
- Lets `profile.mjs` and the functional-test targets reach a stack off localhost.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-XXXXX

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## Other information

**Companion:** needs the Firefox iOS side (FXIOS-16685) to answer `pair_oauth_start`.

**Local tests:**
- `npx jest src/lib/channels/firefox.test.ts` (fxa-settings): 28 passed, 0 failed.
- `npx playwright test pairingFlowV2iOS.spec.ts --project=local`: 2 passed, 0 failed.