### PR TITLE
fix(settings): reject pairing sends on a torn-down channel

### DIFF
--- a/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.test.ts
@@ -22,6 +22,7 @@ let mockChannel: {
   _channelId?: string;
   _channelKey?: Uint8Array;
   _connection?: unknown;
+  closed?: boolean;
 };
 
 jest.mock(
@@ -56,6 +57,7 @@ describe('PairingChannelClient', () => {
       // 'testkey1' — the same bytes VALID_KEY decodes to.
       _channelId: CHAN,
       _channelKey: new TextEncoder().encode('testkey1'),
+      closed: false,
     };
     jest.clearAllMocks();
     client = new PairingChannelClient();
@@ -184,6 +186,16 @@ describe('PairingChannelClient', () => {
 
     it('throws when not connected', async () => {
       await expect(client.send('msg')).rejects.toThrow('Not connected');
+    });
+
+    it('throws CONNECTION_CLOSED when the channel is torn down', async () => {
+      await client.open(SERVER, CHAN, VALID_KEY);
+      mockChannel.closed = true;
+
+      await expect(client.send('pair:supp:authorize')).rejects.toMatchObject({
+        errno: 1006,
+      });
+      expect(mockChannel.send).not.toHaveBeenCalled();
     });
 
     it('throws for empty message', async () => {

--- a/packages/fxa-settings/src/lib/channels/pairing-channel.ts
+++ b/packages/fxa-settings/src/lib/channels/pairing-channel.ts
@@ -156,6 +156,8 @@ type PairingChannelSocket = {
    * socket goes away, and the package's `close()` dereferences it unguarded.
    */
   _connection?: unknown;
+  /** True once fxa-pairing-channel has torn the WebSocket down. */
+  readonly closed?: boolean;
 };
 
 export class PairingChannelClient extends EventTarget {
@@ -290,6 +292,10 @@ export class PairingChannelClient extends EventTarget {
     if (!this.channel) {
       console.warn('No pairing channel!');
       throw new PairingChannelError('NOT_CONNECTED');
+    }
+    if (this.channel.closed) {
+      console.warn('Pairing channel is closed!');
+      throw new PairingChannelError('CONNECTION_CLOSED');
     }
     if (!message) {
       console.warn('No message!');


### PR DESCRIPTION
## Because

- When the channel-server socket dies mid-pairing, `fxa-pairing-channel` dispatches `error` rather than `close`, so the wrapper keeps using a channel the library has already discarded.
- Sending on that channel reported a raw `TypeError` with no errno instead of a pairing error the flow could act on.
- The authority sends an OAuth `code`/`state` immediately after minting it, so the send should refuse a dead socket before handing anything over.

## This pull request

- Throws `CONNECTION_CLOSED` (errno 1006) from `PairingChannelClient.send()` when the underlying channel reports itself `closed`.
- Adds unit coverage for send after teardown.

## Issue that this pull request solves

Closes: FXA-14484

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: the `send()` guard in `packages/fxa-settings/src/lib/channels/pairing-channel.ts`.
- Suggested review order: the guard, then the new test. Skip the 9 deleted lines — lint-staged prettier churn (semicolons, quote style, `scope:string`), not the fix.
- Risky or complex parts: the guard reads the `closed` getter from `fxa-pairing-channel` 1.0.2 (`!this._socket || readyState === 3`). Verified by removing the guard and confirming the new test fails.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Companion to #21152 (FXA-14443 / FXA-14445), which guards the `close()` path in the same file. Expect a small conflict on the `PairingChannelSocket` type if that lands first — #21152 adds `_connection`, this adds the public `closed` getter.
- `/fxa-security-review` covered this guard on the earlier branch: no Critical or High findings.
- Sibling Sentry bug FXA-14446 (TLS `DECODE_ERROR`) is one path that tears the channel down; not fixed here.
