### PR TITLE
fix(settings): stop reporting expected pairing channel closes to Sentry

### DIFF
--- a/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
@@ -208,6 +208,56 @@ describe('PairingChannelClient', () => {
       expect(onError).toHaveBeenCalled();
     });
 
+    it('reports an unexpected connect rejection to Sentry', async () => {
+      const {
+        PairingChannel,
+      } = require('fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js');
+      const sentryMetrics = require('fxa-shared/sentry/browser');
+      const err = new Error('connection refused');
+      PairingChannel.connect.mockRejectedValueOnce(err);
+
+      await client.open(SERVER, CHAN, VALID_KEY);
+
+      expect(sentryMetrics.captureException).toHaveBeenCalledWith(err);
+    });
+
+    // The channel server drops the socket for any channel it will not serve,
+    // which the supplicant hits routinely on its post-pairing reload.
+    it('dispatches a CONNECTION_CLOSED error when the socket closes during connect', async () => {
+      const {
+        PairingChannel,
+      } = require('fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js');
+      PairingChannel.connect.mockRejectedValueOnce(
+        new Error('WebSocket unexpectedly closed')
+      );
+      const onError = jest.fn();
+      client.addEventListener('error', onError);
+
+      await client.open(SERVER, CHAN, VALID_KEY);
+
+      expect(client.isConnected).toBe(false);
+      const detail = onError.mock.calls[0][0].detail;
+      expect(detail).toBeInstanceOf(PairingChannelError);
+      expect(detail.errno).toBe(1006);
+      expect(detail.message).toBe(
+        'Connection to remote device closed, please try again'
+      );
+    });
+
+    it('does not report a closed socket during connect to Sentry', async () => {
+      const {
+        PairingChannel,
+      } = require('fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js');
+      const sentryMetrics = require('fxa-shared/sentry/browser');
+      PairingChannel.connect.mockRejectedValueOnce(
+        new Error('WebSocket unexpectedly closed')
+      );
+
+      await client.open(SERVER, CHAN, VALID_KEY);
+
+      expect(sentryMetrics.captureException).not.toHaveBeenCalled();
+    });
+
     it('rejects concurrent open during in-flight connect', async () => {
       const {
         PairingChannel,

--- a/packages/fxa-settings/src/lib/channels/pairing-channel.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.ts
@@ -70,10 +70,9 @@ export type PairingChannelV2SupplicantRequestMessage = {
   code_challenge: string;
   code_challenge_method: string;
   keys_jwk: string;
-  scope:string;
-  state:string;
-}
-
+  scope: string;
+  state: string;
+};
 
 // Error definitions matching Backbone's pairing-channel-client-errors
 export const PairingChannelErrors = {
@@ -118,6 +117,20 @@ export class PairingChannelError extends Error {
     this.name = 'PairingChannelError';
     this.errno = def.errno;
   }
+}
+
+/**
+ * The channel server drops the socket rather than answering when the channel is
+ * gone — expired, already consumed by a completed pairing, or at its two-client
+ * limit. The same rejection covers a socket lost mid-handshake, which the
+ * supplicant's mobile webview hits on any network change or backgrounding.
+ * fxa-pairing-channel raises a bare Error for all of it, so the message is the
+ * only signal to match on.
+ */
+const CHANNEL_CLOSED_MESSAGE = 'WebSocket unexpectedly closed';
+
+function isChannelClosedError(err: unknown): boolean {
+  return err instanceof Error && err.message === CHANNEL_CLOSED_MESSAGE;
 }
 
 /**
@@ -245,8 +258,21 @@ export class PairingChannelClient extends EventTarget {
       channel.addEventListener('error', this.handleError);
       channel.addEventListener('close', this.handleClose);
     } catch (err) {
-      sentryMetrics.captureException(err);
-      this.dispatchEvent(new CustomEvent('error', { detail: err }));
+      // A dropped socket is the channel server's normal answer for a channel it
+      // will not serve, so it carries no signal worth an exception report. The
+      // flow still ends on the failure screen; the console breadcrumb keeps it
+      // visible in the trail of any real error that follows.
+      if (isChannelClosedError(err)) {
+        console.warn('Pairing channel closed before it opened', channelId);
+        this.dispatchEvent(
+          new CustomEvent('error', {
+            detail: new PairingChannelError('CONNECTION_CLOSED'),
+          })
+        );
+      } else {
+        sentryMetrics.captureException(err);
+        this.dispatchEvent(new CustomEvent('error', { detail: err }));
+      }
     } finally {
       this._opening = false;
     }
@@ -257,11 +283,11 @@ export class PairingChannelClient extends EventTarget {
     data: Record<string, unknown> = {}
   ): Promise<void> {
     if (!this.channel) {
-      console.warn('No pairing channel!')
+      console.warn('No pairing channel!');
       throw new PairingChannelError('NOT_CONNECTED');
     }
     if (!message) {
-      console.warn('No message!')
+      console.warn('No message!');
       throw new PairingChannelError('INVALID_OUTBOUND_MESSAGE');
     }
     console.info('Sending pairing message', message);
@@ -276,10 +302,10 @@ export class PairingChannelClient extends EventTarget {
     this.channel = null;
     this.removeChannelListeners(ch);
     try {
-      console.info('Closing channel ', ch._channelId)
+      console.info('Closing channel ', ch._channelId);
       await ch.close();
     } catch (err) {
-      console.error("Error closing channel", err);
+      console.error('Error closing channel', err);
       sentryMetrics.captureException(err);
     }
   }
@@ -307,7 +333,7 @@ export class PairingChannelClient extends EventTarget {
 
       const { data = {}, message } = payload;
 
-      console.info(`Receiving pairing message`, message)
+      console.info(`Receiving pairing message`, message);
 
       // Enrich with sender metadata (same shape as Backbone)
       data.remoteMetaData = {


### PR DESCRIPTION
## Because

- `PairingChannelClient.open()` reported every connect failure to Sentry, but a dropped socket is the channel server's normal answer for a channel it will not serve.
- The mobile supplicant hits that on its post-pairing reload — a path the integration already ignores — and on any webview network change.
- Triage already tracks "WebSocket unexpectedly closed" as known client-side noise.

## This pull request

- Classifies a closed socket during connect and dispatches `CONNECTION_CLOSED` (errno 1006) rather than capturing an exception.
- Leaves every other connect failure reporting to Sentry.
- Logs the suppressed close as a console breadcrumb.
- Adds tests for both sides of the split.

## Issue that this pull request solves

Closes: FXA-14444

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- 6 of the deleted lines are prettier churn the pre-commit hook applied to pre-existing formatting in the same file.
- `create()` on the authority side still reports closed sockets; this ticket is scoped to `open()`.
- FXA-14483 (stacked PR) fixes two further defects in the same catch block.
