### PR TITLE
fix(settings): repair broken Pair and ConnectAnotherDevice stories

### DIFF
--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import ConnectAnotherDevice, { Devices } from '.';
+import ConnectAnotherDevice from '.';
 import AppLayout from '../../components/AppLayout';
+import { Devices } from '../../lib/utilities';
 import { MemoryRouter } from 'react-router';
 import { ENTRYPOINTS } from '../../constants';
 import { Meta } from '@storybook/react';

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import ConnectAnotherDevice from '.';
-import AppLayout from '../../components/AppLayout';
 import { Devices } from '../../lib/utilities';
 import { MemoryRouter } from 'react-router';
 import { ENTRYPOINTS } from '../../constants';
@@ -31,101 +30,81 @@ export default {
 } as Meta;
 
 export const CanSignInNoSuccessMessage = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      email={MOCK_ACCOUNT.primaryEmail.email}
-      entrypoint={ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT}
-      device={Devices.FIREFOX_DESKTOP}
-      showSuccessMessage={false}
-      isSignIn={false}
-      isSignUp={false}
-      isSignedIn={false}
-      canSignIn
-      fxaStatus={mockFxAStatus()}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    email={MOCK_ACCOUNT.primaryEmail.email}
+    entrypoint={ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT}
+    device={Devices.FIREFOX_DESKTOP}
+    showSuccessMessage={false}
+    isSignIn={false}
+    isSignUp={false}
+    isSignedIn={false}
+    canSignIn
+    fxaStatus={mockFxAStatus()}
+  />
 );
 
 export const CannotSignIn = () => (
-  <AppLayout>
-    <ConnectAnotherDevice isSignIn={false} isSignUp {...MOCK_BASIC_PROPS} />
-  </AppLayout>
+  <ConnectAnotherDevice isSignIn={false} isSignUp {...MOCK_BASIC_PROPS} />
 );
 export const WithSignupSuccessMessage = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      isSignIn={false}
-      isSignUp
-      showSuccessMessage
-      isSignedIn={false}
-      canSignIn
-      {...MOCK_DEFAULTS}
-      fxaStatus={mockFxAStatus()}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    isSignIn={false}
+    isSignUp
+    showSuccessMessage
+    isSignedIn={false}
+    canSignIn
+    {...MOCK_DEFAULTS}
+    fxaStatus={mockFxAStatus()}
+  />
 );
 
 export const WithSignInSuccessMessage = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      isSignIn
-      isSignUp={false}
-      showSuccessMessage
-      isSignedIn={false}
-      canSignIn
-      {...MOCK_DEFAULTS}
-      fxaStatus={mockFxAStatus()}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    isSignIn
+    isSignUp={false}
+    showSuccessMessage
+    isSignedIn={false}
+    canSignIn
+    {...MOCK_DEFAULTS}
+    fxaStatus={mockFxAStatus()}
+  />
 );
 
 export const WithFirefoxDesktop = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      device={Devices.FIREFOX_DESKTOP}
-      {...MOCK_DEVICE_BASIC_PROPS}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    device={Devices.FIREFOX_DESKTOP}
+    {...MOCK_DEVICE_BASIC_PROPS}
+  />
 );
 
 export const WithFirefoxAndroid = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      device={Devices.FIREFOX_ANDROID}
-      {...MOCK_DEVICE_BASIC_PROPS}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    device={Devices.FIREFOX_ANDROID}
+    {...MOCK_DEVICE_BASIC_PROPS}
+  />
 );
 
 export const WithFirefoxIos = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      device={Devices.FIREFOX_IOS}
-      {...MOCK_DEVICE_BASIC_PROPS}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    device={Devices.FIREFOX_IOS}
+    {...MOCK_DEVICE_BASIC_PROPS}
+  />
 );
 
 export const WithOtherAndroid = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      device={Devices.OTHER_ANDROID}
