### PR TITLE
fix(pair): let a failed channel open be retried

### DIFF
--- a/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
@@ -73,6 +73,19 @@ describe('PairingChannelClient', () => {
       expect(onConnected).toHaveBeenCalled();
     });
 
+    // A message can land in the same tick the handshake completes, so the
+    // listeners have to be attached by the time `connected` observers run.
+    it('registers channel listeners before dispatching connected', async () => {
+      let listenersAtConnected = 0;
+      client.addEventListener('connected', () => {
+        listenersAtConnected = mockChannel.addEventListener.mock.calls.length;
+      });
+
+      await client.open(SERVER, CHAN, VALID_KEY);
+
+      expect(listenersAtConnected).toBe(3);
+    });
+
     it('throws for missing params', async () => {
       await expect(client.open('', CHAN, VALID_KEY)).rejects.toThrow(
         'Invalid channel server configuration'
@@ -215,7 +228,9 @@ describe('PairingChannelClient', () => {
 
       const onError = jest.fn();
       client.addEventListener('error', onError);
-      await client.open(SERVER, CHAN, VALID_KEY);
+      await expect(client.open(SERVER, CHAN, VALID_KEY)).rejects.toThrow(
+        'connection refused'
+      );
 
       expect(client.isConnected).toBe(false);
       expect(onError).toHaveBeenCalled();
@@ -229,7 +244,7 @@ describe('PairingChannelClient', () => {
       const err = new Error('connection refused');
       PairingChannel.connect.mockRejectedValueOnce(err);
 
-      await client.open(SERVER, CHAN, VALID_KEY);
+      await expect(client.open(SERVER, CHAN, VALID_KEY)).rejects.toThrow(err);
 
       expect(sentryMetrics.captureException).toHaveBeenCalledWith(err);
     });
@@ -246,7 +261,9 @@ describe('PairingChannelClient', () => {
       const onError = jest.fn();
       client.addEventListener('error', onError);
 
-      await client.open(SERVER, CHAN, VALID_KEY);
+      await expect(client.open(SERVER, CHAN, VALID_KEY)).rejects.toThrow(
+        'Connection to remote device closed, please try again'
+      );
 
       expect(client.isConnected).toBe(false);
       const detail = onError.mock.calls[0][0].detail;
@@ -266,9 +283,27 @@ describe('PairingChannelClient', () => {
         new Error('WebSocket unexpectedly closed')
       );
 
-      await client.open(SERVER, CHAN, VALID_KEY);
+      await expect(client.open(SERVER, CHAN, VALID_KEY)).rejects.toThrow(
+        PairingChannelError
+      );
 
       expect(sentryMetrics.captureException).not.toHaveBeenCalled();
+    });
+
+    it('allows a retry after a failed open', async () => {
+      const {
+        PairingChannel,
+      } = require('fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js');
+      PairingChannel.connect.mockRejectedValueOnce(
+        new Error('WebSocket unexpectedly closed')
+      );
+      await expect(client.open(SERVER, CHAN, VALID_KEY)).rejects.toThrow(
+        PairingChannelError
+      );
+
+      await client.open(SERVER, CHAN, VALID_KEY);
+
+      expect(client.isConnected).toBe(true);
     });
 
     it('rejects concurrent open during in-flight connect', async () => {

--- a/packages/fxa-settings/src/lib/channels/pairing-channel.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.ts
@@ -259,27 +259,36 @@ export class PairingChannelClient extends EventTarget {
       );
 
       this.channel = channel;
-      this.dispatchEvent(new CustomEvent('connected'));
 
+      // Listeners go on before `connected` so a message that arrives in the
+      // same tick as the handshake completing is not dropped.
       channel.addEventListener('message', this.handleMessage);
       channel.addEventListener('error', this.handleError);
       channel.addEventListener('close', this.handleClose);
+
+      this.dispatchEvent(new CustomEvent('connected'));
     } catch (err) {
       // A dropped socket is the channel server's normal answer for a channel it
       // will not serve, so it carries no signal worth an exception report. The
-      // flow still ends on the failure screen; the console breadcrumb keeps it
-      // visible in the trail of any real error that follows.
-      if (isChannelClosedError(err)) {
+      // console breadcrumb keeps it visible in the trail of any real error
+      // that follows.
+      const closed = isChannelClosedError(err);
+      if (closed) {
         console.warn('Pairing channel closed before it opened', channelId);
-        this.dispatchEvent(
-          new CustomEvent('error', {
-            detail: new PairingChannelError('CONNECTION_CLOSED'),
-          })
-        );
       } else {
         sentryMetrics.captureException(err);
-        this.dispatchEvent(new CustomEvent('error', { detail: err }));
       }
+
+      // Report the closed socket under its own errno so a caller reading the
+      // error sees the same 1006 a mid-flow close produces.
+      const detail = closed
+        ? new PairingChannelError('CONNECTION_CLOSED')
+        : err;
+      this.dispatchEvent(new CustomEvent('error', { detail }));
+
+      // Rejecting is what lets the caller drop this instance; resolving leaves
+      // a client that looks live and blocks every later reopen.
+      throw detail;
     } finally {
       this._opening = false;
     }

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
@@ -429,6 +429,37 @@ describe('PairingSupplicantIntegration', () => {
       expect(integration.state).toBe(SupplicantState.Failed);
       expect(onError).toHaveBeenCalled();
     });
+
+    // The channel server refuses the socket outright for a channel already
+    // consumed, so the Android post-OAuth reload sees the rejection rather
+    // than a close event on a live channel.
+    it('open failure while still Connecting is ignored when completion marker is set', async () => {
+      sessionStorage.setItem(PAIR_COMPLETE_STORAGE_PREFIX + 'c', '1');
+      mockOpen.mockRejectedValueOnce(
+        new Error('Connection to remote device closed, please try again')
+      );
+      const integration = createIntegration();
+      const onError = jest.fn();
+      const onStateChange = jest.fn();
+      integration.onError = onError;
+      integration.onStateChange = onStateChange;
+
+      await integration.openChannel('wss://ch.example.com', 'c', 'k');
+
+      expect(integration.state).toBe(SupplicantState.Connecting);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onStateChange).not.toHaveBeenCalled();
+    });
+
+    it('allows a retry on the same channel after a failed open', async () => {
+      mockOpen.mockRejectedValueOnce(new Error('ws connect failed'));
+      const integration = createIntegration();
+
+      await integration.openChannel('wss://ch.example.com', 'c', 'k');
+      await integration.openChannel('wss://ch.example.com', 'c', 'k');
+
+      expect(mockOpen).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('authority cancel', () => {

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
@@ -292,10 +292,8 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
       // Reset _channel so a subsequent openChannel() call can retry
       this._channel = null;
       // A consumed channel refusing the socket is the post-OAuth reload, not a
-      // failure. open() dispatches an `error` event before it rejects, so
-      // handleChannelError has usually settled the state by now; fail() is a
-      // no-op once it has, and still catches the errors raised before any
-      // event went out.
+      // failure. fail() still has to run for the config and already-connected
+      // errors, which reject before open() dispatches any `error` event.
       if (!this.isPostCompletionReconnect()) {
         this.fail(err);
       }
@@ -336,7 +334,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
 
       // Send OAuth request to authority
       if (!this._channel) {
-        throw new Error('Channel no longe exists!');
+        throw new Error('Channel no longer exists!');
       }
       await this._channel.send('pair:supp:request', oauthParams);
     })().catch((err: unknown) => {

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
@@ -291,7 +291,14 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     } catch (err: unknown) {
       // Reset _channel so a subsequent openChannel() call can retry
       this._channel = null;
-      this.fail(err);
+      // A consumed channel refusing the socket is the post-OAuth reload, not a
+      // failure. open() dispatches an `error` event before it rejects, so
+      // handleChannelError has usually settled the state by now; fail() is a
+      // no-op once it has, and still catches the errors raised before any
+      // event went out.
+      if (!this.isPostCompletionReconnect()) {
+        this.fail(err);
+      }
     }
   }
 


### PR DESCRIPTION
## Because

- `open()` resolved on a failed connect, so `openChannel()`'s catch never cleared its client reference; every later call returned early on "Pairing channel already open!".
- The supplicant could not retry a channel after a flaky network or a consumed channel id, short of a full page reload.
- `create()` rethrows and attaches its listeners before `connected`; `open()` did neither.

## This pull request

- Rejects from `open()` once the error event has gone out.
- Guards `openChannel()`'s catch with `isPostCompletionReconnect()`.
- Attaches the channel listeners before dispatching `connected`.
- Adds regression tests for the retry path, the listener order, and the reload guard.

## Issue that this pull request solves

Closes: FXA-14483

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the `open()` catch in `pairing-channel.ts`, and the `openChannel()` catch in `pairing-supplicant-integration.ts`.
- Suggested review order: the new reject in `pairing-channel.ts`, then the integration guard that absorbs it, then the tests.
- Risky or complex parts: the guard. With `open()` rejecting, the FXA-13616 post-OAuth Android reload would otherwise navigate to the failure screen. Removing the guard fails `open failure while still Connecting is ignored when completion marker is set` with `Expected "connecting", Received "failed"`.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Stacked on #21157 (FXA-14444). Base is `fxa-14444`; retarget to `main` once that merges.
- ~15 lines in `pairing-supplicant-integration.ts` are prettier churn from the pre-commit hook; the actual change there is the 7-line guard.
- The listener reorder has no repro today — no `await` separates the dispatch from the registration. Included because `create()` treats the order as load-bearing.
- FXA-14446 (`TLS Alert: DECODE_ERROR`) is another connect rejection reaching this catch block; expect a textual conflict if it lands first.
