### PR TITLE
fix(pair): center the loading spinner on the supplicant connect screen

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.test.tsx
@@ -115,6 +115,19 @@ describe('Pair2/Supplicant/ConnectThisDevice container', () => {
     );
   });
 
+  // A bare spinner has no layout of its own, so the browser parked it in the
+  // top-left corner while the channel opened. Rendering it through the same
+  // layout the connect prompt uses keeps it centered on the page.
+  it('renders the spinner inside the page layout while the channel opens', async () => {
+    // Leave the channel pending so the loading state is the rendered output.
+    integration.openChannel.mockReturnValue(new Promise<void>(() => {}));
+
+    renderContainer();
+
+    const spinner = await screen.findByRole('img', { name: 'Loading…' });
+    expect(screen.getByRole('main')).toContainElement(spinner);
+  });
+
   it('renders the device details once the authority metadata arrives', async () => {
     renderContainer();
     await waitFor(() => expect(integration.onStateChange).toBeTruthy());

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/ConnectThisDevice/container.tsx
@@ -12,7 +12,7 @@ import {
   SupplicantState,
 } from '../../../../models';
 import config from '../../../../lib/config';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import AppLayout from '../../../../components/AppLayout';
 import ConnectThisDevice from '.';
 import { navigateWithQuery } from '../../../../lib/utilities';
 
@@ -107,7 +107,9 @@ export const ConnectThisDeviceContainer = ({
   };
 
   if (!ready || !remoteMetadata) {
-    return <LoadingSpinner />
+    // Rendered through AppLayout rather than a bare spinner so the wait for the
+    // channel keeps the page chrome and centering of the card that follows it.
+    return <AppLayout loading />
   }
 
   return <ConnectThisDevice {...{remoteMetadata, email, onCancel, onConnect }} />


### PR DESCRIPTION
## Because

- On Android, the loading state shown just before `/pair/supplicant/connect_this_device` put its spinner in the upper-left corner of the page instead of the center.

## This pull request

- Renders the `connect_this_device` loading state through `AppLayout`'s `loading` state, so the spinner is centered inside the same page chrome and card as the connect prompt that follows it.
- Adds a container test asserting the spinner renders within the page layout while the pairing channel opens.

## Issue that this pull request solves

Closes: FXA-14457

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="535" height="1098" alt="image" src="https://github.com/user-attachments/assets/9234cabe-995f-4d5f-8c96-5f27c6617c2f" />

## Other information (Optional)

- The bug was reported on Android, but the bare spinner had no centering on any platform — the fix is not platform-specific.
- `Pair2/Authority/ApproveSignIn/container.tsx` has the same bare `<LoadingSpinner />` on its own loading state. Left alone here as it is a different screen than the one this ticket covers; worth a follow-up ticket.
