### PR TITLE
fix(pair): route in-app camera v2 scans to the v2 supplicant screens

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -1052,7 +1052,11 @@ const AuthAndAccountSetupRoutes = ({
         <Route path="/pair/supp/complete/*" element={<PairSuccess />} />
         <Route
           path="/pair/supp/*"
-          element={<PairSupp integration={integration} />}
+          element={
+            <PairSupp
+              {...{ integration, fxaStatusResult: useFxAStatusResult }}
+            />
+          }
         />
         <Route
           path="/pair/auth/allow/*"

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
@@ -45,7 +45,9 @@ const VALID_CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 const VALID_OAUTH_CODE =
   'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
 
-function createIntegration(dataOverrides: Record<string, string> = {}) {
+function createIntegration(
+  dataOverrides: Record<string, string | undefined> = {}
+) {
   // Keys must be snake_case to match @bind(T.snakeCase) decorators
   const data = new GenericData({
     client_id: '3c49430b43dfba77',
@@ -200,9 +202,9 @@ describe('PairingSupplicantIntegration', () => {
     });
   });
 
-  // v2 asks the browser for its OAuth params instead of reading them from the
-  // URL, so the state to check `pair:auth:authorize` against is the one
-  // `pairOauthStart` handed back — not `this.data.state`, which v2 never sets.
+  // A v2 supplicant reached by a scanned QR has no OAuth params in its URL and
+  // asks the browser for them, so the state to check `pair:auth:authorize`
+  // against is the one `pairOauthStart` handed back, not `this.data.state`.
   describe('v2 approval state machine', () => {
     const BROWSER_STATE = 'browser-generated-state';
 
@@ -278,6 +280,77 @@ describe('PairingSupplicantIntegration', () => {
 
       expect(integration.state).toBe(SupplicantState.Failed);
       expect(integration.error?.message).toContain('no request state recorded');
+    });
+  });
+
+  // The mobile app's own QR scanner runs OAuth start itself and opens the page
+  // with the params in the URL. Asking the browser for a second set there would
+  // strand the verifier the app is holding for the code it expects back.
+  describe('v2 with OAuth params in the URL', () => {
+    beforeEach(() => {
+      jest.spyOn(firefox, 'pairOauthStart').mockResolvedValue({
+        state: 'browser-generated-state',
+        scope: 'profile',
+        code_challenge: VALID_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        keys_jwk: 'dGVzdGtleXM',
+      });
+    });
+
+    it('requests with the URL params rather than asking the browser', async () => {
+      const integration = createIntegration();
+      await integration.openChannel('wss://ch.example.com', 'c', 'k', 2);
+      emit('connected');
+
+      await waitFor(() =>
+        expect(mockSend).toHaveBeenCalledWith('pair:supp:request', {
+          access_type: 'offline',
+          client_id: '3c49430b43dfba77',
+          code_challenge: VALID_CODE_CHALLENGE,
+          code_challenge_method: 'S256',
+          keys_jwk: 'dGVzdGtleXM',
+          scope: 'profile https://identity.mozilla.com/apps/oldsync',
+          state: 'abc123',
+        })
+      );
+      expect(firefox.pairOauthStart).not.toHaveBeenCalled();
+    });
+
+    it('checks the authorize against the URL state', async () => {
+      jest.spyOn(firefox, 'fxaOAuthLogin').mockImplementation(() => {});
+      const integration = createIntegration();
+      await integration.openChannel('wss://ch.example.com', 'c', 'k', 2);
+      emit('connected');
+      await waitFor(() => expect(mockSend).toHaveBeenCalled());
+
+      emit('remote:pair:auth:authorize', {
+        code: VALID_OAUTH_CODE,
+        state: 'abc123',
+      });
+
+      expect(integration.state).toBe(SupplicantState.Complete);
+    });
+
+    // What a scanned QR produces: the bare URL from the code, carrying no OAuth
+    // request. `client_id` stays because a real supplicant falls back to
+    // deriving it from its user agent, which jsdom cannot stand in for.
+    it('asks the browser when the URL carries no OAuth request', async () => {
+      const integration = createIntegration({
+        scope: undefined,
+        state: undefined,
+        code_challenge: undefined,
+        code_challenge_method: undefined,
+        keys_jwk: undefined,
+      });
+      await integration.openChannel('wss://ch.example.com', 'c', 'k', 2);
+      emit('connected');
+
+      await waitFor(() =>
+        expect(mockSend).toHaveBeenCalledWith(
+          'pair:supp:request',
+          expect.objectContaining({ state: 'browser-generated-state' })
+        )
+      );
     });
   });
 

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
@@ -476,8 +476,20 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     this.setState(SupplicantState.Complete);
   }
 
+  private hasUrlOAuthParams(): boolean {
+    return !!(
+      this.data.clientId &&
+      this.data.codeChallenge &&
+      this.data.codeChallengeMethod &&
+      this.data.keysJwk &&
+      this.data.state &&
+      this.data.scope
+    );
+  }
+
   /**
-   * Build the OAuth params to send to the authority.
+   * Build the OAuth params to send to the authority, either from the URL or,
+   * in v2, from the browser.
    * Matches Backbone's SupplicantRelier.getOAuthParams() with Vat validation.
    *
    * Required fields (client_id, code_challenge, code_challenge_method,
@@ -485,7 +497,11 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
    * Vat.*.required() validators.
    */
   private async getOAuthParams(): Promise<OAuthStartParams> {
-    if (this._version === 2) {
+    // A supplicant whose own app scanned the QR is opened by app-services,
+    // which has already run OAuth start and put the params in the URL. Asking
+    // the browser again there would begin a second flow and strand the PKCE
+    // verifier the app is holding for the code it expects back.
+    if (this._version === 2 && !this.hasUrlOAuthParams()) {
       const data = await firefox.pairOauthStart({});
       if (!data) {
         throw new Error('Firefox could not provide oauth params.')
@@ -524,7 +540,6 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
       return result;
     }
 
-    // Legacy v1 approach
     const clientId = this.data.clientId;
     const codeChallenge = this.data.codeChallenge;
     const codeChallengeMethod = this.data.codeChallengeMethod;

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.stories.tsx
@@ -6,6 +6,7 @@ import Supp from '.';
 import { MemoryRouter } from 'react-router';
 import { Meta } from '@storybook/react';
 import { MOCK_ERROR } from './mocks';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 
 export default {
@@ -21,6 +22,10 @@ export default {
   ],
 } as Meta;
 
-export const DefaultLoadingState = () => <Supp />;
+export const DefaultLoadingState = () => (
+  <Supp fxaStatusResult={mockUseFxAStatus()} />
+);
 
-export const WithError = () => <Supp error={MOCK_ERROR} />;
+export const WithError = () => (
+  <Supp error={MOCK_ERROR} fxaStatusResult={mockUseFxAStatus()} />
+);

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
@@ -8,6 +8,7 @@ import Supp from '.';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { Integration } from '../../../models/integrations/integration';
+import { mockUseFxAStatus } from '../../../lib/hooks/useFxAStatus/mocks';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
@@ -63,10 +64,13 @@ jest.mock('../../../lib/config', () => {
       pairing: {
         serverBaseUri: 'wss://test.example.com',
         clients: [],
+        version: 1,
       },
     },
   };
 });
+
+const mockConfig = jest.requireMock('../../../lib/config').default;
 
 const mockNavigateWithQuery = jest.fn();
 jest.mock('../../../lib/hooks/useNavigateWithQuery', () => ({
@@ -75,18 +79,24 @@ jest.mock('../../../lib/hooks/useNavigateWithQuery', () => ({
 
 describe('Pair/Supp page', () => {
   it('renders the default loading state as expected', () => {
-    renderWithLocalizationProvider(<Supp />);
+    renderWithLocalizationProvider(
+      <Supp fxaStatusResult={mockUseFxAStatus()} />
+    );
 
     screen.queryByTestId('loading-spinner');
   });
 
   it('renders as expected when component mounts', () => {
-    renderWithLocalizationProvider(<Supp />);
+    renderWithLocalizationProvider(
+      <Supp fxaStatusResult={mockUseFxAStatus()} />
+    );
     // Supp is now self-contained, no error prop
   });
 
   it('emits the expected metrics event on render', () => {
-    renderWithLocalizationProvider(<Supp />);
+    renderWithLocalizationProvider(
+      <Supp fxaStatusResult={mockUseFxAStatus()} />
+    );
 
     expect(usePageViewEvent).toHaveBeenCalledWith(
       'pair.supp',
@@ -111,6 +121,7 @@ describe('Pair/Supp page', () => {
       mockIntegration = new PSI();
       mockNavigateWithQuery.mockClear();
       sessionStorage.clear();
+      mockConfig.pairing.version = 1;
       window.location.hash = '#channel_id=test-chan&channel_key=dGVzdA';
     });
 
@@ -119,11 +130,28 @@ describe('Pair/Supp page', () => {
       sessionStorage.clear();
     });
 
+    // Defaults to a browser that answered fxa_status reporting v1 pairing.
+    const renderSupp = (fxaStatusResult = mockUseFxAStatus()) =>
+      renderWithLocalizationProvider(
+        <Supp
+          integration={mockIntegration as unknown as Integration}
+          {...{ fxaStatusResult }}
+        />
+      );
+
+    // The v1 flow's signature: this page opens the channel itself and stays put.
+    const expectV1Flow = () => {
+      expect(mockIntegration.openChannel).toHaveBeenCalledWith(
+        'wss://test.example.com',
+        'test-chan',
+        'dGVzdA'
+      );
+      expect(mockNavigateWithQuery).not.toHaveBeenCalled();
+    };
+
     it('shows error when hash params are missing', () => {
       window.location.hash = '';
-      renderWithLocalizationProvider(
-        <Supp integration={mockIntegration as unknown as Integration} />
-      );
+      renderSupp();
       expect(
         screen.getByText('Invalid pairing configuration')
       ).toBeInTheDocument();
@@ -131,16 +159,12 @@ describe('Pair/Supp page', () => {
 
     it('shows error when pairing client is invalid', () => {
       mockIntegration.validatePairingClient.mockReturnValue(false);
-      renderWithLocalizationProvider(
-        <Supp integration={mockIntegration as unknown as Integration} />
-      );
+      renderSupp();
       expect(screen.getByText('Invalid pairing client')).toBeInTheDocument();
     });
 
     it('calls openChannel with params from hash', () => {
-      renderWithLocalizationProvider(
-        <Supp integration={mockIntegration as unknown as Integration} />
-      );
+      renderSupp();
       expect(mockIntegration.openChannel).toHaveBeenCalledWith(
         'wss://test.example.com',
         'test-chan',
@@ -149,9 +173,7 @@ describe('Pair/Supp page', () => {
     });
 
     it('navigates on WaitingForAuthorizations', () => {
-      renderWithLocalizationProvider(
-        <Supp integration={mockIntegration as unknown as Integration} />
-      );
+      renderSupp();
       act(() => {
         mockIntegration.onStateChange?.('waiting_for_authorizations');
       });
@@ -160,9 +182,7 @@ describe('Pair/Supp page', () => {
 
     it('redirects to success when completion marker is set for this channel', () => {
       sessionStorage.setItem('fxa.pair.complete.test-chan', '1');
-      renderWithLocalizationProvider(
-        <Supp integration={mockIntegration as unknown as Integration} />
-      );
+      renderSupp();
       expect(mockIntegration.openChannel).not.toHaveBeenCalled();
       expect(mockNavigateWithQuery).toHaveBeenCalledWith(
         '/oauth/success/test-client'
@@ -172,11 +192,86 @@ describe('Pair/Supp page', () => {
 
     it('ignores completion marker for a different channel', () => {
       sessionStorage.setItem('fxa.pair.complete.other-chan', '1');
-      renderWithLocalizationProvider(
-        <Supp integration={mockIntegration as unknown as Integration} />
-      );
+      renderSupp();
       expect(mockIntegration.openChannel).toHaveBeenCalled();
       expect(mockNavigateWithQuery).not.toHaveBeenCalled();
+    });
+
+    it('runs the v1 flow when the fragment has no version', () => {
+      mockConfig.pairing.version = 2;
+      renderSupp(mockUseFxAStatus({ pairingVersion: 2 }));
+      expectV1Flow();
+    });
+
+    // An app that scanned the QR with its own camera opens this page with the
+    // authority's fragment copied over, so a v2 authority's `v=2` arrives here.
+    describe('with a v2 fragment', () => {
+      // A browser that answered fxa_status reporting v2 pairing support.
+      const v2Browser = mockUseFxAStatus({ pairingVersion: 2 });
+
+      beforeEach(() => {
+        window.location.hash = '#channel_id=test-chan&channel_key=dGVzdA&v=2';
+        mockConfig.pairing.version = 2;
+      });
+
+      it('hands off to the v2 supplicant flow, without the hash', () => {
+        renderSupp(v2Browser);
+        expect(mockNavigateWithQuery).toHaveBeenCalledWith(
+          '/pair/supplicant/connect_this_device',
+          {
+            state: {
+              channelId: 'test-chan',
+              channelKey: 'dGVzdA',
+              version: '2',
+            },
+          },
+          false
+        );
+      });
+
+      it('leaves the channel for the v2 flow to open', () => {
+        renderSupp(v2Browser);
+        expect(mockIntegration.openChannel).not.toHaveBeenCalled();
+      });
+
+      it('redirects to the v2 success screen when the channel is complete', () => {
+        sessionStorage.setItem('fxa.pair.complete.test-chan', '1');
+        renderSupp(v2Browser);
+        expect(mockNavigateWithQuery).toHaveBeenCalledWith(
+          '/pair/supplicant/sync_success',
+          {},
+          false
+        );
+        expect(
+          sessionStorage.getItem('fxa.pair.complete.test-chan')
+        ).toBeNull();
+      });
+
+      it('runs the v1 flow when the browser does not report v2 pairing', () => {
+        renderSupp(mockUseFxAStatus({ pairingVersion: 1 }));
+        expectV1Flow();
+      });
+
+      it('runs the v1 flow when the browser never answered fxa_status', () => {
+        renderSupp(
+          mockUseFxAStatus({ fxaStatusState: 'unanswered', pairingVersion: 1 })
+        );
+        expectV1Flow();
+      });
+
+      it('chooses no flow while fxa_status is still pending', () => {
+        renderSupp(
+          mockUseFxAStatus({ fxaStatusState: 'pending', pairingVersion: 2 })
+        );
+        expect(mockIntegration.openChannel).not.toHaveBeenCalled();
+        expect(mockNavigateWithQuery).not.toHaveBeenCalled();
+      });
+
+      it('runs the v1 flow when FxA has v2 disabled', () => {
+        mockConfig.pairing.version = 1;
+        renderSupp(v2Browser);
+        expectV1Flow();
+      });
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
@@ -9,6 +9,7 @@ import AppLayout from '../../../components/AppLayout';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import Banner from '../../../components/Banner';
 import { useNavigateWithQuery } from '../../../lib/hooks';
+import type { UseFxAStatusResult } from '../../../lib/hooks';
 import config from '../../../lib/config';
 import { Integration } from '../../../models';
 import {
@@ -17,20 +18,34 @@ import {
   PairingSupplicantIntegration,
   SupplicantState,
 } from '../../../models/integrations/pairing-supplicant-integration';
+import { parsePairingHash } from '../../../lib/pairing/pair-url';
 
 // URL format: /pair/supp?client_id=...&scope=...#channel_id=...&channel_key=...
+//
+// A mobile Firefox that scans the QR with its own camera opens this page through
+// app-services, which runs OAuth start itself and copies the authority's
+// fragment over verbatim — so both protocol versions arrive here.
 
 export const viewName = 'pair.supp';
 
 type SuppProps = {
   integration?: Integration;
   error?: string;
+  fxaStatusResult: UseFxAStatusResult;
 };
 
-const Supp = ({ integration, error: errorProp }: SuppProps) => {
+const Supp = ({
+  integration,
+  error: errorProp,
+  fxaStatusResult,
+}: SuppProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const navigateWithQuery = useNavigateWithQuery();
   const [error, setError] = useState<string | undefined>(errorProp);
+
+  const { fxaStatusState } = fxaStatusResult;
+  const supplicantPairingVersion =
+    fxaStatusResult.fxaStatus?.capabilities.pairingVersion;
 
   useEffect(() => {
     if (!(integration instanceof PairingSupplicantIntegration)) {
@@ -38,7 +53,8 @@ const Supp = ({ integration, error: errorProp }: SuppProps) => {
     }
 
     // channel_id/key live in the URL hash so they're not sent to the server.
-    const hashParams = new URLSearchParams(window.location.hash.substring(1));
+    const hash = window.location.hash;
+    const hashParams = new URLSearchParams(hash.substring(1));
     const channelId = hashParams.get('channel_id');
     const channelKey = hashParams.get('channel_key');
     const channelServerUri = config.pairing?.serverBaseUri;
@@ -53,7 +69,28 @@ const Supp = ({ integration, error: errorProp }: SuppProps) => {
       return;
     }
 
+    // Three things have to agree before the v2 screens are the right ones: the
+    // authority encoded `v=2` into the fragment, FxA has v2 enabled, and this
+    // browser reported over the web channel that it speaks v2. A supplicant
+    // without the v2 commands belongs on the v1 flow, which it can complete.
+    const v2Channel = parsePairingHash(hash);
+    const authorityWantsV2 =
+      config.pairing?.version === 2 && v2Channel !== undefined;
+
+    // Only a v=2 fragment has anything to learn from fxa_status, so a v1 URL
+    // never waits on the reply. 'unanswered' is an answer: none is coming.
+    if (authorityWantsV2 && fxaStatusState === 'pending') {
+      return;
+    }
+
+    const isV2 = authorityWantsV2 && supplicantPairingVersion === 2;
+
     if (isChannelComplete(channelId)) {
+      if (isV2) {
+        clearChannelComplete(channelId);
+        navigateWithQuery('/pair/supplicant/sync_success', {}, false);
+        return;
+      }
       const clientId = integration.getClientId();
       if (clientId) {
         // We can now remove the flag, since we are about to navigate to the success page
@@ -64,6 +101,18 @@ const Supp = ({ integration, error: errorProp }: SuppProps) => {
       // Without a clientId, fall through rather than build /oauth/success/.
       // Don't clear the marker so isPostCompletionReconnect() can still
       // suppress the consumed-channel close/error from the WS reconnect.
+    }
+
+    if (isV2) {
+      // The v2 flow opens the channel itself, on the screen it lands on. The
+      // channel key is the pairing PSK, so it travels in router state and the
+      // hash it arrived in must not follow it into the next URL.
+      navigateWithQuery(
+        '/pair/supplicant/connect_this_device',
+        { state: v2Channel },
+        false
+      );
+      return;
     }
 
     integration.onStateChange = (state: SupplicantState) => {
@@ -90,7 +139,12 @@ const Supp = ({ integration, error: errorProp }: SuppProps) => {
       integration.onStateChange = null;
       integration.onError = null;
     };
-  }, [integration, navigateWithQuery]);
+  }, [
+    integration,
+    navigateWithQuery,
+    fxaStatusState,
+    supplicantPairingVersion,
+  ]);
 
   return error ? (
     <AppLayout>


### PR DESCRIPTION
## Because

- A v2 QR scanned with a mobile Firefox's own camera opens /pair/supp, the v1 supplicant entry, so pairing completed on the legacy screens.
- app-services holds the PKCE verifier for the code it expects back, so the page must not begin a second OAuth flow.


## This pull request

- Hands /pair/supp off to /pair/supplicant/connect_this_device only when the authority's fragment, the browser's fxa_status and pairing.version all say v2
- Waits on fxa_status before choosing a flow, and only for a v=2 fragment
- Sends the v2 post-OAuth reload to /pair/supplicant/sync_success instead of /oauth/success/:clientId
- Reads the OAuth request from the URL in v2 when it carries one, asking the browser only when it does not
- Adds unit coverage for the version gate and the param source

## Issue that this pull request solves

Closes: FXA-14427

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

**Scanning with in-app camera before fix (pointing at staging):**
<img width="674" height="644" alt="image" src="https://github.com/user-attachments/assets/e51b854c-76e8-4f56-aee9-60f9de1f8c7c" />


**Scanning wiht in-app camera after fix:**
<img width="650" height="510" alt="image" src="https://github.com/user-attachments/assets/9da41bf6-b607-4017-a76c-e863ae98fa91" />


## Other information (Optional)

Any other information that is important to this pull request.
