### PR TITLE
fix(settings): wrap the scan-QR help link inside the phone frame

### DIFF
--- a/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair2/Authority/ScanQR/index.tsx
@@ -80,9 +80,14 @@ const ScanQR = ({ qrCodeValue }: ScanQRProps) => {
             {/* `FtlMsg` wraps the text rather than the link so the localized
                 string does not absorb the "opens in new window" note that
                 `LinkExternal` appends for screen readers. */}
+            {/* The phone's screen is about half the artwork wide, so the link
+                is capped just inside it: longer translations wrap onto a
+                second line on the screen rather than running past the bezel.
+                The overlay leaves room for two lines above the artwork's
+                bottom edge. */}
             <LinkExternal
               href={Constants.SYNC_SUMO_URL}
-              className="mt-2 rounded-sm text-sm text-grey-900 underline focus-visible-default hover:text-grey-700"
+              className="mt-2 max-w-[46%] rounded-sm text-sm text-grey-900 underline focus-visible-default hover:text-grey-700"
             >
               <FtlMsg id="pair2-authority-scan-qr-help-link">
                 Get help scanning


### PR DESCRIPTION
## Because

- On the new pairing scan-QR page, long translations of the "Get help scanning" link (French, for one) overflow the phone graphic frame.

## This pull request

- Caps the help link's width so long strings wrap onto a second line inside the phone screen.

## Issue that this pull request solves

Closes: FXA-14486

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

**FXA-14486 — "Get help scanning" link, French, on `/pair/authority/scan_qr`**

Storybook, `Pages/Pair2/Authority/ScanQR`, Firefox with locale `fr`. The local l10n bundle has no French for this key yet, so the link text is the string quoted in the ticket, placed into the link's text node. Link measures 220x42 px against the 46% cap of a 480 px card.

| After (this branch) | After, denser QR |
|---|---|
| ![After: French help link wraps inside the phone screen](https://github.com/user-attachments/assets/24c4a7bf-971a-4cc7-981e-52ece7fe29b4) | ![After: same, with a denser QR code](https://github.com/user-attachments/assets/d6623725-8754-4394-a6cc-30356d0017d1) |

## Other information (Optional)

- The overlay does not grow the card, so a translation needing a third line would still clip below the artwork. The French string fits in two.


