### PR TITLE
fix(pair): send an iOS QR scan straight to /pair/unsupported

### DIFF
--- a/packages/functional-tests/tests/pairing/CLAUDE.md
+++ b/packages/functional-tests/tests/pairing/CLAUDE.md
@@ -75,8 +75,8 @@ IOS_PAIRING_ENABLED=1 \
   npx playwright test pairingFlowiOS.spec.ts --project=local
 ```
 
-iOS v2 (needs the stack started with `PAIRING_VERSION=2` and
-`PAIRING_IOS_URL_SCHEME=fennec`):
+iOS v2 (needs the stack started with `PAIRING_VERSION=2`,
+`PAIRING_IOS_URL_SCHEME=fennec` and `PAIRING_IOS_HANDOFF=true`):
 
 ```bash
 cd packages/functional-tests
@@ -93,10 +93,13 @@ npx playwright test pairingFlowV2iOS.spec.ts -g 'from a deep link'   # test buil
 npx playwright test pairingFlowV2iOS.spec.ts -g "page's own"         # page supplies the link
 ```
 
-`PAIRING_IOS_URL_SCHEME` only matters to the hand-off delivery, whose link the
-`/pair` page builds from the served `pairing.iosUrlScheme`. It has to name this
-build (`fennec`) or the link points at an install that is not there. The
-deep-link delivery builds its own URL in `IOSSupplicant` and ignores the config.
+`PAIRING_IOS_URL_SCHEME` and `PAIRING_IOS_HANDOFF` only matter to the hand-off
+delivery, whose link the `/pair` page builds from the served
+`pairing.iosUrlScheme`. The scheme has to name this build (`fennec`) or the link
+points at an install that is not there, and without the hand-off enabled the
+page sends an iOS browser to `/pair/unsupported` instead of offering a link at
+all. The deep-link delivery builds its own URL in `IOSSupplicant` and ignores
+both.
 
 `IOS_DESTINATION` is optional; without it `IOSSupplicant` targets whichever
 Simulator is booted. `IOS_SIMULATOR_UDID` picks one when several are.

--- a/packages/functional-tests/tests/pairing/pairingFlowV2iOS.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingFlowV2iOS.spec.ts
@@ -39,9 +39,9 @@
  *
  * Local target only, gated behind IOS_PAIRING_V2_ENABLED, and skipped by default in every
  * case. Prerequisites: the FxA stack
- * started with PAIRING_VERSION=2, a booted Simulator, a firefox-ios checkout built with
- * `build-for-testing` for the SyncIntegrationTestPlan, and Firefox Nightly for the authority
- * (or FIREFOX_BINARY at a v2-capable build).
+ * started with PAIRING_VERSION=2 and PAIRING_IOS_HANDOFF=true, a booted Simulator, a
+ * firefox-ios checkout built with `build-for-testing` for the SyncIntegrationTestPlan, and
+ * Firefox Nightly for the authority (or FIREFOX_BINARY at a v2-capable build).
  */
 
 import { writeFileSync } from 'fs';
@@ -152,7 +152,8 @@ const DELIVERIES = [
  * Render `/pair` as a non-Firefox phone would and return the hand-off link it offers.
  *
  * The iOS descriptor makes `detectDevice` report iOS. The card renders only once `fxa_status`
- * goes unanswered, which is a timeout rather than a reply, so it is absent on first paint.
+ * goes unanswered, which is a timeout rather than a reply, so it is absent on first paint —
+ * and only where the stack serves `PAIRING_IOS_HANDOFF=true`.
  */
 async function readHandoffDeepLink(
   browser: Browser,

--- a/packages/functional-tests/tests/pairing/pairingUnsupported.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairingUnsupported.spec.ts
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * Unsupported-browser pairing test.
+ * Unsupported-browser pairing tests.
  *
- * Spoofs the user-agent to a non-Firefox desktop browser, opens /pair,
- * and verifies the unsupported screen renders with the "Oops!" heading
- * and a Download Firefox link.
+ * Spoofs the user-agent to a browser that cannot pair — a non-Firefox desktop,
+ * and an iPhone opening a scanned pairing URL — and verifies both land on the
+ * unsupported screen.
  *
  * Runs on the standard Firefox project — only the UA string is faked,
  * so no extra browser binary is required.
@@ -24,6 +24,14 @@ const CHROME_DESKTOP_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
   'AppleWebKit/537.36 (KHTML, like Gecko) ' +
   'Chrome/124.0.0.0 Safari/537.36';
+
+const IOS_SAFARI_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) ' +
+  'AppleWebKit/605.1.15 (KHTML, like Gecko) ' +
+  'Version/17.4 Mobile/15E148 Safari/604.1';
+
+/** What the system camera opens after scanning a v2 authority QR. */
+const PAIRING_HASH = '#channel_id=chan-1&channel_key=key-1&v=2';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('pairing unsupported browser', () => {
@@ -64,6 +72,27 @@ test.describe('severity-2 #smoke', () => {
         'href',
         /mozilla\.org\/firefox\/new/
       );
+    });
+  });
+
+  // Firefox iOS cannot finish a pairing that started in another browser, so
+  // offering to hand off to it would only be a tap in front of this screen.
+  test.describe('pairing from the iOS system camera', () => {
+    test.use({ userAgent: IOS_SAFARI_UA });
+
+    test('opening a scanned pairing URL on iOS redirects to /pair/unsupported', async ({
+      target,
+      page,
+    }) => {
+      await page.goto(`${target.contentServerUrl}/pair${PAIRING_HASH}`, {
+        waitUntil: 'load',
+      });
+
+      await page.waitForURL(/\/pair\/unsupported/, { timeout: 10_000 });
+      await expect(page.locator('#pair-unsupported-header')).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: /Continue in Firefox/i })
+      ).toBeHidden();
     });
   });
 });

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -114,6 +114,7 @@ const settingsConfig = {
   pairing: {
     browserBuild: config.get('pairing.browser_build'),
     iosUrlScheme: config.get('pairing.ios_url_scheme'),
+    iosHandoff: config.get('pairing.ios_handoff'),
     clients: config.get('pairing.clients'),
     serverBaseUri: config.get('pairing.server_base_uri'),
     version: config.get('pairing.version'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -791,6 +791,12 @@ const conf = (module.exports = convict({
       env: 'PAIRING_IOS_URL_SCHEME',
       format: ['firefox', 'fennec', 'firefox-beta', 'firefox-internal'],
     },
+    ios_handoff: {
+      default: false,
+      doc: 'Whether a pairing QR scanned outside Firefox on iOS is handed off to the Firefox app. Disabled while Firefox iOS cannot finish a pairing it did not start, since the hand-off card is then only an extra step in front of /pair/unsupported.',
+      env: 'PAIRING_IOS_HANDOFF',
+      format: Boolean,
+    },
     clients: {
       default: [
         '3c49430b43dfba77', // Reference browser

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -99,6 +99,11 @@ export interface Config {
     browserBuild: 'firefox' | 'fenix';
     /** iOS URL scheme the pairing hand-off opens. See `pairing.ios_url_scheme`. */
     iosUrlScheme: string;
+    /**
+     * Whether a pairing QR scanned outside Firefox on iOS is handed off to the
+     * Firefox app. See `pairing.ios_handoff`.
+     */
+    iosHandoff: boolean;
     clients: string[];
     serverBaseUri: string;
     version: number;
@@ -226,6 +231,7 @@ export function getDefault() {
     pairing: {
       browserBuild: 'firefox',
       iosUrlScheme: 'firefox',
+      iosHandoff: false,
       clients: [],
       serverBaseUri: 'wss://channelserver.services.mozilla.com',
       version: 1,

--- a/packages/fxa-settings/src/lib/pairing/handoff.test.ts
+++ b/packages/fxa-settings/src/lib/pairing/handoff.test.ts
@@ -33,6 +33,7 @@ function createStorage(seed: Record<string, string> = {}) {
   };
 }
 
+/** Hand-off enabled on both platforms; the iOS gate has its own tests. */
 const plan = (device: Devices, storage = createStorage()) =>
   planPairingHandoff({
     device,
@@ -40,6 +41,7 @@ const plan = (device: Devices, storage = createStorage()) =>
     storeLinks: MOCK_STORE_LINKS,
     storage,
     build: 'firefox',
+    iosHandoff: true,
   });
 
 describe('planPairingHandoff', () => {
@@ -81,6 +83,33 @@ describe('planPairingHandoff', () => {
       const url = new URL(deepLink.replace('firefox://', 'https://'));
       expect(url.searchParams.get('url')).toBe(MOCK_TARGET);
     });
+
+    // Firefox iOS cannot finish a pairing it did not start, so handing the URL
+    // over only adds a tap in front of /pair/unsupported.
+    it('plans no hand-off when the Firefox app cannot act on one', () => {
+      expect(
+        planPairingHandoff({
+          device: Devices.OTHER_IOS,
+          targetUrl: MOCK_TARGET,
+          storeLinks: MOCK_STORE_LINKS,
+          storage: createStorage(),
+          build: 'firefox',
+          iosHandoff: false,
+        })
+      ).toEqual({ kind: 'none' });
+    });
+
+    it('plans no hand-off by default', () => {
+      expect(
+        planPairingHandoff({
+          device: Devices.OTHER_IOS,
+          targetUrl: MOCK_TARGET,
+          storeLinks: MOCK_STORE_LINKS,
+          storage: createStorage(),
+          build: 'firefox',
+        })
+      ).toEqual({ kind: 'none' });
+    });
   });
 
   describe('on a non-Firefox Android browser', () => {
@@ -117,6 +146,7 @@ describe('planPairingHandoff', () => {
         storage: createStorage(),
         build: 'firefox',
         iosScheme: 'fennec',
+        iosHandoff: true,
       }) as { deepLink: string };
 
       expect(deepLink).toBe(
@@ -144,6 +174,19 @@ describe('planPairingHandoff', () => {
       );
       // The encoded fallback plus the trailing terminator, and nothing more.
       expect(deepLink.split(';end').length - 1).toBe(1);
+    });
+
+    it('hands off even while the iOS hand-off is disabled', () => {
+      expect(
+        planPairingHandoff({
+          device: Devices.OTHER_ANDROID,
+          targetUrl: MOCK_TARGET,
+          storeLinks: MOCK_STORE_LINKS,
+          storage: createStorage(),
+          build: 'firefox',
+          iosHandoff: false,
+        })
+      ).toEqual(expect.objectContaining({ kind: 'android' }));
     });
 
     it('does not auto-attempt once the token for this target is spent', () => {

--- a/packages/fxa-settings/src/lib/pairing/handoff.ts
+++ b/packages/fxa-settings/src/lib/pairing/handoff.ts
@@ -160,9 +160,10 @@ function buildIosDeepLink(target: string, scheme: string): string {
 /**
  * Decide how — or whether — to hand `targetUrl` to the Firefox app.
  *
- * Only a non-Firefox phone gets a plan. Inside Firefox there is nothing to hand
- * off to and `firefox://` is a no-op, and on desktop there is no app to open,
- * so both fall through to `none` and the caller keeps its existing behaviour.
+ * Only a non-Firefox phone gets a plan, and iOS only once `iosHandoff` says the
+ * app can act on one. Inside Firefox there is nothing to hand off to and
+ * `firefox://` is a no-op, and on desktop there is no app to open, so both fall
+ * through to `none` and the caller keeps its existing behaviour.
  */
 export function planPairingHandoff({
   device,
@@ -171,6 +172,7 @@ export function planPairingHandoff({
   storage,
   build,
   iosScheme = 'firefox',
+  iosHandoff = false,
 }: {
   device: Devices;
   targetUrl: string;
@@ -179,6 +181,13 @@ export function planPairingHandoff({
   build: 'firefox' | 'fenix';
   /** iOS URL scheme to hand off to. See `buildIosDeepLink`. */
   iosScheme?: string;
+  /**
+   * Whether Firefox iOS can finish a pairing that started in another browser.
+   * It cannot until the app supports pairing version 2 from a native-camera
+   * scan, and a hand-off that only ever lands on /pair/unsupported is worse
+   * than going there directly — so off unless the deployment opts in.
+   */
+  iosHandoff?: boolean;
 }): HandoffPlan {
   if (!targetUrl) {
     return { kind: 'none' };
@@ -186,6 +195,9 @@ export function planPairingHandoff({
 
   switch (device) {
     case Devices.OTHER_IOS:
+      if (!iosHandoff) {
+        return { kind: 'none' };
+      }
       return {
         kind: 'ios',
         deepLink: buildIosDeepLink(targetUrl, iosScheme),

--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -675,16 +675,18 @@ describe('Pair', () => {
       // The desktop UA is stubbed for this suite, so the bootstrap reaching the
       // choice screen is what proves the hold expired. Waits past the grace
       // period, which is longer than the default findBy timeout.
-      await screen.findByLabelText(/I already have Firefox for mobile/, undefined, {
-        timeout: 4000,
-      });
+      await screen.findByLabelText(
+        /I already have Firefox for mobile/,
+        undefined,
+        {
+          timeout: 4000,
+        }
+      );
       expect(mockNavigate).not.toHaveBeenCalledWith(
         '/pair/supplicant/connect_this_device',
         expect.anything()
       );
     });
-
-
   });
 });
 
@@ -743,9 +745,10 @@ describe('parseV2PairingHash', () => {
       fxaStatusResult: mockUseFxAStatus({ fxaStatusState: 'unanswered' }),
     };
 
-    const v2AppContext = () => {
+    const v2AppContext = ({ iosHandoff = false } = {}) => {
       const config = getDefault();
       config.pairing.version = 2;
+      config.pairing.iosHandoff = iosHandoff;
       return mockAppContext({ config } as Parameters<typeof mockAppContext>[0]);
     };
 
@@ -753,12 +756,43 @@ describe('parseV2PairingHash', () => {
       mockLocationHash = V2_HASH;
     });
 
-    it.each([
-      ['iOS Safari', IOS_SAFARI],
-      ['Android Chrome', ANDROID_CHROME],
-    ])('offers to continue in Firefox on %s', async (_label, ua) => {
-      setUserAgent(ua);
+    // This describe sits outside the one that clears between tests, so a
+    // navigation recorded here would otherwise be seen by the next test.
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('offers to continue in Firefox on Android Chrome', async () => {
+      setUserAgent(ANDROID_CHROME);
       renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+
+      expect(
+        await screen.findByRole('heading', { name: 'Continue in Firefox' })
+      ).toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    // Firefox iOS cannot finish a pairing that started in another browser, so
+    // the hand-off card would only be a tap in front of the same dead end.
+    it('sends an iOS browser straight to /pair/unsupported', async () => {
+      setUserAgent(IOS_SAFARI);
+      renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(`/pair/unsupported${V2_HASH}`)
+      );
+      expect(
+        screen.queryByRole('heading', { name: 'Continue in Firefox' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('offers to continue in Firefox on iOS once the deployment enables it', async () => {
+      setUserAgent(IOS_SAFARI);
+      renderWithRouter(
+        <Pair {...unansweredProps} />,
+        {},
+        v2AppContext({ iosHandoff: true })
+      );
 
       expect(
         await screen.findByRole('heading', { name: 'Continue in Firefox' })
@@ -770,7 +804,11 @@ describe('parseV2PairingHash', () => {
     // opens on a /pair page with nothing to pair.
     it('hands Firefox the pairing URL the QR encoded', async () => {
       setUserAgent(IOS_SAFARI);
-      renderWithRouter(<Pair {...unansweredProps} />, {}, v2AppContext());
+      renderWithRouter(
+        <Pair {...unansweredProps} />,
+        {},
+        v2AppContext({ iosHandoff: true })
+      );
 
       const cta = await screen.findByRole('link', {
         name: 'Continue in Firefox',

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -149,6 +149,10 @@ const Pair = ({
   // carry the flow, so we will hand the pairing URL to the Firefox app instead,
   // falling back to the app store when it is not installed.
   //
+  // iOS gets a plan only where the deployment says Firefox iOS can act on one.
+  // Without one the flow falls through to /pair/unsupported below, which is
+  // where the hand-off would have led anyway.
+  //
   // Read-only, so it is safe to evaluate during render; the auto-attempt token
   // is only spent by ContinueInFirefox.
   const handoffPlan: HandoffPlan = useMemo(() => {
@@ -160,6 +164,7 @@ const Pair = ({
         storage: getAttemptStorage(),
         build: config.pairing.browserBuild,
         iosScheme: config.pairing.iosUrlScheme,
+        iosHandoff: config.pairing.iosHandoff,
       });
     }
 

--- a/packages/fxa-settings/src/pages/Pair/Unsupported/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Unsupported/index.test.tsx
@@ -210,6 +210,24 @@ describe('PairUnsupported', () => {
         restore();
       }
     });
+
+    // Every branch of this page, in both stacks, anchors its heading here, and
+    // the pairing functional tests key off it.
+    it('gives the heading the shared pair-unsupported-header id', () => {
+      const restore = spoofUserAgent(
+        UA_CHROME_ANDROID,
+        '#channel_id=abc&channel_key=def'
+      );
+      try {
+        renderWithLocalizationProvider(<PairUnsupported />);
+
+        expect(
+          screen.getByRole('heading', { name: 'Pair using an app' })
+        ).toHaveAttribute('id', 'pair-unsupported-header');
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe('desktop Firefox fallback', () => {

--- a/packages/fxa-settings/src/pages/Pair/Unsupported/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Unsupported/index.tsx
@@ -5,7 +5,6 @@
 import React, { useEffect, useMemo } from 'react';
 
 import { FtlMsg } from 'fxa-react/lib/utils';
-import CardHeader from '../../../components/CardHeader';
 import { usePageViewEvent } from '../../../lib/metrics';
 import {
   HeartsBrokenImage,
@@ -64,9 +63,7 @@ function useDeviceContext() {
   }, []);
 }
 
-const PairUnsupported = ({
-  error,
-}: PairUnsupportedProps) => {
+const PairUnsupported = ({ error }: PairUnsupportedProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const {
     isDesktopNonFirefox,
@@ -133,10 +130,15 @@ const PairUnsupported = ({
       {isMobileWithSystemCamera && (
         <>
           <HeartsBrokenImage className="w-3/5 mx-auto" />
-          <CardHeader
-            headingTextFtlId="pair-unsupported-header"
-            headingText="Pair using an app"
-          />
+          <FtlMsg id="pair-unsupported-header">
+            <h1
+              id="pair-unsupported-header"
+              className="card-header mb-2 focus:outline-none"
+              tabIndex={-1}
+            >
+              Pair using an app
+            </h1>
+          </FtlMsg>
           <FtlMsg id="pair-unsupported-message">
             <p className="text-sm">
               Did you use the system camera? You must pair from within a Firefox


### PR DESCRIPTION
## Because

- Firefox iOS cannot finish a pairing started from a native-camera scan, so the "Continue in Firefox" card is only a tap in front of the "pair not supported" roadblock.
- "Continue in Firefox" reads as progress, which makes landing on the roadblock more confusing than going there directly.
- Android is different: updating Firefox there lets the user re-scan the QR with the native camera, so it keeps the card.

## This pull request

- Adds a `pairing.ios_handoff` setting (`PAIRING_IOS_HANDOFF`), default `false`, surfaced as `config.pairing.iosHandoff`.
- `planPairingHandoff` plans no hand-off for a non-Firefox iOS browser while the setting is off, so `/pair` falls through to `/pair/unsupported` with the scanned hash intact.
- Leaves the Android hand-off path untouched.
- Covers the iOS redirect in the `Pair/Index` and `planPairingHandoff` unit tests, and adds an iPhone-UA case to `pairingUnsupported.spec.ts`.
- Clears mocks between tests in the `Pair/Index` hand-off describe, which sits outside the block that already did.
- Names the new flag in `pairingFlowV2iOS.spec.ts` and `tests/pairing/CLAUDE.md`.

## Issue that this pull request solves

Closes: FXA-14467

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-settings/src/lib/pairing/handoff.ts` for the gate; `packages/fxa-settings/src/pages/Pair/Index/index.tsx` for the fall-through to `/pair/unsupported`.
- Suggested review order: handoff planner → `/pair` page → config plumbing → tests.
- Risky or complex parts: the `/pair` mount effect has several ordering-sensitive branches; the iOS case now reaches the existing `!isFirefoxDesktop` branch rather than returning early.

## Screenshots (Optional)

N/A — no component markup changed; iOS now lands on the existing `/pair/unsupported` screen instead of the existing hand-off card.

## Other information (Optional)

- Rollout: the iOS hand-off is preserved, not deleted. Set `PAIRING_IOS_HANDOFF=true` to re-enable it once Firefox iOS can finish a pairing started from a native-camera scan.
- `pairingFlowV2iOS.spec.ts`'s hand-off delivery reads the CTA off the rendered page, so that spec now needs `PAIRING_IOS_HANDOFF=true` on the stack. Documented in the spec header and `tests/pairing/CLAUDE.md`.
- The new `pairingUnsupported.spec.ts` case cannot pass against a stack serving pre-fix code, so it was verified by the unit tests locally rather than against a running local stack.
