### PR TITLE
fix(payments): Resolve payments emails to display card digits

### DIFF
--- a/libs/accounts/email-renderer/src/partials/paymentProvider/index.mjml
+++ b/libs/accounts/email-renderer/src/partials/paymentProvider/index.mjml
@@ -9,8 +9,8 @@
         <b>Payment method:</b> <%- paymentProviderName %>
       </span>
     </mj-text>
-  <% } else { %>
-    <% if (cardName && lastFour) { %>
+  <% } else if (lastFour) { %>
+    <% if (cardName) { %>
       <mj-text css-class="text-body-no-bottom-margin">
         <span data-l10n-id="payment-provider-card-ending-in-card-name" data-l10n-args="<%= JSON.stringify({cardName, lastFour}) %>">
           <b>Payment method:</b> <%- cardName %> ending in <%- lastFour %>

--- a/libs/accounts/email-renderer/src/partials/paymentProvider/index.txt
+++ b/libs/accounts/email-renderer/src/partials/paymentProvider/index.txt
@@ -1,8 +1,8 @@
 <% if (invoiceAmountDueInCents > 0) { %>
   <% if (paymentProviderName) { %>
     payment-method-payment-provider-plaintext = "Payment method: { $paymentProviderName }"
-  <% } else { %>
-    <% if (cardName && lastFour) {%>
+  <% } else if (lastFour) { %>
+    <% if (cardName) {%>
       payment-provider-card-name-ending-in-plaintext = "Payment method: <%- cardName %> ending in <%- lastFour %>"
     <% } else { %>
       payment-provider-card-ending-in-plaintext = "Payment method: Card ending in <%- lastFour %>"

--- a/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.spec.ts
@@ -128,6 +128,35 @@ describe('SubPlat Email Renderer — Invoice emails', () => {
     expect(email.html).toContain('$2.00');
     expect(email.html).toContain('subscription-charges-taxes');
   });
+
+  it('renders the card ending line when the last four digits are known', async () => {
+    const email = await renderer.renderSubscriptionFirstInvoice(
+      { ...baseInvoiceTemplateValues, cardName: undefined },
+      defaultSubscriptionLayoutValues
+    );
+
+    expect(email.html).toContain(
+      'data-l10n-id="payment-provider-card-ending-in"'
+    );
+    expect(email.html).toContain('4242');
+  });
+
+  it('omits the payment method line when the last four digits are unknown', async () => {
+    // Both card strings interpolate $lastFour. Emitting either without the
+    // digits leaves Fluent no argument to substitute, and it renders the
+    // placeable source — a literal {$lastFour} — into the sent email.
+    const email = await renderer.renderSubscriptionFirstInvoice(
+      {
+        ...baseInvoiceTemplateValues,
+        cardName: undefined,
+        lastFour: undefined,
+      },
+      defaultSubscriptionLayoutValues
+    );
+
+    expect(email.html).not.toContain('payment-provider-card-ending-in');
+    expect(email.text).not.toContain('payment-provider-card-ending-in');
+  });
 });
 
 describe('SubPlat Email Renderer — Lifecycle emails', () => {

--- a/libs/accounts/email-renderer/src/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionFirstInvoice/index.stories.ts
@@ -32,10 +32,8 @@ const data = {
   showPaymentMethod: true,
   showProratedAmount: false,
   showTaxAmount: false,
-
-  // Had to add these in! Please double check values
-  cardName: 'foo',
-  paymentProviderName: 'bar',
+  cardName: 'Visa',
+  paymentProviderName: undefined,
   lastFour: '4242',
   remainingAmountTotalInCents: 1000,
   offeringPrice: '$10.00',
@@ -60,8 +58,29 @@ const createStory = subplatStoryWithProps<TemplateData>(
 export const SubscriptionFirstInvoiceWithPayPal = createStory(
   {
     payment_provider: 'paypal',
+    paymentProviderName: 'PayPal',
   },
   'Payment method - PayPal'
+);
+
+export const SubscriptionFirstInvoiceWithCardNoBrand = createStory(
+  {
+    cardType: null,
+    cardName: undefined,
+    lastFour: '4242',
+    payment_provider: 'stripe',
+  },
+  'Payment method - card ending in, brand unknown'
+);
+
+export const SubscriptionFirstInvoiceWithCardNoDigits = createStory(
+  {
+    cardType: null,
+    cardName: undefined,
+    lastFour: null,
+    payment_provider: 'stripe',
+  },
+  'Payment method omitted - digits unavailable'
 );
 
 export const SubscriptionFirstInvoiceWithStripe = createStory(

--- a/libs/accounts/email-renderer/src/templates/subscriptionSubsequentInvoice/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionSubsequentInvoice/index.stories.ts
@@ -31,10 +31,11 @@ const data = {
   showPaymentMethod: true,
   showProratedAmount: false,
   showTaxAmount: false,
-
   productPaymentCycle: 'monthly',
   invoiceAmountDueInCents: 1000,
-  paymentProviderName: 'foo',
+  paymentProviderName: undefined,
+  cardName: undefined,
+  lastFour: undefined,
   remainingAmountTotalInCents: 1000,
   offeringPriceInCents: 1000,
   offeringPrice: '$10.00',
@@ -58,6 +59,7 @@ const createStory = subplatStoryWithProps<TemplateData>(
 export const SubscriptionSubsequentInvoicePayPalProrated = createStory(
   {
     payment_provider: 'paypal',
+    paymentProviderName: 'PayPal',
     paymentProrated: '$5,231.00',
     showProratedAmount: true,
   },
@@ -67,6 +69,7 @@ export const SubscriptionSubsequentInvoicePayPalProrated = createStory(
 export const SubscriptionSubsequentInvoicePayPalNoProrated = createStory(
   {
     payment_provider: 'paypal',
+    paymentProviderName: 'PayPal',
     showProratedAmount: false,
   },
   'PayPal with no prorated amount'

--- a/packages/fxa-auth-server/lib/payments/stripe.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.spec.ts
@@ -705,6 +705,48 @@ describe('StripeHelper', () => {
         });
       });
     });
+
+    describe('when the caller supplies a payment intent', () => {
+      let paymentIntentsRetrieve: jest.Mock;
+
+      beforeEach(() => {
+        customerExpanded.subscriptions.data[0] = {
+          ...deepCopy(subscription2),
+          collection_method: 'charge_automatically',
+        };
+        paymentIntentsRetrieve = jest
+          .fn()
+          .mockResolvedValue({ payment_method: 'pm_mock' });
+        stripeHelper.stripe = {
+          paymentIntents: { retrieve: paymentIntentsRetrieve },
+        };
+        jest
+          .spyOn(stripeHelper, 'getPaymentMethod')
+          .mockResolvedValue({ type: 'card', card: {} });
+      });
+
+      it('uses an expanded payment intent without retrieving it again', async () => {
+        const result = await stripeHelper.getPaymentProvider(customerExpanded, {
+          id: 'pi_mock',
+          payment_method: 'pm_mock',
+        } as any);
+
+        expect(paymentIntentsRetrieve).not.toHaveBeenCalled();
+        expect(stripeHelper.getPaymentMethod).toHaveBeenCalledWith('pm_mock');
+        expect(result).toBe('card');
+      });
+
+      it('retrieves the payment intent when given a bare id', async () => {
+        const result = await stripeHelper.getPaymentProvider(
+          customerExpanded,
+          'pi_mock'
+        );
+
+        expect(paymentIntentsRetrieve).toHaveBeenCalledWith('pi_mock');
+        expect(stripeHelper.getPaymentMethod).toHaveBeenCalledWith('pm_mock');
+        expect(result).toBe('card');
+      });
+    });
   });
 
   describe('hasSubscriptionRequiringPaymentMethod', () => {
@@ -4742,6 +4784,165 @@ describe('StripeHelper', () => {
       stripeHelper.stripe = mockStripe;
     });
 
+    describe('extractInvoicePaymentDetails', () => {
+      const MOCK_INVOICE_ID = 'in_1GQL9sBVqmGyQTMaEl7Oczgm';
+      const MOCK_CHARGE_ID = 'ch_1GQL9tBVqmGyQTMaNLu55LsR';
+      const MOCK_PAYMENT_INTENT_ID = 'pi_1GQL9sBVqmGyQTMaSnFPZJlx';
+
+      const invoiceWithPayment = (payment: any): any => ({
+        id: MOCK_INVOICE_ID,
+        payments: {
+          object: 'list',
+          data: [{ payment, status: 'paid' }],
+          has_more: false,
+          total_count: 1,
+        },
+      });
+
+      const MOCK_PAYMENT_INTENT = {
+        id: MOCK_PAYMENT_INTENT_ID,
+        latest_charge: MOCK_CHARGE_ID,
+      };
+
+      let invoicesRetrieve: jest.Mock;
+      let paymentIntentsRetrieve: jest.Mock;
+
+      beforeEach(() => {
+        expandMock.mockReset().mockResolvedValue(mockCharge);
+        invoicesRetrieve = jest.fn();
+        paymentIntentsRetrieve = jest
+          .fn()
+          .mockResolvedValue(MOCK_PAYMENT_INTENT);
+        stripeHelper.stripe = {
+          ...mockStripe,
+          invoices: { ...mockStripe.invoices, retrieve: invoicesRetrieve },
+          paymentIntents: { retrieve: paymentIntentsRetrieve },
+        };
+      });
+
+      it('resolves the charge through the payment intent when the invoice payment has no charge', async () => {
+        // Stripe surfaces the payment intent in place of the charge whenever
+        // the charge has one, which is every card payment.
+        const result = await stripeHelper.extractInvoicePaymentDetails(
+          invoiceWithPayment({
+            type: 'payment_intent',
+            payment_intent: MOCK_PAYMENT_INTENT_ID,
+          })
+        );
+
+        expect(paymentIntentsRetrieve).toHaveBeenCalledWith(
+          MOCK_PAYMENT_INTENT_ID
+        );
+        expect(expandMock).toHaveBeenCalledWith(MOCK_CHARGE_ID, 'charges');
+        // The resolved object is handed back so getPaymentProvider does not
+        // retrieve the same payment intent a second time.
+        expect(result).toEqual({
+          charge: mockCharge,
+          paymentIntent: MOCK_PAYMENT_INTENT,
+        });
+      });
+
+      it('retrieves the invoice with payments expanded when payments is absent', async () => {
+        // Webhook payloads and the Firestore mirror carry no `payments`.
+        invoicesRetrieve.mockResolvedValue(
+          invoiceWithPayment({
+            type: 'payment_intent',
+            payment_intent: MOCK_PAYMENT_INTENT,
+          })
+        );
+
+        const result = await stripeHelper.extractInvoicePaymentDetails({
+          id: MOCK_INVOICE_ID,
+        } as any);
+
+        expect(invoicesRetrieve).toHaveBeenCalledWith(MOCK_INVOICE_ID, {
+          expand: ['payments.data.payment.payment_intent'],
+        });
+        expect(paymentIntentsRetrieve).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          charge: mockCharge,
+          paymentIntent: MOCK_PAYMENT_INTENT,
+        });
+      });
+
+      it('uses the charge on the invoice payment when Stripe surfaces one', async () => {
+        const result = await stripeHelper.extractInvoicePaymentDetails(
+          invoiceWithPayment({ type: 'charge', charge: MOCK_CHARGE_ID })
+        );
+
+        expect(invoicesRetrieve).not.toHaveBeenCalled();
+        expect(paymentIntentsRetrieve).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          charge: mockCharge,
+          paymentIntent: undefined,
+        });
+      });
+
+      it('falls back to the top-level charge on an acacia-era invoice', async () => {
+        const result = await stripeHelper.extractInvoicePaymentDetails({
+          id: MOCK_INVOICE_ID,
+          charge: MOCK_CHARGE_ID,
+        } as any);
+
+        expect(invoicesRetrieve).not.toHaveBeenCalled();
+        expect(paymentIntentsRetrieve).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          charge: mockCharge,
+          paymentIntent: undefined,
+        });
+      });
+
+      it('returns a null charge when the invoice has no payment', async () => {
+        const result = await stripeHelper.extractInvoicePaymentDetails({
+          id: MOCK_INVOICE_ID,
+          payments: {
+            object: 'list',
+            data: [],
+            has_more: false,
+            total_count: 0,
+          },
+        } as any);
+
+        expect(invoicesRetrieve).not.toHaveBeenCalled();
+        expect(paymentIntentsRetrieve).not.toHaveBeenCalled();
+        expect(expandMock).not.toHaveBeenCalled();
+        expect(result).toEqual({ charge: null, paymentIntent: undefined });
+      });
+
+      it('reports to Sentry and returns a null charge when the payment intent lookup fails', async () => {
+        const scopeContextSpy = jest.fn();
+        jest
+          .spyOn(Sentry, 'withScope')
+          .mockImplementation(((fn: any) =>
+            fn({ setContext: scopeContextSpy })) as any);
+        jest
+          .spyOn(sentryModule, 'reportSentryError')
+          .mockImplementation(jest.fn());
+        const stripeFailure = new Error('Stripe unavailable');
+        paymentIntentsRetrieve.mockRejectedValue(stripeFailure);
+
+        const result = await stripeHelper.extractInvoicePaymentDetails(
+          invoiceWithPayment({
+            type: 'payment_intent',
+            payment_intent: MOCK_PAYMENT_INTENT_ID,
+          })
+        );
+
+        expect(scopeContextSpy).toHaveBeenCalledWith('stripeInvoice', {
+          invoice: { id: MOCK_INVOICE_ID },
+        });
+        expect(sentryModule.reportSentryError).toHaveBeenCalledWith(
+          stripeFailure
+        );
+        // The id survives the failure, so the provider lookup still has
+        // something to work from.
+        expect(result).toEqual({
+          charge: null,
+          paymentIntent: MOCK_PAYMENT_INTENT_ID,
+        });
+      });
+    });
+
     describe('extractInvoiceDetailsForEmail', () => {
       const fixture: any = { ...invoicePaidSubscriptionCreate };
       const fixtureDiscount: any = {
@@ -4895,10 +5096,41 @@ describe('StripeHelper', () => {
         expect(result).toEqual(expected);
       });
 
-      it('does not throw an exception when details on a payment method are missing', async () => {
-        const noChargeFixture = deepCopy(invoicePaidSubscriptionCreate);
-        noChargeFixture.customer = mockCustomer;
-        noChargeFixture.payments.data[0].payment.charge = null;
+      it('extracts card details from a webhook invoice that carries no expanded payments', async () => {
+        // `Invoice.payments` is expansion-only, so a webhook payload arrives
+        // without it and the card details have to be fetched. Without the
+        // fetch, lastFour is null and the email renders a raw {$lastFour}.
+        const webhookFixture = deepCopy(invoicePaidSubscriptionCreate);
+        webhookFixture.customer = mockCustomer;
+        delete webhookFixture.payments;
+
+        const expandedInvoice = deepCopy(invoicePaidSubscriptionCreate);
+        expandedInvoice.payments.data[0].payment = {
+          type: 'payment_intent',
+          payment_intent: {
+            id: 'pi_1GQL9sBVqmGyQTMaSnFPZJlx',
+            latest_charge: chargeId,
+          },
+        };
+        stripeHelper.stripe.invoices.retrieve = jest
+          .fn()
+          .mockResolvedValue(expandedInvoice);
+
+        const result =
+          await stripeHelper.extractInvoiceDetailsForEmail(webhookFixture);
+
+        expect(stripeHelper.stripe.invoices.retrieve).toHaveBeenCalledWith(
+          webhookFixture.id,
+          { expand: ['payments.data.payment.payment_intent'] }
+        );
+        expect(result).toEqual(expected);
+      });
+
+      it('returns no card details when the invoice has no payment', async () => {
+        const noPaymentFixture = deepCopy(invoicePaidSubscriptionCreate);
+        noPaymentFixture.customer = mockCustomer;
+        noPaymentFixture.payments.data = [];
+        noPaymentFixture.payments.total_count = 0;
         expandMock.mockReset().mockResolvedValue({});
         expandMock.mockResolvedValueOnce(mockCustomer);
         expandMock.mockResolvedValueOnce({
@@ -4907,14 +5139,8 @@ describe('StripeHelper', () => {
           metadata: mockPlan.metadata,
           product: mockProduct,
         });
-        expandMock.mockResolvedValueOnce(null);
         const result =
-          await stripeHelper.extractInvoiceDetailsForEmail(noChargeFixture);
-        expect(
-          (stripeHelper.allAbbrevProducts as jest.Mock).mock.calls.length > 0
-        ).toBe(true);
-        expect(mockStripe.products.retrieve.mock.calls.length > 0).toBe(false);
-        expect(expandMock).toHaveBeenCalledTimes(4);
+          await stripeHelper.extractInvoiceDetailsForEmail(noPaymentFixture);
         expect(result).toEqual({
           ...expected,
           lastFour: null,

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1046,7 +1046,7 @@ export class StripeHelper extends StripeHelperBase {
 
   async getPaymentProvider(
     customer: Stripe.Customer,
-    paymentIntentId?: string
+    paymentIntentRef?: string | Stripe.PaymentIntent
   ): Promise<SubPlatPaymentMethodType | 'paypal' | 'not_chosen'> {
     const subscription = customer.subscriptions?.data.find((sub) =>
       ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status)
@@ -1060,9 +1060,13 @@ export class StripeHelper extends StripeHelperBase {
 
     let paymentMethod: Stripe.PaymentMethod | null = null;
 
-    if (paymentIntentId) {
+    if (paymentIntentRef) {
+      // Callers that already resolved the payment intent pass the object, so
+      // only a bare id costs a lookup.
       const paymentIntent =
-        await this.stripe.paymentIntents.retrieve(paymentIntentId);
+        typeof paymentIntentRef === 'string'
+          ? await this.stripe.paymentIntents.retrieve(paymentIntentRef)
+          : paymentIntentRef;
       paymentMethod = await this.getPaymentMethod(
         paymentIntent.payment_method as string
       );
@@ -1072,15 +1076,11 @@ export class StripeHelper extends StripeHelperBase {
         { expand: ['payments'] }
       );
 
-      const invoicePaymentIntent = invoice.payments?.data[0]?.payment
-        .payment_intent;
-      if (
-        invoicePaymentIntent &&
-        typeof invoicePaymentIntent === 'string'
-      ) {
-        const paymentIntent = await this.stripe.paymentIntents.retrieve(
-          invoicePaymentIntent
-        );
+      const invoicePaymentIntent =
+        invoice.payments?.data[0]?.payment.payment_intent;
+      if (invoicePaymentIntent && typeof invoicePaymentIntent === 'string') {
+        const paymentIntent =
+          await this.stripe.paymentIntents.retrieve(invoicePaymentIntent);
         if (paymentIntent.payment_method) {
           paymentMethod = await this.getPaymentMethod(
             paymentIntent.payment_method as string
@@ -1922,6 +1922,75 @@ export class StripeHelper extends StripeHelperBase {
   }
 
   /**
+   * Resolve an invoice's charge and payment intent.
+   *
+   * `Invoice.payments` is expansion-only, so it is absent from webhook payloads
+   * and from invoices read back out of the Firestore mirror. Stripe also only
+   * surfaces `payment.charge` when the charge has no payment intent, so for
+   * card payments the charge has to be reached through the payment intent's
+   * `latest_charge`. The top-level `charge` fallback covers acacia-era invoices
+   * that predate `payments`; remove it once none remain.
+   *
+   * Returns the payment intent expanded where it was already fetched, so the
+   * caller does not retrieve it a second time.
+   *
+   * These are one line of a billing email, so a Stripe failure here is reported
+   * and degraded rather than thrown.
+   */
+  async extractInvoicePaymentDetails(invoice: Stripe.Invoice): Promise<{
+    charge: Stripe.Charge | null;
+    paymentIntent?: string | Stripe.PaymentIntent;
+  }> {
+    const legacyCharge = (
+      invoice as Stripe.Invoice & {
+        charge?: string | Stripe.Charge | null;
+      }
+    ).charge;
+
+    let paymentIntentRef: string | Stripe.PaymentIntent | undefined;
+
+    try {
+      let payments = invoice.payments;
+      if (!payments && !legacyCharge && invoice.id) {
+        const invoiceWithPayments = await this.stripe.invoices.retrieve(
+          invoice.id,
+          { expand: ['payments.data.payment.payment_intent'] }
+        );
+        payments = invoiceWithPayments.payments;
+      }
+
+      const payment = payments?.data[0]?.payment;
+      paymentIntentRef = payment?.payment_intent ?? undefined;
+
+      let chargeRef: string | Stripe.Charge | null | undefined =
+        payment?.charge ?? legacyCharge;
+      if (!chargeRef && paymentIntentRef) {
+        if (typeof paymentIntentRef === 'string') {
+          paymentIntentRef =
+            await this.stripe.paymentIntents.retrieve(paymentIntentRef);
+        }
+        chargeRef = paymentIntentRef.latest_charge as
+          | string
+          | Stripe.Charge
+          | null
+          | undefined;
+      }
+
+      const charge = chargeRef
+        ? await this.expandResource<Stripe.Charge>(chargeRef, CHARGES_RESOURCE)
+        : null;
+
+      return { charge, paymentIntent: paymentIntentRef };
+    } catch (error) {
+      Sentry.withScope((scope) => {
+        scope.setContext('stripeInvoice', { invoice: { id: invoice.id } });
+        reportSentryError(error);
+      });
+      return { charge: null, paymentIntent: paymentIntentRef };
+    }
+  }
+
+  /**
    * Extract invoice details for billing emails.
    *
    * Note that this function throws an error in the following cases:
@@ -1983,22 +2052,20 @@ export class StripeHelper extends StripeHelperBase {
         new Error(`Unexpected line item: ${invoice.lines.data[0].id}`)
       );
     }
-    const plan = await this.expandResource<Stripe.Plan>(
-      priceId,
-      PLAN_RESOURCE
-    );
-    const [abbrevProduct, charge] = await Promise.all([
+    const plan = await this.expandResource<Stripe.Plan>(priceId, PLAN_RESOURCE);
+    const [abbrevProduct, invoicePayment] = await Promise.all([
       this.expandAbbrevProductForPlan(plan),
-      this.expandResource(
-        invoice.payments?.data[0]?.payment.charge,
-        CHARGES_RESOURCE
-      ),
+      this.extractInvoicePaymentDetails(invoice),
     ]);
 
     let discountType: Stripe.Coupon.Duration | null = null;
     let discountDuration: number | null = null;
 
-    if (invoice.id && !!invoice.discounts?.length && invoice.discounts.length === 1) {
+    if (
+      invoice.id &&
+      !!invoice.discounts?.length &&
+      invoice.discounts.length === 1
+    ) {
       // The discount, or its coupon, may arrive as an id, in which case expand it.
       let discount = invoice.discounts[0];
       if (discountsNeedExpansion(invoice.discounts)) {
@@ -2129,17 +2196,12 @@ export class StripeHelper extends StripeHelperBase {
     const planSuccessActionButtonURL = successActionButtonURL || '';
 
     const { lastFour, cardType } = this.extractCardDetails({
-      charge: charge ?? null,
+      charge: invoicePayment.charge,
     });
 
-    const paymentIntentRef = invoice.payments?.data[0]?.payment.payment_intent;
-    const paymentIntent =
-      typeof paymentIntentRef === 'string'
-        ? paymentIntentRef
-        : paymentIntentRef?.id;
     const payment_provider = await this.getPaymentProvider(
       customer,
-      paymentIntent
+      invoicePayment.paymentIntent
     );
 
     const subscription = getInvoiceSubscription(invoice);

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -9,8 +9,8 @@
         <b>Payment method:</b> <%- paymentProviderName %>
       </span>
     </mj-text>
-  <% } else { %>
-    <% if (cardName && lastFour) { %>
+  <% } else if (lastFour) { %>
+    <% if (cardName) { %>
       <mj-text css-class="text-body-no-bottom-margin">
         <span data-l10n-id="payment-provider-card-ending-in-card-name" data-l10n-args="<%= JSON.stringify({cardName, lastFour}) %>">
           <b>Payment method:</b> <%- cardName %> ending in <%- lastFour %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,8 +1,8 @@
 <% if (invoiceAmountDueInCents > 0) { %>
   <% if (paymentProviderName) { %>
     payment-method-payment-provider-plaintext = "Payment method: { $paymentProviderName }"
-  <% } else { %>
-    <% if (cardName && lastFour) {%>
+  <% } else if (lastFour) { %>
+    <% if (cardName) {%>
       payment-provider-card-name-ending-in-plaintext = "Payment method: <%- cardName %> ending in <%- lastFour %>"
     <% } else { %>
       payment-provider-card-ending-in-plaintext = "Payment method: Card ending in <%- lastFour %>"


### PR DESCRIPTION
## Because

- Webhook payloads and mirrored invoices never carried over, so lastFour was always null.
- Fluent has no argument to substitute for a null lastFour, so the email rendered the literal {$lastFour} where the digits belong.

## This pull request

- Adds extractInvoicePaymentDetails to reach the charge through the payment intent's latest_charge and re-retrieves the invoice with payments expanded when it is absent.

## Issue that this pull request solves

Closes: PAY-3909

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.
