### PR TITLE
feat(settings): add the passkey wrap creation hook

### DIFF
--- a/packages/fxa-settings/src/lib/passkeys/wrap/creation.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/wrap/creation.test.ts
@@ -1,0 +1,794 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ERRNO } from '@fxa/accounts/errors';
+import type AuthClient from 'fxa-auth-client/browser';
+import { createPasskeyWrapFlow, createPasskeyWrapStore } from './creation';
+import type {
+  PasskeyWrapCreationFailureReason,
+  PasskeyWrapStore,
+} from './interfaces';
+import {
+  MOCK_CREDENTIAL_ID,
+  MOCK_JWT,
+  MOCK_KB,
+  MOCK_OTHER_CREDENTIAL_ID,
+  MOCK_OTHER_UID,
+  MOCK_PRF_OUT,
+  MOCK_SESSION_TOKEN,
+  MOCK_UID,
+  ZEROED,
+  args,
+  argsFor,
+  deferWrap,
+  mfaTokenFor,
+  opensTo,
+  proofFor,
+  serverError,
+} from './mocks';
+import {
+  JwtNotFoundError,
+  JwtTokenCache,
+  sessionToken as getSessionToken,
+} from '../../cache';
+import type {
+  createWrapEnvelope,
+  openWrapEnvelope,
+} from '../../passkey-crypto';
+
+// Routed through mocks so the seal and verify branches can be forced. Both
+// delegate to the real crypto by default, so every other test seals for real.
+const mockCreateWrapEnvelope: jest.MockedFunction<typeof createWrapEnvelope> =
+  jest.fn();
+const mockOpenWrapEnvelope: jest.MockedFunction<typeof openWrapEnvelope> =
+  jest.fn();
+jest.mock('../../passkey-crypto', () => ({
+  ...jest.requireActual('../../passkey-crypto'),
+  createWrapEnvelope: (...args: Parameters<typeof createWrapEnvelope>) =>
+    mockCreateWrapEnvelope(...args),
+  openWrapEnvelope: (...args: Parameters<typeof openWrapEnvelope>) =>
+    mockOpenWrapEnvelope(...args),
+}));
+
+jest.mock('../../cache', () => ({
+  ...jest.requireActual('../../cache'),
+  sessionToken: jest.fn(),
+}));
+
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/browser', () => ({
+  ...jest.requireActual('@sentry/browser'),
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+let createPasskeyWrap: jest.MockedFunction<AuthClient['createPasskeyWrap']>;
+/** Fresh per test, so a held envelope cannot leak into the next one. */
+let store: PasskeyWrapStore;
+
+const flow = () => createPasskeyWrapFlow({ createPasskeyWrap }, store);
+
+const storedEnvelope = (call = 0) => createPasskeyWrap.mock.calls[call][2];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  createPasskeyWrap = jest.fn().mockResolvedValue({ created: true });
+  store = createPasskeyWrapStore();
+  jest.mocked(getSessionToken).mockReturnValue(undefined);
+  mockCreateWrapEnvelope.mockImplementation(
+    jest.requireActual('../../passkey-crypto').createWrapEnvelope
+  );
+  mockOpenWrapEnvelope.mockImplementation(
+    jest.requireActual('../../passkey-crypto').openWrapEnvelope
+  );
+});
+
+describe('createPasskeyWrapFlow', () => {
+  it('stores one envelope for the credential, authorized by the proof', async () => {
+    await flow().createWrap(args());
+
+    expect(createPasskeyWrap).toHaveBeenCalledTimes(1);
+    const [jwt, credentialId] = createPasskeyWrap.mock.calls[0];
+    expect(jwt).toBe(MOCK_JWT);
+    expect(credentialId).toBe(MOCK_CREDENTIAL_ID);
+  });
+
+  it('seals kB so the same PRF output and credential open it again', async () => {
+    await flow().createWrap(args());
+
+    await opensTo(storedEnvelope());
+  });
+
+  it.each([
+    ['a newly stored wrap', true],
+    ['an identical wrap already stored', false],
+  ])('reports %s as created=%s', async (_label, created) => {
+    createPasskeyWrap.mockResolvedValue({ created });
+
+    const outcome = await flow().createWrap(args());
+
+    expect(outcome).toEqual({ ok: true, created });
+  });
+
+  it('refuses a response with no created field rather than assuming stored', async () => {
+    createPasskeyWrap.mockResolvedValue({} as { created: boolean });
+
+    const outcome = await flow().createWrap(args());
+
+    // Reporting it stored would drop the sealed envelope, so a retry would
+    // seal fresh bytes and earn a permanent errno 235.
+    expect(outcome).toEqual({ ok: false, failure: 'unexpected' });
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      new Error('passkey-wrap-response error'),
+      { tags: { stage: 'store' } }
+    );
+  });
+
+  describe('in-flight state', () => {
+    it('is not in flight before a call', () => {
+      expect(flow().inFlight).toBe(false);
+    });
+
+    it('is in flight until the store answers', async () => {
+      const { called, release } = deferWrap(createPasskeyWrap);
+      const wrapFlow = flow();
+
+      const pending = wrapFlow.createWrap(args());
+      await called;
+      expect(wrapFlow.inFlight).toBe(true);
+
+      release();
+      await pending;
+      expect(wrapFlow.inFlight).toBe(false);
+    });
+
+    it('is released after a rejection', async () => {
+      const { called, refuse } = deferWrap(createPasskeyWrap);
+      const wrapFlow = flow();
+
+      const pending = wrapFlow.createWrap(args());
+      await called;
+      refuse(serverError(ERRNO.PASSKEY_NOT_FOUND));
+      await pending;
+
+      expect(wrapFlow.inFlight).toBe(false);
+    });
+
+    it('refuses a same-tick call while a proof rejection is still settling', async () => {
+      const wrapFlow = flow();
+
+      const first = wrapFlow.createWrap({ ...args(), mfaToken: 'not-a-jwt' });
+      const second = await wrapFlow.createWrap(args());
+
+      expect(second).toEqual({ ok: false, failure: 'in_flight' });
+      await expect(first).resolves.toEqual({
+        ok: false,
+        failure: 'proof_invalid',
+      });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failures', () => {
+    it.each<[number, PasskeyWrapCreationFailureReason]>([
+      [ERRNO.INVALID_MFA_TOKEN, 'proof_invalid'],
+      [ERRNO.INVALID_TOKEN, 'proof_invalid'],
+      [ERRNO.PASSKEY_NOT_FOUND, 'passkey_not_found'],
+      [ERRNO.PASSKEY_WRAP_CONFLICT, 'wrap_conflict'],
+      [ERRNO.THROTTLED, 'throttled'],
+      [ERRNO.REQUEST_BLOCKED, 'throttled'],
+      [ERRNO.FEATURE_NOT_ENABLED, 'feature_disabled'],
+      [ERRNO.UNEXPECTED_ERROR, 'unexpected'],
+    ])('maps errno %i to %s', async (errno, failure) => {
+      createPasskeyWrap.mockRejectedValue(serverError(errno));
+
+      const outcome = await flow().createWrap(args());
+
+      expect(outcome).toEqual({
+        ok: false,
+        failure,
+        cause: { errno, code: undefined, retryAfter: undefined },
+      });
+    });
+
+    it('carries retryAfter through on a throttle so callers can back off', async () => {
+      createPasskeyWrap.mockRejectedValue(
+        serverError(ERRNO.THROTTLED, { code: 429, retryAfter: 900 })
+      );
+
+      const outcome = await flow().createWrap(args());
+
+      expect(outcome).toEqual({
+        ok: false,
+        failure: 'throttled',
+        cause: { errno: ERRNO.THROTTLED, code: 429, retryAfter: 900 },
+      });
+    });
+
+    it('reports an unmapped failure to Sentry, tagged with its errno', async () => {
+      createPasskeyWrap.mockRejectedValue(serverError(ERRNO.UNEXPECTED_ERROR));
+
+      await flow().createWrap(args());
+
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        new Error('passkey-wrap-store error'),
+        { tags: { stage: 'store', errno: String(ERRNO.UNEXPECTED_ERROR) } }
+      );
+    });
+
+    it('tags an errorless envelope failure as none', async () => {
+      mockCreateWrapEnvelope.mockRejectedValue(new Error('seal failed'));
+
+      await flow().createWrap(args());
+
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        new Error('passkey-wrap-seal error'),
+        { tags: { stage: 'seal', errno: 'none' } }
+      );
+    });
+
+    it.each<[number, PasskeyWrapCreationFailureReason]>([
+      [ERRNO.PASSKEY_WRAP_CONFLICT, 'wrap_conflict'],
+      [ERRNO.THROTTLED, 'throttled'],
+      [ERRNO.INVALID_MFA_TOKEN, 'proof_invalid'],
+    ])('keeps errno %i (%s) out of Sentry', async (errno) => {
+      createPasskeyWrap.mockRejectedValue(serverError(errno));
+
+      await flow().createWrap(args());
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('refuses to store an envelope this platform cannot reopen', async () => {
+      // Only opening exercises the skR unwrap and HPKE decap.
+      mockOpenWrapEnvelope.mockRejectedValue(new Error('decap failed'));
+
+      const outcome = await flow().createWrap(args());
+
+      expect(outcome).toEqual({ ok: false, failure: 'platform_crypto' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        new Error('passkey-wrap-verify error'),
+        { tags: { stage: 'verify' } }
+      );
+    });
+
+    it('refuses to store an envelope that reopens to the wrong bytes', async () => {
+      mockOpenWrapEnvelope.mockResolvedValue(new Uint8Array(32).fill(1));
+
+      const outcome = await flow().createWrap(args());
+
+      expect(outcome).toEqual({ ok: false, failure: 'platform_crypto' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+
+    it('maps an envelope that cannot be built to unexpected', async () => {
+      mockCreateWrapEnvelope.mockRejectedValue(new Error('seal failed'));
+
+      const outcome = await flow().createWrap(args());
+
+      expect(outcome).toEqual({ ok: false, failure: 'unexpected' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+
+    it('leaves the key material intact when the envelope cannot be built', async () => {
+      mockCreateWrapEnvelope.mockRejectedValue(new Error('seal failed'));
+      const input = args();
+
+      await flow().createWrap(input);
+
+      expect(input.kB).toEqual(MOCK_KB);
+      expect(input.prfOut).toEqual(MOCK_PRF_OUT);
+    });
+  });
+
+  describe('unusable key material', () => {
+    it.each([
+      ['no PRF output', undefined],
+      ['a zero-length PRF output', new Uint8Array(0)],
+      ['a wrong-width PRF output', new Uint8Array(16).fill(9)],
+    ])('refuses %s without calling the server', async (_label, prfOut) => {
+      const outcome = await flow().createWrap({ ...args(), prfOut });
+
+      expect(outcome).toEqual({ ok: false, failure: 'prf_unsupported' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+
+    it('leaves kB intact when the passkey cannot hold a wrap', async () => {
+      const input = { ...args(), prfOut: undefined };
+
+      await flow().createWrap(input);
+
+      expect(input.kB).toEqual(MOCK_KB);
+    });
+
+    it('refuses a spent prfOut as unusable, not as an unsupported passkey', async () => {
+      const outcome = await flow().createWrap({
+        ...args(),
+        prfOut: new Uint8Array(32),
+      });
+
+      // `prf_unsupported` would blame the authenticator for spent material.
+      expect(outcome).toEqual({ ok: false, failure: 'key_unusable' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+
+    it('leaves prfOut usable after a rejected kB, so a retry can still seal', async () => {
+      const input = args();
+      const { createWrap } = flow();
+
+      // Regenerating the PRF output costs another ceremony and biometric prompt.
+      await createWrap({ ...input, kB: new Uint8Array(16).fill(7) });
+      expect(input.prfOut).toEqual(MOCK_PRF_OUT);
+
+      const outcome = await createWrap(input);
+
+      expect(outcome).toEqual({ ok: true, created: true });
+      await opensTo(storedEnvelope());
+    });
+
+    it('refuses an already-zeroed kB rather than sealing an unopenable wrap', async () => {
+      const outcome = await flow().createWrap({
+        ...args(),
+        kB: new Uint8Array(32),
+      });
+
+      expect(outcome).toEqual({ ok: false, failure: 'key_unusable' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+
+    it('refuses a wrong-width kB', async () => {
+      const outcome = await flow().createWrap({
+        ...args(),
+        kB: new Uint8Array(16).fill(7),
+      });
+
+      expect(outcome).toEqual({ ok: false, failure: 'key_unusable' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('proof claims', () => {
+    it('seals against the uid the proof names', async () => {
+      await flow().createWrap({
+        ...args(),
+        mfaToken: proofFor(MOCK_CREDENTIAL_ID, MOCK_OTHER_UID),
+      });
+
+      await opensTo(storedEnvelope(), { uid: MOCK_OTHER_UID });
+    });
+
+    it('refuses a proof bound to another credential without sealing', async () => {
+      const input = { ...args(), mfaToken: proofFor(MOCK_OTHER_CREDENTIAL_ID) };
+
+      const outcome = await flow().createWrap(input);
+
+      expect(outcome).toEqual({ ok: false, failure: 'proof_invalid' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+      expect(input.kB).toEqual(MOCK_KB);
+      expect(input.prfOut).toEqual(MOCK_PRF_OUT);
+    });
+
+    it('reports a proof bound to another credential as a caller error', async () => {
+      await flow().createWrap({
+        ...args(),
+        mfaToken: proofFor(MOCK_OTHER_CREDENTIAL_ID),
+      });
+
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        new Error('passkey-wrap-proof error'),
+        { tags: { stage: 'proof' } }
+      );
+    });
+
+    it.each([
+      ['a token with no payload segment', 'not-a-jwt'],
+      ['a payload that is not JSON', 'header.bm90LWpzb24.signature'],
+      ['a payload that is not an object', 'header.NDI.signature'],
+      ['a payload carrying no sub', mfaTokenFor({ cid: MOCK_CREDENTIAL_ID })],
+      ['a sub that is not a uid', proofFor(MOCK_CREDENTIAL_ID, 'not-hex')],
+      ['a proof bound to no credential', mfaTokenFor({ sub: MOCK_UID })],
+    ])('refuses %s', async (_label, mfaToken) => {
+      const outcome = await flow().createWrap({ ...args(), mfaToken });
+
+      expect(outcome).toEqual({ ok: false, failure: 'proof_invalid' });
+      expect(createPasskeyWrap).not.toHaveBeenCalled();
+    });
+
+    it('leaves the key material intact when the proof names no account', async () => {
+      const input = { ...args(), mfaToken: 'not-a-jwt' };
+
+      await flow().createWrap(input);
+
+      expect(input.kB).toEqual(MOCK_KB);
+      expect(input.prfOut).toEqual(MOCK_PRF_OUT);
+    });
+  });
+
+  describe('secret handling', () => {
+    it('zeroes kB and the PRF output on success', async () => {
+      const input = args();
+
+      await flow().createWrap(input);
+
+      expect(input.kB).toEqual(ZEROED);
+      expect(input.prfOut).toEqual(ZEROED);
+    });
+
+    it('zeroes kB and the PRF output when the server rejects the wrap', async () => {
+      createPasskeyWrap.mockRejectedValue(serverError(ERRNO.INVALID_MFA_TOKEN));
+      const input = args();
+
+      await flow().createWrap(input);
+
+      expect(input.kB).toEqual(ZEROED);
+      expect(input.prfOut).toEqual(ZEROED);
+    });
+
+    it('zeroes both before the request goes out', async () => {
+      const input = args();
+      let atRequest: { kB: Uint8Array; prfOut: Uint8Array } | undefined;
+      createPasskeyWrap.mockImplementation(async () => {
+        atRequest = {
+          kB: Uint8Array.from(input.kB),
+          prfOut: Uint8Array.from(input.prfOut),
+        };
+        return { created: true };
+      });
+
+      await flow().createWrap(input);
+
+      expect(atRequest).toEqual({ kB: ZEROED, prfOut: ZEROED });
+    });
+  });
+
+  describe('retries', () => {
+    it('re-sends the same envelope after a failed request', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const input = args();
+      const { createWrap } = flow();
+
+      await createWrap(input);
+      expect(input.kB).toEqual(ZEROED);
+
+      const outcome = await createWrap(input);
+
+      // Byte-identical, so a server that already committed answers
+      // `created: false` instead of errno 235.
+      expect(createPasskeyWrap).toHaveBeenCalledTimes(2);
+      expect(storedEnvelope(1)).toEqual(storedEnvelope(0));
+      expect(outcome).toEqual({ ok: true, created: true });
+    });
+
+    it('re-sends the held envelope when a retry repeats the same kB', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const { createWrap } = flow();
+
+      await createWrap(args());
+
+      const retry = args();
+      const outcome = await createWrap(retry);
+
+      expect(outcome).toEqual({ ok: true, created: true });
+      expect(storedEnvelope(1)).toEqual(storedEnvelope(0));
+      expect(retry.kB).toEqual(ZEROED);
+      expect(retry.prfOut).toEqual(ZEROED);
+    });
+
+    it('refuses a retry carrying a different kB and drops the held envelope', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const { createWrap } = flow();
+
+      await createWrap(args());
+      const refused = await createWrap({
+        ...args(),
+        kB: new Uint8Array(32).fill(3),
+      });
+      const retried = await createWrap({
+        credentialId: MOCK_CREDENTIAL_ID,
+        mfaToken: MOCK_JWT,
+      });
+
+      expect(refused).toEqual({ ok: false, failure: 'key_changed' });
+      // Nothing held and no key supplied, so there is nothing to send.
+      expect(retried).toEqual({ ok: false, failure: 'prf_unsupported' });
+      expect(createPasskeyWrap).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the held envelope when a retry carries a wrong-width kB', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const { createWrap } = flow();
+
+      await createWrap(args());
+
+      const refused = await createWrap({
+        ...args(),
+        kB: new Uint8Array(16).fill(7),
+      });
+      const retried = await createWrap({
+        credentialId: MOCK_CREDENTIAL_ID,
+        mfaToken: MOCK_JWT,
+      });
+
+      expect(refused).toEqual({ ok: false, failure: 'key_unusable' });
+      expect(retried).toEqual({ ok: true, created: true });
+      expect(storedEnvelope(1)).toEqual(storedEnvelope(0));
+    });
+
+    it('accepts a retry that omits the spent key material', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const { createWrap } = flow();
+
+      await createWrap(args());
+
+      const outcome = await createWrap({
+        credentialId: MOCK_CREDENTIAL_ID,
+        mfaToken: MOCK_JWT,
+      });
+
+      expect(outcome).toEqual({ ok: true, created: true });
+      expect(storedEnvelope(1)).toEqual(storedEnvelope(0));
+    });
+
+    it.each([
+      ERRNO.PASSKEY_NOT_FOUND,
+      ERRNO.PASSKEY_WRAP_CONFLICT,
+      ERRNO.FEATURE_NOT_ENABLED,
+    ])(
+      'drops the sealed envelope after errno %i, which no retry can clear',
+      async (errno) => {
+        createPasskeyWrap.mockRejectedValueOnce(serverError(errno));
+        const { createWrap } = flow();
+
+        await createWrap(args());
+
+        const outcome = await createWrap({
+          credentialId: MOCK_CREDENTIAL_ID,
+          mfaToken: MOCK_JWT,
+        });
+
+        // Nothing cached and no key supplied, so there is nothing to send.
+        expect(outcome).toEqual({ ok: false, failure: 'prf_unsupported' });
+        expect(createPasskeyWrap).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it('seals a new envelope bound to a different credential', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const { createWrap } = flow();
+
+      await createWrap(args());
+      await createWrap(argsFor(MOCK_OTHER_CREDENTIAL_ID));
+
+      expect(storedEnvelope(1)).not.toEqual(storedEnvelope(0));
+      // Inequality alone would also hold if it re-sealed under the old
+      // credential; only the round trip pins the new binding.
+      await opensTo(storedEnvelope(1), {
+        credentialId: MOCK_OTHER_CREDENTIAL_ID,
+      });
+    });
+
+    it('seals a new envelope when the proof names a different account', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const { createWrap } = flow();
+
+      await createWrap(args());
+      await createWrap({
+        ...args(),
+        mfaToken: proofFor(MOCK_CREDENTIAL_ID, MOCK_OTHER_UID),
+      });
+
+      expect(storedEnvelope(1)).not.toEqual(storedEnvelope(0));
+      await opensTo(storedEnvelope(1), { uid: MOCK_OTHER_UID });
+    });
+
+    it('seals fresh bytes for the same credential after a stored wrap', async () => {
+      const { createWrap } = flow();
+
+      await createWrap(args());
+      await createWrap(args());
+
+      // Kept, it would re-send stale bytes after a kB rotation.
+      expect(createPasskeyWrap).toHaveBeenCalledTimes(2);
+      expect(storedEnvelope(1)).not.toEqual(storedEnvelope(0));
+    });
+
+    it('refuses a concurrent retry on the reuse path', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+      const { createWrap } = flow();
+
+      await createWrap(args());
+
+      const { called, release } = deferWrap(createPasskeyWrap);
+      const settled = Promise.all([createWrap(args()), createWrap(args())]);
+
+      await called;
+      release();
+      const outcomes = await settled;
+
+      expect(outcomes).toContainEqual({ ok: false, failure: 'in_flight' });
+      // Two calls total: the first attempt plus one retry. Without the guard
+      // the reuse path would issue both retries.
+      expect(createPasskeyWrap).toHaveBeenCalledTimes(2);
+    });
+
+    it('refuses a second call while one is in flight', async () => {
+      const { called, release } = deferWrap(createPasskeyWrap);
+      const { createWrap } = flow();
+
+      const first = createWrap(args());
+      const second = await createWrap(args());
+
+      expect(second).toEqual({ ok: false, failure: 'in_flight' });
+
+      await called;
+      release();
+      await first;
+      expect(createPasskeyWrap).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shared store', () => {
+    it('re-sends an envelope another instance sealed', async () => {
+      createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+
+      await flow().createWrap(args());
+      const outcome = await flow().createWrap({
+        credentialId: MOCK_CREDENTIAL_ID,
+        mfaToken: MOCK_JWT,
+      });
+
+      expect(outcome).toEqual({ ok: true, created: true });
+      expect(storedEnvelope(1)).toEqual(storedEnvelope(0));
+    });
+
+    it('refuses a call while another instance has the credential in flight', async () => {
+      const { called, release } = deferWrap(createPasskeyWrap);
+
+      const first = flow().createWrap(args());
+      const second = await flow().createWrap(args());
+
+      expect(second).toEqual({ ok: false, failure: 'in_flight' });
+
+      await called;
+      release();
+      await first;
+      expect(createPasskeyWrap).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets another instance work on a different credential meanwhile', async () => {
+      const { called, release } = deferWrap(createPasskeyWrap);
+
+      const first = flow().createWrap(args());
+      await called;
+      createPasskeyWrap.mockResolvedValue({ created: true });
+      const second = await flow().createWrap(argsFor(MOCK_OTHER_CREDENTIAL_ID));
+
+      expect(second).toEqual({ ok: true, created: true });
+
+      release();
+      await first;
+      expect(createPasskeyWrap).toHaveBeenCalledTimes(2);
+    });
+
+    it('leaves the store empty once the wrap is stored', async () => {
+      await flow().createWrap(args());
+
+      expect(store.held.size).toBe(0);
+      expect(store.inFlight.size).toBe(0);
+    });
+  });
+
+  describe('spent proof eviction', () => {
+    // JwtTokenCache is a real module singleton backed by persistent storage,
+    // so entries survive the test that wrote them.
+    beforeEach(() => {
+      jest.mocked(getSessionToken).mockReturnValue(MOCK_SESSION_TOKEN);
+      JwtTokenCache.removeToken(MOCK_SESSION_TOKEN, 'passkey');
+    });
+
+    afterEach(() => {
+      JwtTokenCache.clearTokens(MOCK_SESSION_TOKEN);
+    });
+
+    it('drops the rejected proof from the JWT cache', async () => {
+      JwtTokenCache.setToken(MOCK_SESSION_TOKEN, 'passkey', MOCK_JWT);
+      createPasskeyWrap.mockRejectedValue(serverError(ERRNO.INVALID_MFA_TOKEN));
+
+      await flow().createWrap(args());
+
+      expect(JwtTokenCache.hasToken(MOCK_SESSION_TOKEN, 'passkey')).toBe(false);
+    });
+
+    it('drops a proof that names no account', async () => {
+      const mfaToken = mfaTokenFor({ scope: ['mfa:passkey'] });
+      JwtTokenCache.setToken(MOCK_SESSION_TOKEN, 'passkey', mfaToken);
+
+      await flow().createWrap({ ...args(), mfaToken });
+
+      expect(JwtTokenCache.hasToken(MOCK_SESSION_TOKEN, 'passkey')).toBe(false);
+    });
+
+    it('keeps an unrelated cached proof for the same session', async () => {
+      JwtTokenCache.setToken(MOCK_SESSION_TOKEN, 'passkey', 'another.mfa.jwt');
+      createPasskeyWrap.mockRejectedValue(serverError(ERRNO.INVALID_MFA_TOKEN));
+
+      await flow().createWrap(args());
+
+      expect(JwtTokenCache.getToken(MOCK_SESSION_TOKEN, 'passkey')).toBe(
+        'another.mfa.jwt'
+      );
+    });
+
+    it('leaves a cached proof alone when there is no session token', async () => {
+      jest.mocked(getSessionToken).mockReturnValue(undefined);
+      JwtTokenCache.setToken(MOCK_SESSION_TOKEN, 'passkey', MOCK_JWT);
+      createPasskeyWrap.mockRejectedValue(serverError(ERRNO.INVALID_MFA_TOKEN));
+
+      await flow().createWrap(args());
+
+      expect(JwtTokenCache.getToken(MOCK_SESSION_TOKEN, 'passkey')).toBe(
+        MOCK_JWT
+      );
+    });
+
+    it('is a no-op when nothing is cached for the session', async () => {
+      createPasskeyWrap.mockRejectedValue(serverError(ERRNO.INVALID_MFA_TOKEN));
+
+      const outcome = await flow().createWrap(args());
+
+      expect(outcome).toEqual({
+        ok: false,
+        failure: 'proof_invalid',
+        cause: {
+          errno: ERRNO.INVALID_MFA_TOKEN,
+          code: undefined,
+          retryAfter: undefined,
+        },
+      });
+      expect(JwtTokenCache.hasToken(MOCK_SESSION_TOKEN, 'passkey')).toBe(false);
+    });
+
+    it('drops an expired proof the server rejected', async () => {
+      const expired = mfaTokenFor({
+        sub: MOCK_UID,
+        cid: MOCK_CREDENTIAL_ID,
+        exp: 1,
+      });
+      JwtTokenCache.setToken(MOCK_SESSION_TOKEN, 'passkey', expired);
+      createPasskeyWrap.mockRejectedValue(serverError(ERRNO.INVALID_MFA_TOKEN));
+
+      await flow().createWrap({ ...args(), mfaToken: expired });
+
+      // `hasToken` already answers false for an expired entry, so only a read
+      // shows whether it was removed.
+      expect(() =>
+        JwtTokenCache.getToken(MOCK_SESSION_TOKEN, 'passkey')
+      ).toThrow(JwtNotFoundError);
+    });
+
+    it('keeps a proof bound to another credential', async () => {
+      const mismatched = proofFor(MOCK_OTHER_CREDENTIAL_ID);
+      JwtTokenCache.setToken(MOCK_SESSION_TOKEN, 'passkey', mismatched);
+
+      await flow().createWrap({ ...args(), mfaToken: mismatched });
+
+      expect(JwtTokenCache.getToken(MOCK_SESSION_TOKEN, 'passkey')).toBe(
+        mismatched
+      );
+    });
+
+    it('leaves the cache alone on a failure that is not a stale proof', async () => {
+      JwtTokenCache.setToken(MOCK_SESSION_TOKEN, 'passkey', MOCK_JWT);
+      createPasskeyWrap.mockRejectedValue(
+        serverError(ERRNO.PASSKEY_WRAP_CONFLICT)
+      );
+
+      await flow().createWrap(args());
+
+      expect(JwtTokenCache.getToken(MOCK_SESSION_TOKEN, 'passkey')).toBe(
+        MOCK_JWT
+      );
+    });
+  });
+});

--- a/packages/fxa-settings/src/lib/passkeys/wrap/creation.ts
+++ b/packages/fxa-settings/src/lib/passkeys/wrap/creation.ts
@@ -1,0 +1,413 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/browser';
+import { ERRNO } from '@fxa/accounts/errors';
+import type { AuthServerError } from 'fxa-auth-client/browser';
+import { base64urlToBytes } from '../../base64url';
+import { JwtTokenCache, sessionToken as getSessionToken } from '../../cache';
+import { isInvalidJwtError } from '../../mfa-guard-utils';
+import { createWrapEnvelope, openWrapEnvelope } from '../../passkey-crypto';
+import { KB_BYTES, PRF_OUT_BYTES } from '../../passkey-crypto/constants';
+import type {
+  CreatePasskeyWrapArgs,
+  CreatePasskeyWrapResult,
+  PasskeyWrapAuthClient,
+  PasskeyWrapCreationCause,
+  PasskeyWrapCreationFailureReason,
+  PasskeyWrapFlow,
+  PasskeyWrapStore,
+} from './interfaces';
+
+/** Failures that no retry of the same envelope can clear. */
+const TERMINAL_FAILURES: ReadonlySet<PasskeyWrapCreationFailureReason> =
+  new Set([
+    'passkey_not_found',
+    'wrap_conflict',
+    'feature_disabled',
+    'key_changed',
+  ]);
+
+/** A store of its own, for flows that must not see the page's held envelopes. */
+export function createPasskeyWrapStore(): PasskeyWrapStore {
+  return { held: new Map(), inFlight: new Set() };
+}
+
+/** The store every flow shares unless handed another. */
+export const passkeyWrapStore = createPasskeyWrapStore();
+
+const heldKey = (uid: string, credentialId: string) => `${uid}:${credentialId}`;
+
+function refused(
+  reason: PasskeyWrapCreationFailureReason,
+  cause?: PasskeyWrapCreationCause
+): CreatePasskeyWrapResult {
+  return { ok: false, failure: reason, ...(cause ? { cause } : {}) };
+}
+
+function causeOf(err: unknown): PasskeyWrapCreationCause | undefined {
+  if (err == null || typeof err !== 'object') {
+    return undefined;
+  }
+  const { errno, code, retryAfter } = err as AuthServerError;
+  if (errno === undefined && code === undefined && retryAfter === undefined) {
+    return undefined;
+  }
+  return { errno, code, retryAfter };
+}
+
+function toFailureReason(err: unknown): PasskeyWrapCreationFailureReason {
+  // Delegated so this cannot drift from the definition the MfaGuard hosts use.
+  if (isInvalidJwtError(err)) {
+    return 'proof_invalid';
+  }
+  switch (causeOf(err)?.errno) {
+    case ERRNO.PASSKEY_NOT_FOUND:
+      return 'passkey_not_found';
+    case ERRNO.PASSKEY_WRAP_CONFLICT:
+      return 'wrap_conflict';
+    case ERRNO.THROTTLED:
+    case ERRNO.REQUEST_BLOCKED:
+      return 'throttled';
+    case ERRNO.FEATURE_NOT_ENABLED:
+      return 'feature_disabled';
+    default:
+      return 'unexpected';
+  }
+}
+
+/** A zeroed buffer is spent, not key material. */
+function isZeroed(bytes: Uint8Array): boolean {
+  return bytes.every((byte) => byte === 0);
+}
+
+/** `fill` throws on a detached buffer, which must not mask the result. */
+function zeroize(...buffers: (Uint8Array | undefined)[]) {
+  for (const buffer of buffers) {
+    try {
+      buffer?.fill(0);
+    } catch {
+      // Detached by a structured-clone transfer; nothing left to clear.
+    }
+  }
+}
+
+/**
+ * Identifies the `kB` an envelope sealed, so a retry cannot substitute another.
+ * Eight bytes of SHA-256 over credential and key: enough to tell 256-bit keys
+ * apart, not enough to invert.
+ */
+async function keyIdFor(credentialId: string, kB: Uint8Array): Promise<string> {
+  const label = new TextEncoder().encode(`${credentialId}:`);
+  const input = new Uint8Array(label.length + kB.length);
+  input.set(label);
+  input.set(kB, label.length);
+  try {
+    const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', input));
+    return Array.from(digest.subarray(0, 8), (byte) =>
+      byte.toString(16).padStart(2, '0')
+    ).join('');
+  } finally {
+    zeroize(input);
+  }
+}
+
+function constantTimeEquals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+/** The proof claims read before the server has seen the token. */
+type ProofClaims = {
+  /** Lowercase hex account id, as the envelope context expects. */
+  uid: string;
+  /** `passkeys.credentialId`, base64url. Absent on a proof bound to none. */
+  cid?: string;
+};
+
+/**
+ * Reads the account and credential the proof was minted for. The server files
+ * the wrap under `sub`, so the sealing context must come from the same claim:
+ * an envelope sealed against any other uid is stored and never opens, and the
+ * local round trip cannot tell. The signature is the server's to verify — a
+ * forged `sub` only yields a wrap its forger cannot open.
+ */
+function claimsFromMfaToken(mfaToken: string): ProofClaims | undefined {
+  const payload = mfaToken.split('.')[1];
+  if (!payload) {
+    return undefined;
+  }
+  try {
+    const claims: unknown = JSON.parse(
+      new TextDecoder().decode(base64urlToBytes(payload))
+    );
+    if (claims === null || typeof claims !== 'object') {
+      return undefined;
+    }
+    const { sub, cid } = claims as { sub?: unknown; cid?: unknown };
+    if (typeof sub !== 'string' || !/^[0-9a-f]{32}$/.test(sub)) {
+      return undefined;
+    }
+    return { uid: sub, cid: typeof cid === 'string' ? cid : undefined };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Compares decoded bytes, as the server does, so padding cannot differ. */
+function isBoundTo(cid: string | undefined, credentialId: string): boolean {
+  if (!cid) {
+    return false;
+  }
+  try {
+    return constantTimeEquals(
+      base64urlToBytes(cid),
+      base64urlToBytes(credentialId)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Drops a rejected proof from the JWT cache, matching on the token: callers
+ * that mint a proof inline may hold an unrelated, still valid `passkey` token
+ * for the same session. `MfaOtpRequestCache` is left alone; `passkey` is not
+ * an OTP scope.
+ */
+function evictRejectedProof(mfaToken: string) {
+  const sessionToken = getSessionToken();
+  if (!sessionToken) {
+    return;
+  }
+  // `getToken` rather than `hasToken`, which answers false for an expired
+  // entry — the usual reason the server rejected it.
+  try {
+    if (JwtTokenCache.getToken(sessionToken, 'passkey') === mfaToken) {
+      JwtTokenCache.removeToken(sessionToken, 'passkey');
+    }
+  } catch {
+    // Nothing cached, or storage refused the write; neither may escape.
+  }
+}
+
+/**
+ * Builds and stores the envelope that lets one passkey unlock `kB`. Every
+ * input but the account id comes from the caller, so the same flow serves the
+ * sign-in opt-in and, later, registration and Settings enrolment.
+ *
+ * **Ownership.** `kB` and `prfOut` are zeroed in place once sealed and left
+ * untouched on every path that rejects first. A caller holding `kB` as a hex
+ * string still owns that copy; Web Crypto's internal copies are out of reach.
+ *
+ * **Retrying.** The store accepts only byte-identical repeats, so sealing
+ * again after a lost response wedges the credential on errno 235. A sealed but
+ * unstored envelope is therefore held and re-sent; a retry may omit `kB` and
+ * `prfOut`, and a `kB` that differs from the sealed one is refused.
+ *
+ * **Sharing.** Held envelopes and the in-flight guard live in a store all
+ * instances share, keyed by account and credential, so a remount or a second
+ * consumer re-sends rather than re-seals. The store lasts the page session;
+ * envelopes are ciphertext.
+ */
+export function createPasskeyWrapFlow(
+  authClient: PasskeyWrapAuthClient,
+  store: PasskeyWrapStore = passkeyWrapStore
+): PasskeyWrapFlow {
+  // Per instance, unlike `store.inFlight`: it answers whether *this* caller's
+  // call is still running, whichever credential it is for.
+  let busy = false;
+
+  const report = (label: string, tags: Record<string, string>) =>
+    Sentry.captureException(new Error(label), { tags });
+
+  const run = async ({
+    credentialId,
+    mfaToken,
+    prfOut,
+    kB,
+  }: CreatePasskeyWrapArgs): Promise<CreatePasskeyWrapResult> => {
+    const claims = claimsFromMfaToken(mfaToken);
+    if (!claims) {
+      evictRejectedProof(mfaToken);
+      return refused('proof_invalid');
+    }
+    const { uid } = claims;
+
+    // The server refuses this too, but only after sealing: the PRF output
+    // belongs to the passkey the proof names, so the envelope could never
+    // open, yet a retry with the right proof would store it. A caller bug, so
+    // the proof stays cached.
+    if (!isBoundTo(claims.cid, credentialId)) {
+      report('passkey-wrap-proof error', { stage: 'proof' });
+      return refused('proof_invalid');
+    }
+
+    const key = heldKey(uid, credentialId);
+
+    // Two envelopes sealed for one credential leave the loser on a permanent
+    // errno 235, so a call for it raised while one runs does nothing.
+    if (store.inFlight.has(key)) {
+      return refused('in_flight');
+    }
+    // Claimed before the first `await` below: a second call raised in the same
+    // tick must not slip past the check above. Released by the `finally`.
+    store.inFlight.add(key);
+
+    const fail = (
+      reason: PasskeyWrapCreationFailureReason,
+      cause?: PasskeyWrapCreationCause
+    ): CreatePasskeyWrapResult => {
+      if (TERMINAL_FAILURES.has(reason)) {
+        store.held.delete(key);
+      }
+      return refused(reason, cause);
+    };
+
+    try {
+      const reusable = store.held.get(key);
+
+      // A zeroed `kB` is the ordinary retry: the first attempt spent it in
+      // place. Live material is compared so a *different* key is refused
+      // rather than stored under a stale envelope.
+      if (reusable && kB && !isZeroed(kB)) {
+        // Malformed input is the caller's to fix; the held envelope is still
+        // good, so only a genuine key mismatch drops it.
+        if (kB.length !== KB_BYTES) {
+          return fail('key_unusable');
+        }
+        if ((await keyIdFor(credentialId, kB)) !== reusable.keyId) {
+          return fail('key_changed');
+        }
+      }
+
+      if (!reusable) {
+        // Width answers "can this authenticator hold a wrap"; all-zero answers
+        // "already spent". They route to different copy.
+        if (prfOut?.length !== PRF_OUT_BYTES) {
+          return fail('prf_unsupported');
+        }
+        if (kB?.length !== KB_BYTES || isZeroed(kB) || isZeroed(prfOut)) {
+          return fail('key_unusable');
+        }
+      }
+
+      let envelope = reusable?.envelope;
+
+      // The reuse path read `kB` to compare it; a caller that re-derived its
+      // key before retrying would otherwise keep both copies live.
+      if (envelope) {
+        zeroize(kB, prfOut);
+      }
+
+      if (!envelope) {
+        // Narrowed by the guards above; the seal branch always has both.
+        const kBToSeal = kB as Uint8Array;
+        const prfToSeal = prfOut as Uint8Array;
+        const keyId = await keyIdFor(credentialId, kBToSeal);
+
+        try {
+          envelope = await createWrapEnvelope({
+            kB: kBToSeal,
+            prfOut: prfToSeal,
+            uid,
+            credentialId,
+          });
+        } catch (err) {
+          // Left intact: nothing was sealed, so a retry is still possible.
+          report('passkey-wrap-seal error', {
+            stage: 'seal',
+            errno: String(causeOf(err)?.errno ?? 'none'),
+          });
+          return fail('unexpected', causeOf(err));
+        }
+
+        // Sealing never runs the open half: `skR` unwrap, raw P-521 scalar
+        // import, HPKE decap. A platform whose EC export diverges (see
+        // `key-wrap.ts`) seals a well-formed envelope that never opens, per
+        // keypair, so only a check on every wrap catches it.
+        let recovered: Uint8Array | undefined;
+        try {
+          recovered = await openWrapEnvelope({
+            envelope,
+            prfOut: prfToSeal,
+            uid,
+            credentialId,
+          });
+          if (!constantTimeEquals(recovered, kBToSeal)) {
+            throw new Error('recovered kB did not match');
+          }
+        } catch {
+          report('passkey-wrap-verify error', { stage: 'verify' });
+          return fail('platform_crypto');
+        } finally {
+          zeroize(recovered, kBToSeal, prfToSeal);
+        }
+
+        store.held.set(key, { keyId, envelope });
+      }
+
+      const { created } = await authClient.createPasskeyWrap(
+        mfaToken,
+        credentialId,
+        envelope
+      );
+
+      if (typeof created !== 'boolean') {
+        // The route pins `created` as required; treating an absent one as
+        // stored would drop the envelope and wedge the retry on errno 235.
+        report('passkey-wrap-response error', { stage: 'store' });
+        return fail('unexpected');
+      }
+
+      store.held.delete(key);
+      return { ok: true, created };
+    } catch (err) {
+      const reason = toFailureReason(err);
+      if (reason === 'proof_invalid') {
+        evictRejectedProof(mfaToken);
+      }
+      if (reason === 'unexpected') {
+        // errno tag only. Upstream messages may carry identifiers.
+        report('passkey-wrap-store error', {
+          stage: 'store',
+          errno: String(causeOf(err)?.errno ?? 'none'),
+        });
+      }
+      return fail(reason, causeOf(err));
+    } finally {
+      store.inFlight.delete(key);
+    }
+  };
+
+  const createWrap = async (
+    args: CreatePasskeyWrapArgs
+  ): Promise<CreatePasskeyWrapResult> => {
+    // Held for every path, including proof rejections that never reach the
+    // store: the hook reads `inFlight` to keep a same-tick second call from
+    // clobbering the state of the one still settling.
+    if (busy) {
+      return refused('in_flight');
+    }
+    busy = true;
+    try {
+      return await run(args);
+    } finally {
+      busy = false;
+    }
+  };
+
+  return {
+    createWrap,
+    get inFlight() {
+      return busy;
+    },
+  };
+}

--- a/packages/fxa-settings/src/lib/passkeys/wrap/index.ts
+++ b/packages/fxa-settings/src/lib/passkeys/wrap/index.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Deep-import this module rather than adding it to `lib/passkeys/index.ts`:
+// `creation` pulls in the HPKE suite, which builds a `CipherSuite` at module
+// scope.
+export * from './interfaces';
+export * from './creation';
+export * from './use-passkey-wrap-creation';

--- a/packages/fxa-settings/src/lib/passkeys/wrap/interfaces.ts
+++ b/packages/fxa-settings/src/lib/passkeys/wrap/interfaces.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type AuthClient from 'fxa-auth-client/browser';
+import type {
+  AuthServerError,
+  PasskeyWrapEnvelope,
+} from 'fxa-auth-client/browser';
+
+/**
+ * Why a wrap could not be stored. The server answers 401, 403 and 404 for more
+ * than one condition each, so callers branch on these rather than on status.
+ *
+ * Deliberately not `AuthUiErrors` entries: these are outcomes, not copy, and
+ * nothing here renders. TODO: FXA-13151 maps them to user-facing strings at
+ * the surface that shows them.
+ */
+export type PasskeyWrapCreationFailureReason =
+  /** No PRF output, or the wrong width: this passkey cannot hold a wrap. */
+  | 'prf_unsupported'
+  /** `kB` is missing, wrong-width or spent, or the PRF output is spent. */
+  | 'key_unusable'
+  /** A retry arrived with a different `kB` than the sealed envelope holds. */
+  | 'key_changed'
+  /** The envelope this platform sealed could not be opened again. */
+  | 'platform_crypto'
+  /**
+   * The proof names no usable account, is bound to another credential, or
+   * was spent, expired, or its session is gone (errno 223, 110).
+   */
+  | 'proof_invalid'
+  /** No such passkey on the account (errno 224). */
+  | 'passkey_not_found'
+  /** A different wrap is already stored for this passkey (errno 235). */
+  | 'wrap_conflict'
+  /** Customs refused the request (errno 114, 125). */
+  | 'throttled'
+  /** Passwordless Sync is switched off server-side (errno 202). */
+  | 'feature_disabled'
+  /** A call was already running; this one did nothing. */
+  | 'in_flight'
+  | 'unexpected';
+
+export type CreatePasskeyWrapArgs = {
+  /** WebAuthn credential id, base64url, as stored in `passkeys`. */
+  credentialId: string;
+  /**
+   * MFA JWT scoped `mfa:passkey` and bound to `credentialId`. Its `sub` names
+   * the account the envelope is sealed for.
+   */
+  mfaToken: string;
+  /**
+   * PRF output from the ceremony that produced `mfaToken`. Omit only when
+   * retrying a call that already sealed; a first attempt requires it, and
+   * undefined means the authenticator returned none.
+   */
+  prfOut?: Uint8Array;
+  /** The 32 bytes the wrap seals. Same rule as `prfOut` on a retry. */
+  kB?: Uint8Array;
+};
+
+/** The auth-client error fields callers may safely inspect or report. */
+export type PasskeyWrapCreationCause = Pick<
+  AuthServerError,
+  'errno' | 'code' | 'retryAfter'
+>;
+
+export type CreatePasskeyWrapResult =
+  /** `created` is false when this envelope was already stored. */
+  | { ok: true; created: boolean }
+  | {
+      ok: false;
+      failure: PasskeyWrapCreationFailureReason;
+      cause?: PasskeyWrapCreationCause;
+    };
+
+/** Pick<> so tests can pass minimal mocks without `as any`. */
+export type PasskeyWrapAuthClient = Pick<AuthClient, 'createPasskeyWrap'>;
+
+export type PasskeyWrapFlow = {
+  createWrap: (args: CreatePasskeyWrapArgs) => Promise<CreatePasskeyWrapResult>;
+  /** True while a `createWrap` call through this instance is running. */
+  readonly inFlight: boolean;
+};
+
+/** The envelope built by an attempt that has not yet been stored. */
+export type SealedAttempt = {
+  /** Identifies the `kB` sealed, so a retry cannot substitute another. */
+  keyId: string;
+  envelope: PasskeyWrapEnvelope;
+};
+
+/**
+ * State every flow instance shares, keyed by account and credential, so a
+ * remount or a second consumer finds what an earlier instance sealed instead
+ * of sealing again.
+ */
+export type PasskeyWrapStore = {
+  held: Map<string, SealedAttempt>;
+  inFlight: Set<string>;
+};
+
+export type UsePasskeyWrapCreationResult = {
+  createWrap: PasskeyWrapFlow['createWrap'];
+  isLoading: boolean;
+  failure?: PasskeyWrapCreationFailureReason;
+};

--- a/packages/fxa-settings/src/lib/passkeys/wrap/mocks.ts
+++ b/packages/fxa-settings/src/lib/passkeys/wrap/mocks.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type AuthClient from 'fxa-auth-client/browser';
+import type { PasskeyWrapEnvelope } from 'fxa-auth-client/browser';
+import { bytesToBase64url } from '../../base64url';
+import { openWrapEnvelope } from '../../passkey-crypto';
+import type { CreatePasskeyWrapArgs } from './interfaces';
+
+export const MOCK_UID = '11111111222222223333333344444444';
+export const MOCK_OTHER_UID = 'aaaaaaaabbbbbbbbccccccccdddddddd';
+export const MOCK_CREDENTIAL_ID = 'Y3JlZGVudGlhbA';
+export const MOCK_OTHER_CREDENTIAL_ID = 'b3RoZXI';
+export const MOCK_SESSION_TOKEN = 'a'.repeat(64);
+export const MOCK_KB = new Uint8Array(32).fill(7);
+export const MOCK_PRF_OUT = new Uint8Array(32).fill(9);
+export const ZEROED = new Uint8Array(32);
+
+/** Unsigned: the flow reads `sub` and `cid`, leaving verification to the server. */
+export const mfaTokenFor = (claims: Record<string, unknown>) =>
+  [
+    'header',
+    bytesToBase64url(new TextEncoder().encode(JSON.stringify(claims))),
+    'signature',
+  ].join('.');
+
+/** A proof bound to `credentialId`, as the server mints for a wrap. */
+export const proofFor = (credentialId: string, sub = MOCK_UID) =>
+  mfaTokenFor({ sub, cid: credentialId, scope: ['mfa:passkey'] });
+
+export const MOCK_JWT = proofFor(MOCK_CREDENTIAL_ID);
+
+/** Fresh buffers per call: the flow zeroes the ones it is handed. */
+export const args = () =>
+  ({
+    credentialId: MOCK_CREDENTIAL_ID,
+    mfaToken: MOCK_JWT,
+    prfOut: Uint8Array.from(MOCK_PRF_OUT),
+    kB: Uint8Array.from(MOCK_KB),
+  }) satisfies CreatePasskeyWrapArgs;
+
+/** `args()` for another credential, with a proof bound to it. */
+export const argsFor = (credentialId: string) =>
+  ({
+    ...args(),
+    credentialId,
+    mfaToken: proofFor(credentialId),
+  }) satisfies CreatePasskeyWrapArgs;
+
+/** Asserts `envelope` unseals to `MOCK_KB` under `context`, `args()` by default. */
+export const opensTo = (
+  envelope: PasskeyWrapEnvelope,
+  context: { uid?: string; credentialId?: string } = {}
+) =>
+  expect(
+    openWrapEnvelope({
+      envelope,
+      prfOut: Uint8Array.from(MOCK_PRF_OUT),
+      uid: MOCK_UID,
+      credentialId: MOCK_CREDENTIAL_ID,
+      ...context,
+    })
+  ).resolves.toEqual(MOCK_KB);
+
+export const serverError = (
+  errno: number,
+  extra: Record<string, unknown> = {}
+) => Object.assign(new Error('nope'), { errno, ...extra });
+
+/**
+ * Leaves the request hanging; answer it with `release` or `refuse` once
+ * `called` settles, which is when the flow has reached the store. Answering
+ * earlier rejects a promise nothing awaits yet.
+ */
+export const deferWrap = (
+  createPasskeyWrap: jest.MockedFunction<AuthClient['createPasskeyWrap']>
+) => {
+  // Definite assignment: the Promise executors run synchronously.
+  let answer!: (value: { created: boolean }) => void;
+  let reject!: (reason: unknown) => void;
+  let markCalled!: () => void;
+  const called = new Promise<void>((resolve) => {
+    markCalled = resolve;
+  });
+  createPasskeyWrap.mockImplementation(() => {
+    markCalled();
+    return new Promise((resolve, fail) => {
+      answer = resolve;
+      reject = fail;
+    });
+  });
+  return {
+    called,
+    release: () => answer({ created: true }),
+    refuse: (reason: unknown) => reject(reason),
+  };
+};

--- a/packages/fxa-settings/src/lib/passkeys/wrap/use-passkey-wrap-creation.test.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/wrap/use-passkey-wrap-creation.test.tsx
@@ -1,0 +1,183 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { act, renderHook } from '@testing-library/react';
+import { ERRNO } from '@fxa/accounts/errors';
+import type AuthClient from 'fxa-auth-client/browser';
+import { usePasskeyWrapCreation } from './use-passkey-wrap-creation';
+import { passkeyWrapStore } from './creation';
+import type {
+  CreatePasskeyWrapResult,
+  PasskeyWrapAuthClient,
+} from './interfaces';
+import { args, deferWrap, serverError } from './mocks';
+import { useAuthClient } from '../../../models';
+
+jest.mock('../../../models', () => ({
+  ...jest.requireActual('../../../models'),
+  useAuthClient: jest.fn(),
+}));
+
+let createPasskeyWrap: jest.MockedFunction<AuthClient['createPasskeyWrap']>;
+
+const renderWrapCreation = () => renderHook(() => usePasskeyWrapCreation());
+
+/** Runs a call to completion inside `act`, so state settles before asserting. */
+const createWrap = async (
+  result: ReturnType<typeof renderWrapCreation>['result']
+) => {
+  let outcome!: CreatePasskeyWrapResult;
+  await act(async () => {
+    outcome = await result.current.createWrap(args());
+  });
+  return outcome;
+};
+
+/** Starts a call and returns before it settles; the request stays open. */
+const startWrap = (
+  result: ReturnType<typeof renderWrapCreation>['result'],
+  input = args()
+) => {
+  let pending!: Promise<CreatePasskeyWrapResult>;
+  act(() => {
+    pending = result.current.createWrap(input);
+  });
+  return pending;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The hook uses the page-wide store, so an envelope one test holds would
+  // otherwise be re-sent by the next.
+  passkeyWrapStore.held.clear();
+  passkeyWrapStore.inFlight.clear();
+  createPasskeyWrap = jest.fn().mockResolvedValue({ created: true });
+  // `satisfies` checks the shape the flow consumes; the cast only widens it to
+  // what `useAuthClient` is declared to return.
+  jest.mocked(useAuthClient).mockReturnValue({
+    createPasskeyWrap,
+  } satisfies PasskeyWrapAuthClient as unknown as AuthClient);
+});
+
+describe('usePasskeyWrapCreation', () => {
+  it('starts idle with no failure', () => {
+    const { result } = renderWrapCreation();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.failure).toBeUndefined();
+  });
+
+  it('returns the outcome of the call', async () => {
+    const { result } = renderWrapCreation();
+
+    const outcome = await createWrap(result);
+
+    expect(outcome).toEqual({ ok: true, created: true });
+  });
+
+  it('raises isLoading for the duration of the call', async () => {
+    const { called, release } = deferWrap(createPasskeyWrap);
+    const { result } = renderWrapCreation();
+
+    const pending = startWrap(result);
+    expect(result.current.isLoading).toBe(true);
+
+    await called;
+    release();
+    await act(() => pending);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('lowers isLoading after a rejection', async () => {
+    const { called, refuse } = deferWrap(createPasskeyWrap);
+    const { result } = renderWrapCreation();
+
+    const pending = startWrap(result);
+    await called;
+    refuse(serverError(ERRNO.PASSKEY_NOT_FOUND));
+    await act(() => pending);
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('exposes the failure reason as state', async () => {
+    createPasskeyWrap.mockRejectedValue(serverError(ERRNO.PASSKEY_NOT_FOUND));
+    const { result } = renderWrapCreation();
+
+    await createWrap(result);
+
+    expect(result.current.failure).toBe('passkey_not_found');
+  });
+
+  it('clears a previous failure when a later call succeeds', async () => {
+    createPasskeyWrap.mockRejectedValueOnce(
+      serverError(ERRNO.PASSKEY_NOT_FOUND)
+    );
+    const { result } = renderWrapCreation();
+
+    await createWrap(result);
+    expect(result.current.failure).toBe('passkey_not_found');
+
+    await createWrap(result);
+    expect(result.current.failure).toBeUndefined();
+  });
+
+  it('leaves state to the running call when a second one is refused', async () => {
+    const { called, release } = deferWrap(createPasskeyWrap);
+    const { result } = renderWrapCreation();
+
+    const first = startWrap(result);
+    const second = await createWrap(result);
+
+    expect(second).toEqual({ ok: false, failure: 'in_flight' });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.failure).toBeUndefined();
+
+    await called;
+    release();
+    await act(() => first);
+  });
+
+  it('refuses a same-tick second call while a proof rejection is settling', async () => {
+    const { result } = renderWrapCreation();
+
+    const first = startWrap(result, { ...args(), mfaToken: 'not-a-jwt' });
+    const second = await createWrap(result);
+
+    // Otherwise the first call's continuation would lower isLoading and set
+    // failure while the second was still running.
+    expect(second).toEqual({ ok: false, failure: 'in_flight' });
+    await act(() => first);
+    expect(result.current.failure).toBe('proof_invalid');
+    expect(createPasskeyWrap).not.toHaveBeenCalled();
+  });
+
+  it('keeps the held envelope across re-renders', async () => {
+    createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+    const { result, rerender } = renderWrapCreation();
+
+    await createWrap(result);
+    rerender();
+    const outcome = await createWrap(result);
+
+    expect(outcome).toEqual({ ok: true, created: true });
+    expect(createPasskeyWrap.mock.calls[1][2]).toEqual(
+      createPasskeyWrap.mock.calls[0][2]
+    );
+  });
+
+  it('keeps the held envelope across a remount', async () => {
+    createPasskeyWrap.mockRejectedValueOnce(new Error('network down'));
+    const first = renderWrapCreation();
+
+    await createWrap(first.result);
+    first.unmount();
+    const outcome = await createWrap(renderWrapCreation().result);
+
+    expect(outcome).toEqual({ ok: true, created: true });
+    expect(createPasskeyWrap.mock.calls[1][2]).toEqual(
+      createPasskeyWrap.mock.calls[0][2]
+    );
+  });
+});

--- a/packages/fxa-settings/src/lib/passkeys/wrap/use-passkey-wrap-creation.ts
+++ b/packages/fxa-settings/src/lib/passkeys/wrap/use-passkey-wrap-creation.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useRef, useState } from 'react';
+import { useAuthClient } from '../../../models';
+import { createPasskeyWrapFlow } from './creation';
+import type {
+  CreatePasskeyWrapArgs,
+  CreatePasskeyWrapResult,
+  PasskeyWrapCreationFailureReason,
+  PasskeyWrapFlow,
+  UsePasskeyWrapCreationResult,
+} from './interfaces';
+
+/**
+ * React state around `createPasskeyWrapFlow`. Held envelopes live in the
+ * flow's shared store, so a remount picks up where the last instance left off.
+ *
+ * TODO: FXA-13151 wires the first caller (the passwordless Sync opt-in) and is
+ * where the remaining API questions get settled: whether the session token
+ * behind proof eviction should be injected rather than read globally, and
+ * whether callers read `failure` state or the returned union.
+ */
+export function usePasskeyWrapCreation(): UsePasskeyWrapCreationResult {
+  const authClient = useAuthClient();
+  // Created once: `inFlight` is per instance, so a fresh flow on a re-render
+  // would forget the call still running.
+  const flowRef = useRef<PasskeyWrapFlow | undefined>(undefined);
+  if (!flowRef.current) {
+    flowRef.current = createPasskeyWrapFlow(authClient);
+  }
+  const flow = flowRef.current;
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [failure, setFailure] = useState<
+    PasskeyWrapCreationFailureReason | undefined
+  >();
+
+  const createWrap = useCallback(
+    async (args: CreatePasskeyWrapArgs): Promise<CreatePasskeyWrapResult> => {
+      // Answered by the flow without touching state, which belongs to the
+      // call still running.
+      if (flow.inFlight) {
+        return flow.createWrap(args);
+      }
+      setFailure(undefined);
+      setIsLoading(true);
+      try {
+        const result = await flow.createWrap(args);
+        if (!result.ok) {
+          setFailure(result.failure);
+        }
+        return result;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [flow]
+  );
+
+  return { createWrap, isLoading, failure };
+}


### PR DESCRIPTION
## Because

- Passwordless Sync must seal kB to a passkey's PRF output before a wrap can be stored.
- The store is create-only, so a bad or duplicated envelope wedges the credential until
  the passkey is re-enrolled.

## This pull request

- Adds `lib/passkeys/wrap/`: `createPasskeyWrapFlow` seals `kB` into a wrap envelope and
  stores it under an `mfa:passkey` proof; `usePasskeyWrapCreation` wraps it in React state.
- Reads the account and credential from the proof's `sub`/`cid` before touching key
  material, so the sealing context always matches what the server files the wrap under.
- Reopens each envelope before storing it, and rejects missing, wrong-width or spent key
  material.
- Holds a sealed-but-unstored envelope in a store shared across instances, so a retry —
  including after a remount — re-sends identical bytes.
- Maps server errnos to distinct failure reasons and evicts a rejected proof from
  `JwtTokenCache`.
- Zeroes `kB` and the PRF output once sealed.

## Issue that this pull request solves

Closes: FXA-14425

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- **Key files/areas to focus on:** `wrap/interfaces.ts` (the failure-reason union and
  result types) and `wrap/creation.ts` (the flow). The hook is a 60-line state wrapper.
  Tests and fixtures are ~65% of the diff.
- **Suggested review order:** `interfaces.ts` → `creation.ts` top to bottom →
  `use-passkey-wrap-creation.ts` → `creation.test.ts`, the `retries` and `proof claims`
  blocks.
- **Risky or complex parts:** the create-only store means a mis-sealed or re-sealed
  envelope wedges the credential permanently, so three guards do the heavy lifting: the
  reopen-before-store check, the held envelope shared across instances via
  `passkeyWrapStore`, and the `cid`/`sub` read from the proof before any key material is
  touched. `kB`/`prfOut` zeroing on every path is the other thing worth tracing.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Not exported from `lib/hooks/index.ts` or `lib/passkeys/index.ts`: the flow pulls in the
HPKE suite, which builds a `CipherSuite` at module scope. Consumers deep-import
`lib/passkeys/wrap`, as `pages/Signin` does with `usePasskeySignIn`.
