### PR TITLE
chore: add code comment rules and split them from commit-message guidance

### DIFF
--- a/.claude/rules/code-comments.md
+++ b/.claude/rules/code-comments.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+
+# Code comments
+
+A commit message says what changed. A comment says what is true.
+
+## Adding comments
+
+- Default to none. Add a comment only for a fact the code cannot show: a constraint, an external cause, a non-local consequence.
+- 1-3 lines. If it needs more, it belongs in a docblock or design doc.
+- Never write: section labels (`// Setup`), restatements (`// Get the user` above `getUser()`), change narration (`// Added to fix X`), or history (`used to`, `previously`, `no longer`, `we decided`). History goes in the commit's `Because:` section.
+- No JSDoc on private helpers unless the signature cannot carry the contract.
+
+## Before you finish
+
+List every comment line you added. For each, name the fact the code could not carry. Delete any you cannot justify.
+
+## Editing comments you did not write
+
+- False after your edit: Verify that the change was intended, then fix only the clause that became untrue.
+- Restates the code: you may delete.
+- Cites anything outside the repo (version, vendor, tool or loader behaviour, incident, spec, ticket): keep it whole. Do not shorten.
+- Reason has expired but it still carries a fact: relocate the fact, do not delete both.
+- Otherwise: leave it and mention it in your summary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,8 @@ Skills: `/fxa-test-draft` (draft tests for changes), `/fxa-test-repair` (audit a
 **Be concise.** Applies to commit messages, PR bodies, Jira tickets, and code comments.
 
 - **Cut items before compressing sentences.** Shorten by dropping a point or folding two together; tightening a point worth keeping is fine, but don't squeeze every point into a semicolon-spliced fragment. What survives should read like a person wrote it.
-- **One claim per bullet.** State what changed. Give the reason only when it isn't inferable and lives nowhere else.
+- **One claim per bullet.** In commit messages, PR bodies and tickets, state what changed. Give the reason only when it isn't inferable and lives nowhere else.
+- **Comments state what is true, not what changed.** They're read cold, with no diff — so "used to", "no longer" and "we decided in review" belong in the commit's `Because:` section instead. Detailed rules auto-load from `.claude/rules/code-comments.md` when you touch JavaScript/TypeScript.
 - **Meta-commentary must save the reader work.** Out-of-scope notes and rejected alternatives earn their place when a reviewer would otherwise ask; narrating the diff's boundaries doesn't.
 - **Ticket refs in code only where the history is the answer.** Put the why in the comment. An `FXA-12345` pointer fits when the code reads as complex or non-standard and the explanation outgrows a comment — a workaround, an external constraint. Not in test names. Leave existing refs alone.
 - **Paths earn their place.** Name a file when it saves the reader a search. Skip it when the diff or a reference section already points there.


### PR DESCRIPTION
## Because

- `CLAUDE.md` section 9 governs commit messages and code comments together, but its "state what changed" line is right for the former and wrong for the latter.
- Comments are read cold, with no diff, so "used to" and "no longer" leave a reader with no referent.
- Nothing said when an agent may rewrite a comment it didn't author.

## This pull request

- Adds `.claude/rules/code-comments.md`, auto-loading on TypeScript edits.
- Scopes section 9's "state what changed" to commit messages, PR bodies and tickets, and points comments at the new rule.

## Issue that this pull request solves

Closes: N/A

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