-      {...MOCK_DEVICE_BASIC_PROPS}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    device={Devices.OTHER_ANDROID}
+    {...MOCK_DEVICE_BASIC_PROPS}
+  />
 );
 
 export const WithOtherIos = () => (
-  <AppLayout>
-    <ConnectAnotherDevice
-      device={Devices.OTHER_IOS}
-      {...MOCK_DEVICE_BASIC_PROPS}
-    />
-  </AppLayout>
+  <ConnectAnotherDevice
+    device={Devices.OTHER_IOS}
+    {...MOCK_DEVICE_BASIC_PROPS}
+  />
 );
 
 export const WithOther = () => (
-  <AppLayout>
-    <ConnectAnotherDevice device={Devices.OTHER} {...MOCK_DEVICE_BASIC_PROPS} />
-  </AppLayout>
+  <ConnectAnotherDevice device={Devices.OTHER} {...MOCK_DEVICE_BASIC_PROPS} />
 );

--- a/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
@@ -5,6 +5,7 @@
 import Pair from '.';
 import { Meta } from '@storybook/react';
 import { MemoryRouter } from 'react-router';
+import { Devices } from '../../../lib/utilities';
 import { MOCK_ERROR } from './mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
 import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
@@ -25,7 +26,7 @@ export default {
 
 export const ChoiceScreen = () => (
   <MemoryRouter>
-    <Pair fxaStatusResult={fxaStatusResult} />
+    <Pair fxaStatusResult={fxaStatusResult} device={Devices.FIREFOX_DESKTOP} />
   </MemoryRouter>
 );
 
@@ -33,7 +34,7 @@ export const ChoiceScreenWithSigninBanner = () => (
   <MemoryRouter
     initialEntries={[{ pathname: '/', state: { origin: 'signin' } }]}
   >
-    <Pair fxaStatusResult={fxaStatusResult} />
+    <Pair fxaStatusResult={fxaStatusResult} device={Devices.FIREFOX_DESKTOP} />
   </MemoryRouter>
 );
 
@@ -41,7 +42,7 @@ export const ChoiceScreenWithSignupBanner = () => (
   <MemoryRouter
     initialEntries={[{ pathname: '/', state: { origin: 'signup' } }]}
   >
-    <Pair fxaStatusResult={fxaStatusResult} />
+    <Pair fxaStatusResult={fxaStatusResult} device={Devices.FIREFOX_DESKTOP} />
   </MemoryRouter>
 );
 
@@ -51,13 +52,17 @@ export const ChoiceScreenWithPasswordCreatedBanner = () => (
       { pathname: '/', state: { origin: 'post-verify-set-password' } },
     ]}
   >
-    <Pair fxaStatusResult={fxaStatusResult} />
+    <Pair fxaStatusResult={fxaStatusResult} device={Devices.FIREFOX_DESKTOP} />
   </MemoryRouter>
 );
 
 export const SendTabChoiceScreen = () => (
   <MemoryRouter>
-    <Pair integration={sendTabIntegration} fxaStatusResult={fxaStatusResult} />
+    <Pair
+      integration={sendTabIntegration}
+      fxaStatusResult={fxaStatusResult}
+      device={Devices.FIREFOX_DESKTOP}
+    />
   </MemoryRouter>
 );
 
@@ -65,19 +70,31 @@ export const SendTabChoiceScreenWithSigninBanner = () => (
   <MemoryRouter
     initialEntries={[{ pathname: '/', state: { origin: 'signin' } }]}
   >
-    <Pair integration={sendTabIntegration} fxaStatusResult={fxaStatusResult} />
+    <Pair
+      integration={sendTabIntegration}
+      fxaStatusResult={fxaStatusResult}
+      device={Devices.FIREFOX_DESKTOP}
+    />
   </MemoryRouter>
 );
 
 export const WithError = () => (
   <MemoryRouter>
-    <Pair error={MOCK_ERROR} fxaStatusResult={fxaStatusResult} />
+    <Pair
+      error={MOCK_ERROR}
+      fxaStatusResult={fxaStatusResult}
+      device={Devices.FIREFOX_DESKTOP}
+    />
   </MemoryRouter>
 );
 
 export const WithErrorOnChoiceScreen = () => (
   <MemoryRouter>
-    <Pair error={MOCK_ERROR} fxaStatusResult={fxaStatusResult} />
+    <Pair
+      error={MOCK_ERROR}
+      fxaStatusResult={fxaStatusResult}
+      device={Devices.FIREFOX_DESKTOP}
+    />
   </MemoryRouter>
 );
 
