### PR TITLE
fix(payments): Add 'free' to free trial email subject and title

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.spec.ts
@@ -227,6 +227,30 @@ describe('SubPlat Email Renderer — Lifecycle emails', () => {
     expect(email.html).toContain('11/13/2024');
   });
 
+  it('renderSubscriptionReactivation uses free trial copy when isFreeTrialReactivation is true', async () => {
+    const email = await renderer.renderSubscriptionReactivation(
+      {
+        productName: 'Mozilla VPN',
+        icon: 'https://cdn.accounts.firefox.com/product-icons/mozilla-vpn-email.png',
+        invoiceTotal: '$9.99',
+        nextInvoiceDateOnly: '11/13/2024',
+        subscriptionSupportUrl: mockLinkSupport,
+        isFreeTrialReactivation: true,
+      },
+      defaultSubscriptionLayoutValues
+    );
+
+    expect(email.subject).toBe(
+      'Your Mozilla VPN free trial has been reactivated'
+    );
+    expect(email.html).toContain(
+      'Thank you for reactivating your Mozilla VPN free trial!'
+    );
+    expect(email.text).toContain(
+      'Thank you for reactivating your Mozilla VPN free trial!'
+    );
+  });
+
   it('renderSubscriptionPaymentFailed renders failed payment email', async () => {
     const email = await renderer.renderSubscriptionPaymentFailed(
       {

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/en.ftl
@@ -3,13 +3,13 @@
 subscriptionReactivation-subject-2 = Your { $productName } subscription has been reactivated
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionReactivation-freeTrial-subject = Your { $productName } trial has been reactivated
+subscriptionReactivation-free-trial-subject = Your { $productName } free trial has been reactivated
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionReactivation-title = Thank you for reactivating your { $productName } subscription!
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionReactivation-freeTrial-title = Thank you for reactivating your { $productName } trial!
+subscriptionReactivation-free-trial-title = Thank you for reactivating your { $productName } free trial!
 # Variables:
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 2016/01/20

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.mjml
@@ -8,7 +8,7 @@
   <mj-column>
     <mj-text css-class="text-header">
       <% if (isFreeTrialReactivation) { %>
-        <span data-l10n-id="subscriptionReactivation-freeTrial-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> trial!</span>
+        <span data-l10n-id="subscriptionReactivation-free-trial-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> free trial!</span>
       <% } else { %>
         <span data-l10n-id="subscriptionReactivation-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> subscription!</span>
       <% } %>

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.ts
@@ -16,15 +16,15 @@ export type TemplateData = IconTemplateData &
   };
 
 export const template = 'subscriptionReactivation';
-export const version = 3;
+export const version = 4;
 export const layout = 'subscription';
 
 export function getIncludes(isFreeTrialReactivation: boolean) {
   return {
     subject: isFreeTrialReactivation
       ? {
-          id: 'subscriptionReactivation-freeTrial-subject',
-          message: 'Your <%- productName %> trial has been reactivated',
+          id: 'subscriptionReactivation-free-trial-subject',
+          message: 'Your <%- productName %> free trial has been reactivated',
         }
       : {
           id: 'subscriptionReactivation-subject-2',

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.txt
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.txt
@@ -1,5 +1,5 @@
 <% if (isFreeTrialReactivation) { %>
-subscriptionReactivation-freeTrial-title = "Thank you for reactivating your <%- productName %> trial!"
+subscriptionReactivation-free-trial-title = "Thank you for reactivating your <%- productName %> free trial!"
 <% } else { %>
 subscriptionReactivation-title = "Thank you for reactivating your <%- productName %> subscription!"
 <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -1,6 +1,6 @@
 {
   "freeTrialEndingReminder": 2,
-  "subscriptionReactivation": 3,
+  "subscriptionReactivation": 4,
   "subscriptionRenewalReminder": 4,
   "subscriptionEndingReminder": 2,
   "subscriptionUpgrade": 7,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/en.ftl
@@ -3,13 +3,13 @@
 subscriptionReactivation-subject-2 = Your { $productName } subscription has been reactivated
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionReactivation-freeTrial-subject = Your { $productName } trial has been reactivated
+subscriptionReactivation-free-trial-subject = Your { $productName } free trial has been reactivated
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionReactivation-title = Thank you for reactivating your { $productName } subscription!
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionReactivation-freeTrial-title = Thank you for reactivating your { $productName } trial!
+subscriptionReactivation-free-trial-title = Thank you for reactivating your { $productName } free trial!
 # Variables:
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 2016/01/20

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.ts
@@ -9,8 +9,8 @@ export const getIncludes = (
 ): GlobalTemplateValues => ({
   subject: isFreeTrialReactivation
     ? {
-        id: 'subscriptionReactivation-freeTrial-subject',
-        message: 'Your <%- productName %> trial has been reactivated',
+        id: 'subscriptionReactivation-free-trial-subject',
+        message: 'Your <%- productName %> free trial has been reactivated',
       }
     : {
         id: 'subscriptionReactivation-subject-2',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
@@ -8,7 +8,7 @@
   <mj-column>
     <mj-text css-class="text-header">
       <% if (isFreeTrialReactivation) { %>
-        <span data-l10n-id="subscriptionReactivation-freeTrial-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> trial!</span>
+        <span data-l10n-id="subscriptionReactivation-free-trial-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> free trial!</span>
       <% } else { %>
         <span data-l10n-id="subscriptionReactivation-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> subscription!</span>
       <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.txt
@@ -1,5 +1,5 @@
 <% if (isFreeTrialReactivation) { %>
-subscriptionReactivation-freeTrial-title = "Thank you for reactivating your <%- productName %> trial!"
+subscriptionReactivation-free-trial-title = "Thank you for reactivating your <%- productName %> free trial!"
 <% } else { %>
 subscriptionReactivation-title = "Thank you for reactivating your <%- productName %> subscription!"
 <% } %>


### PR DESCRIPTION
## Because

- Reactivation email subject and title currently reflects "Your <product> trial has been reactivated"

## This pull request
- Updates subject and title to include "free" - "Your <product> free trial has been reactivated"

## Issue that this pull request solves

Closes: PAY-3914

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.