### PR TITLE
feat(passkey): Mint an MFA token from passkey sign-in

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.challenge.manager.ts
+++ b/libs/accounts/passkey/src/lib/passkey.challenge.manager.ts
@@ -64,6 +64,11 @@ export interface StoredChallenge {
    */
   uid?: string;
 
+  /**
+   * MFA scope this ceremony was started for, fixed before the user is prompted.
+   */
+  scope?: string;
+
   /** Unix timestamp (milliseconds) when this challenge was created. */
   createdAt: number;
 
@@ -126,8 +131,8 @@ export class PasskeyChallengeManager {
    *
    * @returns Base64url-encoded 32-byte challenge string.
    */
-  async generateAuthenticationChallenge(): Promise<string> {
-    return this.generateChallenge('authentication');
+  async generateAuthenticationChallenge(scope?: string): Promise<string> {
+    return this.generateChallenge('authentication', undefined, scope);
   }
 
   /**
@@ -243,7 +248,8 @@ export class PasskeyChallengeManager {
 
   private async generateChallenge(
     type: ChallengeType,
-    uid?: string
+    uid?: string,
+    scope?: string
   ): Promise<string> {
     const challenge = randomBytes(32).toString('base64url');
     const now = Date.now();
@@ -254,6 +260,7 @@ export class PasskeyChallengeManager {
       challenge,
       type,
       uid,
+      scope,
       createdAt: now,
       expiresAt: now + timeout,
     };

--- a/libs/accounts/passkey/src/lib/passkey.service.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.spec.ts
@@ -835,7 +835,27 @@ describe('PasskeyService', () => {
         mockResponse,
         MOCK_CHALLENGE
       );
-      expect(result).toEqual({ uid: MOCK_UID });
+      expect(result).toEqual({
+        uid: MOCK_UID,
+        credentialId: MOCK_CREDENTIAL_ID,
+      });
+    });
+
+    it('returns the stored credentialId, not the one from the request', async () => {
+      mockManager.findPasskeyByUidAndCredentialId.mockResolvedValue(
+        mockPasskey
+      );
+      mockManager.findPasskeyByCredentialId.mockResolvedValue({
+        ...mockPasskey,
+        credentialId: 'stored-canonical-id',
+      });
+
+      const result = await service.verifyAuthenticationResponse(
+        { ...mockResponse, id: MOCK_CREDENTIAL_ID },
+        MOCK_CHALLENGE
+      );
+
+      expect(result.credentialId).toBe('stored-canonical-id');
     });
 
     it('looks up passkey by credential ID decoded from response.id', async () => {
@@ -896,7 +916,10 @@ describe('PasskeyService', () => {
         MOCK_CHALLENGE,
         MOCK_UID
       );
-      expect(result).toEqual({ uid: MOCK_UID });
+      expect(result).toEqual({
+        uid: MOCK_UID,
+        credentialId: MOCK_CREDENTIAL_ID,
+      });
     });
 
     it('throws a passkeyNotFound AppError when the credential is not registered', async () => {
@@ -1044,7 +1067,10 @@ describe('PasskeyService', () => {
           true
         );
 
-        expect(result).toEqual({ uid: MOCK_UID });
+        expect(result).toEqual({
+          uid: MOCK_UID,
+          credentialId: MOCK_CREDENTIAL_ID,
+        });
         expect(mockManager.setPasskeyPrfEnabled).toHaveBeenCalledWith(
           MOCK_UID,
           MOCK_CREDENTIAL_ID
@@ -1108,7 +1134,10 @@ describe('PasskeyService', () => {
           true
         );
 
-        expect(result).toEqual({ uid: MOCK_UID });
+        expect(result).toEqual({
+          uid: MOCK_UID,
+          credentialId: MOCK_CREDENTIAL_ID,
+        });
         expect(mockMetrics.increment).toHaveBeenCalledWith(
           'passkey.authentication.prf.update_failed',
           { reason: 'dbError' }

--- a/libs/accounts/passkey/src/lib/passkey.service.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.ts
@@ -40,6 +40,17 @@ import { AppError } from '@fxa/accounts/errors';
 export interface AuthenticationResult {
   /** Authenticated user ID as a hex string. */
   uid: string;
+
+  /**
+   * `passkeys.credentialId` of the credential that signed this assertion, as
+   * stored. The request's `id` only has to decode to the same bytes.
+   */
+  credentialId: string;
+
+  /**
+   * MFA scope the challenge was created with. Absent when none was asked for.
+   */
+  scope?: string;
 }
 
 /**
@@ -442,11 +453,11 @@ export class PasskeyService {
    * @returns WebAuthn authentication options
    */
   async generateAuthenticationChallenge(
-    options: { uid?: string; keysRequired?: boolean } = {}
+    options: { uid?: string; keysRequired?: boolean; scope?: string } = {}
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
-    const { uid, keysRequired = false } = options;
+    const { uid, keysRequired = false, scope } = options;
     const challenge =
-      await this.challengeManager.generateAuthenticationChallenge();
+      await this.challengeManager.generateAuthenticationChallenge(scope);
 
     let allowCredentials: string[] = [];
     if (uid) {
@@ -602,7 +613,11 @@ export class PasskeyService {
       }
     }
 
-    return { uid };
+    return {
+      uid,
+      credentialId: passkey.credentialId,
+      scope: storedChallenge.scope,
+    };
   }
 
   /**

--- a/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
@@ -77,7 +77,10 @@ const PASSKEY_AUTHENTICATION_START_POST = {
       \`navigator.credentials.get\`. \`allowCredentials\` is always empty
       \`allowCredentials\` is omitted when the allow-list is empty (discoverable flow).
 
-      **Request body:** none
+      **Request body:**
+      - \`keysRequired\` (boolean, optional) — hint for the keys-required PRF scope
+      - \`scope\` (string, optional) — an MFA action from \`config.mfa.actions\`. Stored
+        on the challenge, so \`/finish\` returns an \`mfa:<scope>\` token for it.
     `,
   ],
 };
@@ -105,7 +108,9 @@ const PASSKEY_AUTHENTICATION_FINISH_POST = {
         Sync-scoped keys obtained via a follow-up step (a password step today), so
         the server defers its login notifications/metrics until keys are available.
 
-      **Response:** \`uid\`, \`sessionToken\`, \`verified\`, \`hasPassword\`
+      **Response:** \`uid\`, \`sessionToken\`, \`verified\`, \`hasPassword\`, and
+      \`mfaToken\` when \`/start\` was given a \`scope\`. The token carries that scope
+      and the credential that signed the assertion.
 
       **Security event:** \`account.passkey.authentication_success\` recorded on success.
     `,
@@ -187,7 +192,7 @@ const PASSKEYS_API_DOCS = {
     description: '/passkey/wraps',
     notes: [
       dedent`
-        🔒 Authenticated with session token (verified)
+        🔒 Authenticated with MFA JWT (scope: mfa:passkey)
 
         Stores the wrap envelope for one passkey. The envelope is produced entirely
         on the client: \`kB\` is sealed with HPKE to a per-wrap recipient key, whose
@@ -195,7 +200,9 @@ const PASSKEYS_API_DOCS = {
         PRF output. The server stores all five fields uninterpreted and never sees
         \`kB\`, the private key, or the PRF output.
 
-        The credential must belong to the authenticated account.
+        The token must be bound to \`credentialId\`, which \`/passkey/authentication/finish\`
+        does when \`/start\` asks for the \`passkey\` scope. A token minted any other way
+        carries no binding and is rejected.
 
         **Request body:**
         - \`credentialId\` (string, required) — base64url credential ID
@@ -209,7 +216,8 @@ const PASSKEYS_API_DOCS = {
         already stored.
 
         **Errors:**
-        - \`404\` errno 224 — no such passkey for this account
+        - \`401\` errno 223 — the token is invalid, or is not bound to \`credentialId\`
+        - \`404\` errno 224 — the passkey was deleted after the assertion
         - \`409\` errno 235 — a different wrap already exists for this credential
 
         **Security events:** \`account.passkey.wrap_created\` on a new wrap;

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
@@ -7,6 +7,8 @@ import { AppError } from '@fxa/accounts/errors';
 import jwt from 'jsonwebtoken';
 import { strategy } from './mfa';
 
+const CREDENTIAL_ID = 'test-credential-id';
+
 function makeJwt(account: any, sessionToken: any, config: any) {
   const now = Math.floor(Date.now() / 1000);
   const claims = {
@@ -15,6 +17,7 @@ function makeJwt(account: any, sessionToken: any, config: any) {
     iat: now,
     jti: crypto.randomUUID(),
     stid: sessionToken.id,
+    cid: CREDENTIAL_ID,
   };
   const opts: jwt.SignOptions = {
     algorithm: 'HS256',
@@ -111,6 +114,9 @@ describe('lib/routes/auth-schemes/mfa', () => {
 
     // Session token should be decorated with a scope.
     expect(sessionToken.scope[0]).toBe('mfa:test');
+
+    // And with the credential the token was minted from.
+    expect(sessionToken.cid).toBe(CREDENTIAL_ID);
   });
 
   it('should throw an error if no authorization header is provided', async () => {

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
@@ -138,9 +138,9 @@ export const strategy = (
       let sessionToken;
       try {
         sessionToken = await getCredentialsFunc(decoded.stid);
-      } catch (err) { }
+      } catch (err) {}
 
-       if (!sessionToken) {
+      if (!sessionToken) {
         statsd?.increment('mfa.invalid_mfa_token.bad_stid');
         throw AppError.invalidMfaToken();
       }
@@ -207,6 +207,12 @@ export const strategy = (
 
       // Decorate session token with scope
       sessionToken.scope = decoded.scope;
+      // Undefined unless the token was minted from a passkey assertion.
+      //
+      // Follows the line above rather than Hapi's `artifacts`, which would keep
+      // claims off the shared session instance at the cost of a second place to
+      // look for them.
+      sessionToken.cid = decoded.cid;
 
       // Finalize auth
       return h.authenticated({

--- a/packages/fxa-auth-server/lib/routes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/mfa.ts
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import crypto from 'node:crypto';
 import * as isA from 'joi';
 import { Container } from 'typedi';
 import { StatsD } from 'hot-shots';
-import * as jwt from 'jsonwebtoken';
 import { SecurityEvent } from 'fxa-shared/db/models/auth/security-event';
 import { Account, Email } from 'fxa-shared/db/models/auth';
 import { AuthRequest, SessionTokenAuthCredential } from '../types';
 import { recordSecurityEvent } from './utils/security-event';
+import { signMfaToken } from './utils/mfa-token';
 import { ConfigType } from '../../config';
 import { OtpUtils } from './utils/otp';
 import { AppError } from '@fxa/accounts/errors';
@@ -199,27 +198,11 @@ class MfaHandler {
       // this would allow us to let multiple actions to all be sanctioned by a single jwt.
       const scope = action;
 
-      // Issue jwt
-      // TODO: Use `/mfa/otp/request` and `/mfa/otp/verify` to issue the jwt
-      const now = Math.floor(Date.now() / 1000);
-      const claims = {
-        sub: account.uid,
-        scope: [`mfa:${scope}`],
-        iat: now,
-        jti: crypto.randomUUID(),
-        stid: sessionTokenId,
-      };
-
-      const key = this.config.mfa.jwt.secretKey;
-      const opts = {
-        algorithm: 'HS256' as jwt.Algorithm,
-        expiresIn: this.config.mfa.jwt.expiresInSec,
-        audience: this.config.mfa.jwt.audience,
-        issuer: this.config.mfa.jwt.issuer,
-      } as jwt.SignOptions;
-
-      // Create access token
-      const accessToken: string = jwt.sign(claims, key, opts);
+      const accessToken = signMfaToken(this.config, {
+        uid: account.uid,
+        scope,
+        sessionTokenId,
+      });
 
       await recordSecurityEvent('account.mfa_verify_otp_code_success', {
         db: this.db,

--- a/packages/fxa-auth-server/lib/routes/passkey-wraps.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkey-wraps.spec.ts
@@ -60,11 +60,16 @@ describe('passkey wraps routes', () => {
       (r) => r.path === '/passkey/wraps' && r.method === 'POST'
     ) as any;
 
-  async function run(payload: Record<string, unknown> = validPayload()) {
+  async function run(
+    payload: Record<string, unknown> = validPayload(),
+    // An options object so a test can pass no binding at all; a positional
+    // default would swallow `undefined` and assert nothing.
+    { cid }: { cid?: string } = { cid: CREDENTIAL_ID }
+  ) {
     const route = buildRoute();
     const request = {
       headers: { 'user-agent': 'test-agent' },
-      auth: { credentials: { uid: UID, id: 'session-token-id' } },
+      auth: { credentials: { uid: UID, id: 'session-token-id', cid } },
       payload,
       app: {
         clientAddress: '127.0.0.1',
@@ -136,6 +141,28 @@ describe('passkey wraps routes', () => {
       );
     });
 
+    it('refuses a token minted for a different credential', async () => {
+      await expect(
+        run(validPayload(), { cid: 'some-other-cred' })
+      ).rejects.toThrow();
+      expect(service.storePasskeyWrap).not.toHaveBeenCalled();
+    });
+
+    it('accepts a binding that differs only in base64url encoding', async () => {
+      const padded = `${Buffer.from(CREDENTIAL_ID, 'base64url').toString(
+        'base64url'
+      )}=`;
+
+      await expect(run(validPayload(), { cid: padded })).resolves.toEqual({
+        created: true,
+      });
+    });
+
+    it('refuses a token with no credential binding', async () => {
+      await expect(run(validPayload(), {})).rejects.toThrow();
+      expect(service.storePasskeyWrap).not.toHaveBeenCalled();
+    });
+
     it('rate-limits against the current primary email', async () => {
       await run();
 
@@ -195,9 +222,10 @@ describe('passkey wraps routes', () => {
   });
 
   describe('route configuration', () => {
-    it('accepts only a verified session token', () => {
+    it('requires an mfa:passkey token', () => {
       expect(buildRoute().options.auth).toEqual({
-        strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
+        strategy: 'mfa',
+        scope: ['mfa:passkey'],
         payload: false,
       });
     });

--- a/packages/fxa-auth-server/lib/routes/passkey-wraps.ts
+++ b/packages/fxa-auth-server/lib/routes/passkey-wraps.ts
@@ -9,6 +9,7 @@ import {
   V1_WIDTHS,
   type NewPasskeyWrapData,
 } from '@fxa/accounts/passkey';
+import { AppError } from '@fxa/accounts/errors';
 import { AuthRequest } from '../types';
 import { ConfigType } from '../../config';
 import { isPasskeyPasswordlessSyncEnabled } from '../passkey-utils';
@@ -63,17 +64,28 @@ export class PasskeyWrapsHandler {
    * Creates the wrap for a credential that has none. There is no update path,
    * so a stale wrap is resolved by deleting the passkey and re-enrolling.
    *
-   * Takes a verified session, as passkey rename does. Registering and deleting
-   * a credential take the `mfa:passkey` scope; this writes against a credential
-   * that already cleared that bar, and a wrap is inert without its PRF output.
+   * Requires an `mfa:passkey` token bound to the credential being written.
    *
    * @returns `{ created: boolean }` — false when an identical wrap was already
    *   stored.
    */
   async createPasskeyWrap(request: AuthRequest) {
-    const { uid } = request.auth.credentials as { uid: string };
+    const { uid, cid } = request.auth.credentials as {
+      uid: string;
+      cid?: string;
+    };
     const payload = request.payload as WrapPayload;
     const { credentialId } = payload;
+
+    if (
+      !cid ||
+      !Buffer.from(cid, 'base64url').equals(
+        Buffer.from(credentialId, 'base64url')
+      )
+    ) {
+      await this.recordEvent(request, 'account.passkey.wrap_creation_failure');
+      throw AppError.invalidMfaToken();
+    }
 
     const account = await this.db.account(uid);
     await this.customs.checkAuthenticated(
@@ -169,7 +181,8 @@ export const passkeyWrapsRoutes = (
         ...PASSKEYS_API_DOCS.PASSKEY_WRAPS_POST,
         pre: [{ method: passwordlessSyncEnabledCheck }],
         auth: {
-          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
+          strategy: 'mfa',
+          scope: ['mfa:passkey'],
           payload: false,
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -59,13 +59,16 @@ describe('passkeys routes', () => {
   const CREDENTIAL_ID_B64 =
     Buffer.from('credential-id-xyz').toString('base64url');
 
-  // Only the passkeys flags are read by these routes; cast the partial fixture
-  // to the full ConfigType the factory expects.
+  // Only the passkeys flags and the MFA action list are read by these routes;
+  // cast the partial fixture to the full ConfigType the factory expects.
   const config = {
     passkeys: {
       enabled: true,
       registrationEnabled: true,
       authenticationEnabled: true,
+    },
+    mfa: {
+      actions: ['2fa', 'email', 'recovery_key', 'password', 'passkey'],
     },
   } as unknown as ConfigType;
 

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -6,6 +6,7 @@ import * as isA from 'joi';
 import { Container } from 'typedi';
 import { PasskeyService } from '@fxa/accounts/passkey';
 import { AuthClientInfoService, AuthRequest } from '../types';
+import { signMfaToken } from './utils/mfa-token';
 import { recordSecurityEvent } from './utils/security-event';
 import { notifyAttachedServicesForAccountSession } from './utils/account';
 import { schema as METRICS_CONTEXT_SCHEMA } from '../metrics/context';
@@ -127,7 +128,8 @@ export class PasskeyHandler {
     private readonly statsd: any,
     private readonly glean: GleanMetricsType,
     private readonly mailer: any,
-    private readonly oauthClientInfoService: AuthClientInfoService
+    private readonly oauthClientInfoService: AuthClientInfoService,
+    private readonly config: ConfigType
   ) {}
 
   /**
@@ -404,12 +406,14 @@ export class PasskeyHandler {
   async authenticationStart(request: AuthRequest) {
     await this.customs.checkIpOnly(request, 'passkeyAuthStart');
 
-    const { keysRequired } = (request.payload ?? {}) as {
+    const { keysRequired, scope } = (request.payload ?? {}) as {
       keysRequired?: boolean;
+      scope?: string;
     };
 
     const options = await this.service.generateAuthenticationChallenge({
       keysRequired,
+      scope,
     });
 
     this.glean.passkey.authenticationStarted(request);
@@ -442,8 +446,14 @@ export class PasskeyHandler {
       };
 
     let uid: string;
+    let scope: string | undefined;
+    let assertedCredentialId: string;
     try {
-      ({ uid } = await this.service.verifyAuthenticationResponse(
+      ({
+        uid,
+        scope,
+        credentialId: assertedCredentialId,
+      } = await this.service.verifyAuthenticationResponse(
         response,
         challenge,
         undefined,
@@ -497,11 +507,23 @@ export class PasskeyHandler {
 
     const hasPassword = account.verifierSetAt > 0;
 
+    // Minted here rather than at /start, where there is no session yet to bind
+    // the claims to. `scope` is the one the challenge was created with.
+    const mfaToken = scope
+      ? signMfaToken(this.config, {
+          uid,
+          scope,
+          sessionTokenId: sessionToken.id,
+          credentialId: assertedCredentialId,
+        })
+      : undefined;
+
     return {
       uid,
       sessionToken: sessionToken.data,
       verified: true,
       hasPassword,
+      ...(mfaToken && { mfaToken }),
     };
   }
 
@@ -673,7 +695,8 @@ export const passkeyRoutes = (
     statsd,
     glean,
     mailer,
-    oauthClientInfoService
+    oauthClientInfoService,
+    config
   );
 
   return [
@@ -892,6 +915,12 @@ export const passkeyRoutes = (
           payload: isA.object({
             // Hint for the keys-required PRF scope; omitted = not keys-required.
             keysRequired: isA.boolean().optional(),
+            // The action this sign-in should also authorize. Committed to the
+            // challenge here, so /finish cannot be asked for a different one.
+            scope: isA
+              .string()
+              .valid(...config.mfa.actions)
+              .optional(),
           }),
         },
         response: {
@@ -957,6 +986,8 @@ export const passkeyRoutes = (
             sessionToken: isA.string().required(),
             verified: isA.boolean().required(),
             hasPassword: isA.boolean().required(),
+            // Present only when /start requested a scope.
+            mfaToken: isA.string().optional(),
           }),
         },
       },

--- a/packages/fxa-auth-server/lib/routes/utils/mfa-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/mfa-token.spec.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as jwt from 'jsonwebtoken';
+import { signMfaToken } from './mfa-token';
+import { ConfigType } from '../../../config';
+
+const config = {
+  mfa: {
+    jwt: {
+      secretKey: 'a-test-secret',
+      expiresInSec: 600,
+      audience: 'accounts.firefox.com',
+      issuer: 'accounts.firefox.com',
+    },
+  },
+} as unknown as ConfigType;
+
+const UID = 'f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6';
+const SESSION_TOKEN_ID = 'session-token-id';
+
+describe('signMfaToken', () => {
+  it('produces the claim set the mfa strategy verifies', () => {
+    const token = signMfaToken(config, {
+      uid: UID,
+      scope: '2fa',
+      sessionTokenId: SESSION_TOKEN_ID,
+    });
+
+    const decoded = jwt.verify(token, config.mfa.jwt.secretKey, {
+      audience: config.mfa.jwt.audience,
+      issuer: config.mfa.jwt.issuer,
+    }) as Record<string, unknown>;
+
+    expect(decoded).toMatchObject({
+      sub: UID,
+      scope: ['mfa:2fa'],
+      stid: SESSION_TOKEN_ID,
+    });
+    expect(decoded.jti).toEqual(expect.any(String));
+    expect(decoded.exp).toEqual(expect.any(Number));
+  });
+
+  it('binds the token to the given session', () => {
+    const token = signMfaToken(config, {
+      uid: UID,
+      scope: '2fa',
+      sessionTokenId: SESSION_TOKEN_ID,
+    });
+
+    const decoded = jwt.decode(token) as { stid: string };
+    expect(decoded.stid).toBe(SESSION_TOKEN_ID);
+  });
+
+  it('binds the token to the asserted credential when one is given', () => {
+    const token = signMfaToken(config, {
+      uid: UID,
+      scope: 'passkey',
+      sessionTokenId: SESSION_TOKEN_ID,
+      credentialId: 'cred-abc',
+    });
+
+    expect(jwt.decode(token)).toMatchObject({ cid: 'cred-abc' });
+  });
+
+  it('omits cid when no credential is given', () => {
+    const token = signMfaToken(config, {
+      uid: UID,
+      scope: 'passkey',
+      sessionTokenId: SESSION_TOKEN_ID,
+    });
+
+    expect(jwt.decode(token)).not.toHaveProperty('cid');
+  });
+
+  it('gives each token a distinct jti', () => {
+    const first = jwt.decode(
+      signMfaToken(config, {
+        uid: UID,
+        scope: '2fa',
+        sessionTokenId: SESSION_TOKEN_ID,
+      })
+    ) as { jti: string };
+    const second = jwt.decode(
+      signMfaToken(config, {
+        uid: UID,
+        scope: '2fa',
+        sessionTokenId: SESSION_TOKEN_ID,
+      })
+    ) as { jti: string };
+
+    expect(first.jti).not.toBe(second.jti);
+  });
+});

--- a/packages/fxa-auth-server/lib/routes/utils/mfa-token.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/mfa-token.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'node:crypto';
+import * as jwt from 'jsonwebtoken';
+import { ConfigType } from '../../../config';
+
+/**
+ * Signs an MFA access token for one scope, bound to one session.
+ *
+ * @param uid - Hex-encoded uid; becomes `sub`.
+ * @param scope - Bare action name; signed as `mfa:<scope>`.
+ * @param sessionTokenId - Becomes `stid`.
+ * @param credentialId - Stored `passkeys.credentialId`; becomes `cid`, and is
+ *   left out of the claims when not given.
+ * @returns The signed JWT.
+ */
+export function signMfaToken(
+  config: ConfigType,
+  {
+    uid,
+    scope,
+    sessionTokenId,
+    credentialId,
+  }: {
+    uid: string;
+    scope: string;
+    sessionTokenId: string;
+    credentialId?: string;
+  }
+): string {
+  const claims = {
+    sub: uid,
+    scope: [`mfa:${scope}`],
+    iat: Math.floor(Date.now() / 1000),
+    jti: crypto.randomUUID(),
+    stid: sessionTokenId,
+    ...(credentialId && { cid: credentialId }),
+  };
+
+  return jwt.sign(claims, config.mfa.jwt.secretKey, {
+    algorithm: 'HS256' as jwt.Algorithm,
+    expiresIn: config.mfa.jwt.expiresInSec,
+    audience: config.mfa.jwt.audience,
+    issuer: config.mfa.jwt.issuer,
+  } as jwt.SignOptions);
+}

--- a/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
@@ -12,7 +12,10 @@ import {
   PasskeyService,
   V1_WIDTHS,
 } from '@fxa/accounts/passkey';
-import { VirtualAuthenticator } from '@fxa/accounts/passkey/testing';
+import {
+  VirtualAuthenticator,
+  VirtualCredential,
+} from '@fxa/accounts/passkey/testing';
 import { ERRNO } from '@fxa/accounts/errors';
 import Config from '../../config';
 
@@ -110,11 +113,15 @@ afterAll(async () => {
 describe('#integration - remote passkey wrap storage', () => {
   let client: any;
   let credentialId: string;
+  let credential: VirtualCredential;
 
   /**
    * Registers a passkey through the real MFA + WebAuthn flow.
    */
-  async function registerPasskey(): Promise<string> {
+  async function registerPasskey(): Promise<{
+    credentialId: string;
+    credential: VirtualCredential;
+  }> {
     await client.api.doRequest(
       'POST',
       `${client.api.baseURL}/mfa/otp/request`,
@@ -148,15 +155,42 @@ describe('#integration - remote passkey wrap storage', () => {
       { response, challenge: options.challenge }
     );
 
-    return registered.credentialId;
+    return { credentialId: registered.credentialId, credential: cred };
   }
 
-  /** POSTs a wrap. */
-  async function storeWrap(payload: Record<string, unknown>) {
-    return client.api.doRequest(
+  /**
+   * Signs in with the passkey, asking for the passkey scope, and returns the
+   * token that mints.
+   */
+  async function mintWrapToken(
+    assertWith: VirtualCredential = credential
+  ): Promise<string> {
+    const { challenge } = await client.api.doRequest(
+      'POST',
+      `${client.api.baseURL}/passkey/authentication/start`,
+      null,
+      { keysRequired: true, scope: 'passkey' }
+    );
+    const response = VirtualAuthenticator.createAssertionResponse(assertWith, {
+      challenge,
+      origin: passkeyOrigin,
+      rpId: passkeyRpId,
+    });
+    const { mfaToken } = await client.api.doRequest(
+      'POST',
+      `${client.api.baseURL}/passkey/authentication/finish`,
+      null,
+      { response, challenge, keysRequired: true }
+    );
+    return mfaToken;
+  }
+
+  /** POSTs a wrap with a freshly minted token. */
+  async function storeWrap(payload: Record<string, unknown>, token?: string) {
+    return client.api.doRequestWithBearerToken(
       'POST',
       `${client.api.baseURL}/passkey/wraps`,
-      await client.api.Token.SessionToken.fromHex(client.sessionToken),
+      token ?? (await mintWrapToken()),
       payload
     );
   }
@@ -173,7 +207,7 @@ describe('#integration - remote passkey wrap storage', () => {
       server.mailbox,
       { version: 'V2' }
     );
-    credentialId = await registerPasskey();
+    ({ credentialId, credential } = await registerPasskey());
   });
 
   it('stores the envelope and records a security event', async () => {
@@ -239,18 +273,7 @@ describe('#integration - remote passkey wrap storage', () => {
     expect(stored).toBeUndefined();
   });
 
-  it('rejects a credential the account does not own', async () => {
-    await expect(
-      storeCurrentWrap({
-        credentialId: Buffer.from('someone-elses-cred').toString('base64url'),
-      })
-    ).rejects.toMatchObject({
-      code: 404,
-      errno: ERRNO.PASSKEY_NOT_FOUND,
-    });
-  });
-
-  it('requires a session token', async () => {
+  it('requires an mfa token', async () => {
     await expect(
       client.api.doRequestWithBearerToken(
         'POST',
@@ -258,6 +281,15 @@ describe('#integration - remote passkey wrap storage', () => {
         'invalid-token',
         { credentialId, ...envelope() }
       )
+    ).rejects.toMatchObject({ code: 401 });
+  });
+
+  it('refuses a token earned on a different credential', async () => {
+    const other = await registerPasskey();
+    const token = await mintWrapToken(other.credential);
+
+    await expect(
+      storeWrap({ credentialId, ...envelope() }, token)
     ).rejects.toMatchObject({ code: 401 });
   });
 });


### PR DESCRIPTION
## Because

- `POST /passkey/wraps` takes only a verified session, and the inline sign-in flow has no MFA JWT to guard it with — the user has just signed in with a passkey.
- A passkey assertion can earn the same `mfa:<scope>` token an emailed code does, so the wrap route can use the guard every other MFA-protected route already uses.

## This pull request

- Accepts an optional `scope` on `POST /passkey/authentication/start`, validated against `config.mfa.actions` and stored on the challenge before the user is prompted.
- Reads that scope back off the consumed challenge at `/finish` and mints an `mfa:<scope>` token, once the session its claims bind to exists.
- Binds the token to the asserted credential as `cid`, carried onto the session token beside the scope the mfa strategy already copies, and matched at the wrap route.
- Guards `POST /passkey/wraps` on `mfa:passkey`.
- Updates the passkey Swagger notes for the wrap route's new auth, and for the `scope` request field and conditional `mfaToken` response on the authentication routes.
- Moves the JWT claim set into one signer, so `/mfa/otp/verify` and the assertion path cannot drift on the shape the strategy verifies.

## Issue that this pull request solves

Closes: N/A — follows on from FXA-13142.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/routes/utils/mfa-token.ts`, and the mint point in `authenticationFinish`.
- Suggested review order: `mfa-token.ts` → `passkeys.ts` → `auth-schemes/mfa.ts` → `passkey-wraps.ts`
- Risky or complex parts: `strategy: 'mfa'` and its existing consumers are unchanged — `credentials` is still the session token, with `cid` added beside the `scope` the strategy already copies onto it. `/mfa/otp/verify` now signs through the shared helper; the claim set is the same, and its existing tests verify real tokens end to end.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- `mfa:passkey` is the scope passkey registration and deletion already use. The same scope will cover upgrading an existing passkey from settings.
- `cid` could instead live on the session row, which would keep the mfa machinery generic and suit the session-AMR gate discussed separately. Left alone here since that would need a `sessionTokens` migration.


