### PR TITLE
test(passkeys): cover the wrap round-trip through fxa-auth-client

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -34,6 +34,7 @@ export type TestOptions = {
   syncBrowserPages: POMS;
   syncOAuthBrowserPages: POMS;
   testAccountTracker: TestAccountTracker;
+  apiAccountTracker: TestAccountTracker;
   gleanEventsHelper: GleanEventsHelper;
 };
 export type WorkerOptions = { targetName: TargetName; target: ServerTarget };
@@ -87,6 +88,17 @@ export const test = base.extend<TestOptions, WorkerOptions>({
     await handleSyncPagesTraceStop(syncBrowserPages, testInfo);
 
     await syncBrowserPages.browser?.close();
+  },
+
+  // Same tracking and teardown as `testAccountTracker`, without the `page`
+  // dependency that would launch a browser for an API-only spec.
+  apiAccountTracker: async ({ target }, use, testInfo) => {
+    const apiAccountTracker = new TestAccountTracker(target, testInfo);
+
+    await use(apiAccountTracker);
+
+    await target.clearRateLimits();
+    await apiAccountTracker.destroyAllAccounts();
   },
 
   testAccountTracker: async ({ target, page }, use, testInfo) => {

--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -12,10 +12,7 @@ import { Credentials } from './targets';
 import { BaseTarget } from './targets/base';
 import { MfaScope } from 'fxa-settings/src/lib/types';
 import { getTotpCode } from './totp';
-import {
-  SessionStatus,
-  SignedInAccountData,
-} from 'fxa-auth-client/lib/client';
+import { SessionStatus, SignedInAccountData } from 'fxa-auth-client/lib/client';
 
 enum EmailPrefix {
   BLOCKED = 'blocked',
@@ -60,13 +57,27 @@ export class TestAccountTracker {
   accounts: (AccountDetails | Credentials)[];
   private target: BaseTarget;
   private testInfo: TestInfo;
-  private page: Page;
+  private maybePage?: Page;
 
-  constructor(target: BaseTarget, testInfo: TestInfo, page: Page) {
+  /**
+   * `page` is optional so API-level specs can track and destroy accounts
+   * without opening a browser. The JWT-cache helpers are the only members that
+   * need it, and they throw when it is absent.
+   */
+  constructor(target: BaseTarget, testInfo: TestInfo, page?: Page) {
     this.target = target;
     this.testInfo = testInfo;
     this.accounts = [];
-    this.page = page;
+    this.maybePage = page;
+  }
+
+  private get page(): Page {
+    if (!this.maybePage) {
+      throw new Error(
+        'TestAccountTracker was constructed without a page; this helper drives localStorage and needs one.'
+      );
+    }
+    return this.maybePage;
   }
 
   /**
@@ -441,7 +452,7 @@ export class TestAccountTracker {
     const { sessionToken } = await this.target.authClient.signIn(
       {
         primary: account.email,
-        original: account.originalEmail || account.email
+        original: account.originalEmail || account.email,
       },
       account.password,
       {},
@@ -493,7 +504,7 @@ export class TestAccountTracker {
     await this.target.authClient.accountDestroy(
       {
         primary: account.email,
-        original: account.originalEmail || account.email
+        original: account.originalEmail || account.email,
       },
       account.password,
       {},

--- a/packages/functional-tests/tests/passkeyAuth/passkeyWrapApi.spec.ts
+++ b/packages/functional-tests/tests/passkeyAuth/passkeyWrapApi.spec.ts
@@ -1,0 +1,291 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * API-level coverage for the passkey wrap round-trip: seal `kB` for a passkey,
+ * store it, read it back and reopen it, driven through `fxa-auth-client` with
+ * no page.
+ *
+ * Requires `passkeys.enabled`, `registrationEnabled`, `authenticationEnabled`
+ * and `passwordlessSyncEnabled` on the auth-server, a `prfSalt`, and
+ * `requestPrfAtAuthentication` other than `off`.
+ */
+
+import { expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import {
+  VirtualAuthenticator,
+  VirtualCredential,
+} from '@fxa/accounts/passkey/testing';
+import type { PublicKeyCredentialJSON } from 'fxa-auth-client/lib/client';
+import {
+  createWrapEnvelope,
+  openWrapEnvelope,
+} from 'fxa-settings/src/lib/passkey-crypto';
+
+const PASSKEY_SCOPE = 'passkey';
+
+type CeremonyResponse =
+  | ReturnType<typeof VirtualAuthenticator.createAttestationResponse>
+  | ReturnType<typeof VirtualAuthenticator.createAssertionResponse>;
+
+/**
+ * `fxa-auth-client` re-declares the WebAuthn response types rather than
+ * importing them, to keep nx from seeing a circular dependency, and types
+ * `clientExtensionResults` as a `Record` that an interface cannot satisfy
+ * without an index signature.
+ */
+const asCredentialJson = (
+  response: CeremonyResponse
+): PublicKeyCredentialJSON => response as unknown as PublicKeyCredentialJSON;
+
+type PasskeyAccount = {
+  credentials: Credentials;
+  credentialId: string;
+  credential: VirtualCredential;
+  /** `kB` as the password derives it, hex, as `accountKeys` returns it. */
+  passwordKb: string;
+};
+
+type PasskeySignIn = {
+  uid: string;
+  sessionToken: string;
+  mfaToken?: string;
+  /** The eval salt the server issued, absent when it requested no PRF. */
+  prfSalt?: string;
+  /** The authenticator's PRF output, absent when it cannot evaluate one. */
+  prfOut?: Uint8Array;
+};
+
+/** Narrows a value the flow under test is expected to have produced. */
+function required<T>(value: T | undefined, name: string): T {
+  expect(value, `${name} should be present`).toBeDefined();
+  return value as NonNullable<T>;
+}
+
+/**
+ * The auth-server checks the ceremony origin against `passkeys.allowedOrigins`,
+ * which is the content server's origin.
+ */
+function ceremonyOrigin(target: BaseTarget): string {
+  return new URL(target.contentServerUrl).origin;
+}
+
+async function mintMfaJwt(
+  target: BaseTarget,
+  sessionToken: string,
+  email: string
+): Promise<string> {
+  const { status } = await target.authClient.mfaRequestOtp(
+    sessionToken,
+    PASSKEY_SCOPE
+  );
+  expect(status).toEqual('success');
+
+  const code = await target.emailClient.getVerifyAccountChangeCode(email);
+  const { accessToken } = await target.authClient.mfaOtpVerify(
+    sessionToken,
+    code,
+    PASSKEY_SCOPE
+  );
+
+  return accessToken;
+}
+
+/**
+ * Runs the registration ceremony against a virtual authenticator. Pass
+ * `prfSupported: false` for a device that cannot evaluate a PRF.
+ */
+async function registerPasskey(
+  target: BaseTarget,
+  credentials: Credentials,
+  opts: { prfSupported?: boolean } = {}
+): Promise<{ credentialId: string; credential: VirtualCredential }> {
+  const jwt = await mintMfaJwt(
+    target,
+    credentials.sessionToken,
+    credentials.email
+  );
+  const options = await target.authClient.beginPasskeyRegistration(jwt);
+
+  const credential = VirtualAuthenticator.createCredential(opts);
+  const response = VirtualAuthenticator.createAttestationResponse(credential, {
+    challenge: options.challenge,
+    origin: ceremonyOrigin(target),
+    rpId: required(options.rp.id, 'registration rp.id'),
+    extensions: options.extensions,
+  });
+
+  const { credentialId } = await target.authClient.completePasskeyRegistration(
+    jwt,
+    asCredentialJson(response),
+    options.challenge
+  );
+
+  return { credentialId, credential };
+}
+
+async function signInWithPasskey(
+  target: BaseTarget,
+  credential: VirtualCredential
+): Promise<PasskeySignIn> {
+  const options = await target.authClient.beginPasskeyAuthentication({
+    keysRequired: true,
+    scope: PASSKEY_SCOPE,
+  });
+
+  const response = VirtualAuthenticator.createAssertionResponse(credential, {
+    challenge: options.challenge,
+    origin: ceremonyOrigin(target),
+    rpId: required(options.rpId, 'authentication rpId'),
+    extensions: options.extensions,
+  });
+
+  const prfSalt = options.extensions?.prf?.eval?.first;
+  const returnedPrf = (
+    response.clientExtensionResults as {
+      prf?: { results?: { first?: string } };
+    }
+  ).prf?.results?.first;
+
+  const { uid, sessionToken, mfaToken } =
+    await target.authClient.completePasskeyAuthentication(
+      asCredentialJson(response),
+      options.challenge,
+      { keysRequired: true, prfSupported: returnedPrf !== undefined }
+    );
+
+  return {
+    uid,
+    sessionToken,
+    mfaToken,
+    prfSalt,
+    prfOut:
+      returnedPrf === undefined
+        ? undefined
+        : Uint8Array.from(Buffer.from(returnedPrf, 'base64url')),
+  };
+}
+
+/**
+ * Creates a tracked, verified account with a registered passkey, and reads
+ * `kB` out of a password sign-in.
+ */
+async function setUpAccountWithPasskey(
+  target: BaseTarget,
+  accountTracker: TestAccountTracker,
+  opts: { prfSupported?: boolean } = {}
+): Promise<PasskeyAccount> {
+  const credentials = await accountTracker.signUp();
+
+  const { keyFetchToken, unwrapBKey } = await target.authClient.signIn(
+    credentials.email,
+    credentials.password,
+    { keys: true }
+  );
+  const { kB } = await target.authClient.accountKeys(
+    required(keyFetchToken, 'keyFetchToken'),
+    required(unwrapBKey, 'unwrapBKey')
+  );
+
+  const { credentialId, credential } = await registerPasskey(
+    target,
+    credentials,
+    opts
+  );
+
+  return { credentials, credentialId, credential, passwordKb: kB };
+}
+
+test.describe('passkey wrap round-trip', () => {
+  test('reopens a stored wrap to the password-derived kB', async ({
+    target,
+    apiAccountTracker,
+  }) => {
+    const account = await setUpAccountWithPasskey(target, apiAccountTracker);
+    const { uid, mfaToken, prfOut } = await signInWithPasskey(
+      target,
+      account.credential
+    );
+    const envelope = await createWrapEnvelope({
+      kB: Uint8Array.from(Buffer.from(account.passwordKb, 'hex')),
+      prfOut: required(prfOut, 'prfOut'),
+      uid,
+      credentialId: account.credentialId,
+    });
+
+    const { created } = await target.authClient.createPasskeyWrap(
+      required(mfaToken, 'mfaToken'),
+      account.credentialId,
+      envelope
+    );
+    expect(created).toBe(true);
+
+    const stored = await target.authClient.getPasskeyWrap(
+      required(mfaToken, 'mfaToken'),
+      account.credentialId
+    );
+    const recovered = await openWrapEnvelope({
+      envelope: stored,
+      prfOut: required(prfOut, 'prfOut'),
+      uid,
+      credentialId: account.credentialId,
+    });
+
+    expect(Buffer.from(recovered).toString('hex')).toEqual(account.passwordKb);
+  });
+
+  test('recovers kB on a later sign-in without the password', async ({
+    target,
+    apiAccountTracker,
+  }) => {
+    const account = await setUpAccountWithPasskey(target, apiAccountTracker);
+    const enrollment = await signInWithPasskey(target, account.credential);
+    await target.authClient.createPasskeyWrap(
+      required(enrollment.mfaToken, 'mfaToken'),
+      account.credentialId,
+      await createWrapEnvelope({
+        kB: Uint8Array.from(Buffer.from(account.passwordKb, 'hex')),
+        prfOut: required(enrollment.prfOut, 'prfOut'),
+        uid: enrollment.uid,
+        credentialId: account.credentialId,
+      })
+    );
+
+    const signin = await signInWithPasskey(target, account.credential);
+    const stored = await target.authClient.getPasskeyWrap(
+      required(signin.mfaToken, 'mfaToken'),
+      account.credentialId
+    );
+    const recovered = await openWrapEnvelope({
+      envelope: stored,
+      prfOut: required(signin.prfOut, 'prfOut'),
+      uid: signin.uid,
+      credentialId: account.credentialId,
+    });
+
+    expect(Buffer.from(recovered).toString('hex')).toEqual(account.passwordKb);
+  });
+
+  test('yields no PRF output when the authenticator cannot evaluate one', async ({
+    target,
+    apiAccountTracker,
+  }) => {
+    const account = await setUpAccountWithPasskey(target, apiAccountTracker, {
+      prfSupported: false,
+    });
+
+    const signin = await signInWithPasskey(target, account.credential);
+
+    // The salt separates a PRF the server asked for from one it has switched
+    // off, which would also leave prfOut absent.
+    expect(signin.prfSalt).toEqual(expect.any(String));
+    expect(signin.prfOut).toBeUndefined();
+    const passkeys = await target.authClient.listPasskeys(signin.sessionToken);
+    expect(passkeys.map((passkey) => passkey.credentialId)).toEqual([
+      account.credentialId,
+    ]);
+  });
+});

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
@@ -137,6 +137,26 @@ describe('lib/routes/auth-schemes/mfa', () => {
     }
   });
 
+  it('throws when the jwt has expired', async () => {
+    const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
+    jest.useFakeTimers({
+      now: Date.now() + (config.mfa.jwt.expiresInSec + 1) * 1000,
+    });
+
+    try {
+      await authStrategy.authenticate(request, h);
+      throw new Error('Should have thrown an error');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(AppError);
+      const errorResponse = err.output.payload;
+      expect(errorResponse.code).toBe(401);
+      expect(errorResponse.errno).toBe(AppError.ERRNO.INVALID_MFA_TOKEN);
+      expect(errorResponse.message).toBe('Invalid or expired MFA token');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('increments bad_state and throws when the jwt is missing required claims', async () => {
     const now = Math.floor(Date.now() / 1000);
     const tokenWithoutStid = jwt.sign(

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { Schema } from 'joi';
+import jwt from 'jsonwebtoken';
 import { Container } from 'typedi';
 import { PasskeyService } from '@fxa/accounts/passkey';
 import { AppError } from '@fxa/accounts/errors';
@@ -59,8 +60,9 @@ describe('passkeys routes', () => {
   const CREDENTIAL_ID_B64 =
     Buffer.from('credential-id-xyz').toString('base64url');
 
-  // Only the passkeys flags and the MFA action list are read by these routes;
-  // cast the partial fixture to the full ConfigType the factory expects.
+  // Only the passkeys flags, the MFA action list and the JWT signing settings
+  // are read by these routes; cast the partial fixture to the full ConfigType
+  // the factory expects.
   const config = {
     passkeys: {
       enabled: true,
@@ -69,6 +71,12 @@ describe('passkeys routes', () => {
     },
     mfa: {
       actions: ['2fa', 'email', 'recovery_key', 'password', 'passkey'],
+      jwt: {
+        expiresInSec: 300,
+        audience: 'fxa',
+        issuer: 'accounts.firefox.com',
+        secretKey: 'foxes'.repeat(13),
+      },
     },
   } as unknown as ConfigType;
 
@@ -1175,6 +1183,31 @@ describe('passkeys routes', () => {
         verified: true,
         hasPassword: true,
       });
+    });
+
+    it('mints an mfaToken bound to the session and the asserted credential', async () => {
+      mockPasskeyService.verifyAuthenticationResponse.mockResolvedValueOnce({
+        uid: UID,
+        scope: 'passkey',
+        credentialId: CREDENTIAL_ID_B64,
+      });
+
+      const result = await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload,
+      });
+
+      // @types/jsonwebtoken 8 types `verify` as `object | string`, so the
+      // claims this route signs are named here rather than inferred.
+      const claims = jwt.verify(result.mfaToken, config.mfa.jwt.secretKey, {
+        audience: config.mfa.jwt.audience,
+        issuer: config.mfa.jwt.issuer,
+      }) as { sub: string; scope: string[]; cid: string; stid: string };
+      expect(claims.sub).toBe(UID);
+      expect(claims.scope).toEqual(['mfa:passkey']);
+      expect(claims.cid).toBe(CREDENTIAL_ID_B64);
+      expect(claims.stid).toBe('new-session-token-id');
     });
 
     it('forwards prfSupported from the payload to verifyAuthenticationResponse', async () => {


### PR DESCRIPTION
## Because

- The passkey wrap envelope had only unit coverage; nothing had sealed `kB`
  and recovered it against a real auth-server.
- The `mfaToken` minted at `/passkey/authentication/finish`, and the
  rejection of an expired one, were untested at any layer.
- The keyless Sync sign-in path needs proving before the opt-in UI lands.

## This pull request

- Adds a page-less Playwright spec that registers a passkey, seals `kB` with
  `createWrapEnvelope`, stores and fetches the wrap through `fxa-auth-client`,
  and reopens it to the password-derived `kB`.
- Repeats the recovery on a second passkey sign-in with no password involved.
- Covers a `prfSupported: false` authenticator returning no PRF output.
- Adds an `apiAccountTracker` fixture and makes `page` optional on
  `TestAccountTracker`, so API-only specs get the standard account teardown
  without launching a browser.
- Unit-tests the `mfaToken` claims (`sub`, `scope`, `cid`, `stid`) in
  `passkeys.spec.ts`, and expired-token rejection in `auth-schemes/mfa.spec.ts`.

## Issue that this pull request solves

Closes: FXA-14495

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `passkeyWrapApi.spec.ts` — the three tests
  are the substance; the helpers above them are the ceremony plumbing.
- Suggested review order: the spec, then the `TestAccountTracker` /
  `standard.ts` change it relies on, then the two auth-server specs.
- Risky or complex parts: `TestAccountTracker.page` is now a throwing getter.
  Every existing caller still passes a page, so behaviour is unchanged for
  the browser-backed fixture.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The ticket lists "`finish` returns an `mfaToken` carrying `cid`" and "an
expired `mfaToken` is rejected" as functional cases. Both landed as unit
tests instead: the JWT is opaque to a client, so only a unit test can assert
the claims, and expiry is enforced by the shared `mfa` auth scheme used by
13+ routes, not by the wrap endpoints.
