### PR TITLE
fix(emails): Update Mozilla address in SubPlat email footers

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
@@ -48,7 +48,7 @@
 
       <mj-section>
         <mj-column>
-          <mj-text css-class="text-footer">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</mj-text>
+          <mj-text css-class="text-footer">Mozilla. 1875 Mission Street, Suite 103, San Francisco, CA 94103</mj-text>
           <mj-text css-class="text-footer">
             <a class="link-blue" data-l10n-id="moz-accounts-privacy-url-2" href="<%- privacyUrl %>">Mozilla Accounts Privacy Notice</a>
           </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
@@ -1,7 +1,7 @@
 <%- include('/partials/brandMessaging/index.txt') %>
 
 <%- body %>
-Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105
+Mozilla. 1875 Mission Street, Suite 103, San Francisco, CA 94103
 
 moz-accounts-privacy-url-2 = "Mozilla Accounts Privacy Notice"
 <%- privacyUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/strapi.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/strapi.mjml
@@ -44,7 +44,7 @@
 
       <mj-section>
         <mj-column>
-          <mj-text css-class="text-footer">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</mj-text>
+          <mj-text css-class="text-footer">Mozilla. 1875 Mission Street, Suite 103, San Francisco, CA 94103</mj-text>
           <mj-text css-class="text-footer">
             <a class="link-blue" data-l10n-id="moz-accounts-privacy-url-2" href="<%- privacyUrl %>">Mozilla Accounts Privacy Notice</a>
           </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/strapi.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/strapi.txt
@@ -1,7 +1,7 @@
 
 
 <%- body %>
-Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105
+Mozilla. 1875 Mission Street, Suite 103, San Francisco, CA 94103
 
 moz-accounts-privacy-url-2 = "Mozilla Accounts Privacy Notice"
 <%- privacyUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -102,7 +102,7 @@
             title="Mozilla">
           </mj-image>
 
-          <mj-text css-class="footer-text-bottom-margin">149 New Montgomery St, 4th Floor, San Francisco, CA 94105</mj-text>
+          <mj-text css-class="footer-text-bottom-margin">1875 Mission Street, Suite 103, San Francisco, CA 94103</mj-text>
 
           <mj-text css-class="footer-text">
             <a href="https://www.mozilla.org/about/legal/terms/services/" class="footer-link" data-l10n-id="subplat-legal">Legal</a>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -52,7 +52,7 @@ https://www.mozilla.org/about/legal/terms/services/
 <% } %>
 
 Mozilla Corporation
-149 New Montgomery St, 4th Floor, San Francisco, CA 94105
+1875 Mission Street, Suite 103, San Francisco, CA 94103
 
 subplat-legal-plaintext = "Legal:"
 https://www.mozilla.org/about/legal/terms/services/


### PR DESCRIPTION
## Because

- FXA-14150 updated only the copies in libs, but SubPlat still renders from auth-server

## This pull request

- Updates the address in auth-server

## Issue that this pull request solves

Closes: FXA-14437

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.
