### PR TITLE
fix(settings): pass hasPasskey in passkey-enabled signin stories

### DIFF
--- a/packages/fxa-settings/src/components/AlternativeAuthOptions/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AlternativeAuthOptions/index.stories.tsx
@@ -36,6 +36,7 @@ export const WithPasskeySignIn = () => (
   </AppLayout>
 );
 
+// During an in-flight ceremony the page also disables the other options.
 export const WithPasskeySignInLoading = () => (
   <AppLayout>
     <Subject
@@ -44,6 +45,7 @@ export const WithPasskeySignInLoading = () => (
         onClick: action('passkey-sign-in-clicked'),
         isLoading: true,
       }}
+      disabled
     />
   </AppLayout>
 );

--- a/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/components/SigninAlternativeAuthOptions/index.stories.tsx
@@ -52,27 +52,29 @@ const Subject = ({
   finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
   passkeyEnabled = false,
   ...props
-}: SubjectProps) => (
-  <MemoryRouter>
-    <AppContext.Provider
-      value={passkeyEnabled ? passkeyEnabledContext() : mockAppContext()}
-    >
-      <SigninAlternativeAuthOptions
-        {...{
-          integration,
-          email,
-          serviceName,
-          hasLinkedAccount,
-          hasPassword,
-          avatarData,
-          avatarLoading,
-          finishOAuthFlowHandler,
-          ...props,
-        }}
-      />
-    </AppContext.Provider>
-  </MemoryRouter>
-);
+}: SubjectProps) => {
+  const ctx = passkeyEnabled ? passkeyEnabledContext() : mockAppContext();
+
+  return (
+    <MemoryRouter>
+      <AppContext.Provider value={ctx}>
+        <SigninAlternativeAuthOptions
+          {...{
+            integration,
+            email,
+            serviceName,
+            hasLinkedAccount,
+            hasPassword,
+            avatarData,
+            avatarLoading,
+            finishOAuthFlowHandler,
+            ...props,
+          }}
+        />
+      </AppContext.Provider>
+    </MemoryRouter>
+  );
+};
 
 export default {
   title: 'Pages/Signin/SigninAlternativeAuthOptions',
@@ -113,12 +115,15 @@ export const WithErrorBanner = () => (
 );
 
 // Passkey enabled: third-party providers + passkey button stack together.
-export const WithPasskeyEnabled = () => <Subject passkeyEnabled={true} />;
+export const WithPasskeyEnabled = () => (
+  <Subject passkeyEnabled={true} hasPasskey={true} />
+);
 
 // Passkey + Sync: ceremony routes to /signin_passkey_fallback for the password gate.
 export const WithPasskeyEnabledSync = () => (
   <Subject
     passkeyEnabled={true}
+    hasPasskey={true}
     serviceName={MozServices.FirefoxSync}
     integration={createMockSigninOAuthNativeSyncIntegration()}
   />
@@ -128,6 +133,7 @@ export const WithPasskeyEnabledSync = () => (
 export const WithPasskeyEnabledAndErrorBanner = () => (
   <Subject
     passkeyEnabled={true}
+    hasPasskey={true}
     localizedErrorFromLocationState="Your sign-in session has expired."
   />
 );

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -304,7 +304,7 @@ export const CmsCachedNoCachedPageConfig: Story = {
 
 // Passkey button alongside third-party providers, alternative to password entry.
 export const NonCachedAccountHasPasswordWithPasskey: Story = {
-  ...story({ passkeyEnabled: true }),
+  ...story({ passkeyEnabled: true, hasPasskey: true }),
   name: 'Passkey enabled > Non-Cached > Account has password',
 };
 
@@ -312,6 +312,7 @@ export const NonCachedAccountHasPasswordWithPasskey: Story = {
 export const NonCachedSyncWithPasskey: Story = {
   ...story({
     passkeyEnabled: true,
+    hasPasskey: true,
     serviceName: MozServices.FirefoxSync,
     hasLinkedAccount: true,
     hasPassword: true,
@@ -324,6 +325,7 @@ export const NonCachedSyncWithPasskey: Story = {
 export const NonCachedPasswordlessWithPasskey: Story = {
   ...story({
     passkeyEnabled: true,
+    hasPasskey: true,
     hasLinkedAccount: true,
     hasPassword: false,
   }),
@@ -334,6 +336,7 @@ export const NonCachedPasswordlessWithPasskey: Story = {
 export const CachedWithPasskeyFlagOn: Story = {
   ...story({
     passkeyEnabled: true,
+    hasPasskey: true,
     sessionToken: MOCK_SESSION_TOKEN,
   }),
   name: 'Passkey enabled > Cached > passkey button correctly hidden (SigninCached path)',


### PR DESCRIPTION
## Because

- The passkey CTA is gated on account `hasPasskey`, but the passkey-enabled `Signin/SigninAlternativeAuthOptions` stories only flipped the feature flags, so they fell back to the legacy circular third-party buttons with no passkey button.

## This pull request

- Passes `hasPasskey` in all passkey-enabled Signin and SigninAlternativeAuthOptions stories.
- Disables the other auth options in the passkey loading story to match page behaviour during an in-flight ceremony.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
