### PR TITLE
feat(settings): Remove synced tabs CTA from pairing confirmation

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/en.ftl
@@ -1,11 +1,9 @@
 ## SyncSuccess page - Part of the desktop-to-mobile pairing flow
 ## Users see this on their computer once the mobile device has been paired.
-## It confirms that sync is on and offers the follow-up actions.
+## It confirms that sync is on and links to sync settings.
 
-# "syncing" here means copying data between the user's devices
-pair2-authority-sync-success-heading = You’re syncing
-pair2-authority-sync-success-description = Your tabs, bookmarks, passwords, and more are ready across your devices.
-# Opens the tabs that are open on the user's other synced devices
-pair2-authority-sync-success-view-tabs-button = View synced tabs
+pair2-authority-sync-success-heading-v2 = Your device is connected
+# "Syncing" here means copying data between the user's devices
+pair2-authority-sync-success-description-v2 = Syncing is underway. It may take a while for your synced data to appear. Feel free to keep browsing.
 # Opens the browser settings that control what is synced
-pair2-authority-sync-success-sync-settings-button = Sync settings
+pair2-authority-sync-success-sync-settings-button-v2 = Manage sync settings

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.test.tsx
@@ -31,10 +31,10 @@ describe('Pair2/Authority/SyncSuccess page', () => {
     renderWithLocalizationProvider(<Subject />);
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-      'You’re syncing'
+      'Your device is connected'
     );
     screen.getByText(
-      'Your tabs, bookmarks, passwords, and more are ready across your devices.'
+      'Syncing is underway. It may take a while for your synced data to appear. Feel free to keep browsing.'
     );
   });
 
@@ -45,19 +45,15 @@ describe('Pair2/Authority/SyncSuccess page', () => {
       screen
         .getAllByRole('img')
         .map((img) => img.getAttribute('alt') ?? img.getAttribute('aria-label'))
-    ).toEqual([
-      'Mozilla logo'
-    ]);
+    ).toEqual(['Mozilla logo']);
   });
 
-  it('calls onViewSyncedTabs when the primary button is clicked', async () => {
-    const user = userEvent.setup();
-    const onViewSyncedTabs = jest.fn();
-    renderWithLocalizationProvider(<Subject {...{ onViewSyncedTabs }} />);
+  it('offers sync settings as the only action', () => {
+    renderWithLocalizationProvider(<Subject />);
 
-    await user.click(screen.getByRole('button', { name: 'View synced tabs' }));
-
-    expect(onViewSyncedTabs).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getAllByRole('button').map((button) => button.textContent)
+    ).toEqual(['Manage sync settings']);
   });
 
   it('calls onSyncSettings when the sync settings button is clicked', async () => {
@@ -65,7 +61,9 @@ describe('Pair2/Authority/SyncSuccess page', () => {
     const onSyncSettings = jest.fn();
     renderWithLocalizationProvider(<Subject {...{ onSyncSettings }} />);
 
-    await user.click(screen.getByRole('button', { name: 'Sync settings' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Manage sync settings' })
+    );
 
     expect(onSyncSettings).toHaveBeenCalledTimes(1);
   });

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/index.tsx
@@ -9,54 +9,39 @@ import { SyncSuccessImage } from '../../../../components/images';
 
 export type SyncSuccessProps = {
   /**
-   * Opens the list of tabs open on the user's other synced devices. Required so
-   * that routing this card cannot leave the primary action inert — the browser
-   * channel call itself lands with the flow wiring.
+   * Opens sync settings. Optional so that this card can be routed ahead of the
+   * browser channel call, which lands with the flow wiring.
    */
-  onViewSyncedTabs?: () => void;
-  /** Opens sync settings. Required for the same reason as `onViewSyncedTabs`. */
   onSyncSettings?: () => void;
 };
 
 /**
  * The desktop screen shown once the mobile device has finished pairing and
- * sync is active. It confirms what is now syncing and offers the two follow-up
- * actions.
+ * sync is active. It confirms that syncing has started and links to sync
+ * settings.
  */
-const SyncSuccess = ({
-  onViewSyncedTabs,
-  onSyncSettings,
-}: SyncSuccessProps) => (
+const SyncSuccess = ({ onSyncSettings }: SyncSuccessProps) => (
   <AppLayout>
     <div className="flex flex-col items-center text-center">
-      <FtlMsg id="pair2-authority-sync-success-heading">
-        <h1 className="card-header">You’re syncing</h1>
+      <FtlMsg id="pair2-authority-sync-success-heading-v2">
+        <h1 className="card-header">Your device is connected</h1>
       </FtlMsg>
-      <FtlMsg id="pair2-authority-sync-success-description">
+      <FtlMsg id="pair2-authority-sync-success-description-v2">
         <p className="text-base">
-          Your tabs, bookmarks, passwords, and more are ready across your
-          devices.
+          Syncing is underway. It may take a while for your synced data to
+          appear. Feel free to keep browsing.
         </p>
       </FtlMsg>
 
-      <SyncSuccessImage className="mt-8 h-40 w-auto" />
+      <SyncSuccessImage className="mt-6 h-40 w-auto" />
 
-      <FtlMsg id="pair2-authority-sync-success-view-tabs-button">
-        <button
-          type="button"
-          onClick={onViewSyncedTabs}
-          className="cta-primary cta-xl mt-8 w-full"
-        >
-          View synced tabs
-        </button>
-      </FtlMsg>
-      <FtlMsg id="pair2-authority-sync-success-sync-settings-button">
+      <FtlMsg id="pair2-authority-sync-success-sync-settings-button-v2">
         <button
           type="button"
           onClick={onSyncSettings}
-          className="link-dark-grey"
+          className="link-dark-grey mt-6"
         >
-          Sync settings
+          Manage sync settings
         </button>
       </FtlMsg>
     </div>

--- a/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/SyncSuccess/mocks.tsx
@@ -5,8 +5,5 @@
 import SyncSuccess, { SyncSuccessProps } from '.';
 
 export const Subject = ({
-  onViewSyncedTabs = () => {},
   onSyncSettings = () => {},
-}: Partial<SyncSuccessProps> = {}) => (
-  <SyncSuccess {...{ onViewSyncedTabs, onSyncSettings }} />
-);
+}: Partial<SyncSuccessProps> = {}) => <SyncSuccess {...{ onSyncSettings }} />;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/en.ftl
@@ -3,8 +3,7 @@
 ## is signed in and syncing with the computer they paired it with.
 
 pair2-supplicant-sync-success-heading = Your device is connected
-pair2-supplicant-sync-success-description = Your bookmarks, tabs, and more will stay synced in { -brand-firefox }.
-# Opens the view listing tabs open on the user's other synced devices
-pair2-supplicant-sync-success-view-tabs-button = View synced tabs
+# "Syncing" here means copying data between the user's devices
+pair2-supplicant-sync-success-description-v2 = Syncing is underway. It may take a while for your synced data to appear. Feel free to keep browsing.
 # Opens the browser's sync settings, where the user chooses what to sync
-pair2-supplicant-sync-success-sync-settings-button = Sync settings
+pair2-supplicant-sync-success-sync-settings-button-v2 = Manage sync settings

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/index.test.tsx
@@ -33,7 +33,7 @@ describe('Pair2/Supplicant/SyncSuccess page', () => {
       'Your device is connected'
     );
     screen.getByText(
-      'Your bookmarks, tabs, and more will stay synced in Firefox.'
+      'Syncing is underway. It may take a while for your synced data to appear. Feel free to keep browsing.'
     );
   });
 
@@ -48,17 +48,15 @@ describe('Pair2/Supplicant/SyncSuccess page', () => {
       // AppLayout's page header, then the two images this card renders.
       'Mozilla logo',
       'Firefox logo',
-     ]);
+    ]);
   });
 
-  it('calls onViewSyncedTabs when the primary button is clicked', async () => {
-    const user = userEvent.setup();
-    const onViewSyncedTabs = jest.fn();
-    renderWithLocalizationProvider(<Subject {...{ onViewSyncedTabs }} />);
+  it('offers sync settings as the only action', () => {
+    renderWithLocalizationProvider(<Subject />);
 
-    await user.click(screen.getByRole('button', { name: 'View synced tabs' }));
-
-    expect(onViewSyncedTabs).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getAllByRole('button').map((button) => button.textContent)
+    ).toEqual(['Manage sync settings']);
   });
 
   it('calls onSyncSettings when the sync settings button is clicked', async () => {
@@ -66,7 +64,9 @@ describe('Pair2/Supplicant/SyncSuccess page', () => {
     const onSyncSettings = jest.fn();
     renderWithLocalizationProvider(<Subject {...{ onSyncSettings }} />);
 
-    await user.click(screen.getByRole('button', { name: 'Sync settings' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Manage sync settings' })
+    );
 
     expect(onSyncSettings).toHaveBeenCalledTimes(1);
   });

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/index.tsx
@@ -12,10 +12,6 @@ import {
 
 export type SyncSuccessProps = {
   /**
-   * Opens the browser's synced tabs view.
-   */
-  onViewSyncedTabs?: () => void;
-  /**
    * Opens the browser's sync settings.
    */
   onSyncSettings?: () => void;
@@ -23,48 +19,39 @@ export type SyncSuccessProps = {
 
 /**
  * The mobile screen shown once pairing has completed: the device is signed in
- * and syncing. It offers a jump to the synced tabs view and a secondary link to
- * sync settings.
+ * and syncing. It confirms that syncing has started and links to sync
+ * settings.
  */
-const SyncSuccess = ({
-  onViewSyncedTabs,
-  onSyncSettings,
-}: SyncSuccessProps) => {
-  return <AppLayout whiteBackground>
-    <div className="flex flex-col items-center text-center">
-      <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
+const SyncSuccess = ({ onSyncSettings }: SyncSuccessProps) => {
+  return (
+    <AppLayout whiteBackground>
+      <div className="flex flex-col items-center text-center">
+        <FirefoxWordmarkImage className="h-8 w-24 text-black dark:text-white" />
 
-      <SyncSuccessImage className="mt-10 h-[176px] w-auto" />
+        <SyncSuccessImage className="mt-10 h-[176px] w-auto" />
 
-      <FtlMsg id="pair2-supplicant-sync-success-heading">
-        <h1 className="card-header mt-4">Your device is connected</h1>
-      </FtlMsg>
-      <FtlMsg id="pair2-supplicant-sync-success-description">
-        <p className="mt-1 text-base">
-          Your bookmarks, tabs, and more will stay synced in Firefox.
-        </p>
-      </FtlMsg>
+        <FtlMsg id="pair2-supplicant-sync-success-heading">
+          <h1 className="card-header mt-4">Your device is connected</h1>
+        </FtlMsg>
+        <FtlMsg id="pair2-supplicant-sync-success-description-v2">
+          <p className="mt-1 text-base">
+            Syncing is underway. It may take a while for your synced data to
+            appear. Feel free to keep browsing.
+          </p>
+        </FtlMsg>
 
-      <FtlMsg id="pair2-supplicant-sync-success-view-tabs-button">
-        <button
-          type="button"
-          onClick={onViewSyncedTabs}
-          className="cta-primary cta-xl mt-6 w-full"
-        >
-          View synced tabs
-        </button>
-      </FtlMsg>
-      <FtlMsg id="pair2-supplicant-sync-success-sync-settings-button">
-        <button
-          type="button"
-          onClick={onSyncSettings}
-          className="mt-4 py-2 text-base text-grey-900 underline dark:text-grey-10"
-        >
-          Sync settings
-        </button>
-      </FtlMsg>
-    </div>
-  </AppLayout>
+        <FtlMsg id="pair2-supplicant-sync-success-sync-settings-button-v2">
+          <button
+            type="button"
+            onClick={onSyncSettings}
+            className="mt-6 py-2 text-base text-grey-900 underline dark:text-grey-10"
+          >
+            Manage sync settings
+          </button>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
 };
 
 export default SyncSuccess;

--- a/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Supplicant/SyncSuccess/mocks.tsx
@@ -5,8 +5,5 @@
 import SyncSuccess, { SyncSuccessProps } from '.';
 
 export const Subject = ({
-  onViewSyncedTabs = () => {},
   onSyncSettings = () => {},
-}: Partial<SyncSuccessProps> = {}) => (
-  <SyncSuccess {...{ onViewSyncedTabs, onSyncSettings }} />
-);
+}: Partial<SyncSuccessProps> = {}) => <SyncSuccess {...{ onSyncSettings }} />;


### PR DESCRIPTION
## Because

- Synced data is not guaranteed to be available right after pairing, so "View
  synced tabs" could land users on an empty view.
- Users who just set up desktop or mobile Firefox have no synced data yet.
- The open-tabs sync engine may be off, making the CTA misleading.

## This pull request

- Removes the "View synced tabs" button and `onViewSyncedTabs` prop from the
  Authority (desktop) and Supplicant (mobile) SyncSuccess cards.
- Updates heading, description, and link copy on both cards to the final Figma
  design.
- Versions each changed Fluent id to `-v2`; the previous strings shipped in
  v1.343.0.
- Adjusts desktop image and link spacing to the 24px redlines.
- Replaces each card's CTA click test with an assertion that "Manage sync
  settings" is the only button.

## Issue that this pull request solves

Closes: FXA-14475

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Copy was taken from Figma as of 2026-09-08. The ticket's AC 3 ("copy is not
  finalized") is still open and no finalized-copy comment has been posted —
  confirm before marking ready.
- AC 1 also names the native Android and iOS confirmation screens. Those live in
  the mobile repos and are not covered here.
- Figma's updated illustration is marked "Github link to come", so
  `SyncSuccessImage` is unchanged. Needs a follow-up when the asset lands.
- Related: FXA-14491 (confirmation screen not appearing after pairing).
  `onSyncSettings` stays unwired until that flow work lands.
