### PR TITLE
feat(passkey): Surface wrap state on the passkey endpoints

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.manager.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.ts
@@ -17,10 +17,12 @@ import {
   findPasskeyByCredentialId as repositoryFindPasskeyByCredentialId,
   findPasskeyByUidAndCredentialId as repositoryFindPasskeyByUidAndCredentialId,
   findPasskeysByUid,
+  findPasskeysWithWrapStateByUid,
   insertPasskey,
   isMysqlDupEntry,
   NewPasskeyData,
   PasskeyRecord,
+  PasskeyWithWrapState,
   updatePasskeyCounterAndLastUsed,
   updatePasskeyName,
   updatePasskeyPrfEnabled,
@@ -170,6 +172,18 @@ export class PasskeyManager {
    */
   async listPasskeysForUser(uid: string): Promise<PasskeyRecord[]> {
     return findPasskeysByUid(this.db, uid);
+  }
+
+  /**
+   * List all passkeys for a user, each flagged with whether it holds a wrap.
+   *
+   * @param uid - User ID as a hex string
+   * @returns Array of passkeys ordered by createdAt descending
+   */
+  async listPasskeysWithWrapStateForUser(
+    uid: string
+  ): Promise<PasskeyWithWrapState[]> {
+    return findPasskeysWithWrapStateByUid(this.db, uid);
   }
 
   /**

--- a/libs/accounts/passkey/src/lib/passkey.repository.ts
+++ b/libs/accounts/passkey/src/lib/passkey.repository.ts
@@ -105,6 +105,14 @@ export type PasskeyRecord = Omit<Passkey, 'aaguid' | 'credentialId'> & {
   credentialId: string;
 };
 
+/**
+ * A passkey plus whether it holds a wrap, and so can unlock `kB` without a
+ * password.
+ */
+export type PasskeyWithWrapState = PasskeyRecord & {
+  hasPasswordlessSync: boolean;
+};
+
 function toPasskeyRecord(row: Passkey): PasskeyRecord {
   return {
     ...row,
@@ -147,6 +155,40 @@ export async function findPasskeysByUid(
     .orderBy('credentialId', 'asc')
     .execute();
   return rows.map(toPasskeyRecord);
+}
+
+/**
+ * Find all passkeys for a user, each flagged with whether it holds a wrap.
+ *
+ * One LEFT JOIN rather than a lookup per passkey: this backs `GET /passkeys`
+ * and `/account`, both of which run on every Settings page load.
+ *
+ * @param db - Database instance
+ * @param uid - User ID as a hex string
+ * @returns Array of passkeys ordered by createdAt descending
+ */
+export async function findPasskeysWithWrapStateByUid(
+  db: AccountDatabase,
+  uid: string
+): Promise<PasskeyWithWrapState[]> {
+  const rows = await db
+    .selectFrom('passkeys')
+    .leftJoin('passkeyWraps', (join) =>
+      join
+        .onRef('passkeyWraps.uid', '=', 'passkeys.uid')
+        .onRef('passkeyWraps.credentialId', '=', 'passkeys.credentialId')
+    )
+    .selectAll('passkeys')
+    .select('passkeyWraps.createdAt as wrapCreatedAt')
+    .where('passkeys.uid', '=', uuidTransformer.to(uid))
+    .orderBy('passkeys.createdAt', 'desc')
+    .orderBy('passkeys.credentialId', 'asc')
+    .execute();
+
+  return rows.map(({ wrapCreatedAt, ...row }) => ({
+    ...toPasskeyRecord(row),
+    hasPasswordlessSync: wrapCreatedAt !== null,
+  }));
 }
 
 /**

--- a/libs/accounts/passkey/src/lib/passkey.service.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.spec.ts
@@ -135,6 +135,7 @@ describe('PasskeyService', () => {
       | 'checkPasskeyCount'
       | 'registerPasskey'
       | 'listPasskeysForUser'
+      | 'listPasskeysWithWrapStateForUser'
       | 'countPasskeys'
       | 'findPasskeyByCredentialId'
       | 'findPasskeyByUidAndCredentialId'
@@ -149,6 +150,7 @@ describe('PasskeyService', () => {
     checkPasskeyCount: jest.fn(),
     registerPasskey: jest.fn(),
     listPasskeysForUser: jest.fn(),
+    listPasskeysWithWrapStateForUser: jest.fn(),
     countPasskeys: jest.fn(),
     findPasskeyByCredentialId: jest.fn(),
     findPasskeyByUidAndCredentialId: jest.fn(),
@@ -1147,17 +1149,25 @@ describe('PasskeyService', () => {
   });
 
   describe('listPasskeysForUser', () => {
-    const mockPasskeys = [passkeyRecord({ name: 'Passkey' })];
+    const mockPasskeys = [
+      { ...passkeyRecord({ name: 'Passkey' }), hasPasswordlessSync: true },
+    ];
 
-    it('returns passkeys from manager', async () => {
-      mockManager.listPasskeysForUser.mockResolvedValue(mockPasskeys);
+    it('returns passkeys with their wrap state', async () => {
+      mockManager.listPasskeysWithWrapStateForUser.mockResolvedValue(
+        mockPasskeys
+      );
       const result = await service.listPasskeysForUser(MOCK_UID);
       expect(result).toBe(mockPasskeys);
-      expect(mockManager.listPasskeysForUser).toHaveBeenCalledWith(MOCK_UID);
+      expect(mockManager.listPasskeysWithWrapStateForUser).toHaveBeenCalledWith(
+        MOCK_UID
+      );
     });
 
     it('increments passkey.list.success metric', async () => {
-      mockManager.listPasskeysForUser.mockResolvedValue(mockPasskeys);
+      mockManager.listPasskeysWithWrapStateForUser.mockResolvedValue(
+        mockPasskeys
+      );
       await service.listPasskeysForUser(MOCK_UID);
       expect(mockMetrics.increment).toHaveBeenCalledWith(
         'passkey.list.success'

--- a/libs/accounts/passkey/src/lib/passkey.service.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.ts
@@ -21,6 +21,7 @@ import {
   isMysqlDupEntry,
   NewPasskeyData,
   PasskeyRecord,
+  PasskeyWithWrapState,
 } from './passkey.repository';
 import { PasskeyWrapEnvelope } from './passkey.wrap.repository';
 import type { PasskeyWrap } from '@fxa/shared/db/mysql/account';
@@ -266,8 +267,9 @@ export class PasskeyService {
    * @param uid - User ID as a hex string
    * @returns Array of passkeys belonging to the user
    */
-  async listPasskeysForUser(uid: string): Promise<PasskeyRecord[]> {
-    const passkeys = await this.passkeyManager.listPasskeysForUser(uid);
+  async listPasskeysForUser(uid: string): Promise<PasskeyWithWrapState[]> {
+    const passkeys =
+      await this.passkeyManager.listPasskeysWithWrapStateForUser(uid);
     this.metrics.increment('passkey.list.success');
     return passkeys;
   }

--- a/libs/accounts/passkey/src/lib/passkey.wrap.repository.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.wrap.repository.in.spec.ts
@@ -13,6 +13,7 @@ import { AccountManager } from '@fxa/shared/account/account';
 import {
   bufferToAaguid,
   findPasskeyByCredentialId,
+  findPasskeysWithWrapStateByUid,
   insertPasskey,
 } from './passkey.repository';
 import {
@@ -240,6 +241,83 @@ describe('PasskeyWrapRepository (Integration)', () => {
       await expect(
         findPasskeyWrap(db, uid, credentialId)
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('findPasskeysWithWrapStateByUid', () => {
+    /** Adds a second passkey to an existing account. */
+    async function addPasskey(uid: string) {
+      const passkey = PasskeyFactory({ prfEnabled: true });
+      const credentialId = passkey.credentialId.toString('base64url');
+      await insertPasskey(db, uid, {
+        ...passkey,
+        credentialId,
+        aaguid: bufferToAaguid(passkey.aaguid),
+      });
+      return credentialId;
+    }
+
+    it('flags only the passkeys that hold a wrap', async () => {
+      const { uid, credentialId: wrapped } = await createAccountWithPasskey();
+      const bare = await addPasskey(uid);
+      await insertPasskeyWrap(db, uid, envelope(wrapped), NOW);
+
+      const rows = await findPasskeysWithWrapStateByUid(db, uid);
+
+      expect(
+        Object.fromEntries(
+          rows.map((r) => [r.credentialId, r.hasPasswordlessSync])
+        )
+      ).toEqual({ [wrapped]: true, [bare]: false });
+    });
+
+    it('resolves wrap state in a single query', async () => {
+      const { uid, credentialId } = await createAccountWithPasskey();
+      await addPasskey(uid);
+      await addPasskey(uid);
+      await insertPasskeyWrap(db, uid, envelope(credentialId), NOW);
+
+      // `transformQuery` runs once per compiled query, so it counts round
+      // trips without reaching into the driver.
+      let queries = 0;
+      const counted = db.withPlugin({
+        transformQuery(args) {
+          queries++;
+          return args.node;
+        },
+        async transformResult(args) {
+          return args.result;
+        },
+      });
+
+      const rows = await findPasskeysWithWrapStateByUid(counted, uid);
+
+      // Three passkeys, one round trip: a per-row lookup would make this an
+      // N+1 on a route that runs on every Settings page load.
+      expect(rows).toHaveLength(3);
+      expect(queries).toBe(1);
+    });
+
+    it("does not see another account's wrap", async () => {
+      const { uid, credentialId } = await createAccountWithPasskey();
+      const other = await createAccountWithPasskey();
+      await insertPasskeyWrap(db, other.uid, envelope(other.credentialId), NOW);
+
+      const rows = await findPasskeysWithWrapStateByUid(db, uid);
+
+      expect(rows).toEqual([
+        expect.objectContaining({ credentialId, hasPasswordlessSync: false }),
+      ]);
+    });
+
+    it('returns nothing for an account with no passkeys', async () => {
+      const uid = await accountManager.createAccountStub(
+        faker.internet.email(),
+        1,
+        'en-US'
+      );
+
+      expect(await findPasskeysWithWrapStateByUid(db, uid)).toEqual([]);
     });
   });
 });

--- a/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
@@ -54,8 +54,7 @@ const PASSKEY_REGISTRATION_FINISH_POST = {
       - \`response\` (object, required) — RegistrationResponseJSON from the browser
       - \`challenge\` (string, required) — The challenge returned by the start endpoint
 
-      **Response:** passkey metadata including \`credentialId\`, \`name\`,
-      \`createdAt\`, \`lastUsedAt\`, and \`transports\`.
+      **Response:** passkey metadata, the same shape \`GET /passkeys\` returns.
     `,
   ],
 };
@@ -134,7 +133,10 @@ const PASSKEYS_API_DOCS = {
         from the response as they are internal implementation details.
 
         **Response:** Array of passkey metadata objects, each containing
-        \`credentialId\`, \`name\`, \`createdAt\`, \`lastUsedAt\`, \`transports\`, and \`prfEnabled\`.
+        \`credentialId\`, \`name\`, \`createdAt\`, \`lastUsedAt\`, \`transports\`, \`prfEnabled\`,
+        and \`hasPasswordlessSync\` — whether the passkey holds a wrap and can
+        therefore unlock \`kB\` without a password. Only the routes that list
+        passkeys resolve that last field.
       `,
     ],
   },
@@ -176,8 +178,7 @@ const PASSKEYS_API_DOCS = {
         **Request body:**
         - \`name\` (string, required) — new display name (1–255 chars)
 
-        **Response:** Updated passkey metadata including \`credentialId\`, \`name\`,
-        \`createdAt\`, \`lastUsedAt\`, \`transports\`, and \`prfEnabled\`.
+        **Response:** the updated passkey, the same shape \`GET /passkeys\` returns.
       `,
     ],
   },

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -4808,6 +4808,7 @@ describe('/account', () => {
       backupEligible: true,
       backupState: false,
       prfEnabled: true,
+      hasPasswordlessSync: true,
     };
 
     function buildPasskeysRoute(
@@ -4845,6 +4846,7 @@ describe('/account', () => {
         backupEligible: mockPasskey.backupEligible,
         backupState: mockPasskey.backupState,
         prfEnabled: mockPasskey.prfEnabled,
+        hasPasswordlessSync: mockPasskey.hasPasswordlessSync,
       });
     });
 
@@ -5044,6 +5046,7 @@ describe('/account response schema - passkeys', () => {
     backupEligible: true,
     backupState: true,
     prfEnabled: false,
+    hasPasswordlessSync: false,
   };
 
   let schema: Schema;

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -71,7 +71,7 @@ import { FxaMailerFormat } from '../senders/fxa-mailer-format';
 import { OAuthClientInfoServiceName } from '../senders/oauth_client_info';
 import { BackupCodeManager } from '@fxa/accounts/two-factor';
 import { RecoveryPhoneService } from '@fxa/accounts/recovery-phone';
-import { PasskeyService, PasskeyRecord } from '@fxa/accounts/passkey';
+import { PasskeyService, PasskeyWithWrapState } from '@fxa/accounts/passkey';
 import {
   BOUNCE_TYPE_HARD,
   escapeLikePattern,
@@ -2392,7 +2392,7 @@ export class AccountHandler {
 
     const passkeys =
       passkeysResult.status === 'fulfilled'
-        ? (passkeysResult.value as PasskeyRecord[]).map(
+        ? (passkeysResult.value as PasskeyWithWrapState[]).map(
             ({
               credentialId,
               name,
@@ -2403,6 +2403,7 @@ export class AccountHandler {
               backupEligible,
               backupState,
               prfEnabled,
+              hasPasswordlessSync,
             }) => ({
               credentialId,
               name,
@@ -2413,6 +2414,7 @@ export class AccountHandler {
               backupEligible,
               backupState,
               prfEnabled,
+              hasPasswordlessSync,
             })
           )
         : [];

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -104,6 +104,7 @@ describe('passkeys routes', () => {
     backupEligible: true,
     backupState: false,
     prfEnabled: true,
+    hasPasswordlessSync: true,
   };
 
   async function runTest(
@@ -652,6 +653,7 @@ describe('passkeys routes', () => {
         backupEligible: mockPasskeyRecord.backupEligible,
         backupState: mockPasskeyRecord.backupState,
         prfEnabled: mockPasskeyRecord.prfEnabled,
+        hasPasswordlessSync: mockPasskeyRecord.hasPasswordlessSync,
       });
       expect(result[0]).not.toHaveProperty('publicKey');
       expect(result[0]).not.toHaveProperty('signCount');
@@ -2101,6 +2103,7 @@ describe('passkeys routes', () => {
       backupEligible: true,
       backupState: true,
       prfEnabled: false,
+      hasPasswordlessSync: false,
     };
     const BAD_AAGUID_PASSKEY = {
       ...VALID_PASSKEY,

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -55,6 +55,8 @@ export const passkeyResponseSchema = isA.object({
   backupEligible: isA.boolean().required(),
   backupState: isA.boolean().required(),
   prfEnabled: isA.boolean().required(),
+  // Optional: only the routes that list passkeys resolve wrap state.
+  hasPasswordlessSync: isA.boolean().optional(),
 });
 
 /** Subset of the Customs service used by passkey routes. */
@@ -292,6 +294,7 @@ export class PasskeyHandler {
         backupEligible,
         backupState,
         prfEnabled,
+        hasPasswordlessSync,
       }) => ({
         credentialId,
         name,
@@ -302,6 +305,7 @@ export class PasskeyHandler {
         backupEligible,
         backupState,
         prfEnabled,
+        hasPasswordlessSync,
       })
     );
   }


### PR DESCRIPTION
## Because

- Settings needs to know which passkeys can already unlock `kB`, to show a Sync-ready state and gate the upgrade CTA.

## This pull request

- Adds a required `hasPasswordlessSync` to the shared passkey response schema, so every route returning a passkey carries it.
- Resolves wrap existence for a list in one LEFT JOIN.

## Issue that this pull request solves

Closes: FXA-14154

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- `passkeyResponseSchema` is shared by four routes, so the field is populated at all four: the two list routes from the join, rename from a single lookup, and registration-finish as a constant `false`.
