### PR TITLE
feat(ci): Set up remote PR debugging via yarn debug-pr

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -52,6 +52,107 @@ circleci config process .circleci/config.yml > .circleci/local.yml
 circleci local execute -c .circleci/local.yml --job test-many
 ```
 
+## Interactive PR stack (`yarn pr-debug`)
+
+`yarn pr-debug [--tunnel | --ssh] [pr-number | branch]` boots the
+dev stack for a branch in CircleCI and lets you reach it from your
+machine. Use it as an ephemeral environment to try a branch without checking
+it out, or to keep several PR stacks up and hop between them. Claude
+will also find clever ways to leverage this as well.
+
+| Command                  | What it does                                                                                                                                        |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `yarn pr-debug`          | Boots the stack and returns once it is up. Reports the job if one is already running for the commit.                                                |
+| `yarn pr-debug --tunnel` | Forwards the service ports to `localhost` and holds them until Ctrl-C. Closes any tunnel a previous run opened, so switching stacks is one command. |
+| `yarn pr-debug --ssh`    | Opens a shell in `~/project`. Binds no ports, so it sits beside a tunnel (`yarn pm2 log`), and connects even if a CI step failed.                   |
+
+All three default to the current branch. Needs `CIRCLECI_TOKEN` (a personal
+token — project tokens cannot trigger pipelines), `jq` and `nc`; `gh` only
+when passing a PR number. `--tunnel` runs ssh non-interactively, so the key
+registered with your GitHub account must be in `ssh-agent`.
+
+Switching between two PRs looks like this:
+
+```sh
+yarn pr-debug 1234            # boot PR 1234's stack, ~7 minutes cold
+yarn pr-debug 5678            # boot PR 5678's stack
+yarn pr-debug --tunnel 1234   # localhost:3030 is PR 1234
+yarn pr-debug --tunnel 5678   # drops the first tunnel; localhost:3030 is PR 5678
+```
+
+The `/fxa-pr-debug` Claude skill wraps the boot and tunnel: it tells you when
+the stack is up, and can write and run a throwaway Playwright test from a
+description.
+
+Under the hood (`_scripts/pr-debug.sh`), the boot:
+
+1. Triggers the `stack` workflow: one `Stack (SSH)` job that installs, builds
+   and starts the stack against the `functional-test-executor`'s service
+   containers. It runs only when the `run_stack` pipeline parameter is set, so
+   ordinary pipelines never see it.
+2. Cancels that run as soon as the job starts and reruns it with SSH enabled.
+   CircleCI cannot enable SSH from config and only enables it on the rerun of a
+   finished workflow, so the throwaway first pass is the price of scripting
+   this. A run already made for the same commit is reused instead.
+3. Waits for `Start services` and prints the connect commands.
+
+`--tunnel` and `--ssh` look up the newest running SSH job on the branch (any
+commit, with a warning if origin has moved on), pin the host key CircleCI
+reports for it, and run `ssh` with the forwards or a shell. In that shell you
+will mostly want pm2 logs, e.g. `yarn pm2 log inbox` tails the mail helper,
+which is the quickest way to grab a signup or reset code.
+
+A cold boot takes about seven minutes: about two for the throwaway first pass
+(container spin-up, then the cancel) and five for the SSH job. Reusing a run for
+the same commit skips the first pass.
+
+### Lifetime
+
+After it boots, the job holds the stack up for 30 minutes whether or not anyone
+is connected (`PR_DEBUG_MINUTES` at boot time changes it; it is passed as the
+`stack_minutes` pipeline parameter). That is what lets several stacks sit side
+by side. Once the hold ends, CircleCI's rules apply: the job stays up while an
+SSH session is open and shuts down about ten minutes after the last one
+closes, two hours per job at most. Tunnel and shell sessions are capped at the
+same number of minutes; rerun the command to reconnect. To release a stack
+early, cancel the job from its CircleCI page.
+
+### Using the stack
+
+Open <http://localhost:3030>. Ports are forwarded same-number because the
+services advertise `localhost:<port>` URLs: 3030 content, 3000 fxa-settings
+(dev server, hot-rebuilds), 9000 auth, 9001 mail helper, 1111/1112 profile,
+8080 123done, 8091/8095 admin panel/server, 9130/9160 node inspectors.
+
+Sign up with an `@restmail.net` address and read the mail at
+`http://localhost:9001/mail/<local-part>`; the request blocks until mail
+arrives. The stack runs `NODE_ENV=test` with the executor's forced feature
+flags and customs disabled, so it matches CI, not `yarn start`.
+
+### Access and exposure
+
+Triggering, canceling and rerunning need project write access (GitHub team
+membership), and the rerun installs only the token owner's VCS keys, so the
+person who booted the stack is the one who can connect. The container has no
+inbound ports other than CircleCI's SSH gateway, so a forwarded port is not a
+published one. Fork authors have no write access and the workflow never runs
+unless explicitly triggered.
+
+The shell inherits the project's env vars, which is where this repo keeps its CI
+secrets. A write-access user could read those from any `run:` step already, but
+an SSH session leaves no diff, so treat it as the less auditable path. Step
+output is public and the executor logs at debug level: use throwaway identities
+only, never real accounts or stage/production credentials, and never echo `env`.
+pm2 logs are deliberately not stored as artifacts for the same reason.
+
+Docker `xlarge` bills 20 credits/min while the job is up: the boot, the hold,
+and up to ten minutes after the last session closes. A stack left to its
+default hold costs roughly 800 credits.
+
+The job pins `mozilla/fxa-circleci:ci-builder-vN` (it needs the baked-in
+`node_modules` and `yarn.lock.base`), so bump it with the other `-vN`
+references (below).
+
 ## Updating the CI images (Playwright / dependency bumps)
 
 Most jobs run in pre-built images published to Docker Hub as

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,14 @@ parameters:
   enable_nightly:
     type: boolean
     default: true
