### PR TITLE
feat(profile): add additionalEmails to the account profile

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -121,9 +121,9 @@ const ACCOUNT_EMAILS_GET = {
   ...TAGS_ACCOUNT,
   description: '/account/emails',
   notes: [
-    'Returns the current primary email, secondary email, and original email that was used during sign up.'
-  ]
-}
+    'Returns the current primary email, secondary email, and original email that was used during sign up.',
+  ],
+};
 
 const ACCOUNT_PROFILE_GET = {
   ...TAGS_ACCOUNT,
@@ -136,6 +136,7 @@ const ACCOUNT_PROFILE_GET = {
 
       If an OAuth bearer token is used, the values returned depend on the scopes that the token is authorized for:
         - \`email\` requires \`profile:email\` scope.
+        - \`additionalEmails\` requires \`profile:additionalEmails\` scope. It lists the account's verified secondary email addresses.
         - \`locale\` requires \`profile:locale\` scope.
         - \`authenticationMethods\` and \`authenticatorAssuranceLevel\` require \`profile:amr\` scope.
         - \`accountDisabledAt\` requires \`profile:account_disabled_at\` scope.

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1672,6 +1672,11 @@ export class AccountHandler {
     if (scope.contains('profile:email')) {
       res.email = account.primaryEmail?.email;
     }
+    if (scope.contains('profile:additionalEmails')) {
+      res.additionalEmails = (account.emails ?? [])
+        .filter((email) => !email.isPrimary && email.isVerified)
+        .map((email) => email.email);
+    }
     if (scope.contains('profile:locale') && account.locale) {
       res.locale = account.locale;
     }
@@ -2789,6 +2794,7 @@ export const accountRoutes = (
         response: {
           schema: isA.object({
             email: isA.string().optional(),
+            additionalEmails: isA.array().items(isA.string()).optional(),
             locale: isA.string().optional().allow(null),
             authenticationMethods: isA
               .array()

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -138,7 +138,9 @@ module.exports = (
   /** @type import('../payments/stripe').StripeHelper */
   stripeHelper,
   authServerCacheRedis,
-  statsd
+  statsd,
+  /** @type import('@fxa/profile/client').ProfileClient */
+  profileClient
 ) => {
   const fxaMailer = Container.get(FxaMailer);
   const oauthClientInfoService = Container.get(OAuthClientInfoServiceName);
@@ -146,6 +148,32 @@ module.exports = (
   const REMINDER_PATTERN = new RegExp(
     `^(?:${verificationReminders.keys.join('|')})$`
   );
+
+  // `additionalEmails` is part of the cached profile, so verifying or deleting
+  // a secondary address invalidates that cache.
+  async function tryInvalidateProfileCache(request, uid) {
+    const [deleteReq, notifyEvent] = await Promise.allSettled([
+      profileClient.deleteCache(uid),
+      log.notifyAttachedServices('profileDataChange', request, { uid }),
+    ]);
+
+    if (deleteReq.status === 'rejected') {
+      log.error('secondary_email.invalidateProfileCache.clientDelete', {
+        uid,
+        err: deleteReq.reason,
+      });
+      Sentry.captureException(deleteReq.reason);
+    }
+    if (notifyEvent.status === 'rejected') {
+      log.error('secondary_email.invalidateProfileCache.notifyEvent', {
+        uid,
+        err: notifyEvent.reason,
+      });
+      Sentry.captureException(notifyEvent.reason);
+    }
+
+    return undefined;
+  }
 
   const otpOptions = config.otp;
   const otpUtils = require('./utils/otp').default(db, statsd);
@@ -514,6 +542,8 @@ module.exports = (
         });
         // don't throw on email send error
       }
+
+      await tryInvalidateProfileCache(request, uid);
 
       return {};
     },
@@ -1151,6 +1181,8 @@ module.exports = (
           ...FxaMailerFormat.sync(false),
           secondaryEmail: email,
         });
+
+        await tryInvalidateProfileCache(request, uid);
 
         return {};
       },

--- a/packages/fxa-auth-server/lib/routes/emails.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/emails.spec.ts
@@ -200,6 +200,8 @@ const makeRoutes = function (options: any = {}) {
     del: jest.fn().mockResolvedValue(1),
   };
 
+  const profile = options.profile || mocks.mockProfile();
+
   const routeModule = require('./emails');
 
   const routes = routeModule(
@@ -215,9 +217,11 @@ const makeRoutes = function (options: any = {}) {
     undefined,
     options.stripeHelper,
     authServerCacheRedis,
-    statsd
+    statsd,
+    profile
   );
   (routes as any).__redis = authServerCacheRedis;
+  (routes as any).__profile = profile;
   return routes;
 };
 
@@ -1620,6 +1624,207 @@ describe('/emails/reminders/cad', () => {
 
       expect(response).toBeTruthy();
       expect(Object.keys(response)).toHaveLength(0);
+    });
+  });
+});
+
+describe('profile cache invalidation', () => {
+  const directError = new Error('profile server unavailable');
+  const eventError = new Error('sns unavailable');
+  let uid: string, mockLog: any, mockDB: any, profile: any, mockRequest: any;
+
+  beforeEach(() => {
+    mocks.mockOAuthClientInfo();
+    uid = crypto.randomBytes(16).toString('hex');
+    mockLog = createMock<AuthLogger>();
+    mockLog.notifyAttachedServices = jest.fn().mockResolvedValue(undefined);
+    profile = mocks.mockProfile();
+  });
+
+  describe('/mfa/recovery_email/secondary/verify_code - newly verified', () => {
+    let route: any;
+    const secret = 'abcd1234abcd1234abcd1234abcd1234';
+
+    beforeEach(() => {
+      mocks.mockAccountEventsManager();
+      installMockFxaMailer();
+      mockDB = mocks.mockDB({
+        uid,
+        email: TEST_EMAIL,
+        emailVerified: true,
+      });
+
+      const authServerCacheRedis = {
+        get: jest.fn().mockResolvedValue(JSON.stringify({ uid, secret })),
+        set: jest.fn().mockResolvedValue('OK'),
+        del: jest.fn().mockResolvedValue(1),
+      };
+      const routes = makeRoutes({
+        db: mockDB,
+        log: mockLog,
+        mailer: mocks.mockMailer(),
+        authServerCacheRedis,
+        profile,
+      });
+      route = getRoute(routes, '/mfa/recovery_email/secondary/verify_code');
+
+      const otpUtilsLocal = require('./utils/otp').default(
+        {},
+        { histogram: () => {} }
+      );
+      mockRequest = mocks.mockRequest({
+        credentials: { uid, email: TEST_EMAIL },
+        log: mockLog,
+        payload: {
+          email: TEST_EMAIL_ADDITIONAL,
+          code: otpUtilsLocal.generateOtpCode(secret, otpOptions),
+        },
+      });
+    });
+
+    afterEach(() => {
+      mocks.unMockAccountEventsManager();
+      uninstallMockFxaMailer();
+    });
+
+    it('invalidates the profile cache after verification', async () => {
+      const response = await runTest(route, mockRequest);
+
+      expect(response).toEqual({});
+      expect(profile.deleteCache).toHaveBeenCalledTimes(1);
+      expect(profile.deleteCache).toHaveBeenCalledWith(uid);
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledTimes(1);
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledWith(
+        'profileDataChange',
+        mockRequest,
+        { uid }
+      );
+    });
+
+    it('succeeds when only the direct delete rejects', async () => {
+      profile.deleteCache.mockRejectedValue(directError);
+
+      const response = await runTest(route, mockRequest);
+
+      expect(response).toEqual({});
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledTimes(1);
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'secondary_email.invalidateProfileCache.clientDelete',
+        { uid, err: directError }
+      );
+    });
+
+    it('succeeds when only the notification event rejects', async () => {
+      mockLog.notifyAttachedServices.mockRejectedValue(eventError);
+
+      const response = await runTest(route, mockRequest);
+
+      expect(response).toEqual({});
+      expect(profile.deleteCache).toHaveBeenCalledTimes(1);
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'secondary_email.invalidateProfileCache.notifyEvent',
+        { uid, err: eventError }
+      );
+    });
+
+    it('does not throw when both reject', async () => {
+      // invalidation is best effort
+      profile.deleteCache.mockRejectedValue(directError);
+      mockLog.notifyAttachedServices.mockRejectedValue(eventError);
+
+      const response = await runTest(route, mockRequest);
+
+      expect(response).toEqual({});
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'secondary_email.invalidateProfileCache.clientDelete',
+        { uid, err: directError }
+      );
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'secondary_email.invalidateProfileCache.notifyEvent',
+        { uid, err: eventError }
+      );
+    });
+  });
+
+  describe('/mfa/recovery_email/destroy', () => {
+    let fxaMailer: any, route: any;
+
+    const makeDestroyRoute = () => {
+      const routes = makeRoutes({
+        db: mockDB,
+        log: mockLog,
+        mailer: mocks.mockMailer(),
+        profile,
+      });
+      return getRoute(routes, '/mfa/recovery_email/destroy');
+    };
+
+    beforeEach(() => {
+      mocks.mockAccountEventsManager();
+      fxaMailer = installMockFxaMailer();
+      mockDB = mocks.mockDB({ uid, email: TEST_EMAIL, emailVerified: true });
+      route = makeDestroyRoute();
+      mockRequest = mocks.mockRequest({
+        credentials: { uid, email: TEST_EMAIL },
+        log: mockLog,
+        payload: { email: TEST_EMAIL_ADDITIONAL },
+      });
+    });
+
+    afterEach(() => {
+      mocks.unMockAccountEventsManager();
+      uninstallMockFxaMailer();
+    });
+
+    const withVerifiedSecondary = () => {
+      mockDB.account = jest.fn().mockResolvedValue({
+        uid,
+        email: TEST_EMAIL,
+        emails: [
+          {
+            email: TEST_EMAIL,
+            normalizedEmail: normalizeEmail(TEST_EMAIL),
+            isPrimary: true,
+            isVerified: true,
+          },
+          {
+            email: TEST_EMAIL_ADDITIONAL,
+            normalizedEmail: normalizeEmail(TEST_EMAIL_ADDITIONAL),
+            isPrimary: false,
+            isVerified: true,
+          },
+        ],
+      });
+      route = makeDestroyRoute();
+    };
+
+    it('does not invalidate when the removed address was never verified', async () => {
+      const response = await runTest(route, mockRequest);
+
+      expect(response).toEqual({});
+      expect(profile.deleteCache).not.toHaveBeenCalled();
+      expect(mockLog.notifyAttachedServices).not.toHaveBeenCalled();
+      expect(fxaMailer.sendPostRemoveSecondaryEmail).not.toHaveBeenCalled();
+    });
+
+    it('invalidates the profile cache when a verified address is removed', async () => {
+      withVerifiedSecondary();
+
+      const response = await runTest(route, mockRequest);
+
+      expect(response).toEqual({});
+      expect(mockDB.deleteEmail).toHaveBeenCalledWith(
+        uid,
+        normalizeEmail(TEST_EMAIL_ADDITIONAL)
+      );
+      expect(profile.deleteCache).toHaveBeenCalledTimes(1);
+      expect(profile.deleteCache).toHaveBeenCalledWith(uid);
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledTimes(1);
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledWith(
+        'profileDataChange',
+        mockRequest,
+        { uid }
+      );
     });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -126,7 +126,8 @@ module.exports = function (
     zendeskClient,
     stripeHelper,
     authServerCacheRedis,
-    statsd
+    statsd,
+    profile
   );
   const password = require('./password')(
     log,

--- a/packages/fxa-auth-server/test/remote/account_profile.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_profile.in.spec.ts
@@ -2,13 +2,59 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
+import crypto from 'crypto';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Client = require('../client')();
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const jwt = require('jsonwebtoken');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tokens = require('../../lib/tokens')({ trace: function () {} });
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const baseConfig = require('../../config').default.getProperties();
 
 let server: TestServerInstance;
 let CLIENT_ID: string;
+
+async function generateMfaJwt(client: any) {
+  const sessionToken = await tokens.SessionToken.fromHex(client.sessionToken);
+  const now = Math.floor(Date.now() / 1000);
+
+  return jwt.sign(
+    {
+      sub: client.uid,
+      scope: ['mfa:email'],
+      iat: now,
+      jti: crypto.randomUUID(),
+      stid: sessionToken.id,
+    },
+    baseConfig.mfa.jwt.secretKey,
+    {
+      algorithm: 'HS256',
+      expiresIn: baseConfig.mfa.jwt.expiresInSec,
+      audience: baseConfig.mfa.jwt.audience,
+      issuer: baseConfig.mfa.jwt.issuer,
+    }
+  );
+}
+
+async function addVerifiedSecondaryEmail(
+  client: any,
+  mfaJwt: string,
+  email: string
+) {
+  await client.createEmail(mfaJwt, email);
+  const emailData = await server.mailbox.waitForEmail(email);
+  await client.verifySecondaryEmailWithCode(
+    mfaJwt,
+    emailData['headers']['x-verify-code'],
+    email
+  );
+}
 
 beforeAll(async () => {
   server = await createTestServer({
@@ -57,6 +103,82 @@ describe.each(testVersions)(
         expect(response.authenticatorAssuranceLevel).toBe(1);
         expect(response.profileChangedAt).toBeTruthy();
       });
+
+      it('returns an empty additionalEmails when there is no secondary email', async () => {
+        const response = await client.accountProfile();
+
+        expect(response.additionalEmails).toEqual([]);
+      });
+    });
+
+    describe('additionalEmails and secondary email state', () => {
+      let client: any;
+      let secondEmail: string;
+
+      beforeEach(async () => {
+        secondEmail = server.uniqueEmail();
+        client = await Client.createAndVerify(
+          server.publicUrl,
+          server.uniqueEmail(),
+          'password',
+          server.mailbox,
+          { ...testOptions, lang: 'en-US' }
+        );
+      });
+
+      it('excludes an unverified secondary email and includes it once verified', async () => {
+        const mfaJwt = await generateMfaJwt(client);
+        await client.createEmail(mfaJwt, secondEmail);
+
+        let response = await client.accountProfile();
+        expect(response.additionalEmails).toEqual([]);
+
+        const sentEmail = await server.mailbox.waitForEmail(secondEmail);
+        const verifyCode = sentEmail['headers']['x-verify-code'];
+        await client.verifySecondaryEmailWithCode(
+          mfaJwt,
+          verifyCode,
+          secondEmail
+        );
+
+        response = await client.accountProfile();
+        expect(response.additionalEmails).toEqual([secondEmail]);
+      });
+
+      it('returns every verified secondary email', async () => {
+        const thirdEmail = server.uniqueEmail();
+        const mfaJwt = await generateMfaJwt(client);
+
+        await addVerifiedSecondaryEmail(client, mfaJwt, secondEmail);
+        await addVerifiedSecondaryEmail(client, mfaJwt, thirdEmail);
+
+        const response = await client.accountProfile();
+
+        expect(response.additionalEmails).toHaveLength(2);
+        expect(response.additionalEmails).toEqual(
+          expect.arrayContaining([secondEmail, thirdEmail])
+        );
+      });
+
+      it('drops a deleted secondary email from the profile', async () => {
+        const mfaJwt = await generateMfaJwt(client);
+        await addVerifiedSecondaryEmail(client, mfaJwt, secondEmail);
+
+        expect((await client.accountProfile()).additionalEmails).toEqual([
+          secondEmail,
+        ]);
+
+        await client.deleteEmail(mfaJwt, secondEmail);
+
+        expect((await client.accountProfile()).additionalEmails).toEqual([]);
+      });
+
+      it('never returns the primary email in additionalEmails', async () => {
+        const response = await client.accountProfile();
+
+        expect(response.email).toBeTruthy();
+        expect(response.additionalEmails).not.toContain(response.email);
+      });
     });
 
     describe('when a request is authenticated with a valid oauth token', () => {
@@ -74,13 +196,12 @@ describe.each(testVersions)(
           { ...testOptions, lang: 'en-US' }
         );
 
-        const tokenResponse =
-          await client.grantOAuthTokensFromSessionToken({
-            grant_type: 'fxa-credentials',
-            client_id: CLIENT_ID,
-            access_type: 'offline',
-            scope: scope,
-          });
+        const tokenResponse = await client.grantOAuthTokensFromSessionToken({
+          grant_type: 'fxa-credentials',
+          client_id: CLIENT_ID,
+          access_type: 'offline',
+          scope: scope,
+        });
 
         token = tokenResponse.access_token;
       }
@@ -122,6 +243,31 @@ describe.each(testVersions)(
             expect(response.email).toBeFalsy();
             expect(response.locale).toBe('en-US');
             expect(response.profileChangedAt).toBeTruthy();
+          });
+        });
+
+        describe('additionalEmails', () => {
+          it('omits additionalEmails for an email only token', async () => {
+            await initialize('profile:email');
+            const response = await client.accountProfile(token);
+
+            expect(response.email).toBeTruthy();
+            expect(response.additionalEmails).toBeUndefined();
+          });
+
+          it('returns an empty array when there are no secondary emails', async () => {
+            await initialize('profile:additionalEmails');
+            const response = await client.accountProfile(token);
+
+            expect(response.additionalEmails).toEqual([]);
+            expect(response.email).toBeFalsy();
+          });
+
+          it('returns additionalEmails for a profile scoped token', async () => {
+            await initialize('profile');
+            const response = await client.accountProfile(token);
+
+            expect(response.additionalEmails).toEqual([]);
           });
         });
 

--- a/packages/fxa-profile-server/docs/API.md
+++ b/packages/fxa-profile-server/docs/API.md
@@ -87,6 +87,7 @@ curl -v \
 {
   "uid": "6d940dd41e636cc156074109b8092f96",
   "email": "user@example.domain",
+  "additionalEmails": ["backup@example.domain"],
   "locale": "en-US",
   "amrValues": ["pwd", "otp"],
   "twoFactorAuthentication": true,
@@ -96,6 +97,10 @@ curl -v \
   "subscriptions": ["foo", "bar", "baz"]
 }
 ```
+
+`additionalEmails` lists the account's verified secondary email addresses and
+requires the `profile:additionalEmails` scope (also granted by `profile`). It
+defaults to an empty array when there are no verified secondary addresses.
 
 #### OpenID Connect UserInfo Endpoint
 

--- a/packages/fxa-profile-server/lib/routes/_core_profile.js
+++ b/packages/fxa-profile-server/lib/routes/_core_profile.js
@@ -22,6 +22,7 @@ module.exports = {
     strategy: 'oauth',
     scope: [
       'profile:email',
+      'profile:additionalEmails',
       'profile:locale',
       'profile:amr',
       'profile:subscriptions',
@@ -33,6 +34,7 @@ module.exports = {
   response: {
     schema: Joi.object({
       email: Joi.string().optional(),
+      additionalEmails: Joi.array().items(Joi.string()).optional(),
       locale: Joi.string().optional(),
       amrValues: Joi.array().items(Joi.string().required()).optional(),
       twoFactorAuthentication: Joi.boolean().optional(),
@@ -99,6 +101,9 @@ module.exports = {
       const result = {};
       if (typeof body.email !== 'undefined') {
         result.email = body.email;
+      }
+      if (typeof body.additionalEmails !== 'undefined') {
+        result.additionalEmails = body.additionalEmails;
       }
       if (typeof body.locale !== 'undefined') {
         result.locale = body.locale;

--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -75,6 +75,7 @@ module.exports = {
   response: {
     schema: Joi.object({
       email: Joi.string().allow(null),
+      additionalEmails: Joi.array().items(Joi.string()).optional(),
       uid: Joi.string().allow(null),
       avatar: Joi.string().allow(null),
       avatarDefault: Joi.boolean().allow(null),

--- a/packages/fxa-profile-server/test/api.in.spec.ts
+++ b/packages/fxa-profile-server/test/api.in.spec.ts
@@ -156,6 +156,23 @@ describe('#integration - api', () => {
       assertSecurityHeaders(res);
     });
 
+    it('should return additionalEmails when the auth-server provides them', async () => {
+      mock.tokenGood();
+      mock.coreProfile({
+        email: 'user@example.domain',
+        additionalEmails: ['second@example.domain'],
+      });
+      const res = await Server.api.get({
+        url: '/profile',
+        headers: {
+          authorization: 'Bearer ' + tok,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.result.additionalEmails).toEqual(['second@example.domain']);
+      assertSecurityHeaders(res);
+    });
+
     it('should handle auth server errors', async () => {
       mock.token({
         user: USERID,
@@ -596,6 +613,77 @@ describe('#integration - api', () => {
         },
       });
       expect(res.statusCode).toBe(403);
+      assertSecurityHeaders(res);
+    });
+
+    it('should NOT return additionalEmails', async () => {
+      // `/email` authorizes only the primary address; do not leak secondaries.
+      mock.tokenGood();
+      mock.coreProfile({
+        email: 'user@example.domain',
+        additionalEmails: ['second@example.domain'],
+      });
+      const res = await Server.api.get({
+        url: '/email',
+        headers: {
+          authorization: 'Bearer ' + tok,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.payload);
+      expect(body.email).toBe('user@example.domain');
+      expect(body.additionalEmails).toBeUndefined();
+      assertSecurityHeaders(res);
+    });
+  });
+
+  describe('/profile additionalEmails', () => {
+    var tok = token();
+
+    it('should omit additionalEmails when the auth-server does not return it', async () => {
+      // Preserve omission when the auth server withholds the field.
+      mock.token({
+        user: USERID,
+        scope: ['profile:email'],
+      });
+      mock.coreProfile({ email: 'user@example.domain' });
+      const res = await Server.api.get({
+        url: '/profile',
+        headers: {
+          authorization: 'Bearer ' + tok,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.payload);
+      expect(body.email).toBe('user@example.domain');
+      expect(body.additionalEmails).toBeUndefined();
+      assertSecurityHeaders(res);
+    });
+
+    it('should return additionalEmails for a token scoped to only profile:additionalEmails', async () => {
+      // Only `_core_profile` accepts this scope; `/profile` must still succeed
+      // when its other batched requests are unauthorized.
+      mock.token({
+        user: USERID,
+        scope: ['profile:additionalEmails'],
+      });
+      // This scope does not authorize the primary address.
+      mock.coreProfile({
+        additionalEmails: ['second@example.domain', 'third@example.domain'],
+      });
+      const res = await Server.api.get({
+        url: '/profile',
+        headers: {
+          authorization: 'Bearer ' + tok,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.payload);
+      expect(body.additionalEmails).toEqual([
+        'second@example.domain',
+        'third@example.domain',
+      ]);
+      expect(body.email).toBeUndefined();
       assertSecurityHeaders(res);
     });
   });


### PR DESCRIPTION
Because:
 - RPs might be interested in secondary emails for verification/recovery

This commit:
  - adds `additionalEmails` to /account/profile
  - allows fetching with `profile:additionalEmails` scope
  - invalidates the profile cache on secondary email verify and delete

