### PR TITLE
feat(passkey): expose wrap state on the password reset flow

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1097,6 +1097,7 @@ export default class AuthClient {
     token: string;
     uid: string;
     hasPasskey?: boolean;
+    hasPasskeyWraps?: boolean;
   }> {
     const payload = {
       email,

--- a/packages/fxa-auth-server/docs/swagger/password-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/password-api.ts
@@ -14,7 +14,7 @@ const PASSWORD_CHANGE_START_POST = {
   description: '/password/change/start',
   notes: [
     'Begin the "change password" process. Returns a single-use `passwordChangeToken`, to be sent to `POST /password/change/finish`. Also returns a single-use `keyFetchToken`.',
-    'Important! the email value must be the original account email, i.e. the email used during initial sign up, and NOT the current primary email!'
+    'Important! the email value must be the original account email, i.e. the email used during initial sign up, and NOT the current primary email!',
   ],
   plugins: {
     'hapi-swagger': {
@@ -70,6 +70,8 @@ const PASSWORD_FORGOT_VERIFY_OTP_POST = {
   notes: [
     dedent`
       Verify the OTP from \`/password/forgot/send_otp\` to receive the PasswordForgotToken and its code to continue the password reset process.
+
+      When the passkey feature is enabled, the response also carries \`hasPasskey\` (the account has a registered passkey) and \`hasPasskeyWraps\` (a passkey can recover the account's encryption keys without the password). Both drive the reset-flow messaging and are omitted when the lookup fails. They are exposed here — behind the verified OTP — and not on \`/account/status\`.
     `,
   ],
 };

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { createMock } from '@golevelup/ts-jest';
+import { PasskeyService } from '@fxa/accounts/passkey';
 import type { Schema } from 'joi';
 import { StatsD } from 'hot-shots';
 import { AuthLogger as AuthLoggerType } from '../types';
@@ -1804,6 +1805,64 @@ describe('/account/status', () => {
       expect(response.exists).toBe(true);
       expect(response.hasLinkedAccount).toBe(true);
       expect(response.hasPassword).toBe(false);
+    });
+  });
+
+  // Key-wrap presence is scoped to /password/forgot/verify_otp, which is reached
+  // only after the emailed OTP is verified. This route is unauthenticated, so
+  // carrying the signal here would disclose per-account credential state to
+  // anyone who knows an email address.
+  describe('hasPasskeyWraps is never exposed', () => {
+    let mockPasskeyService: PasskeyService;
+
+    beforeEach(() => {
+      mockPasskeyService = createMock<PasskeyService>({
+        hasPasskey: jest.fn().mockResolvedValue(true),
+        hasPasskeyWraps: jest.fn().mockResolvedValue(true),
+      });
+      Container.set(PasskeyService, mockPasskeyService);
+    });
+
+    afterEach(() => {
+      Container.remove(PasskeyService);
+    });
+
+    const setupStatusRoute = () => {
+      const { route, mockRequest } = setup({
+        dbOptions: { linkedAccounts: [{}], verifierSetAt: 0 },
+        shouldError: false,
+        extraConfig: {
+          passkeys: { enabled: true, authenticationEnabled: true },
+          passwordlessOtp: { forcedEmailAddresses: /^$/, allowedClientIds: [] },
+        },
+      });
+      mockRequest.payload.thirdPartyAuthStatus = true;
+      return { route, mockRequest };
+    };
+
+    it('is rejected by the response schema', () => {
+      const { route } = setupStatusRoute();
+
+      const { error } = route.options.response.schema.validate({
+        exists: true,
+        hasPasskeyWraps: true,
+      });
+
+      expect(
+        error?.details.some(
+          (detail) => detail.context?.key === 'hasPasskeyWraps'
+        )
+      ).toBe(true);
+    });
+
+    it('is absent from the response, and never looked up', async () => {
+      const { route, mockRequest } = setupStatusRoute();
+
+      const response = await runTest(route, mockRequest);
+
+      expect(response.hasPasskey).toBe(true);
+      expect(response).not.toHaveProperty('hasPasskeyWraps');
+      expect(mockPasskeyService.hasPasskeyWraps).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/fxa-auth-server/lib/routes/password.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/password.spec.ts
@@ -410,60 +410,109 @@ describe('/password', () => {
         );
       }
 
-      it('reports hasPasskey when the passkey feature is enabled', async () => {
-        const mockPasskeyService = createMock<PasskeyService>({
-          hasPasskey: jest.fn().mockResolvedValue(true),
+      const withPasskeys = (passkeys: { hasPasswordlessSync: boolean }[]) =>
+        createMock<PasskeyService>({
+          listPasskeysForUser: jest.fn().mockResolvedValue(passkeys),
         });
+
+      it('reports both signals when the passkey feature is enabled', async () => {
+        const mockPasskeyService = withPasskeys([
+          { hasPasswordlessSync: true },
+        ]);
         Container.set(PasskeyService, mockPasskeyService);
 
         const response = await runVerifyOtp(mockPasskeyConfig);
 
-        expect(mockPasskeyService.hasPasskey).toHaveBeenCalledWith(uid);
+        expect(mockPasskeyService.listPasskeysForUser).toHaveBeenCalledWith(
+          uid
+        );
         expect(response.hasPasskey).toBe(true);
+        expect(response.hasPasskeyWraps).toBe(true);
       });
 
-      it('omits hasPasskey when the passkey feature is disabled', async () => {
-        const mockPasskeyService = createMock<PasskeyService>({
-          hasPasskey: jest.fn().mockResolvedValue(true),
-        });
+      it('reports hasPasskeyWraps false for a passkey without a wrap', async () => {
+        Container.set(
+          PasskeyService,
+          withPasskeys([{ hasPasswordlessSync: false }])
+        );
+
+        const response = await runVerifyOtp(mockPasskeyConfig);
+
+        expect(response.hasPasskey).toBe(true);
+        expect(response.hasPasskeyWraps).toBe(false);
+      });
+
+      it('reports a wrap when any of several passkeys holds one', async () => {
+        Container.set(
+          PasskeyService,
+          withPasskeys([
+            { hasPasswordlessSync: false },
+            { hasPasswordlessSync: true },
+          ])
+        );
+
+        const response = await runVerifyOtp(mockPasskeyConfig);
+
+        expect(response.hasPasskeyWraps).toBe(true);
+      });
+
+      it('reports both false for an account with no passkey', async () => {
+        Container.set(PasskeyService, withPasskeys([]));
+
+        const response = await runVerifyOtp(mockPasskeyConfig);
+
+        expect(response.hasPasskey).toBe(false);
+        expect(response.hasPasskeyWraps).toBe(false);
+      });
+
+      it('omits both signals when the passkey feature is disabled', async () => {
+        const mockPasskeyService = withPasskeys([
+          { hasPasswordlessSync: true },
+        ]);
         Container.set(PasskeyService, mockPasskeyService);
 
         const response = await runVerifyOtp(mockConfig);
 
+        expect(mockPasskeyService.listPasskeysForUser).not.toHaveBeenCalled();
         expect(response.hasPasskey).toBeUndefined();
+        expect(response.hasPasskeyWraps).toBeUndefined();
       });
 
-      it('leaves hasPasskey undefined when the lookup throws', async () => {
-        const mockPasskeyService = createMock<PasskeyService>({
-          hasPasskey: jest.fn().mockRejectedValue(new Error('boom')),
-        });
-        Container.set(PasskeyService, mockPasskeyService);
+      it('leaves both signals undefined when the lookup throws', async () => {
+        Container.set(
+          PasskeyService,
+          createMock<PasskeyService>({
+            listPasskeysForUser: jest.fn().mockRejectedValue(new Error('boom')),
+          })
+        );
 
         const response = await runVerifyOtp(mockPasskeyConfig);
 
         expect(response.hasPasskey).toBeUndefined();
+        expect(response.hasPasskeyWraps).toBeUndefined();
         expect(mockLog.error).toHaveBeenCalledWith(
-          'passwordForgotVerifyOtp.hasPasskey',
+          'passwordForgotVerifyOtp.passkeySignals',
           expect.objectContaining({ err: expect.any(Error) })
         );
         expect(mockStatsd.increment).toHaveBeenCalledWith(
-          'password.forgotVerifyOtp.hasPasskey.error'
+          'password.forgotVerifyOtp.passkeySignals.error'
         );
       });
 
-      it('logs an error and leaves hasPasskey undefined when enabled but the passkey service is unregistered', async () => {
+      it('logs an error and leaves both signals undefined when enabled but the passkey service is unregistered', async () => {
         const response = await runVerifyOtp(mockPasskeyConfig);
 
         expect(response.hasPasskey).toBeUndefined();
+        expect(response.hasPasskeyWraps).toBeUndefined();
         expect(mockStatsd.increment).toHaveBeenCalledWith(
-          'password.forgotVerifyOtp.hasPasskey.error'
+          'password.forgotVerifyOtp.passkeySignals.error'
         );
       });
 
       it('returns only the allowlisted response keys, never an internal field', async () => {
-        const mockPasskeyService = createMock<PasskeyService>({
-          hasPasskey: jest.fn().mockResolvedValue(true),
-        });
+        const mockPasskeyService = withPasskeys([
+          { hasPasswordlessSync: true },
+        ]);
         Container.set(PasskeyService, mockPasskeyService);
 
         const response = await runVerifyOtp(mockPasskeyConfig);
@@ -471,7 +520,14 @@ describe('/password', () => {
         // Guards the token-returning route against an accidental internal-field
         // spread slipping past the .unknown(true) response schema.
         expect(Object.keys(response).sort()).toEqual(
-          ['code', 'emailToHashWith', 'hasPasskey', 'token', 'uid'].sort()
+          [
+            'code',
+            'emailToHashWith',
+            'hasPasskey',
+            'hasPasskeyWraps',
+            'token',
+            'uid',
+          ].sort()
         );
       });
     });

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -1072,6 +1072,7 @@ module.exports = function (
             token: isA.string().required(),
             uid: isA.string().required(),
             hasPasskey: isA.boolean().optional(),
+            hasPasskeyWraps: isA.boolean().optional(),
           }),
         },
       },
@@ -1120,20 +1121,31 @@ module.exports = function (
           getClientServiceTags(request)
         );
 
-        // Passkey-aware reset messaging: does the account have a passkey? Fail
-        // open so the reset flow never breaks.
+        // Passkey-aware reset messaging: does the account have a passkey, and
+        // can that passkey recover the account's encryption keys? Fail open so
+        // the reset flow never breaks.
+        //
+        // These signals are scoped to this route because it is reached only
+        // after the emailed OTP is verified. They must not be added to the
+        // unauthenticated /account/status, where they would leak per-account
+        // credential state to anyone who knows an email address.
         let hasPasskey: boolean | undefined;
+        let hasPasskeyWraps: boolean | undefined;
         if (
           config.passkeys?.enabled &&
           config.passkeys?.authenticationEnabled
         ) {
           try {
-            hasPasskey = await Container.get(PasskeyService).hasPasskey(
-              account.uid
-            );
+            // One LEFT JOIN answers both signals. A wrap is flagged per
+            // credential, so this reports only wraps a live passkey can open.
+            const passkeys = await Container.get(
+              PasskeyService
+            ).listPasskeysForUser(account.uid);
+            hasPasskey = passkeys.length > 0;
+            hasPasskeyWraps = passkeys.some((p) => p.hasPasswordlessSync);
           } catch (err) {
-            log.error('passwordForgotVerifyOtp.hasPasskey', { err });
-            statsd.increment('password.forgotVerifyOtp.hasPasskey.error');
+            log.error('passwordForgotVerifyOtp.passkeySignals', { err });
+            statsd.increment('password.forgotVerifyOtp.passkeySignals.error');
           }
         }
 
@@ -1143,6 +1155,7 @@ module.exports = function (
           token: passwordForgotToken.data,
           uid: passwordForgotToken.uid,
           hasPasskey,
+          hasPasskeyWraps,
         };
       },
     },

--- a/packages/fxa-auth-server/test/remote/account_status.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_status.in.spec.ts
@@ -114,6 +114,9 @@ describe.each(testVersions)(
       });
       expect(response.exists).toBe(true);
       expect(response.hasPasskey).toBe(false);
+      // Key-wrap presence stays on the OTP-verified reset route; this one is
+      // unauthenticated.
+      expect(response.hasPasskeyWraps).toBeUndefined();
     });
 
     it('account status by email omits hasPasskey without thirdPartyAuthStatus', async () => {

--- a/packages/fxa-auth-server/test/remote/password_forgot.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/password_forgot.in.spec.ts
@@ -113,7 +113,7 @@ describe.each(testVersions)(
       expect(client.kB.length).toBe(64);
     });
 
-    it('verify_otp reports hasPasskey=false for an account without a passkey', async () => {
+    it('verify_otp reports both passkey signals false for an account without a passkey', async () => {
       const email = server.uniqueEmail();
       const password = 'allyourbasearebelongtous';
 
@@ -135,6 +135,10 @@ describe.each(testVersions)(
       );
 
       expect(result.hasPasskey).toBe(false);
+      // Determined, not unknown: the lookup ran and found no passkey, so no
+      // wrap. `undefined` is reserved for the feature being off or the lookup
+      // failing.
+      expect(result.hasPasskeyWraps).toBe(false);
     });
 
     it('forgot password limits verify attempts', async () => {

--- a/packages/fxa-settings/src/lib/passkeys/should-show-passkey-reset-option.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/should-show-passkey-reset-option.test.ts
@@ -18,6 +18,14 @@ const flagsOff = {
   },
 };
 
+/** Sync surfaces additionally need the passwordless flag to offer a passkey. */
+const passwordlessSyncFlagsOn = {
+  featureFlags: {
+    ...flagsOn.featureFlags,
+    passkeyPasswordlessSyncEnabled: true,
+  },
+};
+
 describe('shouldShowPasskeyResetOption', () => {
   describe('feature flag gating', () => {
     it('returns false when the passkey feature is off, even post-OTP with a passkey', () => {
@@ -41,7 +49,7 @@ describe('shouldShowPasskeyResetOption', () => {
       ).toBe(true);
     });
 
-    it('suppresses for a Sync flow (serviceRequiresKeys)', () => {
+    it('suppresses for a Sync flow, where the wrap status is not yet known', () => {
       expect(
         shouldShowPasskeyResetOption(flagsOn, { serviceRequiresKeys: true })
       ).toBe(false);
@@ -76,14 +84,62 @@ describe('shouldShowPasskeyResetOption', () => {
       ).toBe(false);
     });
 
-    it('suppresses for a Sync flow even with a passkey', () => {
+    it('returns true for a Sync flow when the account has a key-wrap', () => {
+      expect(
+        shouldShowPasskeyResetOption(passwordlessSyncFlagsOn, {
+          hasPasskey: true,
+          hasPasskeyWraps: true,
+          requireHasPasskey: true,
+          serviceRequiresKeys: true,
+        })
+      ).toBe(true);
+    });
+
+    it('suppresses for a Sync flow with a key-wrap when passwordless Sync is off', () => {
+      // Wraps can exist before sign-in can unwrap them, and the footer would
+      // otherwise send the user to a passkey sign-in that asks for the password
+      // they just declared forgotten.
       expect(
         shouldShowPasskeyResetOption(flagsOn, {
           hasPasskey: true,
+          hasPasskeyWraps: true,
           requireHasPasskey: true,
           serviceRequiresKeys: true,
         })
       ).toBe(false);
+    });
+
+    it('suppresses for a Sync flow when the account has no key-wrap', () => {
+      expect(
+        shouldShowPasskeyResetOption(flagsOn, {
+          hasPasskey: true,
+          hasPasskeyWraps: false,
+          requireHasPasskey: true,
+          serviceRequiresKeys: true,
+        })
+      ).toBe(false);
+    });
+
+    it('suppresses for a Sync flow when the wrap status is unknown', () => {
+      expect(
+        shouldShowPasskeyResetOption(flagsOn, {
+          hasPasskey: true,
+          hasPasskeyWraps: undefined,
+          requireHasPasskey: true,
+          serviceRequiresKeys: true,
+        })
+      ).toBe(false);
+    });
+
+    it('returns true for a non-Sync flow without a key-wrap', () => {
+      expect(
+        shouldShowPasskeyResetOption(flagsOn, {
+          hasPasskey: true,
+          hasPasskeyWraps: false,
+          requireHasPasskey: true,
+          serviceRequiresKeys: false,
+        })
+      ).toBe(true);
     });
   });
 

--- a/packages/fxa-settings/src/lib/passkeys/should-show-passkey-reset-option.ts
+++ b/packages/fxa-settings/src/lib/passkeys/should-show-passkey-reset-option.ts
@@ -5,6 +5,7 @@
 import {
   PasskeySigninFlags,
   passkeySigninFeatureEnabled,
+  passwordlessSyncEnabled,
 } from './should-show-passkey-signin';
 
 /**
@@ -21,18 +22,26 @@ import {
  *
  * Keys guard: `serviceRequiresKeys` describes the requested service (the flow) —
  * not the account — and is currently `integration.isSync()`. When the service
- * needs the account's encryption keys (Sync), a passkey authenticates but cannot
- * derive them, so the password is still required and the passkey wording is
- * suppressed. Fails closed.
+ * needs the account's encryption keys (Sync), a passkey is only an alternative
+ * to the password if the account has a key-wrap the passkey can unwrap those
+ * keys from (`hasPasskeyWraps`) AND sign-in can actually perform that unwrap
+ * (`passkeyPasswordlessSyncEnabled`). Wrap storage and wrap consumption ship
+ * under one flag but not necessarily in one release, so without the flag the
+ * footer would send a user who has forgotten their password to a passkey
+ * sign-in that asks for it again. Fails closed, so the pre-OTP pages — which
+ * don't know the account and so can't know its wraps — never show the passkey
+ * wording for Sync.
  */
 export function shouldShowPasskeyResetOption(
   config: PasskeySigninFlags,
   {
     hasPasskey,
+    hasPasskeyWraps,
     serviceRequiresKeys = false,
     requireHasPasskey = false,
   }: {
     hasPasskey?: boolean;
+    hasPasskeyWraps?: boolean;
     serviceRequiresKeys?: boolean;
     requireHasPasskey?: boolean;
   }
@@ -43,9 +52,10 @@ export function shouldShowPasskeyResetOption(
   if (requireHasPasskey && hasPasskey !== true) {
     return false;
   }
-  // TODO(FXA-14220): re-enable for Sync once passkey key-wraps can recover the
-  // account's encryption keys without the password.
-  if (serviceRequiresKeys) {
+  if (
+    serviceRequiresKeys &&
+    !(hasPasskeyWraps === true && passwordlessSyncEnabled(config))
+  ) {
     return false;
   }
   return true;

--- a/packages/fxa-settings/src/lib/passkeys/should-show-passkey-signin.ts
+++ b/packages/fxa-settings/src/lib/passkeys/should-show-passkey-signin.ts
@@ -7,6 +7,7 @@ export type PasskeySigninFlags = {
   featureFlags?: {
     passkeysEnabled?: boolean;
     passkeyAuthenticationEnabled?: boolean;
+    passkeyPasswordlessSyncEnabled?: boolean;
   };
 };
 
@@ -24,6 +25,14 @@ export function passkeySigninFeatureEnabled(
     config.featureFlags?.passkeysEnabled &&
     config.featureFlags?.passkeyAuthenticationEnabled
   );
+}
+
+/**
+ * Whether a passkey can recover the account's Sync encryption keys, so sign-in
+ * can skip the password. Gates every surface that offers that as an option.
+ */
+export function passwordlessSyncEnabled(config: PasskeySigninFlags): boolean {
+  return !!config.featureFlags?.passkeyPasswordlessSyncEnabled;
 }
 
 /**

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../models/hooks';
 
 import { AccountRecoveryConfirmKeyLocationState } from './interfaces';
-import { ResetPasswordIntegration } from '../interfaces';
+import { PasskeyResetSignals, ResetPasswordIntegration } from '../interfaces';
 
 import AccountRecoveryConfirmKey from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks';
@@ -48,10 +48,15 @@ const AccountRecoveryConfirmKeyContainer = ({
     uid,
     totpExists,
     hasPasskey,
+    hasPasskeyWraps,
   } = (location.state as AccountRecoveryConfirmKeyLocationState) || {};
 
+  // Built once and spread, so a new signal is one edit rather than one per
+  // navigate target — an omission arrives undefined and fails closed silently.
+  const passkeySignals: PasskeyResetSignals = { hasPasskey, hasPasskeyWraps };
+
   const showPasskeyOption = shouldShowPasskeyResetOption(config, {
-    hasPasskey,
+    ...passkeySignals,
     serviceRequiresKeys: integration.isSync(),
     requireHasPasskey: true,
   });
@@ -94,7 +99,7 @@ const AccountRecoveryConfirmKeyContainer = ({
         estimatedSyncDeviceCount,
         kB,
         recoveryKeyId,
-        hasPasskey,
+        ...passkeySignals,
       },
       replace: true,
     });
@@ -140,7 +145,7 @@ const AccountRecoveryConfirmKeyContainer = ({
         verifyRecoveryKey,
         uid,
         totpExists,
-        hasPasskey,
+        ...passkeySignals,
         showPasskeyOption,
       }}
     />

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -20,6 +20,7 @@ import {
   AccountRecoveryConfirmKeyFormData,
   AccountRecoveryConfirmKeyProps,
 } from './interfaces';
+import { PasskeyResetSignals } from '../interfaces';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import { RecoveryKeyImage } from '../../../components/images';
 import { Constants } from '../../../lib/constants';
@@ -48,8 +49,10 @@ const AccountRecoveryConfirmKey = ({
   uid,
   totpExists,
   hasPasskey,
+  hasPasskeyWraps,
   showPasskeyOption,
 }: AccountRecoveryConfirmKeyProps) => {
+  const passkeySignals: PasskeyResetSignals = { hasPasskey, hasPasskeyWraps };
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
 
@@ -223,7 +226,7 @@ const AccountRecoveryConfirmKey = ({
               recoveryKeyHint,
               token,
               uid,
-              hasPasskey,
+              ...passkeySignals,
             }}
             onClick={() => GleanMetrics.passwordReset.recoveryKeyCannotFind()}
           >
@@ -244,7 +247,7 @@ const AccountRecoveryConfirmKey = ({
               recoveryKeyHint,
               token,
               uid,
-              hasPasskey,
+              ...passkeySignals,
             }}
             onClick={() => GleanMetrics.passwordReset.recoveryKeyCannotFind()}
           >

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -100,6 +100,7 @@ const CompleteResetPasswordContainer = ({
     recoveryKeyExists,
     estimatedSyncDeviceCount,
     hasPasskey,
+    hasPasskeyWraps,
   } = location.state as CompleteResetPasswordLocationState;
 
   const kB = sensitiveDataClient.getDataType(
@@ -124,6 +125,7 @@ const CompleteResetPasswordContainer = ({
   // non-Sync reset even when the account has Sync data on other devices.
   const showPasskeyOption = shouldShowPasskeyResetOption(config, {
     hasPasskey,
+    hasPasskeyWraps,
     serviceRequiresKeys: integration.isSync(),
     requireHasPasskey: true,
   });

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmBackupCodeResetPassword/container.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from 'react';
 import { useLocation } from 'react-router';
 import { useAuthClient, useConfig, useFtlMsgResolver } from '../../../models';
-import { ResetPasswordIntegration } from '../interfaces';
+import { PasskeyResetSignals, ResetPasswordIntegration } from '../interfaces';
 import ConfirmBackupCodeResetPassword from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks';
 import { CompleteResetPasswordLocationState } from '../CompleteResetPassword/interfaces';
@@ -30,13 +30,18 @@ const ConfirmBackupCodeResetPasswordContainer = ({
     estimatedSyncDeviceCount,
     uid,
     hasPasskey,
+    hasPasskeyWraps,
   } = location.state as CompleteResetPasswordLocationState;
+
+  // Built once and spread, so a new signal is one edit rather than one per
+  // navigate target — an omission arrives undefined and fails closed silently.
+  const passkeySignals: PasskeyResetSignals = { hasPasskey, hasPasskeyWraps };
 
   const ftlMsgResolver = useFtlMsgResolver();
   const navigateWithQuery = useNavigateWithQuery();
 
   const showPasskeyOption = shouldShowPasskeyResetOption(config, {
-    hasPasskey,
+    ...passkeySignals,
     serviceRequiresKeys: integration.isSync(),
     requireHasPasskey: true,
   });
@@ -53,7 +58,7 @@ const ConfirmBackupCodeResetPasswordContainer = ({
         recoveryKeyExists,
         token,
         uid,
-        hasPasskey,
+        ...passkeySignals,
       },
       replace: true,
     });

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.test.tsx
@@ -89,13 +89,14 @@ describe('ConfirmResetPasswordContainer', () => {
     mockNavigate.mockReset();
   });
 
-  it('threads hasPasskey from verify_otp into navigation state', async () => {
+  it('threads the passkey signals from verify_otp into navigation state', async () => {
     mockVerifyOtp.mockResolvedValueOnce({
       code: 'the-code',
       emailToHashWith: MOCK_EMAIL,
       token: MOCK_PASSWORD_CHANGE_TOKEN,
       uid: MOCK_UID,
       hasPasskey: true,
+      hasPasskeyWraps: true,
     });
     mockRecoveryKeyStatus.mockResolvedValueOnce({
       exists: false,
@@ -113,6 +114,7 @@ describe('ConfirmResetPasswordContainer', () => {
       state: expect.objectContaining({
         uid: MOCK_UID,
         hasPasskey: true,
+        hasPasskeyWraps: true,
       }),
       replace: true,
     });

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
@@ -33,8 +33,8 @@ const ConfirmResetPasswordContainer = ({
   const ftlMsgResolver = useFtlMsgResolver();
 
   // The account isn't known until the OTP is verified, so the footer is shown
-  // unconditionally when the feature is on — except for an active Sync sign-in,
-  // where a passkey can't recover Sync data in Phase 1.
+  // unconditionally when the feature is on — except for a Sync sign-in, which
+  // needs the account's wrap status to know a passkey can recover Sync data.
   const showPasskeyOption = shouldShowPasskeyResetOption(config, {
     serviceRequiresKeys: integration.isSync(),
   });
@@ -61,6 +61,7 @@ const ConfirmResetPasswordContainer = ({
     recoveryKeyHint,
     totpExists,
     hasPasskey,
+    hasPasskeyWraps,
   }: {
     code: string;
     emailToHashWith: string;
@@ -71,6 +72,10 @@ const ConfirmResetPasswordContainer = ({
     recoveryKeyHint?: string;
     totpExists?: boolean;
   } & PasskeyResetSignals) => {
+    // Built once and spread, so a new signal is one edit rather than one per
+    // navigate target — an omission arrives undefined and fails closed silently.
+    const passkeySignals: PasskeyResetSignals = { hasPasskey, hasPasskeyWraps };
+
     if (totpExists && recoveryKeyExists === false) {
       navigateWithQuery('/confirm_totp_reset_password', {
         state: {
@@ -82,7 +87,7 @@ const ConfirmResetPasswordContainer = ({
           recoveryKeyHint,
           token,
           uid,
-          hasPasskey,
+          ...passkeySignals,
         },
         replace: true,
       });
@@ -98,7 +103,7 @@ const ConfirmResetPasswordContainer = ({
           token,
           uid,
           totpExists,
-          hasPasskey,
+          ...passkeySignals,
         },
         replace: true,
       });
@@ -112,7 +117,7 @@ const ConfirmResetPasswordContainer = ({
           recoveryKeyExists,
           token,
           uid,
-          hasPasskey,
+          ...passkeySignals,
         },
         replace: true,
       });
@@ -148,7 +153,7 @@ const ConfirmResetPasswordContainer = ({
     const options = { metricsContext };
     try {
       GleanMetrics.passwordReset.emailConfirmationSubmit();
-      const { code, emailToHashWith, token, uid, hasPasskey } =
+      const { code, emailToHashWith, token, uid, hasPasskey, hasPasskeyWraps } =
         await authClient.passwordForgotVerifyOtp(email, otpCode, options);
       const {
         exists: recoveryKeyExists,
@@ -168,6 +173,7 @@ const ConfirmResetPasswordContainer = ({
         recoveryKeyHint,
         totpExists,
         hasPasskey,
+        hasPasskeyWraps,
       });
     } catch (error) {
       // return custom error for expired or incorrect code

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.test.tsx
@@ -24,6 +24,7 @@ jest.mock('../../../models', () => ({
     featureFlags: {
       passkeysEnabled: true,
       passkeyAuthenticationEnabled: true,
+      passkeyPasswordlessSyncEnabled: true,
     },
   }),
   useFtlMsgResolver: () => ({
@@ -31,8 +32,9 @@ jest.mock('../../../models', () => ({
   }),
 }));
 
+let mockIsSync = false;
 const mockIntegration: ResetPasswordIntegration = {
-  isSync: () => false,
+  isSync: () => mockIsSync,
   getCmsInfo: () => undefined,
 };
 
@@ -41,7 +43,7 @@ jest.mock('../../../lib/hooks/useNavigateWithQuery', () => ({
   useNavigateWithQuery: () => mockNavigate,
 }));
 
-let mockLocationState = {
+const BASE_LOCATION_STATE = {
   code: 'ignored',
   email: MOCK_EMAIL,
   token: MOCK_PASSWORD_CHANGE_TOKEN,
@@ -50,6 +52,8 @@ let mockLocationState = {
   estimatedSyncDeviceCount: 2,
   uid: MOCK_UID,
 };
+
+let mockLocationState: Record<string, unknown> = { ...BASE_LOCATION_STATE };
 
 jest.mock('react-router', () => {
   const actual = jest.requireActual('react-router');
@@ -79,6 +83,8 @@ async function renderComponent() {
 describe('ConfirmTotpResetPasswordContainer', () => {
   beforeEach(() => {
     capturedProps = undefined;
+    mockIsSync = false;
+    mockLocationState = { ...BASE_LOCATION_STATE };
     mockCheckTotp.mockReset();
     mockNavigate.mockReset();
     mockRecoveryPhoneGetWithPasswordForgotToken.mockReset();
@@ -124,6 +130,60 @@ describe('ConfirmTotpResetPasswordContainer', () => {
     });
 
     expect(capturedProps.codeErrorMessage).toBe('Valid code required');
+  });
+
+  describe('passkey reset footer', () => {
+    it('shows the passkey option for a Sync flow when the account has a key-wrap', async () => {
+      mockIsSync = true;
+      mockLocationState = {
+        ...BASE_LOCATION_STATE,
+        hasPasskey: true,
+        hasPasskeyWraps: true,
+      };
+
+      await renderComponent();
+
+      expect(capturedProps.showPasskeyOption).toBe(true);
+    });
+
+    it('hides the passkey option for a Sync flow when the account has no key-wrap', async () => {
+      mockIsSync = true;
+      mockLocationState = {
+        ...BASE_LOCATION_STATE,
+        hasPasskey: true,
+        hasPasskeyWraps: false,
+      };
+
+      await renderComponent();
+
+      expect(capturedProps.showPasskeyOption).toBe(false);
+    });
+
+    it('carries the passkey signals into the next page', async () => {
+      mockLocationState = {
+        ...BASE_LOCATION_STATE,
+        hasPasskey: true,
+        hasPasskeyWraps: true,
+      };
+      mockCheckTotp.mockResolvedValueOnce({ success: true });
+      mockRecoveryPhoneGetWithPasswordForgotToken.mockResolvedValueOnce({
+        exists: false,
+      });
+
+      await renderComponent();
+
+      await act(async () => {
+        await capturedProps.verifyCode('123456');
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/complete_reset_password', {
+        state: expect.objectContaining({
+          hasPasskey: true,
+          hasPasskeyWraps: true,
+        }),
+        replace: true,
+      });
+    });
   });
 
   it('forwards location.state when onTroubleWithCode is invoked', async () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.tsx
@@ -8,7 +8,7 @@ import { useAuthClient, useConfig, useFtlMsgResolver } from '../../../models';
 import ConfirmTotpResetPassword from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks';
 import { CompleteResetPasswordLocationState } from '../CompleteResetPassword/interfaces';
-import { ResetPasswordIntegration } from '../interfaces';
+import { PasskeyResetSignals, ResetPasswordIntegration } from '../interfaces';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { shouldShowPasskeyResetOption } from '../../../lib/passkeys';
@@ -30,13 +30,18 @@ const ConfirmTotpResetPasswordContainer = ({
     estimatedSyncDeviceCount,
     uid,
     hasPasskey,
+    hasPasskeyWraps,
   } = location.state as CompleteResetPasswordLocationState;
+
+  // Built once and spread, so a new signal is one edit rather than one per
+  // navigate target — an omission arrives undefined and fails closed silently.
+  const passkeySignals: PasskeyResetSignals = { hasPasskey, hasPasskeyWraps };
 
   const ftlMsgResolver = useFtlMsgResolver();
   const navigateWithQuery = useNavigateWithQuery();
 
   const showPasskeyOption = shouldShowPasskeyResetOption(config, {
-    hasPasskey,
+    ...passkeySignals,
     serviceRequiresKeys: integration.isSync(),
     requireHasPasskey: true,
   });
@@ -53,7 +58,7 @@ const ConfirmTotpResetPasswordContainer = ({
         recoveryKeyExists,
         token,
         uid,
-        hasPasskey,
+        ...passkeySignals,
       },
       replace: true,
     });
@@ -93,7 +98,7 @@ const ConfirmTotpResetPasswordContainer = ({
         recoveryKeyExists,
         token,
         uid,
-        hasPasskey,
+        ...passkeySignals,
       },
       replace: false,
     });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/container.tsx
@@ -24,8 +24,8 @@ const ResetPasswordContainer = ({
   const navigateWithQuery = useNavigateWithQuery();
 
   // The account isn't known yet at reset entry, so the passkey footer is shown
-  // unconditionally when the feature is on — except for an active Sync sign-in,
-  // where a passkey can't recover Sync data in Phase 1.
+  // unconditionally when the feature is on — except for a Sync sign-in, which
+  // needs the account's wrap status to know a passkey can recover Sync data.
   const showPasskeyOption = shouldShowPasskeyResetOption(config, {
     serviceRequiresKeys: integration.isSync(),
   });

--- a/packages/fxa-settings/src/pages/ResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/interfaces.ts
@@ -10,9 +10,13 @@ export type ResetPasswordIntegration = Pick<
 >;
 
 /**
- * Passkey-aware reset-messaging signal from the /password/forgot/verify_otp
+ * Passkey-aware reset-messaging signals from the /password/forgot/verify_otp
  * response, threaded through the reset flow.
+ *
+ * `hasPasskeyWraps` means the account holds a key-wrap, so a passkey can recover
+ * its encryption keys without the password.
  */
 export type PasskeyResetSignals = {
   hasPasskey?: boolean;
+  hasPasskeyWraps?: boolean;
 };


### PR DESCRIPTION
## Because

- A Sync account whose passkey can recover its encryption keys should get the
  passkey wording on the reset footer; it was suppressed for every Sync sign-in
  while wraps did not exist.
- Wrap state describes account state, so it belongs on the email-verified step of
  the reset flow and on no unauthenticated route.

## This pull request

- Returns `hasPasskey` and `hasPasskeyWraps` from `/password/forgot/verify_otp`,
  both from one passkey lookup.
- Returns `hasPasskeyWraps` from `/password/forgot/verify_otp` and adds it to the
  auth-client return type.
- Threads the passkey signals through the reset flow as one grouped object.
- Gates the passkey reset footer on a stored wrap plus `passkeyPasswordlessSyncEnabled`
  for Sync, failing closed when either is unknown.
- Asserts the flag is absent from `/account/status` and never looked up there.

## Issue that this pull request solves

Closes: FXA-14220

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/routes/password.ts` for the new lookup and its
  gating, and `lib/passkeys/should-show-passkey-reset-option.ts` for the footer decision.
- Suggested review order: `passkey.wrap.repository.ts` → `passkey.service.ts` →
  `routes/password.ts` → `should-show-passkey-reset-option.ts` → the reset-flow containers.
- Risky or complex parts: the exposure boundary. `hasPasskeyWraps` must stay off
  `/account/status`; `account.spec.ts` asserts both the handler omission and the
  Joi schema rejection.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Both signals come from the existing per-credential wrap-state lookup, so this
  adds nothing to `libs/accounts/passkey` and the route makes one query where it
  previously made two.
- The Sync branch also requires `passkeyPasswordlessSyncEnabled`, beyond the ticket's
  acceptance criteria. Wrap storage can ship ahead of wrap consumption, and without
  the gate the footer would send a user mid-reset to a passkey sign-in that asks for
  the password they just declared forgotten.