+  # Set by `yarn pr-debug` (_scripts/pr-debug.sh). Never true on its own.
+  run_stack:
+    type: boolean
+    default: false
+  # How long the stack job stays up after boot, connected or not.
+  stack_minutes:
+    type: integer
+    default: 30
   force-deploy-fxa-ci-images:
     type: boolean
     default: false
@@ -136,9 +144,12 @@ executors:
       resource_class:
         type: string
         default: xlarge
+      image:
+        type: string
+        default: mozilla/fxa-circleci:ci-functional-test-runner-v10
     resource_class: << parameters.resource_class >>
     docker:
-      - image: mozilla/fxa-circleci:ci-functional-test-runner-v10
+      - image: << parameters.image >>
       - image: redis
       - image: pafortin/goaws
       - image: cimg/mysql:8.0
@@ -920,6 +931,58 @@ jobs:
           workflow: << parameters.workflow >>
           test_suite: e2e
 
+  # Boots the functional-test stack in one self-contained job (install, build,
+  # start) so a dev can drive it over "Rerun job with SSH". Runs no tests.
+  # Only the stack workflow runs it; `yarn pr-debug` drives the whole flow.
+  # See the interactive stack section of .circleci/README.md.
+  #
+  # Runs on the builder image rather than the functional-test one: it ships
+  # node_modules and yarn.lock.base, so `provision` skips the install when the
+  # lockfile matches main, and nothing here needs a browser.
+  stack:
+    executor:
+      name: functional-test-executor
+      image: mozilla/fxa-circleci:ci-builder-v10
+    steps:
+      - git-checkout
+      - provision
+      - run:
+          # The migration patcher imports fxa-shared's build output. Other
+          # callers of wait-for-infrastructure get it from the Build workspace;
+          # this job has none, so build it first. start-services.sh reuses it.
+          name: Build fxa-shared for the migration patcher
+          command: NODE_OPTIONS="--max-old-space-size=7168" npx nx build fxa-shared
+          environment:
+            NODE_ENV: test
+      - run:
+          name: Add localhost
+          command: |
+            sudo tee -a /etc/hosts \<<<'127.0.0.1 localhost'
+            sudo cat /etc/hosts
+      - wait-for-infrastructure
+      - run:
+          name: Start services
+          command: ./packages/functional-tests/scripts/start-services.sh
+          environment:
+            NODE_ENV: test
+          no_output_timeout: 20m
+      - run:
+          name: How to connect
+          command: ./.circleci/stack-info.sh
+      # Keeps the job up whether or not anyone is connected, so several stacks
+      # can sit side by side and `yarn pr-debug --tunnel` can hop between them.
+      # Without it CircleCI ends an idle SSH job after ten minutes. Echoes each
+      # minute so no_output_timeout does not cut the hold short.
+      - run:
+          name: Hold the stack
+          command: |
+            for ((i = 1; i <= << pipeline.parameters.stack_minutes >>; i++)); do
+              sleep 60
+              echo "up for ${i} of << pipeline.parameters.stack_minutes >> minutes"
+            done
+      # No store-artifacts: pm2 logs from a hands-on session would publish
+      # whatever the operator typed (debug log level) to a public artifact store.
+
   # Runs payments-next functional tests using playwright.
   # For local: uses functional-test-executor with full infra.
   # For stage/production: uses smoke-test-executor.
@@ -1163,6 +1226,13 @@ workflows:
             - Integration Test - Libraries (PR)
             # Surface auto-run functional-test failures on bot branches.
             - Firefox Functional Tests - Playwright (auto)
+
+  # Triggered by `yarn pr-debug`; never runs on its own. See .circleci/README.md
+  stack:
+    when: << pipeline.parameters.run_stack >>
+    jobs:
+      - stack:
+          name: Stack (SSH)
 
   # Triggered remotely. See .circleci/README.md
   production_smoke_tests:

--- a/.circleci/stack-info.sh
+++ b/.circleci/stack-info.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Connection banner for the stack job. The SSH host and port are assigned by
+# CircleCI's gateway and not visible to the job, hence no ssh line here.
+
+set -euo pipefail
+
+cat <<'BANNER'
+
+================================================================================
+  FxA stack is up!   Notes: .circleci/README.md (Interactive stack)
+================================================================================
+
+  From your machine, on the branch this job built (or pass its PR number):
+  - Stop your local pm2 stack first: `yarn stop`
+  - Forward the ports: `yarn pr-debug --tunnel`
+  - Open http://localhost:3030. You are now on the CI servers for this commit.
+
+  For logs, open a shell beside the tunnel: `yarn pr-debug --ssh`
+  then `yarn pm2 log` on the box.
+
+  Sign up with an @restmail.net address; read the mail at
+  http://localhost:9001/mail/<local-part> (blocks until mail arrives).
+
+  The job holds the stack up for the next step's duration whether or not you
+  are connected, then CircleCI's limits apply: it shuts down about ten minutes
+  after the last SSH session closes, two hours per job at most.
+
+================================================================================
+
+BANNER

