### PR TITLE
feat(auth-client): Add passkey wrap methods and assertion scope

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -7,6 +7,7 @@ import { Credentials } from './crypto';
 import { deriveTokenCredentials } from './hawk';
 import { bearerHeader, BearerTokenKind } from './bearer';
 import { SaltVersion, createSaltV2 } from './salt';
+import { base64UrlToUint8, uint8ToBase64Url } from './utils';
 import * as Sentry from '@sentry/browser';
 import { MetricsContext } from '@fxa/shared/metrics/glean';
 
@@ -267,7 +268,59 @@ export type PasskeyAuthenticationResult = {
   sessionToken: hexstring;
   verified: boolean;
   hasPassword: boolean;
+  /**
+   * Scoped MFA token, present only when `beginPasskeyAuthentication` asked for
+   * a scope.
+   */
+  mfaToken?: string;
 };
+
+/**
+ * Field list for the wrap envelope, shared by the encode and decode paths so
+ * they cannot drift.
+ */
+const WRAP_ENVELOPE_FIELDS = [
+  'pkR',
+  'prfWrappedSkR',
+  'keyWrapIv',
+  'hpkeEncapsulatedSecret',
+  'hpkeSealedKb',
+] as const;
+
+/**
+ * Envelope bytes, as the `passkey-crypto` module produces and consumes them.
+ * Base64url encoding is a transport concern and does not leave this client.
+ */
+export type PasskeyWrapEnvelope = Record<
+  (typeof WRAP_ENVELOPE_FIELDS)[number],
+  Uint8Array
+>;
+
+/**
+ * A stored envelope, with the time the server recorded it.
+ */
+export type StoredPasskeyWrap = PasskeyWrapEnvelope & { createdAt: number };
+
+type PasskeyWrapEnvelopeJSON = Record<
+  (typeof WRAP_ENVELOPE_FIELDS)[number],
+  string
+>;
+
+function encodeWrapEnvelope(
+  envelope: PasskeyWrapEnvelope
+): PasskeyWrapEnvelopeJSON {
+  return Object.fromEntries(
+    WRAP_ENVELOPE_FIELDS.map((name) => [name, uint8ToBase64Url(envelope[name])])
+  ) as PasskeyWrapEnvelopeJSON;
+}
+
+function decodeWrapEnvelope(
+  envelope: PasskeyWrapEnvelopeJSON
+): PasskeyWrapEnvelope {
+  return Object.fromEntries(
+    WRAP_ENVELOPE_FIELDS.map((name) => [name, base64UrlToUint8(envelope[name])])
+  ) as PasskeyWrapEnvelope;
+}
 
 export interface PublicKeyCredentialJSON {
   id: Base64URLString;
@@ -3713,6 +3766,53 @@ export default class AuthClient {
   }
 
   /**
+   * Stores the wrap envelope that lets one passkey unlock `kB`. An identical
+   * repeat reports `created: false` rather than failing.
+   *
+   * @param jwt MFA JWT with scope `mfa:passkey`, minted for this credential
+   * @param credentialId The base64url-encoded credential ID to store against
+   * @param envelope The envelope bytes from `passkey-crypto`
+   * @param headers Optional additional headers
+   */
+  async createPasskeyWrap(
+    jwt: string,
+    credentialId: string,
+    envelope: PasskeyWrapEnvelope,
+    headers?: Headers
+  ): Promise<{ created: boolean }> {
+    return this.jwtPost(
+      '/passkey/wraps',
+      jwt,
+      { credentialId, ...encodeWrapEnvelope(envelope) },
+      headers
+    );
+  }
+
+  /**
+   * Fetches the wrap envelope for one passkey, so the client can unseal `kB`
+   * without a password.
+   *
+   * 404 covers three conditions, so callers branch on errno: 224 no such
+   * passkey, 234 no wrap stored, 236 the wrap predates the current `kB`.
+   *
+   * @param jwt MFA JWT with scope `mfa:passkey`
+   * @param credentialId The base64url-encoded credential ID to fetch
+   * @param headers Optional additional headers
+   */
+  async getPasskeyWrap(
+    jwt: string,
+    credentialId: string,
+    headers?: Headers
+  ): Promise<StoredPasskeyWrap> {
+    const { createdAt, ...envelope } = await this.jwtGet(
+      `/passkey/wraps/${encodeURIComponent(credentialId)}`,
+      jwt,
+      headers
+    );
+    return { ...decodeWrapEnvelope(envelope), createdAt };
+  }
+
+  /**
    * Starts a passkey authentication (assertion) flow.
    *
    * No email is sent — the server returns options with an empty
@@ -3721,16 +3821,20 @@ export default class AuthClient {
    *
    * @param options.keysRequired Hints that this is a keys-required (Sync)
    *   sign-in, so the server may request PRF under the keys-required scope.
+   * @param options.scope Bare action name (e.g. `passkey`) this sign-in should
+   *   also authorize; makes `/finish` return an `mfaToken`.
    * @param headers Optional additional headers
    */
   async beginPasskeyAuthentication(
-    options: { keysRequired?: boolean } = {},
+    options: { keysRequired?: boolean; scope?: string } = {},
     headers?: Headers
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
-    const payload =
-      options.keysRequired === undefined
+    const payload = {
+      ...(options.keysRequired === undefined
         ? {}
-        : { keysRequired: options.keysRequired };
+        : { keysRequired: options.keysRequired }),
+      ...(options.scope === undefined ? {} : { scope: options.scope }),
+    };
     return this.request(
       'POST',
       '/passkey/authentication/start',

--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -136,6 +136,117 @@ describe('lib/client', () => {
     });
   });
 
+  describe('passkey wraps', () => {
+    let httpsClient: AuthClient;
+    let originalFetch: typeof globalThis.fetch;
+    let lastUrl: string | undefined;
+    let lastInit: RequestInit | undefined;
+    let responseBody: string;
+
+    const jwt = 'mfa.jwt.token';
+    const credentialId = 'Y3JlZC1pZA';
+
+    // Distinct fills, so a field swapped for another is visible.
+    const envelope = {
+      pkR: new Uint8Array(133).fill(0x04),
+      prfWrappedSkR: new Uint8Array(82).fill(0x11),
+      keyWrapIv: new Uint8Array(12).fill(0x22),
+      hpkeEncapsulatedSecret: new Uint8Array(133).fill(0x33),
+      hpkeSealedKb: new Uint8Array(48).fill(0x44),
+    };
+
+    const wireEnvelope = {
+      pkR: Buffer.alloc(133, 0x04).toString('base64url'),
+      prfWrappedSkR: Buffer.alloc(82, 0x11).toString('base64url'),
+      keyWrapIv: Buffer.alloc(12, 0x22).toString('base64url'),
+      hpkeEncapsulatedSecret: Buffer.alloc(133, 0x33).toString('base64url'),
+      hpkeSealedKb: Buffer.alloc(48, 0x44).toString('base64url'),
+    };
+
+    before(() => {
+      httpsClient = new AuthClient('https://localhost:9000');
+    });
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      lastUrl = undefined;
+      lastInit = undefined;
+      responseBody = '{}';
+      globalThis.fetch = (async (url: string, init?: RequestInit) => {
+        lastUrl = url;
+        lastInit = init;
+        return new Response(responseBody, {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('encodes the envelope to base64url on the way out', async () => {
+      responseBody = '{"created":true}';
+
+      await httpsClient.createPasskeyWrap(jwt, credentialId, envelope);
+
+      assert.equal(lastUrl, 'https://localhost:9000/v1/passkey/wraps');
+      assert.deepEqual(JSON.parse(lastInit?.body as string), {
+        credentialId,
+        ...wireEnvelope,
+      });
+    });
+
+    it('decodes the envelope to bytes on the way in, keeping createdAt', async () => {
+      responseBody = JSON.stringify({
+        ...wireEnvelope,
+        createdAt: 1700000000000,
+      });
+
+      const result = await httpsClient.getPasskeyWrap(jwt, credentialId);
+
+      assert.deepEqual(result, { ...envelope, createdAt: 1700000000000 });
+      assert.equal(
+        lastUrl,
+        `https://localhost:9000/v1/passkey/wraps/${credentialId}`
+      );
+    });
+
+    it('escapes a credential id containing url-unsafe characters', async () => {
+      responseBody = JSON.stringify({ ...wireEnvelope, createdAt: 1 });
+
+      await httpsClient.getPasskeyWrap(jwt, 'a/b?c');
+
+      assert.equal(
+        lastUrl,
+        'https://localhost:9000/v1/passkey/wraps/a%2Fb%3Fc'
+      );
+    });
+
+    it('forwards scope to the assertion challenge when set', async () => {
+      responseBody = '{"challenge":"abc","userVerification":"required"}';
+
+      await httpsClient.beginPasskeyAuthentication({
+        keysRequired: true,
+        scope: 'passkey',
+      });
+
+      assert.deepEqual(JSON.parse(lastInit?.body as string), {
+        keysRequired: true,
+        scope: 'passkey',
+      });
+    });
+
+    it('omits scope from the assertion challenge when not set', async () => {
+      responseBody = '{"challenge":"abc","userVerification":"required"}';
+
+      await httpsClient.beginPasskeyAuthentication({ keysRequired: true });
+
+      assert.ok(!('scope' in JSON.parse(lastInit?.body as string)));
+    });
+  });
+
   describe('request() error handling', () => {
     let httpClient: AuthClient;
     let originalFetch: typeof globalThis.fetch;


### PR DESCRIPTION
## Because

- Passwordless sign-in needs the wrap envelope, and no client method reaches the wrap endpoints.
- A passkey assertion can now mint a scoped MFA token, which callers need in order to request and spend one.

## This pull request

- Adds `createPasskeyWrap` and `getPasskeyWrap`, both taking an `mfa:passkey` JWT.
- Keeps base64url on the wire and `Uint8Array` in the caller's hands; both codecs iterate one field list so they cannot drift.
- Adds the optional `scope` param to `beginPasskeyAuthentication` and surfaces `mfaToken` on the authentication result.

## Issue that this pull request solves

Closes: FXA-13148

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)


## Other information (Optional)

- The ticket predates the current API and is stale: endpoints moved from `/passkey/keys` to `/passkey/wraps`, auth moved from `verifiedSessionToken` to the `mfa:passkey` token, the `passkeyVerificationProof` design was dropped, and errno 236 is now `PASSKEY_WRAP_STALE` rather than a PRF-support error.
