### PR TITLE
feat(passkey): Record security events on wrap retrieval

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
@@ -259,8 +259,11 @@ const PASSKEYS_API_DOCS = {
         - \`404\` errno 234 — the passkey has no wrap
         - \`404\` errno 236 — the wrap predates the account's \`keysChangedAt\`
 
-        **Security events:** none. This runs on every passwordless sign-in, so an
-        event here would bury the history it is meant to make legible.
+        **Security events:** \`account.passkey.wrap_retrieved\` on a returned
+        envelope; \`account.passkey.wrap_retrieval_failure\` on an unbound token,
+        a stale wrap, or a lookup that finds none. Rejections before the handler
+        — authentication and rate limiting — are not recorded. Both are recorded
+        for the audit trail and hidden from the account settings activity list.
       `,
     ],
   },

--- a/packages/fxa-auth-server/lib/routes/passkey-wraps.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkey-wraps.spec.ts
@@ -313,10 +313,73 @@ describe('passkey wraps routes', () => {
       );
     });
 
-    it('records no security event', async () => {
+    it('records a wrap_retrieved event on a returned envelope', async () => {
       await runGet();
 
-      expect(recordSecurityEvent).not.toHaveBeenCalled();
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.wrap_retrieved',
+        expect.objectContaining({ db, request: expect.any(Object) })
+      );
+    });
+
+    it('records a wrap_retrieval_failure event when the fetch throws', async () => {
+      service.getPasskeyWrap.mockRejectedValue(AppError.passkeyWrapNotFound());
+
+      await expect(runGet()).rejects.toMatchObject({
+        errno: ERRNO.PASSKEY_WRAP_NOT_FOUND,
+      });
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.wrap_retrieval_failure',
+        expect.objectContaining({ db, request: expect.any(Object) })
+      );
+    });
+
+    it('records a wrap_retrieval_failure event on a stale wrap', async () => {
+      db.account.mockResolvedValue({
+        primaryEmail: { email: TEST_EMAIL },
+        keysChangedAt: WRAP_CREATED_AT + 1,
+      } as Awaited<ReturnType<DB['account']>>);
+
+      await expect(runGet()).rejects.toMatchObject({
+        errno: ERRNO.PASSKEY_WRAP_STALE,
+      });
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.wrap_retrieval_failure',
+        expect.objectContaining({ db, request: expect.any(Object) })
+      );
+    });
+
+    it('records a wrap_retrieval_failure event for an unbound token', async () => {
+      await expect(
+        runGet({ credentialId: CREDENTIAL_ID }, { cid: 'some-other-cred' })
+      ).rejects.toThrow();
+
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.wrap_retrieval_failure',
+        expect.objectContaining({ db, request: expect.any(Object) })
+      );
+    });
+
+    it('surfaces the fetch error even when the audit write fails', async () => {
+      service.getPasskeyWrap.mockRejectedValue(AppError.passkeyWrapNotFound());
+      (recordSecurityEvent as jest.Mock).mockRejectedValueOnce(
+        new Error('audit write failed')
+      );
+
+      await expect(runGet()).rejects.toMatchObject({
+        errno: ERRNO.PASSKEY_WRAP_NOT_FOUND,
+      });
+    });
+
+    it('returns the envelope even when the audit write fails', async () => {
+      (recordSecurityEvent as jest.Mock).mockRejectedValueOnce(
+        new Error('audit write failed')
+      );
+
+      await expect(runGet()).resolves.toHaveProperty(
+        'createdAt',
+        WRAP_CREATED_AT
+      );
     });
 
     it('rate-limits against the current primary email', async () => {

--- a/packages/fxa-auth-server/lib/routes/passkey-wraps.ts
+++ b/packages/fxa-auth-server/lib/routes/passkey-wraps.ts
@@ -154,8 +154,9 @@ export class PasskeyWrapsHandler {
    * Bound to the asserted credential as the write is. A wrap should only ever
    * be fetched to complete a sign-in with that same credential.
    *
-   * No security event: this runs on every passwordless sign-in, so an event
-   * here would bury the history it is meant to make legible (FXA-13139).
+   * Both `wrap_retrieved` and `wrap_retrieval_failure` land on every
+   * passwordless sign-in, so both are kept out of the settings activity list
+   * by `HIDDEN_SECURITY_EVENT_NAMES` in fxa-settings.
    *
    * @returns The base64url envelope plus the time it was stored.
    */
@@ -167,6 +168,7 @@ export class PasskeyWrapsHandler {
     const { credentialId } = request.params as { credentialId: string };
 
     if (!isBoundTo(cid, credentialId)) {
+      await this.recordEvent(request, 'account.passkey.wrap_retrieval_failure');
       throw AppError.invalidMfaToken();
     }
 
@@ -180,11 +182,20 @@ export class PasskeyWrapsHandler {
 
     // Throws 404 for both an unknown credential (errno 224) and a credential
     // with no wrap (errno 234); the distinction is PasskeyService's contract.
-    const wrap = await this.service.getPasskeyWrap(uid, credentialId);
+    let wrap: Awaited<ReturnType<PasskeyService['getPasskeyWrap']>>;
+    try {
+      wrap = await this.service.getPasskeyWrap(uid, credentialId);
+    } catch (err) {
+      await this.recordEvent(request, 'account.passkey.wrap_retrieval_failure');
+      throw err;
+    }
 
     if (isWrapStale(wrap.createdAt, account.keysChangedAt)) {
+      await this.recordEvent(request, 'account.passkey.wrap_retrieval_failure');
       throw AppError.passkeyWrapStale();
     }
+
+    await this.recordEvent(request, 'account.passkey.wrap_retrieved');
 
     return {
       ...encodePasskeyWrapEnvelope(wrap),

--- a/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkey_wraps.in.spec.ts
@@ -313,13 +313,18 @@ describe('#integration - remote passkey wrap storage', () => {
         .execute();
     }
 
-    it('returns the stored envelope', async () => {
+    it('returns the stored envelope and records a security event', async () => {
       await storeCurrentWrap();
 
       const result = await fetchWrap();
 
       expect(result).toMatchObject(envelope());
       expect(result.createdAt).toEqual(expect.any(Number));
+
+      const events = await client.securityEvents();
+      expect(events.map((e: any) => e.name)).toContain(
+        'account.passkey.wrap_retrieved'
+      );
     });
 
     it('404s when the passkey has no wrap', async () => {
@@ -327,6 +332,11 @@ describe('#integration - remote passkey wrap storage', () => {
         code: 404,
         errno: ERRNO.PASSKEY_WRAP_NOT_FOUND,
       });
+
+      const events = await client.securityEvents();
+      expect(events.map((e: any) => e.name)).toContain(
+        'account.passkey.wrap_retrieval_failure'
+      );
     });
 
     it('withholds a wrap that predates the current kB', async () => {


### PR DESCRIPTION
Because:

* GET /passkey/wraps/{credentialId} left no audit trail, so a wrap read
  could not be reconstructed from an account's history.

This commit:

* Records account.passkey.wrap_retrieved on a returned envelope.
* Records account.passkey.wrap_retrieval_failure on an unbound token, a
  failed fetch, and a stale wrap.
* Documents both events on the GET endpoint in the swagger notes.

Closes #FXA-14480

