### PR TITLE
bug(settings): Make the mobile card span the viewport

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<AppLayout /> snapshots renders correctly with CMS: header logo 1`] = `
 
 exports[`<AppLayout /> snapshots renders correctly with CMS: split layout main 1`] = `
 <main
-  class="flex mobileLandscape:items-center flex-1"
+  class="flex w-full mobileLandscape:w-auto mobileLandscape:items-center flex-1"
 />
 `;
 

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -140,8 +140,12 @@ export const AppLayout = ({
 
         {!splitLayout ? (
           <>
-            <main className="flex mobileLandscape:items-center flex-1">
-              <section>
+            {/* The mobile card is full-bleed, so these span the viewport below
+                `mobileLandscape` — left to shrink-to-fit, a card with narrow
+                content ends up narrower than the screen. Above that breakpoint
+                shrink-to-fit is what centers the fixed-width card. */}
+            <main className="flex w-full mobileLandscape:w-auto mobileLandscape:items-center flex-1">
+              <section className="w-full mobileLandscape:w-auto">
                 {loading ? (
                   <>
                     <CardLoadingSpinner />


### PR DESCRIPTION
## Because

- The location/IP address container on the mobile "One last step to sync" screen renders narrower than the Figma spec on Android, with visible dead space either side.
- `AppLayout` gives `<main>` and `<section>` no width, so they shrink to fit their content and `.card`'s own `w-full` never applies below `mobileLandscape`. No page-local change can widen a child past its card.

## This pull request

- Spans `<main>` and `<section>` to the viewport below `mobileLandscape`, leaving shrink-to-fit in place above it.
- Updates the `AppLayout` snapshot for the new `main` class list.

## Issue that this pull request solves

Closes: FXA-14460

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="571" height="1038" alt="image" src="https://github.com/user-attachments/assets/d4612c47-bdc1-41d3-ab4b-b37927d767ec" />

## Other information (Optional)

- `AppLayout` is shared, so this affects every non-split page below the 480px `mobileLandscape` breakpoint. Only cards whose content is narrower than the viewport change — measured geometry is identical at 480px and above.
- The split-layout branch already rendered full-bleed at phone widths; this brings the non-split branch in line with it.
- Out of scope: the Figma board's other note that Supplicant screens should have a white background on mobile.
