### PR TITLE
fix(auth): import VirtualAuthenticator from passkey testing entry point

### DIFF
--- a/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
@@ -11,8 +11,8 @@ import {
   PasskeyManager,
   PasskeyService,
   V1_WIDTHS,
-  VirtualAuthenticator,
 } from '@fxa/accounts/passkey';
+import { VirtualAuthenticator } from '@fxa/accounts/passkey/testing';
 import { ERRNO } from '@fxa/accounts/errors';
 import Config from '../../config';
 


### PR DESCRIPTION
## Because

- All six tests in `passkey_wraps.in.spec.ts` throw before they send a request. `Integration Test - Servers - Auth (PR)` fails on every PR branch that includes main after 2026-09-02, so nothing can merge.
- Two commits landed on main the same day, neither one had the other, so both went green. `192b53e271` moved `VirtualAuthenticator` out of the `@fxa/accounts/passkey` barrel into `@fxa/accounts/passkey/testing`. `be37bdaaeb` added this spec, importing it from the old path. The import gives back `undefined`, and the tests die on `Cannot read properties of undefined (reading 'createCredential')`.

## This pull request

- Imports `VirtualAuthenticator` from `@fxa/accounts/passkey/testing` in `passkey_wraps.in.spec.ts`, and leaves the other five members on the `@fxa/accounts/passkey` barrel.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14471

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts`.
- Suggested review order: compare the import block against the sibling `passkeys.in.spec.ts`, which already splits the two entry points.
- Risky or complex parts: none. The barrel `libs/accounts/passkey/src/index.ts` stays as it is. It leaves the virtual authenticator out on purpose.

## Screenshots (Optional)

## Other information (Optional)

The six repaired tests are remote integration tests. They need MySQL and Redis, so CI is the real gate. That is also why I left the "tests pass locally" box unticked.

Local checks:

- `npx nx lint fxa-auth-server`: passed.
- `npx tsc -p packages/fxa-auth-server/tsconfig.json --noEmit`: no error in any passkey file. It reports 71 errors, all already on main, in the Stripe conversion scripts and `account_consents.in.spec.ts`.
- `TEST_TYPE=unit scripts/test-ci.sh`: 3828 passed, 8 failed. The 8 are sandbox environment failures in `account.spec.ts`, `session.spec.ts` and `signin.spec.ts`, all geo and locale assertions such as `acceptLanguage` giving `en` instead of `en-US`. The unit project ignores `*.in.spec.ts`, so it never loads the file this PR touches.
