### PR TITLE
fix(settings): show canceled screen when mobile cancels pairing

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.test.tsx
@@ -118,7 +118,7 @@ describe('Pair2/Supplicant/ApproveSignIn container', () => {
       await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
       expect(navigateWithQuery).toHaveBeenCalledWith(
         '/pair/supplicant/timeout_and_cancel',
-        {},
+        { state: { reason: 'canceled' } },
         true
       );
     });
@@ -135,7 +135,7 @@ describe('Pair2/Supplicant/ApproveSignIn container', () => {
       await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
       expect(navigateWithQuery).toHaveBeenCalledWith(
         '/pair/supplicant/timeout_and_cancel',
-        {},
+        { state: { reason: 'canceled' } },
         true
       );
     });

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ApproveSignIn/container.tsx
@@ -39,14 +39,20 @@ export const ApproveSignInContainer = ({integration}:{integration:Integration|Pa
     };
   },[integration])
 
-  const onCancel = () => {
-    integration.destroy()
-      .then(() => {
-        navigateWithQuery('/pair/supplicant/timeout_and_cancel', {}, true)
-      }).catch((err) => {
-        Sentry.captureException(err);
-        navigateWithQuery('/pair/supplicant/timeout_and_cancel', {}, true)
-      });
+  // Leave even if the channel will not close; the user asked to stop. The
+  // reason rides along so the dead-end screen says "Canceled" rather than
+  // blaming a timeout the user never waited out.
+  const onCancel = async () => {
+    try {
+      await integration.destroy();
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+    navigateWithQuery(
+      '/pair/supplicant/timeout_and_cancel',
+      { state: { reason: 'canceled' } },
+      true
+    );
   }
 
   return <ApproveSignIn {...{ remoteMetadata:integration.remoteMetadata, onCancel }}/>

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.test.tsx
@@ -192,6 +192,8 @@ describe('Pair2/Supplicant/ConnectThisDevice container', () => {
       );
     });
 
+    // The reason has to travel with the navigation: without it the dead-end
+    // screen blames a timeout for a pairing the user deliberately stopped.
     it('closes the channel before leaving for the cancel screen', async () => {
       const user = userEvent.setup();
       await renderReady();
@@ -199,8 +201,28 @@ describe('Pair2/Supplicant/ConnectThisDevice container', () => {
       await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => expect(integration.destroy).toHaveBeenCalled());
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/pair/supplicant/timeout_and_cancel'
+      expect(navigateWithQuery).toHaveBeenCalledWith(
+        '/pair/supplicant/timeout_and_cancel',
+        { state: { reason: 'canceled' } },
+        true
+      );
+    });
+
+    // The user asked to stop, so a channel that will not close cleanly cannot
+    // keep them on a screen that is waiting on a pairing they cancelled.
+    it('still leaves for the cancel screen when the channel cannot be closed', async () => {
+      const user = userEvent.setup();
+      const err = new Error('channel server unreachable');
+      integration.destroy.mockRejectedValue(err);
+      await renderReady();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(captureException).toHaveBeenCalledWith(err));
+      expect(navigateWithQuery).toHaveBeenCalledWith(
+        '/pair/supplicant/timeout_and_cancel',
+        { state: { reason: 'canceled' } },
+        true
       );
     });
   });

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.tsx
@@ -83,15 +83,20 @@ export const ConnectThisDeviceContainer = ({
     };
   }, [integration, location, navigate]);
 
-  const onCancel = () => {
-    integration.destroy()
-      .then(() => {
-        navigate('/pair/supplicant/timeout_and_cancel')
-      })
-      .catch((err) => {
-        Sentry.captureException(err);
-        navigate('/pair/supplicant/timeout_and_cancel');
-      });
+  // Leave even if the channel will not close; the user asked to stop. The
+  // reason rides along so the dead-end screen says "Canceled" rather than
+  // blaming a timeout the user never waited out.
+  const onCancel = async () => {
+    try {
+      await integration.destroy();
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+    navigateWithQuery(
+      '/pair/supplicant/timeout_and_cancel',
+      { state: { reason: 'canceled' } },
+      true
+    );
   }
 
   const onConnect = () => {


### PR DESCRIPTION
## Because

- Cancelling on the mobile pairing screen landed on "Looks like we timed out", blaming a wait the user never made. The designs call for the "Canceled" screen.

## This pull request

- Passes `reason: 'canceled'` when the supplicant cancels from `connect_this_device` or `approve_signin`, so the shared dead-end screen renders the Canceled variant.
- Routes those two exits through `navigateWithQuery`, keeping the pairing query string on the navigation.
- Adds a cancel-with-unclosable-channel case to the `connect_this_device` container tests.

## Issue that this pull request solves

Closes: FXA-14452

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

`Supplicant/ApproveSignIn` had the same defect on its Cancel button. The ticket only reports the first screen, but leaving the second one blaming a timeout would be the same bug.