--- a/.claude/skills/fxa-pr-debug/SKILL.md
+++ b/.claude/skills/fxa-pr-debug/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: fxa-pr-debug
+description: Boots a branch's FxA stack in CircleCI with `yarn pr-debug`, tunnels it to localhost with `yarn pr-debug --tunnel`, and reports when it is up. Given a description of what to check, also writes and runs a throwaway Playwright test against it in a headed local Firefox. Requires CIRCLECI_TOKEN. Use to try a branch or PR without checking it out.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TaskOutput, TaskStop, AskUserQuestion
+argument-hint: [pr-number] [what to test]
+user-invocable: true
+context: inherit
+---
+
+# Debug a PR on a CI stack
+
+Two commands: `yarn pr-debug [pr]` boots the branch's stack in CircleCI and
+returns once it is up; `yarn pr-debug --tunnel [pr]` then forwards every
+service port to `localhost`, so `http://localhost:3030` *is* the CI stack and
+`yarn playwright test --project=local` runs against it unchanged. The stack
+stays up 30 minutes after boot whether or not a tunnel is open, so several
+can run side by side and `--tunnel` hops between them. How the script gets
+there is documented in `.circleci/README.md` (Interactive stack); this skill
+only drives it.
+
+Arguments: a leading integer is a PR number; everything else is the test
+description. Either is optional.
+
+## Hard rules
+
+- The stack is a public CI job: only throwaway identities (`testAccountTracker`
+  makes them), never real accounts or stage/production credentials, and never
+  print the container's `env`.
+- Scratch specs live in `packages/functional-tests/tests/scratch/` and are
+  deleted before this skill ends. Never stage or commit one. If the user wants
+  to keep it, say it must become a real test (`/fxa-test-draft`) first.
+- Ask before `yarn stop` (their local stack) or `npx playwright install`
+  (network). Do not edit `_scripts/pr-debug.sh` or `.circleci/config.yml` here.
+- `--tunnel` closes any tunnel already open from this machine. If `pgrep -f
+  fxa-pr-debug-tunnel` finds one, say which stack it will drop and ask first.
+- A host key mismatch from the script is a stop, not something to bypass.
+
+## Steps
+
+### 1. Preflight (run these in parallel)
+
+- Token present, without printing it:
+  `if [ -n "$CIRCLECI_TOKEN" ] || [ -n "$CIRCLECI_CLI_TOKEN" ]; then echo set; else echo missing; fi`.
+  Missing → point at https://app.circleci.com/settings/user/tokens and stop.
+- `git status -sb`. Without a PR number, the branch must not be `main`/`HEAD`,
+  and must exist on origin; if local is ahead, say so — CI builds origin.
+- `ssh-add -l`. `--tunnel` runs ssh non-interactively, so the key registered
+  with the user's GitHub account must be in the agent. If the agent is empty,
+  ask them to `ssh-add` it in their terminal and stop until they confirm.
+- Existing tunnel: `pgrep -fl fxa-pr-debug-tunnel` (see hard rules).
+- Forwarded ports free:
+  `for p in 3030 3000 9000 9001 1111 1112 8080 8091 8095 9130 9160 6379; do nc -z -w1 127.0.0.1 $p && echo "$p busy"; done`.
+  Busy ports with no tunnel running usually mean a local `yarn start`; ask
+  before `yarn stop`.
+- With a test description: a local Firefox for Playwright
+  (`ls ~/Library/Caches/ms-playwright | grep -c firefox`). None → ask before
+  `npx playwright install firefox`.
+
+### 2. Boot the stack
+
+Run from the repo root in the background with the maximum timeout:
+
+```sh
+yarn pr-debug [pr-number]
+```
+
+It prints each CI step as it goes ("Canceling first pass" is expected — SSH can
+only be enabled on a rerun), then `Job #N: <url>`, and exits with "Stack for
+<branch> is up". A cold boot is about seven minutes (two of them the
+throwaway first pass); a rerun on the same commit skips that pass and takes
+about five. If a stack is already running for the commit it says so and exits
+at once.
+
+### 3. Draft the test while it boots (only with a description)
+
+Write `packages/functional-tests/tests/scratch/<kebab-slug>.spec.ts`:
+
+- `import { test, expect } from '../../lib/fixtures/standard';` — fixtures are
+  `target`, `page`, `pages` (the POMs under `pages/`), `testAccountTracker`,
+  `syncBrowserPages`. Read `lib/testAccountTracker.ts` for how accounts are
+  created and cleaned up, and the spec under `tests/` closest to the request
+  for the flow.
+- One `test.describe('scratch: <description>')` with one `test()`. Assert with
+  `expect`; no severity tags.
+- Locator rules in `.claude/rules/testing/functional-pages.md` apply (they load
+  when you touch the file): structural locators and POM getters, never CMS
+  copy.
+
+### 4. Open the tunnel
+
+Once the boot task has exited successfully, run in the background with the
+maximum timeout:
+
+```sh
+yarn pr-debug --tunnel [pr-number]
+```
+
+It prints `Job #N`, the SSH endpoint, then "Tunnel open". Then confirm the
+ports answer, in one bounded call rather than a sleep loop:
+
+```sh
+curl -sf --retry 20 --retry-all-errors --retry-delay 5 --retry-max-time 120 \
+  -o /dev/null http://localhost:3030/ && curl -sf -o /dev/null http://localhost:9000/__heartbeat__ && echo up
+```
+
+`--retry-all-errors` matters: a forwarded port whose remote side is not
+listening yet returns an empty reply, which curl otherwise treats as final.
+
+If either task fails, read its output: "No stack is running" means the boot
+did not finish or the stack has shut down (rerun step 2); a "Step failed" line
+carries the job URL. Do not guess at the cause; relay the failing step.
+
+### 5. Tell the user
+
+One message: the stack is at <http://localhost:3030>, the job URL, when the
+30-minute hold ends, and that mail for `@restmail.net` signups is read at
+`http://localhost:9001/mail/<local-part>` (the request blocks until mail
+arrives). For a shell on the box alongside the tunnel — `yarn pm2 log`, say —
+they run `yarn pr-debug --ssh [pr-number]` in their own terminal; it binds no
+ports.
+
+### 6. Run the test (only with a description)
+
+```sh
+cd packages/functional-tests && DEBUG=1 PLAYWRIGHT_WORKERS=1 \
+  yarn test tests/scratch/<slug>.spec.ts --retries=0
+```
+
+The package's `test` script pins `--project=local` and the ipv4-first DNS
+order the tunnel needs. `DEBUG=1` runs headed, so the user watches the CI stack
+drive a local Firefox. An existing spec works just as well as a scratch one
+when the request matches a flow the suite already covers; pick one test with
+`-g "<title>$"`.
+
+In a checkout without `node_modules` (a fresh worktree), `yarn` refuses to run.
+Node resolution walks up to the main checkout's `node_modules`, so run its
+binary against this checkout's config instead:
+`NODE_OPTIONS=--dns-result-order=ipv4first <main-checkout>/node_modules/.bin/playwright test --config <this-checkout>/packages/functional-tests/playwright.config.ts --project=local …`.
+Report the result plainly: which assertion failed and what the page showed. On
+failure the trace is under `artifacts/functional/`; give the
+`yarn playwright show-trace <zip>` command. Offer to adjust and rerun — the
+stack is warm, so a rerun is seconds.
+
+### 7. Wrap up
+
+Delete `tests/scratch/` and confirm `git status --short packages/functional-tests`
+is clean. Then ask what to do with the stack:
+
+- **Keep the tunnel** — they browse `localhost:3030` until the session cap.
+- **Stop the tunnel** (`TaskStop`) — the stack stays up for the rest of its
+  hold, and `yarn pr-debug --tunnel` reconnects to it.
+- **Release now** — stop the tunnel, then cancel the job (URL first, so the
+  Bash permission rule for CircleCI POSTs matches):
+  `curl https://circleci.com/api/v2/project/gh/mozilla/fxa/job/<N>/cancel -sS -X POST -H "Circle-Token: $CIRCLECI_TOKEN"`.
+
+## Notes
+
+- Docker `xlarge` bills 20 credits/min while the job is up. The 30-minute hold
+  is set at boot (`PR_DEBUG_MINUTES` overrides it); after it the job shuts down
+  about ten minutes after the last SSH session closes. Tunnel and shell
+  sessions are capped at the same number of minutes and never cancel the job.
+- Redis (6379) is forwarded because the `target` fixture resets rate limits
+  through it; without that forward every test hangs on connect.
+- Script errors to relay verbatim rather than work around: "No stack is
+  running", "Local ports in use", "Host key mismatch", "Step failed", "Timed
+  out waiting".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Every skill's name and description loads automatically — this section only cov
 - **Before merging:** `/fxa-review` for auth, payments, crypto, migrations, or multi-package changes; `/fxa-review-quick` otherwise. `/fxa-security-review` on top when the change touches auth, sessions, tokens, or payments.
 - **Filing a ticket:** `/fxa-jira-feature-description` or `/fxa-jira-bug-description`, even when the ask arrives mid-task.
 - **Opening a PR:** `/fxa-pr-open`. It handles the template, the alignment pass against Jira, and the draft-only rule.
+- **Trying a branch without checking it out:** `/fxa-pr-debug`. Boots the branch's stack in CircleCI, tunnels it to `localhost`, and can run a throwaway Playwright check you describe.
 
 ## 8) Testing Guidelines
 

--- a/_scripts/pr-debug.sh
+++ b/_scripts/pr-debug.sh
@@ -1,0 +1,352 @@
+#! /bin/bash
+#
+# Drive the FxA stack for a branch in CircleCI: boot it, tunnel its ports to
+# localhost, or open a shell on it.
+#
+# Usage: CIRCLECI_TOKEN=<token> yarn pr-debug [--tunnel | --ssh] [pr-number | branch]
+#
+#   yarn pr-debug           Boots the stack in CI and returns once it is up. Reports
+#                           the job instead if one is already running.
+#   yarn pr-debug --tunnel  Forwards the service ports to localhost and holds
+#                           them until Ctrl-C. Closes any tunnel this script
+#                           opened before, so switching between PR stacks is
+#                           one command. Non-interactive: your key must be in
+#                           ssh-agent.
+#   yarn pr-debug --ssh     Opens a shell in ~/project. Binds no ports, so it
+#                           sits beside a tunnel (for `yarn pm2 log`, say), and
+#                           connects even if a CI step failed.
+#
+# Defaults to the current branch. Needs a personal API token (project tokens
+# cannot trigger or rerun pipelines): https://app.circleci.com/settings/user/tokens
+# Falls back to CIRCLECI_CLI_TOKEN. Also needs jq and nc; `gh` only when given
+# a PR number.
+#
+# How the boot works:
+#   1. Triggers the `stack` workflow on the branch, or reuses one already run
+#      for the same commit.
+#   2. Cancels that run as soon as its job starts, then reruns the job with SSH
+#      enabled. CircleCI only enables SSH on the rerun of a finished workflow,
+#      so a throwaway first pass is the price of scripting this.
+#   3. Waits for the stack to boot, then prints how to connect.
+#
+# The job holds the stack up for PR_DEBUG_MINUTES (default 30) after it boots,
+# connected or not, then shuts down about ten minutes after the last SSH
+# session closes (CircleCI's rule; two hours per job at most). Tunnel and shell
+# sessions are capped at the same number of minutes; reconnect by rerunning.
+
+set -euo pipefail
+
+slug="github/mozilla/fxa"
+api="https://circleci.com/api/v2"
+api_v1="https://circleci.com/api/v1.1/project/gh/mozilla/fxa"
+workflow_name="stack"
+job_name="Stack (SSH)"
+# Same-number forwards: the services advertise localhost:<port> URLs. Redis is
+# included because the Playwright fixtures reset rate limits through it.
+ports=(3030 3000 9000 9001 1111 1112 8080 8091 8095 9130 9160 6379)
+minutes="${PR_DEBUG_MINUTES:-30}"
+[[ "${minutes}" =~ ^[0-9]+$ ]] || { echo "PR_DEBUG_MINUTES must be a whole number." >&2; exit 1; }
+# Passed as $0 to the remote shell, so it shows up in the local ssh argv and
+# `--tunnel` can find (and close) tunnels opened by earlier runs.
+tunnel_marker="fxa-pr-debug-tunnel"
+shell_marker="fxa-pr-debug-shell"
+
+token="${CIRCLECI_TOKEN:-${CIRCLECI_CLI_TOKEN:-}}"
+: "${token:?set CIRCLECI_TOKEN (https://app.circleci.com/settings/user/tokens)}"
+auth=(-H "Circle-Token: ${token}")
+
+log() { printf '\033[1;34m[pr-debug]\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31m[pr-debug]\033[0m %s\n' "$*" >&2; exit 1; }
+get() { curl -fsS "${auth[@]}" "$@"; }
+post() { curl -fsS "${auth[@]}" -X POST -H "Content-Type: application/json" "$@"; }
+job_url() { echo "https://app.circleci.com/jobs/${slug}/$1"; }
+
+# Calls a function every 10s until it prints something, then echoes that.
+poll() { # <timeout-seconds> <description> <function> [args...]
+  local deadline=$(( $(date +%s) + $1 )) desc="$2" out
+  shift 2
+  while :; do
+    out=$("$@" 2>/dev/null || true)
+    if [[ -n "${out}" ]]; then
+      printf '%s\n' "${out}"
+      return 0
+    fi
+    (( $(date +%s) < deadline )) || die "Timed out waiting for ${desc}."
+    sleep 10
+  done
+}
+
+is_terminal() { [[ "$1" =~ ^(success|failed|error|canceled|unauthorized)$ ]]; }
+
+# --- CircleCI lookups -------------------------------------------------------
+
+stack_job() { # <workflow-id> -> job json, or nothing
+  get "${api}/workflow/$1/job" \
+    | jq -c --arg n "${job_name}" '[.items[] | select(.name == $n)] | .[0] // empty'
+}
+
+has_ssh() { # <job-number>
+  [[ -n "$(get "${api_v1}/$1" | jq -r '.ssh_users[0].login // empty')" ]]
+}
+
+# Newest stack workflow built from this commit, as "<workflow-id> <status>".
+find_existing_workflow() {
+  local pid
+  for pid in $(get --get --data-urlencode "branch=${branch}" "${api}/project/${slug}/pipeline" \
+      | jq -r --arg rev "${remote_rev}" '.items[] | select(.vcs.revision == $rev) | .id'); do
+    get "${api}/pipeline/${pid}/workflow" \
+      | jq -r --arg n "${workflow_name}" \
+          '[.items[] | select(.name == $n)] | sort_by(.created_at) | last // empty | "\(.id) \(.status)"'
+  done | grep . | head -1
+}
+
+# Newest running SSH-enabled stack job on the branch, any commit, as
+# "<job-number> <revision>". Checks the ten most recent pipelines.
+find_ssh_job() {
+  local pid rev wf num
+  while read -r pid rev; do
+    for wf in $(get "${api}/pipeline/${pid}/workflow" \
+        | jq -r --arg n "${workflow_name}" \
+            '[.items[] | select(.name == $n)] | sort_by(.created_at) | reverse | .[].id'); do
+      num=$(stack_job "${wf}" | jq -r 'select(.status == "running") | .job_number // empty')
+      [[ -n "${num}" ]] && has_ssh "${num}" || continue
+      echo "${num} ${rev}"
+      return 0
+    done
+  done < <(get --get --data-urlencode "branch=${branch}" "${api}/project/${slug}/pipeline" \
+             | jq -r '.items[:10][] | "\(.id) \(.vcs.revision)"')
+  return 1
+}
+
+workflow_id_in_pipeline() { # <pipeline-id>
+  get "${api}/pipeline/$1/workflow" \
+    | jq -r --arg n "${workflow_name}" '.items[] | select(.name == $n) | .id' | head -1
+}
+
+running_job_number() { stack_job "$1" | jq -r 'select(.status == "running") | .job_number'; }
+any_job_number()     { stack_job "$1" | jq -r 'select(.job_number != null) | .job_number'; }
+terminal_status() {
+  local s
+  s=$(get "${api}/workflow/$1" | jq -r .status)
+  is_terminal "${s}" && echo "${s}" || true
+}
+
+# "<port> <host> <ed25519-fingerprint>" once the Enable SSH step has printed
+# the connection line. The fingerprint lets us pin the host key without
+# trusting the first connection.
+ssh_endpoint() { # <job-number>
+  local step out
+  step=$(get "${api_v1}/$1" \
+    | jq -r '.steps[] | select(.name == "Enable SSH") | .actions[0] | select(.has_output) | .step' | head -1)
+  [[ -n "${step}" ]] || return 0
+  out=$(get "${api_v1}/$1/output/${step}/0" | jq -r '.[].message')
+  local endpoint fp
+  endpoint=$(grep -oE 'ssh -p [0-9]+ [0-9.]+' <<<"${out}" | awk '{print $3, $4}' | head -1)
+  fp=$(grep -oE 'SHA256:[A-Za-z0-9+/=]+ \(ED25519\)' <<<"${out}" | awk '{print $1}' | head -1)
+  [[ -n "${endpoint}" && -n "${fp}" ]] && echo "${endpoint} ${fp}"
+}
+
+# Blocks until `Start services` has succeeded on the job. A failed step is
+# fatal unless <lenient> is set, in which case it returns 1 so the caller can
+# connect anyway.
+wait_for_stack() { # <job-number> [lenient]
+  local job="$1" lenient="${2:-}" deadline last="" steps failed current
+  log "Waiting for the stack (install, build, start; about seven minutes cold)..."
+  deadline=$(( $(date +%s) + 30 * 60 ))
+  while :; do
+    steps=$(get "${api_v1}/${job}" | jq -c '[.steps[] | {name, status: .actions[0].status}]')
+    failed=$(jq -r '[.[] | select(.status == "failed") | .name] | join(", ")' <<<"${steps}")
+    if [[ -n "${failed}" ]]; then
+      [[ -n "${lenient}" ]] || die "Step failed: ${failed}. $(job_url "${job}")"
+      log "Step failed: ${failed}. Connecting anyway so you can look around."
+      return 1
+    fi
+    if jq -e '.[] | select(.name == "Start services" and .status == "success")' <<<"${steps}" >/dev/null; then
+      return 0
+    fi
+    current=$(jq -r '[.[] | select(.status == "running") | .name] | last // "starting"' <<<"${steps}")
+    if [[ "${current}" != "${last}" ]]; then
+      log "  ${current}"
+      last="${current}"
+    fi
+    (( $(date +%s) < deadline )) || die "Timed out waiting for the stack. $(job_url "${job}")"
+    sleep 10
+  done
+}
+
+# --- 1. arguments and the commit CI will build ------------------------------
+
+mode=up # up: boot and return; tunnel: forwards only; ssh: shell only
+target=""
+for arg in "$@"; do
+  case "${arg}" in
+    --tunnel) mode=tunnel ;;
+    --ssh) mode=ssh ;;
+    -*) die "Unknown option '${arg}'. Usage: yarn pr-debug [--tunnel | --ssh] [pr-number | branch]" ;;
+    *) target="${arg}" ;;
+  esac
+done
+
+if [[ "${target}" =~ ^[0-9]+$ ]]; then
+  branch=$(gh pr view "${target}" --repo mozilla/fxa --json headRefName --jq .headRefName)
+elif [[ -n "${target}" ]]; then
+  branch="${target}"
+else
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  [[ "${branch}" != "HEAD" ]] || die "Detached HEAD; pass a branch or PR number."
+fi
+
+remote_rev=$(git ls-remote --heads "https://github.com/mozilla/fxa" "${branch}" | cut -f1)
+[[ -n "${remote_rev}" ]] || die "'${branch}' is not on github.com/mozilla/fxa. Push it first."
+local_rev=$(git rev-parse --verify --quiet "refs/heads/${branch}" || true)
+if [[ -n "${local_rev}" && "${local_rev}" != "${remote_rev}" ]]; then
+  log "WARNING: local ${branch} is ${local_rev:0:7}, origin is ${remote_rev:0:7}. CI builds origin."
+fi
+log "${branch} @ ${remote_rev:0:7}"
+
+# --- 2. boot ----------------------------------------------------------------
+
+if [[ "${mode}" == up ]]; then
+  ssh_job=""
+  existing=$(find_existing_workflow || true)
+  wf_id="${existing%% *}"
+
+  if [[ -n "${wf_id}" ]]; then
+    job=$(stack_job "${wf_id}")
+    status=$(jq -r .status <<<"${job}")
+    num=$(jq -r '.job_number // empty' <<<"${job}")
+    case "${status}" in
+      running)
+        if has_ssh "${num}"; then
+          log "Stack already running as job #${num}."
+          ssh_job="${num}"
+        else
+          log "Canceling non-SSH run #${num} so it can be rerun with SSH."
+          post "${api}/workflow/${wf_id}/cancel" >/dev/null
+        fi
+        ;;
+      success|failed|canceled|error)
+        log "Reusing the ${status} run from this commit."
+        ;;
+      *)
+        num=$(poll 300 "job to start" running_job_number "${wf_id}")
+        log "Canceling queued run #${num} so it can be rerun with SSH."
+        post "${api}/workflow/${wf_id}/cancel" >/dev/null
+        ;;
+    esac
+  else
+    log "Triggering ${workflow_name} on ${branch}..."
+    payload=$(jq -n --arg branch "${branch}" --argjson minutes "${minutes}" '{
+      branch: $branch,
+      parameters: {
+        run_stack: true,
+        stack_minutes: $minutes,
+        enable_test_pull_request: false,
+        enable_test_and_deploy_tag: false,
+        enable_deploy_packages: false,
+        enable_deploy_ci_images: false,
+        enable_nightly: false
+      }
+    }')
+    pipeline_id=$(post -d "${payload}" "${api}/project/${slug}/pipeline" | jq -r '.id // empty')
+    [[ -n "${pipeline_id}" ]] || die "Pipeline trigger failed."
+    wf_id=$(poll 120 "the workflow to appear" workflow_id_in_pipeline "${pipeline_id}")
+    # Cancel as soon as the job is running. CircleCI reruns canceled jobs fine,
+    # but only ones that got far enough to be assigned a number.
+    num=$(poll 300 "the job to start" running_job_number "${wf_id}")
+    log "Canceling first pass #${num}; SSH can only be enabled on a rerun."
+    post "${api}/workflow/${wf_id}/cancel" >/dev/null
+  fi
+
+  if [[ -z "${ssh_job}" ]]; then
+    poll 300 "the workflow to finish" terminal_status "${wf_id}" >/dev/null
+    job_id=$(stack_job "${wf_id}" | jq -r .id)
+    new_wf=$(post -d "{\"enable_ssh\": true, \"jobs\": [\"${job_id}\"]}" \
+      "${api}/workflow/${wf_id}/rerun" | jq -r '.workflow_id // empty')
+    [[ -n "${new_wf}" ]] || die "Rerun with SSH failed."
+    ssh_job=$(poll 300 "the SSH job to start" any_job_number "${new_wf}")
+  fi
+  log "Job #${ssh_job}: $(job_url "${ssh_job}")"
+
+  wait_for_stack "${ssh_job}"
+  hint="${target:+ ${target}}"
+  log "Stack for ${branch} is up. It stays up ${minutes} minutes, longer while a session is open."
+  log "  yarn pr-debug --tunnel${hint}   forward its ports; http://localhost:3030 becomes this stack"
+  log "  yarn pr-debug --ssh${hint}      shell on the box, e.g. yarn pm2 log"
+  exit 0
+fi
+
+# --- 3. connect (tunnel / ssh) ----------------------------------------------
+
+read -r ssh_job job_rev < <(find_ssh_job || true)
+[[ -n "${ssh_job:-}" ]] \
+  || die "No stack is running for ${branch}. Boot one with: yarn pr-debug${target:+ ${target}}"
+if [[ "${job_rev}" != "${remote_rev}" ]]; then
+  log "WARNING: the running stack is built from ${job_rev:0:7}; origin/${branch} is now ${remote_rev:0:7}."
+fi
+log "Job #${ssh_job}: $(job_url "${ssh_job}")"
+
+if [[ "${mode}" == tunnel ]]; then
+  # Replace, rather than stack up, tunnels: only one can hold the ports.
+  old=$(pgrep -f "${tunnel_marker}" || true)
+  if [[ -n "${old}" ]]; then
+    log "Closing the existing tunnel (pid ${old//$'\n'/, })."
+    # shellcheck disable=SC2086
+    kill ${old} 2>/dev/null || true
+    for _ in $(seq 20); do pgrep -f "${tunnel_marker}" >/dev/null || break; sleep 0.5; done
+    pkill -9 -f "${tunnel_marker}" 2>/dev/null || true
+  fi
+  # Anything else on the ports is usually a local `yarn start`.
+  busy=()
+  for p in "${ports[@]}"; do
+    nc -z -w1 127.0.0.1 "${p}" 2>/dev/null && busy+=("${p}")
+  done
+  if (( ${#busy[@]} )); then
+    die "Local ports in use: ${busy[*]}. Stop whatever holds them (a local stack: yarn stop) and retry."
+  fi
+  wait_for_stack "${ssh_job}"
+else
+  wait_for_stack "${ssh_job}" lenient || true
+fi
+
+read -r port host fingerprint < <(poll 300 "the SSH endpoint" ssh_endpoint "${ssh_job}")
+[[ -n "${port:-}" && -n "${host:-}" ]] || die "Could not read the SSH endpoint."
+log "SSH endpoint ${host}:${port}"
+
+# Pin the host key CircleCI reported for this job instead of trusting the
+# first connection. Every job has a fresh key, so nothing goes in ~/.ssh.
+known_hosts=$(mktemp)
+trap 'rm -f "${known_hosts}"' EXIT
+ssh-keyscan -p "${port}" -t ed25519 "${host}" 2>/dev/null > "${known_hosts}"
+scanned=$(ssh-keygen -lf "${known_hosts}" 2>/dev/null | awk '{print $2}')
+[[ "${scanned}" == "${fingerprint}" ]] \
+  || die "Host key mismatch for ${host}:${port} (got ${scanned:-nothing}, CircleCI reports ${fingerprint})."
+
+ssh_opts=(-p "${port}" "${host}"
+  -o UserKnownHostsFile="${known_hosts}" -o StrictHostKeyChecking=yes -o LogLevel=ERROR
+  -o ServerAliveInterval=30 -o ExitOnForwardFailure=yes)
+
+# CircleCI runs the remote command without a shell, so wrap it in one; the
+# inner quotes survive to the remote and keep it a single argument. The marker
+# lands in $0 of that shell. Interactive bash ignores SIGTERM, hence -k to
+# follow up with SIGKILL.
+set +e
+if [[ "${mode}" == tunnel ]]; then
+  for p in "${ports[@]}"; do ssh_opts+=(-L "${p}:127.0.0.1:${p}"); done
+  log "Tunnel open; http://localhost:3030 is the ${branch} stack. Cap ${minutes} minutes; Ctrl-C to stop."
+  ssh "${ssh_opts[@]}" -o BatchMode=yes \
+    "bash -lc \"exec timeout -k 5 ${minutes}m sleep infinity\" ${tunnel_marker}"
+else
+  log "Opening a shell on job #${ssh_job}, no forwards. Cap ${minutes} minutes."
+  ssh "${ssh_opts[@]}" -t \
+    "bash -lc \"cd ~/project && exec timeout --foreground -k 5 ${minutes}m bash\" ${shell_marker}"
+fi
+status=$?
+set -e
+
+case "${status}" in
+  124) log "Session cap of ${minutes} minutes reached. Rerun to reconnect while the stack is up." ;;
+  143) log "Tunnel closed by another yarn pr-debug --tunnel." ;;
+  255) log "Connection dropped. Rerun to reconnect while the stack is up."; exit 1 ;;
+  *) log "Disconnected. Rerun to reconnect while the stack is up." ;;
+esac

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "trigger:docker-push": "_scripts/trigger-docker-push.sh",
     "trigger:docker-push-subplat": "_scripts/trigger-docker-push-subplat.sh",
     "trigger:smoke-tests": "_scripts/trigger-smoke-tests.sh",
+    "pr-debug": "_scripts/pr-debug.sh",
     "trigger:dot-release": "_scripts/trigger-dot-release.sh",
     "trigger:dot-release-subplat": "_scripts/trigger-dot-release-subplat.sh"
   },


### PR DESCRIPTION
## Because

- Validating a branch end to end means checking it out and running the whole stack locally, which is slow and machine specific.
- CI already builds and boots that exact stack for the functional tests, then tears it down. Reaching it by hand takes several UI steps, and an SSH rerun needs a finished workflow, which the functional-test approval hold never allows in `test_pull_request`.

## This pull request

- Adds a `dev_stack` workflow gated by a `run_dev_stack` pipeline parameter (default `false`, so ordinary pipelines never run it) with one self-contained `Dev Stack (SSH)` job: `provision`, `nx build fxa-shared`, migrations, `start-services.sh`, on the builder image.
- Gives `functional-test-executor` an `image` parameter; the default is unchanged, so the Playwright jobs are unaffected.
- Adds `yarn debug-pr [--tunnel | --shell] [pr-number | branch]` (`_scripts/debug-pr.sh`): triggers the workflow, cancels the first pass, reruns with `enable_ssh`, pins the host key CircleCI reports, and opens a tunnel and/or shell with a 20-minute session cap.
- Adds the `/fxa-debug-pr` skill, which boots the stack via `--tunnel`, reports when it is up, and can run Playwright (`--project=local`) against it.
- Skips `store-artifacts` on the job, since pm2 logs from a hands-on session would publish whatever the operator typed.
- Documents the flow, ports, access model and cost in `.circleci/README.md`.

## Issue that this pull request solves

Closes: [FXA-14524](https://mozilla-hub.atlassian.net/browse/FXA-14524)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `_scripts/debug-pr.sh`; in `.circleci/config.yml`, the `dev-stack` job, the `dev_stack` workflow, and the executor `image` parameter.
- Suggested review order: the README section (it explains the flow), then `config.yml`, then the script, then `SKILL.md`.
- Risky or complex parts: the cancel/rerun choreography against the CircleCI API (a v2 rerun with `enable_ssh` requires a terminal workflow); the executor parameter (default preserved); session-end handling (hitting the cap cancels the job, a disconnect does not).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- No ticket: dev-tooling change with no product impact.
- `/fxa-security-review` was run on an earlier revision; its Medium finding (pm2 logs from an interactive session published as artifacts) is fixed by skipping `store-artifacts`. The SSH rerun installs only the token owner's VCS keys, confirmed on a live job.
- Triggering, canceling and rerunning need project write access. Via the GitHub API: `fxa-write` and `fxa-admins` have push/admin; `svcops` and `fxa-community` are read-only.
- Exercised end to end on this branch. The first run surfaced that the migration patcher needs `fxa-shared` built (fixed with a build step); the second boots to a tunnel in about seven minutes, and `severity-1 #smoke › can reset password` passed against the tunnelled stack via `/fxa-debug-pr`.
- The job pins `ci-builder-v10`; bump it with the other `-vN` references when the images change.


[FXA-14524]: https://mozilla-hub.atlassian.net/browse/FXA-14524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