@@ -86,6 +103,10 @@ export const WithErrorOnChoiceScreen = () => (
 // Mirrors the parity Backbone has via fetchCmsConfig() in pair/index.js.
 export const ChoiceScreenWithCmsTheming = () => (
   <MemoryRouter>
-    <Pair cmsInfo={MOCK_CMS_INFO} fxaStatusResult={fxaStatusResult} />
+    <Pair
+      cmsInfo={MOCK_CMS_INFO}
+      fxaStatusResult={fxaStatusResult}
+      device={Devices.FIREFOX_DESKTOP}
+    />
   </MemoryRouter>
 );

--- a/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.stories.tsx
@@ -7,12 +7,15 @@ import { Meta } from '@storybook/react';
 import { MemoryRouter } from 'react-router';
 import { MOCK_ERROR } from './mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import type { Integration } from '../../../models';
 
 const sendTabIntegration = {
   data: { entrypoint: 'send-tab-toolbar-icon' },
 } as unknown as Integration;
+
+const fxaStatusResult = mockUseFxAStatus();
 
 export default {
   title: 'Pages/Pair',
@@ -22,49 +25,59 @@ export default {
 
 export const ChoiceScreen = () => (
   <MemoryRouter>
-    <Pair />
+    <Pair fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
 export const ChoiceScreenWithSigninBanner = () => (
-  <MemoryRouter initialEntries={[{ pathname: '/', state: { origin: 'signin' } }]}>
-    <Pair />
+  <MemoryRouter
+    initialEntries={[{ pathname: '/', state: { origin: 'signin' } }]}
+  >
+    <Pair fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
 export const ChoiceScreenWithSignupBanner = () => (
-  <MemoryRouter initialEntries={[{ pathname: '/', state: { origin: 'signup' } }]}>
-    <Pair />
+  <MemoryRouter
+    initialEntries={[{ pathname: '/', state: { origin: 'signup' } }]}
+  >
+    <Pair fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
 export const ChoiceScreenWithPasswordCreatedBanner = () => (
-  <MemoryRouter initialEntries={[{ pathname: '/', state: { origin: 'post-verify-set-password' } }]}>
-    <Pair />
+  <MemoryRouter
+    initialEntries={[
+      { pathname: '/', state: { origin: 'post-verify-set-password' } },
+    ]}
+  >
+    <Pair fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
 export const SendTabChoiceScreen = () => (
   <MemoryRouter>
-    <Pair integration={sendTabIntegration} />
+    <Pair integration={sendTabIntegration} fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
 export const SendTabChoiceScreenWithSigninBanner = () => (
-  <MemoryRouter initialEntries={[{ pathname: '/', state: { origin: 'signin' } }]}>
-    <Pair integration={sendTabIntegration} />
+  <MemoryRouter
+    initialEntries={[{ pathname: '/', state: { origin: 'signin' } }]}
+  >
+    <Pair integration={sendTabIntegration} fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
 export const WithError = () => (
   <MemoryRouter>
-    <Pair error={MOCK_ERROR} />
+    <Pair error={MOCK_ERROR} fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
 export const WithErrorOnChoiceScreen = () => (
   <MemoryRouter>
-    <Pair error={MOCK_ERROR} />
+    <Pair error={MOCK_ERROR} fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );
 
@@ -73,6 +86,6 @@ export const WithErrorOnChoiceScreen = () => (
 // Mirrors the parity Backbone has via fetchCmsConfig() in pair/index.js.
 export const ChoiceScreenWithCmsTheming = () => (
   <MemoryRouter>
-    <Pair cmsInfo={MOCK_CMS_INFO} />
+    <Pair cmsInfo={MOCK_CMS_INFO} fxaStatusResult={fxaStatusResult} />
   </MemoryRouter>
 );

--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -20,6 +20,7 @@ import { getDefault } from '../../../lib/config';
 import { PAIR_GLEAN_REASONS } from 'fxa-shared/metrics/glean/pair-reasons';
 import { Integration } from '../../../models';
 import { parsePairingHash } from '../../../lib/pairing/pair-url';
+import { Devices } from '../../../lib/utilities';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -900,21 +901,26 @@ describe('parseV2PairingHash', () => {
     it.each([
       ['iOS Safari', IOS_SAFARI, true],
       ['Android Chrome', ANDROID_CHROME, false],
-    ])('routes to the download screen on %s', async (_label, ua, iosHandoff) => {
-      setUserAgent(ua);
-      renderWithRouter(
-        <Pair {...unansweredProps} />,
-        {},
-        v2AppContext({ iosHandoff })
-      );
+    ])(
+      'routes to the download screen on %s',
+      async (_label, ua, iosHandoff) => {
+        setUserAgent(ua);
+        renderWithRouter(
+          <Pair {...unansweredProps} />,
+          {},
+          v2AppContext({ iosHandoff })
+        );
 
-      await waitFor(() =>
-        expect(mockNavigate).toHaveBeenCalledWith(
-          '/pair/supplicant/download_firefox',
-          { state: { channelId: 'chan-1', channelKey: 'key-1', version: '2' } }
-        )
-      );
-    });
+        await waitFor(() =>
+          expect(mockNavigate).toHaveBeenCalledWith(
+            '/pair/supplicant/download_firefox',
+            {
+              state: { channelId: 'chan-1', channelKey: 'key-1', version: '2' },
+            }
+          )
+        );
+      }
+    );
 
     // Firefox iOS cannot finish a pairing that started in another browser, so
     // the hand-off card would only be a tap in front of the same dead end.
@@ -1006,5 +1012,62 @@ describe('parseV2PairingHash', () => {
         expect.anything()
       );
     });
+  });
+});
+
+// The `device` prop is how a caller reaches the pairing screens without a
+// Firefox desktop user agent. This describe sits outside the `Pair` block so
+// that block's Firefox override does not apply.
+describe('device prop', () => {
+  const DESKTOP_CHROME =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+    '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+  const realUserAgent = navigator.userAgent;
+
+  // This describe sits outside the `Pair` block that owns the shared reset, so
+  // a pairing hash or search left by an earlier test would otherwise route
+  // these renders away from the choice screen.
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockLocationState = null;
+    mockLocationSearch = '';
+    mockLocationHash = '';
+    Object.defineProperty(navigator, 'userAgent', {
+      value: DESKTOP_CHROME,
+      configurable: true,
+    });
+    jest.mocked(firefox.requestSignedInUser).mockReset();
+    jest
+      .mocked(firefox.requestSignedInUser)
+      .mockResolvedValue(MOCK_SYNC_SIGNED_IN_USER);
+    jest.mocked(firefox.fxaOAuthFlowBegin).mockReset();
+    jest.mocked(firefox.fxaOAuthFlowBegin).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: realUserAgent,
+      configurable: true,
+    });
+  });
+
+  it('reaches the choice screen when a supported device is supplied', async () => {
+    renderWithRouter(
+      <Pair {...defaultProps} device={Devices.FIREFOX_DESKTOP} />
+    );
+
+    expect(
+      await screen.findByLabelText(/I already have Firefox for mobile/)
+    ).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/pair/unsupported');
+  });
+
+  it('falls back to the user agent when no device is supplied', async () => {
+    renderWithRouter(<Pair {...defaultProps} />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/pair/unsupported')
+    );
   });
 });

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -96,6 +96,9 @@ type PairProps = {
   cmsInfo?: RelierCmsInfo;
   integration?: Integration;
   fxaStatusResult: UseFxAStatusResult;
+  /** @internal Seam for Storybook, which cannot set a user agent. Defaults to
+   * the running browser. */
+  device?: Devices;
 };
 export const viewName = 'pair';
 
@@ -104,6 +107,7 @@ const Pair = ({
   cmsInfo: cmsInfoProp,
   integration,
   fxaStatusResult,
+  device: deviceProp,
 }: PairProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const ftlMsgResolver = useFtlMsgResolver();
@@ -155,7 +159,7 @@ const Pair = ({
     [location.hash]
   );
 
-  const device = detectDevice();
+  const device = deviceProp ?? detectDevice();
   const isFirefoxDesktop = device === Devices.FIREFOX_DESKTOP;
 
   // A phone that scanned the QR with its system camera opens this page in

--- a/packages/fxa-settings/tsconfig.json
+++ b/packages/fxa-settings/tsconfig.json
@@ -15,9 +15,5 @@
   },
   "include": [
     "src"
-  ],
-  "exclude": [
-    "src/**/*.stories.tsx",
-    "src/**/*.stories.ts"
   ]
 }


### PR DESCRIPTION
## Because

- 19 Storybook stories under `Pages/Pair` and `Pages/ConnectAnotherDevice` failed to render, so nobody could review those states.
- `Pair` gained a required `fxaStatusResult` prop and reads `fxaStatusResult.fxaStatusState` without a guard. The 9 Pair stories passed no prop.
- The `Devices` enum moved to `src/lib/utilities.ts`, but the ConnectAnotherDevice story file still imported it from `.`. Webpack resolves the missing named export to `undefined`, so the 7 stories referencing `Devices.*` threw and the other 3 rendered.
- `ConnectAnotherDevice` renders its own `AppLayout`, and every story wrapped it in a second one.
- `Pair` reads `detectDevice()` on mount and redirects without clearing `bootstrapping`, so its stories only left the spinner in Firefox.
- `packages/fxa-settings/tsconfig.json` excluded `src/**/*.stories.tsx`, so no typecheck caught any of it.

## This pull request

- Removes the `src/**/*.stories.tsx` and `src/**/*.stories.ts` exclusions from `packages/fxa-settings/tsconfig.json`, so `tsc` now covers story files.
- Passes `fxaStatusResult` to every `<Pair />` story, built from the existing `mockUseFxAStatus` helper.
- Imports `Devices` from `../../lib/utilities` in the ConnectAnotherDevice story file.
- Removes the duplicate `AppLayout` wrapper from all 10 ConnectAnotherDevice stories.
- Adds an optional `device?: Devices` prop to `Pair` (`pages/Pair/Index/index.tsx`), defaulting to `detectDevice()`, so the stories do not depend on the reviewer's browser UA. Runtime behaviour is unchanged when the prop is omitted.
- Adds a `device prop` describe to `pages/Pair/Index/index.test.tsx` covering the override under a non-Firefox UA and the `detectDevice()` fallback.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-14497

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-settings/tsconfig.json`. It widens typecheck coverage, so it carries more risk than the story files.
- Suggested review order: `tsconfig.json`, then `pages/Pair/Index/index.tsx`, then the two story files, then the new tests.
- Risky or complex parts: `pages/Pair/Index/index.tsx` gains an optional `device` prop with a `detectDevice()` default. No caller passes it outside the stories, so production behaviour is the same. `tsconfig.json` sets `noEmit: true`, so the shipped bundle does not change.
- Trade-off worth knowing: `build-ts` (`tsc --build`, same tsconfig) is in the `build` `dependsOn` chain, and `Build (PR)` runs `nx run-many -t build --all`. So from now a broken story typecheck fails the PR build and nightly, not just Storybook. Confirmed by injecting a deliberate story type error. All 173 story files compile clean today. Note `Unit Test (PR)` would not catch it, since `test-unit` is an `echo` stub in this package.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

No screenshots. Storybook-only changes with no production UI difference. All 19 stories were checked by hand in Firefox and Chrome; Chrome is the case that used to fail.

## Other information (Optional)

Any other information that is important to this pull request.

Local checks:

- `npx tsc -p packages/fxa-settings/tsconfig.json --noEmit`: 0 errors with stories included. No other story file broke.
- `npx nx lint fxa-settings`: 0 errors and 3 warnings. The warnings were already there, in files this branch does not touch.
- `npx nx test-integration fxa-settings`: 300 suites, 3723 passed, 1 skipped.
- `npx nx build-storybook fxa-settings`: passes.
- Jest over Pair and ConnectAnotherDevice: 32 suites, 350 passed, 1 skipped.

`nx test-unit fxa-settings` is an `echo` stub in this package, so the earlier citation of it was not evidence; `test-integration` above replaces it.

The two new tests were checked against a deliberate revert of the `device` override: reverting it fails only `reaches the choice screen when a supported device is supplied`, which is the silent regression the prop would otherwise allow.

Playwright tests did not run here.
