### PR TITLE
feat(webhooks): add the account deletion reason into webhooks

### DIFF
--- a/apps/payments/api/src/scripts/test-fxa-webhook.ts
+++ b/apps/payments/api/src/scripts/test-fxa-webhook.ts
@@ -65,7 +65,7 @@ const EVENT_URIS: Record<string, string> = {
 function buildEventPayload(eventType: string): Record<string, any> {
   switch (eventType) {
     case 'delete':
-      return {};
+      return { reason: 'user' };
     case 'password':
       return { changeTime: Date.now() };
     case 'profile':

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.schemas.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.schemas.ts
@@ -26,7 +26,10 @@ export const fxaSubscriptionStateChangeEventSchema = z.object({
   changeTime: z.number(),
 });
 
-export const fxaDeleteUserEventSchema = z.object({});
+export const fxaDeleteUserEventSchema = z.object({
+  reason: z.string().optional(),
+});
+
 export const fxaMetricsOptOutEventSchema = z.object({});
 export const fxaMetricsOptInEventSchema = z.object({});
 

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.service.spec.ts
@@ -254,9 +254,10 @@ describe('FxaWebhookService', () => {
       );
     });
 
-    it('handles delete-user event', async () => {
+    it('handles a delete-user event with a reason', async () => {
+      const reason = 'user';
       const token = await signToken({
-        [FXA_DELETE_EVENT_URI]: {},
+        [FXA_DELETE_EVENT_URI]: { reason },
       });
 
       await service.handleWebhookEvent(`Bearer ${token}`);
@@ -264,10 +265,26 @@ describe('FxaWebhookService', () => {
       expect(statsd.increment).toHaveBeenCalledWith('fxa.webhook.event', {
         eventType: 'delete-user',
       });
-      expect(logger.log).toHaveBeenCalledWith(
-        'handleDeleteUser',
-        expect.objectContaining({ sub: TEST_UID })
+      expect(logger.log).toHaveBeenCalledWith('handleDeleteUser', {
+        sub: TEST_UID,
+        event: { reason },
+      });
+      expect(paymentsGleanService.handleUserDelete).toHaveBeenCalledWith(
+        TEST_UID
       );
+    });
+
+    it('handles a legacy delete-user event without a reason', async () => {
+      const token = await signToken({
+        [FXA_DELETE_EVENT_URI]: {},
+      });
+
+      await service.handleWebhookEvent(`Bearer ${token}`);
+
+      expect(logger.log).toHaveBeenCalledWith('handleDeleteUser', {
+        sub: TEST_UID,
+        event: {},
+      });
       expect(paymentsGleanService.handleUserDelete).toHaveBeenCalledWith(
         TEST_UID
       );

--- a/packages/fxa-auth-server/lib/account-delete-reason.spec.ts
+++ b/packages/fxa-auth-server/lib/account-delete-reason.spec.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
+
+import { toDeleteUserEventReason } from './account-delete-reason';
+
+describe('toDeleteUserEventReason', () => {
+  it.each([
+    {
+      reason: ReasonForDeletion.UserRequested,
+      expected: 'user',
+    },
+    {
+      reason: ReasonForDeletion.AdminRequested,
+      expected: 'admin',
+    },
+    {
+      reason: ReasonForDeletion.InactiveAccountScheduled,
+      expected: 'inactivity',
+    },
+    {
+      reason: ReasonForDeletion.InactiveAccountEmailBounced,
+      expected: 'inactivity',
+    },
+    {
+      reason: ReasonForDeletion.Unverified,
+      expected: 'unverified',
+    },
+  ])('maps $reason to $expected', ({ reason, expected }) => {
+    expect(toDeleteUserEventReason(reason)).toBe(expected);
+  });
+
+  it.each([
+    ReasonForDeletion.Cleanup,
+    ReasonForDeletion.EmailBounce,
+    ReasonForDeletion.InvalidEmail,
+    ReasonForDeletion.AccountRecreated,
+  ])('does not map %s', (reason) => {
+    expect(toDeleteUserEventReason(reason)).toBeUndefined();
+  });
+
+  it('does not map a missing reason', () => {
+    expect(toDeleteUserEventReason()).toBeUndefined();
+  });
+});

--- a/packages/fxa-auth-server/lib/account-delete-reason.ts
+++ b/packages/fxa-auth-server/lib/account-delete-reason.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
+
+export type DeleteUserEventReason =
+  | 'user'
+  | 'admin'
+  | 'inactivity'
+  | 'unverified';
+
+const DELETE_USER_EVENT_REASON_BY_INTERNAL_REASON: Record<
+  ReasonForDeletion,
+  DeleteUserEventReason | undefined
+> = {
+  [ReasonForDeletion.UserRequested]: 'user',
+  [ReasonForDeletion.AdminRequested]: 'admin',
+  [ReasonForDeletion.InactiveAccountScheduled]: 'inactivity',
+  [ReasonForDeletion.InactiveAccountEmailBounced]: 'inactivity',
+  [ReasonForDeletion.Unverified]: 'unverified',
+  [ReasonForDeletion.Cleanup]: undefined,
+  [ReasonForDeletion.EmailBounce]: undefined,
+  [ReasonForDeletion.InvalidEmail]: undefined,
+  [ReasonForDeletion.AccountRecreated]: undefined,
+};
+
+export function toDeleteUserEventReason(
+  reason?: ReasonForDeletion
+): DeleteUserEventReason | undefined {
+  return reason
+    ? DELETE_USER_EVENT_REASON_BY_INTERNAL_REASON[reason]
+    : undefined;
+}

--- a/packages/fxa-auth-server/lib/account-delete.spec.ts
+++ b/packages/fxa-auth-server/lib/account-delete.spec.ts
@@ -42,7 +42,7 @@ const expectedSubscriptions = [
   { uid, subscriptionId: '456' },
   { uid, subscriptionId: '789' },
 ];
-const deleteReason = 'fxa_user_requested_account_delete';
+const deleteReason = ReasonForDeletion.UserRequested;
 
 describe('AccountDeleteManager', () => {
   let mockFxaDb: any;
@@ -233,6 +233,28 @@ describe('AccountDeleteManager', () => {
       });
     });
 
+    it('notifies attached services with the reason', async () => {
+      await accountDeleteManager.deleteAccount(
+        uid,
+        ReasonForDeletion.AdminRequested
+      );
+
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledWith(
+        'delete',
+        {},
+        { uid, reason: 'admin' }
+      );
+    });
+
+    it('omits reason from the notification when the internal reason has no mapping', async () => {
+      await accountDeleteManager.deleteAccount(uid, ReasonForDeletion.Cleanup);
+
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledTimes(1);
+      const [, , payload] = mockLog.notifyAttachedServices.mock.calls[0];
+      expect(payload).toEqual({ uid });
+      expect(payload).not.toHaveProperty('reason');
+    });
+
     it('should delete even if already deleted from fxa db', async () => {
       const unknownError = AppError.unknownAccount('test@email.com');
       mockFxaDb.account = jest.fn().mockRejectedValue(unknownError);
@@ -246,6 +268,7 @@ describe('AccountDeleteManager', () => {
       expect(mockPush.notifyAccountDestroyed).toHaveBeenCalledTimes(0);
       expect(mockFxaDb.deleteAccount).toHaveBeenCalledTimes(0);
       expect(mockLog.activityEvent).toHaveBeenCalledTimes(0);
+      expect(mockLog.notifyAttachedServices).not.toHaveBeenCalled();
     });
 
     it('does not fail if pushbox fails to delete', async () => {
@@ -375,6 +398,11 @@ describe('AccountDeleteManager', () => {
       expect(mockOAuthDb.deleteAllConsentsForUser).toHaveBeenCalledWith(uid);
       expect(mockStatsd.increment).toHaveBeenCalledWith(
         'account.destroy.quick-delete'
+      );
+      expect(mockLog.notifyAttachedServices).toHaveBeenCalledWith(
+        'delete',
+        {},
+        { uid, reason: 'user' }
       );
     });
 

--- a/packages/fxa-auth-server/lib/account-delete.ts
+++ b/packages/fxa-auth-server/lib/account-delete.ts
@@ -32,6 +32,7 @@ import {
   InactiveStatusOAuthDb,
   requestForGlean,
 } from './inactive-accounts';
+import { toDeleteUserEventReason } from './account-delete-reason';
 
 type OAuthDbDeleteAccount = Pick<
   typeof OAuthDb,
@@ -261,8 +262,10 @@ export class AccountDeleteManager {
 
       try {
         await this.push.notifyAccountDestroyed(uid, devices);
+        const eventReason = toDeleteUserEventReason(reason);
         await this.log.notifyAttachedServices('delete', {} as AuthRequest, {
           uid,
+          ...(eventReason && { reason: eventReason }),
         });
       } catch (error) {
         this.log.error('accountDeleteManager.notify', {

--- a/packages/fxa-event-broker/src/delete-reason/delete-reason.spec.ts
+++ b/packages/fxa-event-broker/src/delete-reason/delete-reason.spec.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  DELETE_USER_EVENT_REASONS,
+  isDeleteUserEventReason,
+  narrowDeleteUserEventReason,
+} from './delete-reason';
+
+describe('isDeleteUserEventReason', () => {
+  it.each(DELETE_USER_EVENT_REASONS)('accepts %s', (reason) => {
+    expect(isDeleteUserEventReason(reason)).toBe(true);
+  });
+
+  it.each([
+    ['an unknown string', 'future_reason'],
+    ['an internal reason string', 'fxa_user_requested_account_delete'],
+    ['an empty string', ''],
+    ['undefined', undefined],
+    ['null', null],
+    ['a number', 1],
+    ['an object', { reason: 'user' }],
+  ])('rejects %s', (_label, value) => {
+    expect(isDeleteUserEventReason(value)).toBe(false);
+  });
+});
+
+describe('narrowDeleteUserEventReason', () => {
+  it.each(DELETE_USER_EVENT_REASONS)(
+    'returns %s as the reason',
+    (reason) => {
+      expect(narrowDeleteUserEventReason(reason)).toEqual({ reason });
+    }
+  );
+
+  it('classifies undefined as missing', () => {
+    expect(narrowDeleteUserEventReason(undefined)).toEqual({
+      fallback: 'missing',
+    });
+  });
+
+  it('classifies an unrecognized string as unknown_string', () => {
+    expect(narrowDeleteUserEventReason('future_reason')).toEqual({
+      fallback: 'unknown_string',
+    });
+  });
+
+  it.each([
+    ['null', null],
+    ['a number', 1],
+    ['an object', { reason: 'user' }],
+  ])('classifies %s as non_string', (_label, value) => {
+    expect(narrowDeleteUserEventReason(value)).toEqual({
+      fallback: 'non_string',
+    });
+  });
+});

--- a/packages/fxa-event-broker/src/delete-reason/delete-reason.ts
+++ b/packages/fxa-event-broker/src/delete-reason/delete-reason.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const DELETE_USER_EVENT_REASONS = [
+  'user',
+  'admin',
+  'inactivity',
+  'unverified',
+] as const;
+
+export type DeleteUserEventReason = (typeof DELETE_USER_EVENT_REASONS)[number];
+
+// statsd metric category labels
+export type DeleteUserEventReasonFallback =
+  | 'missing'
+  | 'unknown_string'
+  | 'non_string';
+
+export function isDeleteUserEventReason(
+  value: unknown
+): value is DeleteUserEventReason {
+  return DELETE_USER_EVENT_REASONS.includes(value as DeleteUserEventReason);
+}
+
+/**
+ * Returns the  reason when it is one of the known values, otherwise a fallback
+ * category as a metric tag.
+ */
+export function narrowDeleteUserEventReason(
+  value: unknown
+):
+  | { reason: DeleteUserEventReason }
+  | { fallback: DeleteUserEventReasonFallback } {
+  if (isDeleteUserEventReason(value)) {
+    return { reason: value };
+  }
+  if (value === undefined || value === '') {
+    return { fallback: 'missing' };
+  }
+  return {
+    fallback: typeof value === 'string' ? 'unknown_string' : 'non_string',
+  };
+}

--- a/packages/fxa-event-broker/src/jwtset/jwtset.service.spec.ts
+++ b/packages/fxa-event-broker/src/jwtset/jwtset.service.spec.ts
@@ -6,13 +6,14 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JWTool, PublicJWK } from '@fxa/vendored/jwtool';
 
 import { JwtsetService } from './jwtset.service';
+import { DELETE_USER_EVENT_REASONS } from '../delete-reason/delete-reason';
 import {
   PASSWORD_CHANGE_EVENT,
   PROFILE_CHANGE_EVENT,
   SUBSCRIPTION_UPDATE_EVENT,
   DELETE_EVENT,
 } from '../queueworker/sqs.dto';
-import { PROFILE_EVENT_ID } from './set.interface';
+import { DELETE_EVENT_ID, PROFILE_EVENT_ID } from './set.interface';
 
 const TEST_KEY = {
   d: 'nvfTzcMqVr8fa-b3IIFBk0J69sZQsyhKc3jYN5pPG7FdJyA-D5aPNv5zsF64JxNJetAS44cAsGAKN3Kh7LfjvLCtV56Ckg2tkBMn3GrbhE1BX6ObYvMuOBz5FJ9GmTOqSCxotAFRbR6AOBd5PCw--Rls4MylX393TFg6jJTGLkuYGuGHf8ILWyb17hbN0iyT9hME-cgLW1uc_u7oZ0vK9IxGPTblQhr82RBPQDTvZTM4s1wYiXzbJNrI_RGTAhdbwXuoXKiBN4XL0YRDKT0ENVqQLMiBwfdT3sW-M0L6kIv-L8qX3RIhbM3WA_a_LjTOM3WwRcNanSGiAeJLHwE5cQ',
@@ -113,6 +114,30 @@ describe('JwtsetService', () => {
       expect(payload.aud).toBe(TEST_CLIENT_ID);
       expect(payload.sub).toBe('uid1234');
       expect(payload.iss).toBe('test');
+    });
+
+    it.each(DELETE_USER_EVENT_REASONS)(
+      'includes the %s reason in a delete SET',
+      async (reason) => {
+        const token = await service.generateDeleteSET({
+          clientId: TEST_CLIENT_ID,
+          reason,
+          uid: 'uid1234',
+        });
+        const payload = await PUBLIC_JWT.verify(token);
+
+        expect(payload.events[DELETE_EVENT_ID]).toEqual({ reason });
+      }
+    );
+
+    it('keeps the delete event empty when the reason is omitted', async () => {
+      const token = await service.generateDeleteSET({
+        clientId: TEST_CLIENT_ID,
+        uid: 'uid1234',
+      });
+      const payload = await PUBLIC_JWT.verify(token);
+
+      expect(payload.events[DELETE_EVENT_ID]).toEqual({});
     });
   });
 });

--- a/packages/fxa-event-broker/src/jwtset/jwtset.service.ts
+++ b/packages/fxa-event-broker/src/jwtset/jwtset.service.ts
@@ -117,7 +117,9 @@ export class JwtsetService {
     return this.generateSET({
       clientId: delEvent.clientId,
       events: {
-        [set.DELETE_EVENT_ID]: {},
+        [set.DELETE_EVENT_ID]: delEvent.reason
+          ? { reason: delEvent.reason }
+          : {},
       },
       uid: delEvent.uid,
     });

--- a/packages/fxa-event-broker/src/jwtset/set.interface.ts
+++ b/packages/fxa-event-broker/src/jwtset/set.interface.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { DeleteUserEventReason } from '../delete-reason/delete-reason';
+
 // SET Event identifiers
 export const DELETE_EVENT_ID =
   'https://schemas.accounts.firefox.com/event/delete-user';
@@ -14,6 +16,7 @@ export const SUBSCRIPTION_STATE_EVENT_ID =
 
 export type deleteEvent = {
   clientId: string;
+  reason?: DeleteUserEventReason;
   uid: string;
 };
 

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
@@ -246,6 +246,38 @@ describe('PubsubProxy Controller', () => {
     }
   });
 
+  it('passes the delete reason to SET generation', async () => {
+    await (controller as any).generateSET(
+      {
+        event: dto.DELETE_EVENT,
+        reason: 'inactivity',
+        uid: 'uid1234',
+      },
+      TEST_CLIENT_ID
+    );
+
+    expect(jwtset.generateDeleteSET).toHaveBeenCalledWith({
+      clientId: TEST_CLIENT_ID,
+      reason: 'inactivity',
+      uid: 'uid1234',
+    });
+  });
+
+  it('omits an unrecognized delete reason from SET generation', async () => {
+    await (controller as any).generateSET(
+      {
+        event: dto.DELETE_EVENT,
+        reason: 'nonsense',
+        uid: 'uid1234',
+      },
+      TEST_CLIENT_ID
+    );
+
+    const [delEvent] = (jwtset.generateDeleteSET as jest.Mock).mock.calls[0];
+    expect(delEvent).toEqual({ clientId: TEST_CLIENT_ID, uid: 'uid1234' });
+    expect(delEvent).not.toHaveProperty('reason');
+  });
+
   it('records proxy.success timing using message.timestamp, not changeTime', async () => {
     // Simulate a password event where changeTime is years-old (the credential
     // generation timestamp) but timestamp reflects when the event was queued.

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
@@ -19,6 +19,7 @@ import { ExtendedError } from 'fxa-shared/nestjs/error';
 
 import { GoogleJwtAuthGuard } from '../auth/google-jwt-auth.guard';
 import { ClientWebhooksService } from '../client-webhooks/client-webhooks.service';
+import { isDeleteUserEventReason } from '../delete-reason/delete-reason';
 import { JwtsetService } from '../jwtset/jwtset.service';
 import * as dto from '../queueworker/sqs.dto';
 
@@ -187,6 +188,9 @@ export class PubsubProxyController {
         return await this.jwtset.generateDeleteSET({
           clientId,
           uid: message.uid,
+          ...(isDeleteUserEventReason(message.reason) && {
+            reason: message.reason,
+          }),
         });
       }
       case dto.PASSWORD_RESET_EVENT:

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -135,6 +135,7 @@ describe('QueueworkerService', () => {
       error: jest.fn(),
       debug: jest.fn(),
       info: jest.fn(),
+      warn: jest.fn(),
     };
     topic = {
       publishMessage: jest.fn().mockResolvedValue('mockid'),
@@ -340,6 +341,71 @@ describe('QueueworkerService', () => {
       const published = topic.publishMessage.mock.calls[0][0].json;
       expect(published.changeTime).toBe(messageWithoutGeneration.timestamp);
     });
+
+    it('preserves a known delete reason in the Pub/Sub message', async () => {
+      const msg = updateStubMessage({
+        ...baseDeleteMessage,
+        reason: 'unverified',
+      });
+
+      await (service as any).handleMessage(msg);
+
+      const published = topic.publishMessage.mock.calls[0][0].json;
+      expect(published.reason).toBe('unverified');
+      expect(firestore.deleteUser).toHaveBeenCalledWith(baseDeleteMessage.uid);
+      expect(metrics.increment).not.toHaveBeenCalledWith(
+        'message.delete.reasonFallback',
+        expect.anything()
+      );
+    });
+
+    it('accepts a legacy delete message without a reason', async () => {
+      const msg = updateStubMessage(baseDeleteMessage);
+
+      await (service as any).handleMessage(msg);
+
+      const published = topic.publishMessage.mock.calls[0][0].json;
+      expect(published).not.toHaveProperty('reason');
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'message.delete.reasonFallback',
+        { category: 'missing' }
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        category: 'unknown_string',
+        reason: 'nonsense',
+        rawValue: 'nonsense',
+      },
+      {
+        category: 'non_string',
+        reason: { rawValue: 'private_reason' },
+        rawValue: 'private_reason',
+      },
+    ])(
+      'drops a $category delete reason without suppressing deletion',
+      async ({ category, reason, rawValue }) => {
+        const msg = updateStubMessage({ ...baseDeleteMessage, reason });
+
+        await (service as any).handleMessage(msg);
+
+        const published = topic.publishMessage.mock.calls[0][0].json;
+        expect(published).not.toHaveProperty('reason');
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'message.delete.reasonFallback',
+          { category }
+        );
+        expect(JSON.stringify(metrics.increment.mock.calls)).not.toContain(
+          rawValue
+        );
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(firestore.deleteUser).toHaveBeenCalledWith(
+          baseDeleteMessage.uid
+        );
+      }
+    );
 
     const invalidMessages = {
       login: { ...baseLoginMessage, clientId: 'test1234' },

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -23,6 +23,10 @@ import * as Sentry from '@sentry/node';
 import { ClientCapabilityService } from '../client-capability/client-capability.service';
 import { ClientWebhooksService } from '../client-webhooks/client-webhooks.service';
 import { AppConfig } from '../config';
+import {
+  DeleteUserEventReason,
+  narrowDeleteUserEventReason,
+} from '../delete-reason/delete-reason';
 import { FirestoreService } from '../firestore/firestore.service';
 import { ServiceNotification } from './service-notification.interface';
 import * as dto from './sqs.dto';
@@ -35,6 +39,14 @@ function extractRegionFromUrl(url: string) {
     return matchResult[1];
   }
 }
+
+type MessageFanoutEventType = 'delete' | 'password' | 'profile';
+
+type MessageFanoutAdditionalEventProperties = {
+  delete?: { reason: DeleteUserEventReason };
+  password?: never;
+  profile?: never;
+};
 
 @Injectable()
 export class QueueworkerService
@@ -182,11 +194,13 @@ export class QueueworkerService
    * Generic fan-out of the message to the pubsub clientId queues.
    *
    * @param message Incoming SQS message type supported for generic fanout.
-   * @param eventType Event type to use for metrics
+   * @param eventType Event type to use for metrics.
+   * @param additionalEventProperties Optional properties based on event type.
    */
   private async handleMessageFanout(
     message: dto.deleteSchema | dto.profileSchema | dto.passwordSchema,
-    eventType: string
+    eventType: MessageFanoutEventType,
+    additionalEventProperties?: MessageFanoutAdditionalEventProperties
   ) {
     this.metrics.increment('message.type', { eventType });
     const clientIds = await this.clientIdsForUserAndResourceServers(
@@ -207,6 +221,7 @@ export class QueueworkerService
         uid: message.uid,
         //@ts-ignore
         email: message.email,
+        ...(additionalEventProperties?.[eventType] ?? {}),
       });
       this.log.debug('publishedMessage', { clientId, messageId });
     }
@@ -219,7 +234,18 @@ export class QueueworkerService
    * @private
    */
   private async handleDeleteEvent(message: dto.deleteSchema) {
-    await this.handleMessageFanout(message, 'delete');
+    const result = narrowDeleteUserEventReason(message.reason);
+    if ('fallback' in result) {
+      this.metrics.increment('message.delete.reasonFallback', {
+        category: result.fallback,
+      });
+    }
+
+    await this.handleMessageFanout(
+      message,
+      'delete',
+      'reason' in result ? { delete: { reason: result.reason } } : undefined
+    );
 
     await this.firestore.deleteUser(message.uid);
   }

--- a/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
+++ b/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
@@ -100,6 +100,7 @@ export const PROFILE_CHANGE_SCHEMA = joi
 
 export type deleteSchema = {
   event: typeof DELETE_EVENT;
+  reason?: unknown;
   timestamp?: number;
   ts: number;
   uid: string;


### PR DESCRIPTION
Because:
 - RPs might want to handle account deletions differently based on the reason 

This commit:
 - maps the deletion reasons to a set of public reasons
 - includes the reason in SQS events
 - adds the reason to the delete-user webhook event

