### PR TITLE
fix(settings): Skip pairing channel close once the socket is gone

### DIFF
--- a/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
@@ -21,6 +21,7 @@ let mockChannel: {
   removeEventListener: jest.Mock;
   _channelId?: string;
   _channelKey?: Uint8Array;
+  _connection?: unknown;
 };
 
 jest.mock(
@@ -248,6 +249,23 @@ describe('PairingChannelClient', () => {
       mockChannel.close.mockRejectedValueOnce(new Error('close failed'));
       await client.open(SERVER, CHAN, VALID_KEY);
       await expect(client.close()).resolves.toBeUndefined();
+      expect(client.isConnected).toBe(false);
+    });
+
+    // A socket error disconnects the channel without a matching `close` event,
+    // and the integrations tear down in response — so close() runs against a
+    // channel the package has already unwired.
+    it('skips the underlying close once the socket is gone', async () => {
+      await client.open(SERVER, CHAN, VALID_KEY);
+      getMockHandler('error')(
+        new CustomEvent('error', { detail: new Error('ws fail') })
+      );
+      mockChannel._connection = null;
+
+      await expect(client.close()).resolves.toBeUndefined();
+
+      expect(mockChannel.close).not.toHaveBeenCalled();
+      expect(mockChannel.removeEventListener).toHaveBeenCalled();
       expect(client.isConnected).toBe(false);
     });
   });

--- a/packages/fxa-settings/src/lib/channels/pairing-channel.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.ts
@@ -138,6 +138,11 @@ type PairingChannelSocket = {
   removeEventListener(type: string, listener: EventListener): void;
   _channelId?: string;
   _channelKey?: Uint8Array;
+  /**
+   * fxa-pairing-channel's own handle on the socket. It is nulled out when the
+   * socket goes away, and the package's `close()` dereferences it unguarded.
+   */
+  _connection?: unknown;
 };
 
 export class PairingChannelClient extends EventTarget {
@@ -275,6 +280,13 @@ export class PairingChannelClient extends EventTarget {
     const ch = this.channel;
     this.channel = null;
     this.removeChannelListeners(ch);
+
+    // An absent `_connection` is not the same signal as a null one.
+    // Only null means the channel tore down the socket.
+    if (ch._connection === null) {
+      return;
+    }
+
     try {
       console.info('Closing channel ', ch._channelId)
       await ch.close();


### PR DESCRIPTION
## Because

- A socket error disconnects the pairing channel without firing `close`, so the
  authority's teardown calls into a dead channel and fxa-pairing-channel's own
  `close()` throws.
- The throw is already caught, so no user flow breaks — but it has reported 43
  TypeErrors to Sentry on stage since 27 Aug, crowding out real pairing failures.
- The supplicant's cancel path reaches the same line and has reported 1646
  TypeErrors in prod since 30 Apr (FXA-CONTENT-1K0J).

## This pull request

- Skips the underlying `close()` in `PairingChannelClient` when
  fxa-pairing-channel has already dropped the socket.
- Adds a regression test covering close after a socket error.

## Issue that this pull request solves

Closes: FXA-14443
Closes: FXA-14445

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- The guard tests `_connection === null` rather than falsy on purpose. Only
  `null` means the package tore the socket down; if a future version renames or
  removes the property it reads as `undefined` and falls through to the existing
  try/catch-guarded `close()`, rather than silently leaving channels open.
- `pairing-channel.ts` and `pairing-authority-integration.ts` carry leftover
  `console.info` / `console.warn` debug logging from 3155801606. Left untouched
  here — worth a separate cleanup.

