### PR TITLE
fix(passkey): import VirtualAuthenticator from the testing entry point

### DIFF
--- a/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
@@ -11,8 +11,8 @@ import {
   PasskeyManager,
   PasskeyService,
   V1_WIDTHS,
-  VirtualAuthenticator,
 } from '@fxa/accounts/passkey';
+import { VirtualAuthenticator } from '@fxa/accounts/passkey/testing';
 import { ERRNO } from '@fxa/accounts/errors';
 import Config from '../../config';
 


### PR DESCRIPTION
## Because

  - `@fxa/accounts/passkey` no longer exports the virtual authenticator
  - the wrap-storage remote suite resolved it as undefined, so every test failed in beforeEach
  - see https://app.circleci.com/pipelines/github/mozilla/fxa/72820/workflows/41095306-e0e3-4d1b-9666-36e65e54888a/jobs/703302

## This pull request

  - imports VirtualAuthenticator from `@fxa/accounts/passkey/testing`

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
