### PR TITLE
ci: auto-run functional tests on blender/* branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1126,6 +1126,7 @@ workflows:
               ignore:
                 - /^dependabot\/.*/
                 - /^func\/.*/
+                - /^blender\/security-bump-.*/
       - playwright-functional-tests:
           name: Firefox Functional Tests - Playwright (PR)
           workflow: test_pull_request
@@ -1137,6 +1138,7 @@ workflows:
               ignore:
                 - /^dependabot\/.*/
                 - /^func\/.*/
+                - /^blender\/security-bump-.*/
       # Auto-run functional tests (no manual approval) on filtered branches,
       # so the check reaches a real conclusion instead of hanging pending.
       - playwright-functional-tests:
@@ -1149,6 +1151,7 @@ workflows:
               only:
                 - /^dependabot\/.*/
                 - /^func\/.*/
+                - /^blender\/security-bump-.*/
       - on-complete:
           name: Tests Complete (PR)
           stage: Tests


### PR DESCRIPTION
## Because

- BLEnder's own bump PRs (`blender/security-bump-*`) hit the manual functional-test approval hold; the auto-run filter only covered `dependabot/*` and `func/*`.

## This pull request

- Adds `/^blender\/security-bump-.*/` to the three functional-test branch filters so BLEnder bump PRs auto-run like Dependabot's (scoped to bump branches, not all `blender/*`).

## Issue that this pull request solves

Closes: FXA-14501

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.