### PR TITLE
feat(passkey): Add default rate limit rules for passkey wraps

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -189,6 +189,28 @@ passkeysRename                         : ip_uid            : 100         : 15 mi
 passkeyDelete                          : ip_uid            : 100         : 15 minutes      : 15 minutes  : block
 
 #
+# Passkey Wraps
+# The envelopes that let a passkey unseal kB. Every endpoint requires an mfa:passkey JWT, so a caller
+# has already completed a WebAuthn assertion. That token is not single-use and lives for
+# mfa.jwt.expiresInSec, so one assertion can drive many wrap calls — these rules, not
+# passkeyAuthFinish, are what bound the volume.
+#
+# Retrieval runs once per passwordless sign-in. Creation runs once per credential, and a user can
+# hold at most ten. Deletion is not credential-bound, so settings can sweep every credential in one
+# sitting; the daily cap leaves room for a delete-then-recreate replacement. No ip rule on any of
+# them: the JWT already gates them, and an ip ban on the sign-in path would take out everyone behind
+# a shared NAT.
+#
+# Counts sit above the prod config, with the extra headroom for local development and stage.
+#
+passkeyWrapsCreate                     : ip_uid            : 8           : 15 minutes      : 15 minutes  : block
+passkeyWrapsCreate                     : uid               : 15          : 24 hours        : 24 hours    : block
+passkeyWrapsGet                        : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
+passkeyWrapsGet                        : uid               : 30          : 15 minutes      : 15 minutes  : block
+passkeyWrapsDelete                     : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
+passkeyWrapsDelete                     : uid               : 30          : 24 hours        : 24 hours    : block
+
+#
 # Passwordless Authentication OTP Limits
 # Controls the rate at which passwordless OTP codes can be sent and verified
 #


### PR DESCRIPTION
## Because

- The passkey wrap endpoints only had rate limit rules in the prod config, so every other environment fell through to the tolerant catch-all `default` rule.
- The upcoming `DELETE /passkey/wraps/{credentialId}` route (#21165) needs a rule of its own.

## This pull request

- Adds a Passkey Wraps section to `packages/fxa-auth-server/config/rate-limit-rules.txt` covering `passkeyWrapsCreate`, `passkeyWrapsGet` and `passkeyWrapsDelete`.

## Issue that this pull request solves

Follow-up to review feedback on #21165.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

The prod-side counterpart is [webservices-infra#12390](https://github.com/mozilla/webservices-infra/pull/12390).

Sizing notes, all of which assume the `mfa:passkey` JWT has already gated the caller through a WebAuthn assertion:

- `passkeyWrapsGet` — one call per passwordless sign-in, with room for a client retry.
- `passkeyWrapsCreate` — one call per credential, and a user can hold at most ten.
- `passkeyWrapsDelete` — not credential-bound, so settings can sweep every credential in one sitting; the daily cap leaves room for a delete-then-recreate replacement.

No `ip` rule on any of them: an ip ban on the sign-in path would take out everyone behind a shared NAT.

`passkeyWrapsDelete` is inert until #21165 lands.
